### PR TITLE
feat: improve error handling and add doc tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,8 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
+//! ```rust
 //! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
-//! use tower::ServiceBuilder;
 //! use schemars::JsonSchema;
 //! use serde::Deserialize;
 //!
@@ -32,19 +31,15 @@
 //! let evaluate = ToolBuilder::new("evaluate")
 //!     .description("Evaluate a JMESPath expression")
 //!     .handler(|input: EvaluateInput| async move {
-//!         // implementation
-//!         Ok(CallToolResult::text("result"))
+//!         Ok(CallToolResult::text(format!("Evaluated: {}", input.expression)))
 //!     })
-//!     .build();
+//!     .build()
+//!     .expect("valid tool name");
 //!
 //! // Create router with tools
 //! let router = McpRouter::new()
 //!     .server_info("my-server", "1.0.0")
 //!     .tool(evaluate);
-//!
-//! // Add middleware via tower's ServiceBuilder
-//! let service = ServiceBuilder::new()
-//!     .service(router);
 //! ```
 
 pub mod error;
@@ -55,7 +50,7 @@ pub mod tool;
 pub mod transport;
 
 // Re-exports
-pub use error::{Error, Result};
+pub use error::{Error, Result, ToolError};
 pub use protocol::{
     CallToolResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage,
     McpRequest, McpResponse,

--- a/src/router.rs
+++ b/src/router.rs
@@ -22,16 +22,23 @@ use crate::tool::Tool;
 ///
 /// # Example
 ///
-/// ```rust,ignore
+/// ```rust
+/// use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+/// use schemars::JsonSchema;
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize, JsonSchema)]
+/// struct Input { value: String }
+///
+/// let tool = ToolBuilder::new("echo")
+///     .description("Echo input")
+///     .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
+///     .build()
+///     .unwrap();
+///
 /// let router = McpRouter::new()
 ///     .server_info("my-server", "1.0.0")
-///     .tool(evaluate_tool)
-///     .tool(validate_tool);
-///
-/// // Use with tower middleware
-/// let service = ServiceBuilder::new()
-///     .layer(TracingLayer::new())
-///     .service(router);
+///     .tool(tool);
 /// ```
 #[derive(Clone)]
 pub struct McpRouter {
@@ -314,7 +321,7 @@ impl Service<RouterRequest> for McpRouter {
                 id: req.id,
                 inner: result.map_err(|e| match e {
                     Error::JsonRpc(err) => err,
-                    Error::Tool(msg) => JsonRpcError::internal_error(msg),
+                    Error::Tool(err) => JsonRpcError::internal_error(err.to_string()),
                     e => JsonRpcError::internal_error(e.to_string()),
                 }),
             })

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -20,13 +20,18 @@ use crate::router::{JsonRpcService, McpRouter};
 ///
 /// # Example
 ///
-/// ```rust,ignore
-/// let router = McpRouter::new()
-///     .server_info("my-server", "1.0.0")
-///     .tool(my_tool);
+/// ```rust,no_run
+/// use tower_mcp::{McpRouter, StdioTransport};
 ///
-/// let transport = StdioTransport::new(router);
-/// transport.run().await?;
+/// #[tokio::main]
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+///     let router = McpRouter::new()
+///         .server_info("my-server", "1.0.0");
+///
+///     let mut transport = StdioTransport::new(router);
+///     transport.run().await?;
+///     Ok(())
+/// }
 /// ```
 pub struct StdioTransport {
     service: JsonRpcService<McpRouter>,


### PR DESCRIPTION
## Summary

### Doc Tests (#10)
- All doc examples now compile and run
- `lib.rs`: Fixed example to handle `Result` from `build()`
- `ToolBuilder`: Added complete working example with imports
- `McpTool`: Added full trait implementation example
- `McpRouter`: Added working router setup example
- `StdioTransport`: Changed to `no_run` (requires actual stdin)

### Error Handling (#12)
- New `ToolError` struct with:
  - Optional tool name for context
  - Error message
  - Optional source error for chaining
- New `Error::tool()` and `Error::tool_with_name()` constructors
- `ToolError` exported from library

### Error Path Tests (#13)
Added 6 new error path tests:
- `test_error_unknown_method` - Unknown JSON-RPC method
- `test_error_malformed_tool_arguments` - Wrong argument types
- `test_error_double_initialization` - Re-initialization behavior
- `test_error_missing_required_params` - Missing tool arguments
- `test_error_resources_not_found` - Resource read when none exist
- `test_error_prompts_not_found` - Prompt get when none exist

## Test plan

- [x] 13 unit tests passing
- [x] 17 integration tests passing (6 new)
- [x] 5 doc tests passing (all now compile)
- [x] Clippy clean

Closes #10, #12, #13