### PR TITLE
feat: MCP spec compliance and documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ optional = true
 [dependencies.http-body-util]
 version = "0.1"
 optional = true
+
+[[example]]
+name = "basic"
+path = "examples/basic.rs"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,211 @@
+# tower-mcp
+
+Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
+
+## Overview
+
+tower-mcp provides a composable, middleware-friendly approach to building MCP servers using the [Tower](https://github.com/tower-rs/tower) service abstraction. Unlike framework-style MCP implementations, tower-mcp treats MCP as just another protocol that can be served through Tower's `Service` trait.
+
+This means:
+- Standard tower middleware (tracing, metrics, rate limiting, auth) just works
+- Same service can be exposed over multiple transports (stdio, HTTP, WebSocket)
+- Easy integration with existing tower-based applications (axum, tonic)
+
+## Status
+
+**Early development** - Core protocol types and routing are implemented. Transports are not yet available.
+
+### Implemented
+- JSON-RPC 2.0 message types and validation
+- MCP protocol types (tools, resources, prompts)
+- Tool builder with type-safe handlers and JSON Schema generation via [schemars](https://crates.io/crates/schemars)
+- `McpTool` trait for complex tools
+- `McpRouter` implementing Tower's `Service` trait
+- `JsonRpcService` layer for protocol framing
+- Session state management (initialization lifecycle)
+- Protocol version negotiation
+- Tool annotations (behavior hints for trust/safety)
+
+### Not Yet Implemented
+- Transports (stdio, HTTP/SSE, WebSocket)
+- Resources (read, subscribe)
+- Prompts
+- Batch request handling
+- Progress notifications
+- Request cancellation
+
+## Installation
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+tower-mcp = { git = "https://github.com/joshrotenberg/tower-mcp" }
+```
+
+## Quick Start
+
+```rust
+use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+// Define your input type - schema is auto-generated
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GreetInput {
+    name: String,
+}
+
+// Build a tool with type-safe handler
+let greet = ToolBuilder::new("greet")
+    .description("Greet someone by name")
+    .handler(|input: GreetInput| async move {
+        Ok(CallToolResult::text(format!("Hello, {}!", input.name)))
+    })
+    .build();
+
+// Create router with tools
+let router = McpRouter::new()
+    .server_info("my-server", "1.0.0")
+    .instructions("This server provides greeting functionality")
+    .tool(greet);
+
+// The router implements tower::Service and can be composed with middleware
+```
+
+## Tool Definition
+
+### Builder Pattern (Recommended)
+
+```rust
+use tower_mcp::{ToolBuilder, CallToolResult};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+let add = ToolBuilder::new("add")
+    .description("Add two numbers")
+    .read_only()  // Hint: this tool doesn't modify state
+    .handler(|input: AddInput| async move {
+        Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+    })
+    .build();
+```
+
+### Trait-Based (For Complex Tools)
+
+```rust
+use tower_mcp::tool::McpTool;
+use tower_mcp::{Result, CallToolResult};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+struct Calculator {
+    precision: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CalcInput {
+    expression: String,
+}
+
+impl McpTool for Calculator {
+    const NAME: &'static str = "calculate";
+    const DESCRIPTION: &'static str = "Evaluate a mathematical expression";
+
+    type Input = CalcInput;
+    type Output = f64;
+
+    async fn call(&self, input: Self::Input) -> Result<Self::Output> {
+        // Your calculation logic here
+        Ok(42.0)
+    }
+}
+
+// Convert to Tool and register
+let calc = Calculator { precision: 10 };
+let router = McpRouter::new().tool(calc.into_tool());
+```
+
+### Raw JSON Handler (Escape Hatch)
+
+```rust
+let echo = ToolBuilder::new("echo")
+    .description("Echo back the input")
+    .raw_handler(|args: serde_json::Value| async move {
+        Ok(CallToolResult::json(args))
+    });
+```
+
+## Architecture
+
+```
+                    +-----------------+
+                    |  Your App       |
+                    +-----------------+
+                           |
+                    +-----------------+
+                    | Tower Middleware|  <-- tracing, metrics, auth, etc.
+                    +-----------------+
+                           |
+                    +-----------------+
+                    | JsonRpcService  |  <-- JSON-RPC 2.0 framing
+                    +-----------------+
+                           |
+                    +-----------------+
+                    |   McpRouter     |  <-- Request dispatch
+                    +-----------------+
+                           |
+              +------------+------------+
+              |            |            |
+         +--------+   +--------+   +--------+
+         | Tool 1 |   | Tool 2 |   | Tool N |
+         +--------+   +--------+   +--------+
+```
+
+## Comparison with rmcp
+
+| Aspect | rmcp | tower-mcp |
+|--------|------|-----------|
+| Style | Framework | Library |
+| Tool definition | `#[tool]` macro | Builder or trait |
+| Middleware | Bolt-on | Native tower layers |
+| Transport | Built-in | Pluggable (planned) |
+| Learning curve | Lower | Higher (tower knowledge helpful) |
+| Flexibility | Limited | High |
+| Integration | Standalone | Composable with axum/tonic |
+
+## Protocol Compliance
+
+tower-mcp targets the [MCP specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26). Current compliance:
+
+- [x] JSON-RPC 2.0 message format
+- [x] Protocol version negotiation
+- [x] Capability negotiation
+- [x] Initialize/initialized lifecycle
+- [x] tools/list and tools/call
+- [x] Tool annotations
+- [ ] Batch requests (receiving)
+- [ ] resources/list, resources/read, resources/subscribe
+- [ ] prompts/list, prompts/get
+- [ ] Progress notifications
+- [ ] Request cancellation
+
+## Development
+
+```bash
+# Format, lint, and test
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,166 @@
+//! Basic example showing how to create an MCP server with tools.
+//!
+//! This example demonstrates:
+//! - Creating tools with the builder pattern
+//! - Setting up an McpRouter
+//! - Using the JsonRpcService for protocol framing
+//!
+//! Note: This example doesn't include a transport layer yet.
+//! It shows how to manually process requests for testing.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::{Service, ServiceExt};
+use tower_mcp::{CallToolResult, JsonRpcRequest, JsonRpcService, McpRouter, ToolBuilder};
+
+// Input types for our tools - schemars generates JSON Schema automatically
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GreetInput {
+    /// The name to greet
+    name: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    /// First number
+    a: i64,
+    /// Second number
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EchoInput {
+    /// Message to echo back
+    message: String,
+    /// Number of times to repeat (optional)
+    #[serde(default = "default_repeat")]
+    repeat: u32,
+}
+
+fn default_repeat() -> u32 {
+    1
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing for debug output
+    tracing_subscriber::fmt()
+        .with_env_filter("tower_mcp=debug")
+        .init();
+
+    // Build our tools
+    let greet = ToolBuilder::new("greet")
+        .description("Greet someone by name")
+        .read_only() // This tool doesn't modify any state
+        .handler(|input: GreetInput| async move {
+            Ok(CallToolResult::text(format!("Hello, {}!", input.name)))
+        })
+        .build();
+
+    let add = ToolBuilder::new("add")
+        .description("Add two numbers together")
+        .read_only()
+        .idempotent() // Same inputs always produce same output
+        .handler(|input: AddInput| async move {
+            let result = input.a + input.b;
+            Ok(CallToolResult::text(format!("{}", result)))
+        })
+        .build();
+
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back, optionally repeated")
+        .read_only()
+        .handler(|input: EchoInput| async move {
+            let repeated: Vec<_> = std::iter::repeat(&input.message)
+                .take(input.repeat as usize)
+                .cloned()
+                .collect();
+            Ok(CallToolResult::text(repeated.join(" ")))
+        })
+        .build();
+
+    // Create the router with our tools
+    let router = McpRouter::new()
+        .server_info("basic-example", "0.1.0")
+        .instructions("A simple example server with greeting and math tools")
+        .tool(greet)
+        .tool(add)
+        .tool(echo);
+
+    // Wrap with JsonRpcService for protocol framing
+    let mut service = JsonRpcService::new(router);
+
+    // Simulate some requests (in a real app, these would come from a transport)
+    println!("=== Simulating MCP requests ===\n");
+
+    // 1. Initialize
+    println!("1. Initialize request:");
+    let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {
+            "name": "example-client",
+            "version": "1.0.0"
+        }
+    }));
+    let resp = service.ready().await?.call(init_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 2. List tools
+    println!("2. List tools request:");
+    let list_req = JsonRpcRequest::new(2, "tools/list");
+    let resp = service.ready().await?.call(list_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 3. Call the greet tool
+    println!("3. Call greet tool:");
+    let call_req = JsonRpcRequest::new(3, "tools/call").with_params(serde_json::json!({
+        "name": "greet",
+        "arguments": {
+            "name": "World"
+        }
+    }));
+    let resp = service.ready().await?.call(call_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 4. Call the add tool
+    println!("4. Call add tool:");
+    let call_req = JsonRpcRequest::new(4, "tools/call").with_params(serde_json::json!({
+        "name": "add",
+        "arguments": {
+            "a": 17,
+            "b": 25
+        }
+    }));
+    let resp = service.ready().await?.call(call_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 5. Call the echo tool with repeat
+    println!("5. Call echo tool:");
+    let call_req = JsonRpcRequest::new(5, "tools/call").with_params(serde_json::json!({
+        "name": "echo",
+        "arguments": {
+            "message": "tower-mcp!",
+            "repeat": 3
+        }
+    }));
+    let resp = service.ready().await?.call(call_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 6. Ping
+    println!("6. Ping request:");
+    let ping_req = JsonRpcRequest::new(6, "ping");
+    let resp = service.ready().await?.call(ping_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 7. Try calling a non-existent tool
+    println!("7. Call non-existent tool (error case):");
+    let call_req = JsonRpcRequest::new(7, "tools/call").with_params(serde_json::json!({
+        "name": "does_not_exist",
+        "arguments": {}
+    }));
+    let resp = service.ready().await?.call(call_req).await?;
+    println!("   Response: {}\n", serde_json::to_string_pretty(&resp)?);
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,41 +17,45 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! use tower_mcp::{McpRouter, Tool, ToolBuilder};
+//! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
 //! use tower::ServiceBuilder;
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
 //!
-//! // Define a tool using the builder
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct EvaluateInput {
+//!     expression: String,
+//!     data: serde_json::Value,
+//! }
+//!
+//! // Define a tool using the builder - type is inferred from handler
 //! let evaluate = ToolBuilder::new("evaluate")
 //!     .description("Evaluate a JMESPath expression")
-//!     .input::<EvaluateInput>()
 //!     .handler(|input: EvaluateInput| async move {
 //!         // implementation
-//!         Ok(result)
+//!         Ok(CallToolResult::text("result"))
 //!     })
 //!     .build();
 //!
 //! // Create router with tools
 //! let router = McpRouter::new()
-//!     .tool(evaluate)
-//!     .tool(validate);
+//!     .server_info("my-server", "1.0.0")
+//!     .tool(evaluate);
 //!
-//! // Add middleware
+//! // Add middleware via tower's ServiceBuilder
 //! let service = ServiceBuilder::new()
-//!     .layer(TracingLayer::new())
-//!     .layer(MetricsLayer::new())
 //!     .service(router);
-//!
-//! // Serve over any transport
-//! StdioTransport::serve(service).await;
 //! ```
 
 pub mod error;
 pub mod protocol;
 pub mod router;
+pub mod session;
 pub mod tool;
 
 // Re-exports
 pub use error::{Error, Result};
-pub use protocol::{JsonRpcRequest, JsonRpcResponse, McpRequest, McpResponse};
-pub use router::McpRouter;
+pub use protocol::{CallToolResult, JsonRpcRequest, JsonRpcResponse, McpRequest, McpResponse};
+pub use router::{JsonRpcService, McpRouter};
+pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,0 +1,154 @@
+//! MCP session state management
+//!
+//! Tracks the lifecycle state of an MCP connection as per the specification.
+//! The session progresses through phases: Uninitialized -> Initializing -> Initialized.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
+
+/// Session lifecycle phase
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SessionPhase {
+    /// Initial state - only `initialize` and `ping` requests are valid
+    Uninitialized = 0,
+    /// Server has responded to `initialize`, waiting for `initialized` notification
+    Initializing = 1,
+    /// `initialized` notification received, normal operation
+    Initialized = 2,
+}
+
+impl From<u8> for SessionPhase {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => SessionPhase::Uninitialized,
+            1 => SessionPhase::Initializing,
+            2 => SessionPhase::Initialized,
+            _ => SessionPhase::Uninitialized,
+        }
+    }
+}
+
+/// Shared session state that can be cloned across requests.
+///
+/// Uses atomic operations for thread-safe state transitions.
+#[derive(Clone)]
+pub struct SessionState {
+    phase: Arc<AtomicU8>,
+}
+
+impl Default for SessionState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SessionState {
+    /// Create a new session in the Uninitialized phase
+    pub fn new() -> Self {
+        Self {
+            phase: Arc::new(AtomicU8::new(SessionPhase::Uninitialized as u8)),
+        }
+    }
+
+    /// Get the current session phase
+    pub fn phase(&self) -> SessionPhase {
+        SessionPhase::from(self.phase.load(Ordering::Acquire))
+    }
+
+    /// Check if the session is initialized (operation phase)
+    pub fn is_initialized(&self) -> bool {
+        self.phase() == SessionPhase::Initialized
+    }
+
+    /// Transition from Uninitialized to Initializing.
+    /// Called after responding to an `initialize` request.
+    /// Returns true if the transition was successful.
+    pub fn mark_initializing(&self) -> bool {
+        self.phase
+            .compare_exchange(
+                SessionPhase::Uninitialized as u8,
+                SessionPhase::Initializing as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Transition from Initializing to Initialized.
+    /// Called when receiving an `initialized` notification.
+    /// Returns true if the transition was successful.
+    pub fn mark_initialized(&self) -> bool {
+        self.phase
+            .compare_exchange(
+                SessionPhase::Initializing as u8,
+                SessionPhase::Initialized as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    /// Check if a request method is allowed in the current phase.
+    /// Per spec:
+    /// - Before initialization: only `initialize` and `ping` are valid
+    /// - During all phases: `ping` is always valid
+    pub fn is_request_allowed(&self, method: &str) -> bool {
+        match self.phase() {
+            SessionPhase::Uninitialized => {
+                matches!(method, "initialize" | "ping")
+            }
+            SessionPhase::Initializing | SessionPhase::Initialized => true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_lifecycle() {
+        let session = SessionState::new();
+
+        // Initial state
+        assert_eq!(session.phase(), SessionPhase::Uninitialized);
+        assert!(!session.is_initialized());
+
+        // Only initialize and ping allowed
+        assert!(session.is_request_allowed("initialize"));
+        assert!(session.is_request_allowed("ping"));
+        assert!(!session.is_request_allowed("tools/list"));
+
+        // Transition to initializing
+        assert!(session.mark_initializing());
+        assert_eq!(session.phase(), SessionPhase::Initializing);
+        assert!(!session.is_initialized());
+
+        // Can't mark initializing again
+        assert!(!session.mark_initializing());
+
+        // All requests allowed during initializing
+        assert!(session.is_request_allowed("tools/list"));
+
+        // Transition to initialized
+        assert!(session.mark_initialized());
+        assert_eq!(session.phase(), SessionPhase::Initialized);
+        assert!(session.is_initialized());
+
+        // Can't mark initialized again
+        assert!(!session.mark_initialized());
+    }
+
+    #[test]
+    fn test_session_clone_shares_state() {
+        let session1 = SessionState::new();
+        let session2 = session1.clone();
+
+        session1.mark_initializing();
+        assert_eq!(session2.phase(), SessionPhase::Initializing);
+
+        session2.mark_initialized();
+        assert_eq!(session1.phase(), SessionPhase::Initialized);
+    }
+}


### PR DESCRIPTION
## Summary

This PR brings tower-mcp closer to full MCP spec (2025-03-26) compliance and adds documentation.

### Protocol Compliance
- JSON-RPC version validation (must be "2.0")
- Protocol version negotiation (server responds with supported version)
- Tool annotations with behavior hints (readOnlyHint, destructiveHint, idempotentHint, openWorldHint)
- Content annotations (audience, priority)
- Instructions field in InitializeResult
- Session state tracking (Uninitialized -> Initializing -> Initialized)
- Initialized notification handling
- Subscribe/Unsubscribe resource request types (stubs)

### Code Quality
- Router now uses `Arc<Inner>` for cheap clones (was cloning strings on every request)
- Serialization failures now return proper JSON-RPC errors (was silently returning null)
- Fixed doc example in lib.rs

### Documentation
- Added comprehensive README with usage examples and architecture diagram
- Added `examples/basic.rs` demonstrating tool creation

### Still TODO (separate PRs)
- #2 Batch request support
- #3 Progress notifications
- #4 Request cancellation
- #5 Stdio transport
- #6 HTTP/SSE transport
- #7 Resources implementation
- #8 Prompts implementation

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (7 tests)
- [x] `cargo run --example basic` works