### PR TITLE
feat: add resources and prompts support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,9 @@
 //! ```
 
 pub mod error;
+pub mod prompt;
 pub mod protocol;
+pub mod resource;
 pub mod router;
 pub mod session;
 pub mod tool;
@@ -51,10 +53,13 @@ pub mod transport;
 
 // Re-exports
 pub use error::{Error, Result, ToolError};
+pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{
-    CallToolResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage,
-    McpRequest, McpResponse,
+    CallToolResult, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+    JsonRpcResponseMessage, McpRequest, McpResponse, PromptMessage, PromptRole, ReadResourceResult,
+    ResourceContent,
 };
+pub use resource::{Resource, ResourceBuilder, ResourceHandler};
 pub use router::{JsonRpcService, McpRouter};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,443 @@
+//! Prompt definition and builder API
+//!
+//! Provides ergonomic ways to define MCP prompts:
+//!
+//! 1. **Builder pattern** - Fluent API for defining prompts
+//! 2. **Trait-based** - Implement `McpPrompt` for full control
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::protocol::{
+    Content, GetPromptResult, PromptArgument, PromptDefinition, PromptMessage, PromptRole,
+};
+
+/// A boxed future for prompt handlers
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Prompt handler trait - the core abstraction for prompt generation
+pub trait PromptHandler: Send + Sync {
+    /// Get the prompt with the given arguments
+    fn get(&self, arguments: HashMap<String, String>) -> BoxFuture<'_, Result<GetPromptResult>>;
+}
+
+/// A complete prompt definition with handler
+pub struct Prompt {
+    pub name: String,
+    pub description: Option<String>,
+    pub arguments: Vec<PromptArgument>,
+    handler: Arc<dyn PromptHandler>,
+}
+
+impl Clone for Prompt {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            arguments: self.arguments.clone(),
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for Prompt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Prompt")
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("arguments", &self.arguments)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Prompt {
+    /// Create a new prompt builder
+    pub fn builder(name: impl Into<String>) -> PromptBuilder {
+        PromptBuilder::new(name)
+    }
+
+    /// Get the prompt definition for prompts/list
+    pub fn definition(&self) -> PromptDefinition {
+        PromptDefinition {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            arguments: self.arguments.clone(),
+        }
+    }
+
+    /// Get the prompt with arguments
+    pub fn get(
+        &self,
+        arguments: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<GetPromptResult>> {
+        self.handler.get(arguments)
+    }
+}
+
+// =============================================================================
+// Builder API
+// =============================================================================
+
+/// Builder for creating prompts with a fluent API
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::prompt::PromptBuilder;
+/// use tower_mcp::protocol::{GetPromptResult, PromptMessage, PromptRole, Content};
+///
+/// let prompt = PromptBuilder::new("greet")
+///     .description("Generate a greeting")
+///     .required_arg("name", "The name to greet")
+///     .handler(|args| async move {
+///         let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+///         Ok(GetPromptResult {
+///             description: Some("A greeting prompt".to_string()),
+///             messages: vec![PromptMessage {
+///                 role: PromptRole::User,
+///                 content: Content::Text {
+///                     text: format!("Please greet {}", name),
+///                     annotations: None,
+///                 },
+///             }],
+///         })
+///     });
+///
+/// assert_eq!(prompt.name, "greet");
+/// ```
+pub struct PromptBuilder {
+    name: String,
+    description: Option<String>,
+    arguments: Vec<PromptArgument>,
+}
+
+impl PromptBuilder {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: None,
+            arguments: Vec::new(),
+        }
+    }
+
+    /// Set the prompt description
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Add a required argument
+    pub fn required_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.arguments.push(PromptArgument {
+            name: name.into(),
+            description: Some(description.into()),
+            required: true,
+        });
+        self
+    }
+
+    /// Add an optional argument
+    pub fn optional_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
+        self.arguments.push(PromptArgument {
+            name: name.into(),
+            description: Some(description.into()),
+            required: false,
+        });
+        self
+    }
+
+    /// Add an argument with full control
+    pub fn argument(mut self, arg: PromptArgument) -> Self {
+        self.arguments.push(arg);
+        self
+    }
+
+    /// Set the handler function for getting the prompt
+    pub fn handler<F, Fut>(self, handler: F) -> Prompt
+    where
+        F: Fn(HashMap<String, String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<GetPromptResult>> + Send + 'static,
+    {
+        Prompt {
+            name: self.name,
+            description: self.description,
+            arguments: self.arguments,
+            handler: Arc::new(FnHandler { handler }),
+        }
+    }
+
+    /// Create a static prompt (no arguments needed)
+    pub fn static_prompt(self, messages: Vec<PromptMessage>) -> Prompt {
+        let description = self.description.clone();
+        self.handler(move |_| {
+            let messages = messages.clone();
+            let description = description.clone();
+            async move {
+                Ok(GetPromptResult {
+                    description,
+                    messages,
+                })
+            }
+        })
+    }
+
+    /// Create a simple text prompt with a user message
+    pub fn user_message(self, text: impl Into<String>) -> Prompt {
+        let text = text.into();
+        self.static_prompt(vec![PromptMessage {
+            role: PromptRole::User,
+            content: Content::Text {
+                text,
+                annotations: None,
+            },
+        }])
+    }
+
+    /// Finalize the builder into a Prompt
+    ///
+    /// This is an alias for `handler` for when you want to explicitly mark the build step.
+    pub fn build<F, Fut>(self, handler: F) -> Prompt
+    where
+        F: Fn(HashMap<String, String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<GetPromptResult>> + Send + 'static,
+    {
+        self.handler(handler)
+    }
+}
+
+// =============================================================================
+// Handler implementations
+// =============================================================================
+
+/// Handler wrapping a function
+struct FnHandler<F> {
+    handler: F,
+}
+
+impl<F, Fut> PromptHandler for FnHandler<F>
+where
+    F: Fn(HashMap<String, String>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<GetPromptResult>> + Send + 'static,
+{
+    fn get(&self, arguments: HashMap<String, String>) -> BoxFuture<'_, Result<GetPromptResult>> {
+        Box::pin((self.handler)(arguments))
+    }
+}
+
+// =============================================================================
+// Trait-based prompt definition
+// =============================================================================
+
+/// Trait for defining prompts with full control
+///
+/// Implement this trait when you need more control than the builder provides,
+/// or when you want to define prompts as standalone types.
+///
+/// # Example
+///
+/// ```rust
+/// use std::collections::HashMap;
+/// use tower_mcp::prompt::McpPrompt;
+/// use tower_mcp::protocol::{GetPromptResult, PromptArgument, PromptMessage, PromptRole, Content};
+/// use tower_mcp::error::Result;
+///
+/// struct CodeReviewPrompt;
+///
+/// impl McpPrompt for CodeReviewPrompt {
+///     const NAME: &'static str = "code_review";
+///     const DESCRIPTION: &'static str = "Review code for issues";
+///
+///     fn arguments(&self) -> Vec<PromptArgument> {
+///         vec![
+///             PromptArgument {
+///                 name: "code".to_string(),
+///                 description: Some("The code to review".to_string()),
+///                 required: true,
+///             },
+///             PromptArgument {
+///                 name: "language".to_string(),
+///                 description: Some("Programming language".to_string()),
+///                 required: false,
+///             },
+///         ]
+///     }
+///
+///     async fn get(&self, args: HashMap<String, String>) -> Result<GetPromptResult> {
+///         let code = args.get("code").map(|s| s.as_str()).unwrap_or("");
+///         let lang = args.get("language").map(|s| s.as_str()).unwrap_or("unknown");
+///
+///         Ok(GetPromptResult {
+///             description: Some("Code review prompt".to_string()),
+///             messages: vec![PromptMessage {
+///                 role: PromptRole::User,
+///                 content: Content::Text {
+///                     text: format!("Please review this {} code:\n\n```{}\n{}\n```", lang, lang, code),
+///                     annotations: None,
+///                 },
+///             }],
+///         })
+///     }
+/// }
+///
+/// let prompt = CodeReviewPrompt.into_prompt();
+/// assert_eq!(prompt.name, "code_review");
+/// ```
+pub trait McpPrompt: Send + Sync + 'static {
+    const NAME: &'static str;
+    const DESCRIPTION: &'static str;
+
+    /// Define the arguments for this prompt
+    fn arguments(&self) -> Vec<PromptArgument> {
+        Vec::new()
+    }
+
+    fn get(
+        &self,
+        arguments: HashMap<String, String>,
+    ) -> impl Future<Output = Result<GetPromptResult>> + Send;
+
+    /// Convert to a Prompt instance
+    fn into_prompt(self) -> Prompt
+    where
+        Self: Sized,
+    {
+        let arguments = self.arguments();
+        let prompt = Arc::new(self);
+        Prompt {
+            name: Self::NAME.to_string(),
+            description: Some(Self::DESCRIPTION.to_string()),
+            arguments,
+            handler: Arc::new(McpPromptHandler { prompt }),
+        }
+    }
+}
+
+/// Wrapper to make McpPrompt implement PromptHandler
+struct McpPromptHandler<T: McpPrompt> {
+    prompt: Arc<T>,
+}
+
+impl<T: McpPrompt> PromptHandler for McpPromptHandler<T> {
+    fn get(&self, arguments: HashMap<String, String>) -> BoxFuture<'_, Result<GetPromptResult>> {
+        let prompt = self.prompt.clone();
+        Box::pin(async move { prompt.get(arguments).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_builder_prompt() {
+        let prompt = PromptBuilder::new("greet")
+            .description("A greeting prompt")
+            .required_arg("name", "Name to greet")
+            .handler(|args| async move {
+                let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+                Ok(GetPromptResult {
+                    description: Some("Greeting".to_string()),
+                    messages: vec![PromptMessage {
+                        role: PromptRole::User,
+                        content: Content::Text {
+                            text: format!("Hello, {}!", name),
+                            annotations: None,
+                        },
+                    }],
+                })
+            });
+
+        assert_eq!(prompt.name, "greet");
+        assert_eq!(prompt.description.as_deref(), Some("A greeting prompt"));
+        assert_eq!(prompt.arguments.len(), 1);
+        assert!(prompt.arguments[0].required);
+
+        let mut args = HashMap::new();
+        args.insert("name".to_string(), "Alice".to_string());
+        let result = prompt.get(args).await.unwrap();
+
+        assert_eq!(result.messages.len(), 1);
+        match &result.messages[0].content {
+            Content::Text { text, .. } => assert_eq!(text, "Hello, Alice!"),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_static_prompt() {
+        let prompt = PromptBuilder::new("help")
+            .description("Help prompt")
+            .user_message("How can I help you today?");
+
+        let result = prompt.get(HashMap::new()).await.unwrap();
+        assert_eq!(result.messages.len(), 1);
+        match &result.messages[0].content {
+            Content::Text { text, .. } => assert_eq!(text, "How can I help you today?"),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_trait_prompt() {
+        struct TestPrompt;
+
+        impl McpPrompt for TestPrompt {
+            const NAME: &'static str = "test";
+            const DESCRIPTION: &'static str = "A test prompt";
+
+            fn arguments(&self) -> Vec<PromptArgument> {
+                vec![PromptArgument {
+                    name: "input".to_string(),
+                    description: Some("Test input".to_string()),
+                    required: true,
+                }]
+            }
+
+            async fn get(&self, args: HashMap<String, String>) -> Result<GetPromptResult> {
+                let input = args.get("input").map(|s| s.as_str()).unwrap_or("default");
+                Ok(GetPromptResult {
+                    description: Some("Test".to_string()),
+                    messages: vec![PromptMessage {
+                        role: PromptRole::User,
+                        content: Content::Text {
+                            text: format!("Input: {}", input),
+                            annotations: None,
+                        },
+                    }],
+                })
+            }
+        }
+
+        let prompt = TestPrompt.into_prompt();
+        assert_eq!(prompt.name, "test");
+        assert_eq!(prompt.arguments.len(), 1);
+
+        let mut args = HashMap::new();
+        args.insert("input".to_string(), "hello".to_string());
+        let result = prompt.get(args).await.unwrap();
+
+        match &result.messages[0].content {
+            Content::Text { text, .. } => assert_eq!(text, "Input: hello"),
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[test]
+    fn test_prompt_definition() {
+        let prompt = PromptBuilder::new("test")
+            .description("Test description")
+            .required_arg("arg1", "First arg")
+            .optional_arg("arg2", "Second arg")
+            .user_message("Test");
+
+        let def = prompt.definition();
+        assert_eq!(def.name, "test");
+        assert_eq!(def.description.as_deref(), Some("Test description"));
+        assert_eq!(def.arguments.len(), 2);
+        assert!(def.arguments[0].required);
+        assert!(!def.arguments[1].required);
+    }
+}

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1,0 +1,397 @@
+//! Resource definition and builder API
+//!
+//! Provides ergonomic ways to define MCP resources:
+//!
+//! 1. **Builder pattern** - Fluent API for defining resources
+//! 2. **Trait-based** - Implement `McpResource` for full control
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::protocol::{ReadResourceResult, ResourceContent, ResourceDefinition};
+
+/// A boxed future for resource handlers
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// Resource handler trait - the core abstraction for resource reading
+pub trait ResourceHandler: Send + Sync {
+    /// Read the resource contents
+    fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>>;
+}
+
+/// A complete resource definition with handler
+pub struct Resource {
+    pub uri: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub mime_type: Option<String>,
+    handler: Arc<dyn ResourceHandler>,
+}
+
+impl Clone for Resource {
+    fn clone(&self) -> Self {
+        Self {
+            uri: self.uri.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            mime_type: self.mime_type.clone(),
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for Resource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Resource")
+            .field("uri", &self.uri)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("mime_type", &self.mime_type)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Resource {
+    /// Create a new resource builder
+    pub fn builder(uri: impl Into<String>) -> ResourceBuilder {
+        ResourceBuilder::new(uri)
+    }
+
+    /// Get the resource definition for resources/list
+    pub fn definition(&self) -> ResourceDefinition {
+        ResourceDefinition {
+            uri: self.uri.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            mime_type: self.mime_type.clone(),
+        }
+    }
+
+    /// Read the resource
+    pub fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>> {
+        self.handler.read()
+    }
+}
+
+// =============================================================================
+// Builder API
+// =============================================================================
+
+/// Builder for creating resources with a fluent API
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::resource::ResourceBuilder;
+/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+///
+/// let resource = ResourceBuilder::new("file:///config.json")
+///     .name("Configuration")
+///     .description("Application configuration file")
+///     .mime_type("application/json")
+///     .handler(|| async {
+///         Ok(ReadResourceResult {
+///             contents: vec![ResourceContent {
+///                 uri: "file:///config.json".to_string(),
+///                 mime_type: Some("application/json".to_string()),
+///                 text: Some(r#"{"setting": "value"}"#.to_string()),
+///                 blob: None,
+///             }],
+///         })
+///     });
+///
+/// assert_eq!(resource.uri, "file:///config.json");
+/// ```
+pub struct ResourceBuilder {
+    uri: String,
+    name: Option<String>,
+    description: Option<String>,
+    mime_type: Option<String>,
+}
+
+impl ResourceBuilder {
+    pub fn new(uri: impl Into<String>) -> Self {
+        Self {
+            uri: uri.into(),
+            name: None,
+            description: None,
+            mime_type: None,
+        }
+    }
+
+    /// Set the resource name (human-readable)
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the resource description
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the MIME type of the resource
+    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
+        self.mime_type = Some(mime_type.into());
+        self
+    }
+
+    /// Set the handler function for reading the resource
+    pub fn handler<F, Fut>(self, handler: F) -> Resource
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
+    {
+        // Default name to URI if not specified
+        let name = self.name.unwrap_or_else(|| self.uri.clone());
+
+        Resource {
+            uri: self.uri.clone(),
+            name,
+            description: self.description,
+            mime_type: self.mime_type,
+            handler: Arc::new(FnHandler { handler }),
+        }
+    }
+
+    /// Create a static text resource (convenience method)
+    pub fn text(self, content: impl Into<String>) -> Resource {
+        let uri = self.uri.clone();
+        let content = content.into();
+        let mime_type = self.mime_type.clone();
+
+        self.handler(move || {
+            let uri = uri.clone();
+            let content = content.clone();
+            let mime_type = mime_type.clone();
+            async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type,
+                        text: Some(content),
+                        blob: None,
+                    }],
+                })
+            }
+        })
+    }
+
+    /// Create a static JSON resource (convenience method)
+    pub fn json(mut self, value: serde_json::Value) -> Resource {
+        let uri = self.uri.clone();
+        self.mime_type = Some("application/json".to_string());
+        let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| "{}".to_string());
+
+        self.handler(move || {
+            let uri = uri.clone();
+            let text = text.clone();
+            async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("application/json".to_string()),
+                        text: Some(text),
+                        blob: None,
+                    }],
+                })
+            }
+        })
+    }
+}
+
+// =============================================================================
+// Handler implementations
+// =============================================================================
+
+/// Handler wrapping a function
+struct FnHandler<F> {
+    handler: F,
+}
+
+impl<F, Fut> ResourceHandler for FnHandler<F>
+where
+    F: Fn() -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
+{
+    fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>> {
+        Box::pin((self.handler)())
+    }
+}
+
+// =============================================================================
+// Trait-based resource definition
+// =============================================================================
+
+/// Trait for defining resources with full control
+///
+/// Implement this trait when you need more control than the builder provides,
+/// or when you want to define resources as standalone types.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::resource::McpResource;
+/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+/// use tower_mcp::error::Result;
+///
+/// struct ConfigResource {
+///     config: String,
+/// }
+///
+/// impl McpResource for ConfigResource {
+///     const URI: &'static str = "file:///config.json";
+///     const NAME: &'static str = "Configuration";
+///     const DESCRIPTION: Option<&'static str> = Some("Application configuration");
+///     const MIME_TYPE: Option<&'static str> = Some("application/json");
+///
+///     async fn read(&self) -> Result<ReadResourceResult> {
+///         Ok(ReadResourceResult {
+///             contents: vec![ResourceContent {
+///                 uri: Self::URI.to_string(),
+///                 mime_type: Self::MIME_TYPE.map(|s| s.to_string()),
+///                 text: Some(self.config.clone()),
+///                 blob: None,
+///             }],
+///         })
+///     }
+/// }
+///
+/// let resource = ConfigResource { config: "{}".to_string() }.into_resource();
+/// assert_eq!(resource.uri, "file:///config.json");
+/// ```
+pub trait McpResource: Send + Sync + 'static {
+    const URI: &'static str;
+    const NAME: &'static str;
+    const DESCRIPTION: Option<&'static str> = None;
+    const MIME_TYPE: Option<&'static str> = None;
+
+    fn read(&self) -> impl Future<Output = Result<ReadResourceResult>> + Send;
+
+    /// Convert to a Resource instance
+    fn into_resource(self) -> Resource
+    where
+        Self: Sized,
+    {
+        let resource = Arc::new(self);
+        Resource {
+            uri: Self::URI.to_string(),
+            name: Self::NAME.to_string(),
+            description: Self::DESCRIPTION.map(|s| s.to_string()),
+            mime_type: Self::MIME_TYPE.map(|s| s.to_string()),
+            handler: Arc::new(McpResourceHandler { resource }),
+        }
+    }
+}
+
+/// Wrapper to make McpResource implement ResourceHandler
+struct McpResourceHandler<T: McpResource> {
+    resource: Arc<T>,
+}
+
+impl<T: McpResource> ResourceHandler for McpResourceHandler<T> {
+    fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>> {
+        let resource = self.resource.clone();
+        Box::pin(async move { resource.read().await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_builder_resource() {
+        let resource = ResourceBuilder::new("file:///test.txt")
+            .name("Test File")
+            .description("A test file")
+            .text("Hello, World!");
+
+        assert_eq!(resource.uri, "file:///test.txt");
+        assert_eq!(resource.name, "Test File");
+        assert_eq!(resource.description.as_deref(), Some("A test file"));
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents.len(), 1);
+        assert_eq!(result.contents[0].text.as_deref(), Some("Hello, World!"));
+    }
+
+    #[tokio::test]
+    async fn test_json_resource() {
+        let resource = ResourceBuilder::new("file:///config.json")
+            .name("Config")
+            .json(serde_json::json!({"key": "value"}));
+
+        assert_eq!(resource.mime_type.as_deref(), Some("application/json"));
+
+        let result = resource.read().await.unwrap();
+        assert!(result.contents[0].text.as_ref().unwrap().contains("key"));
+    }
+
+    #[tokio::test]
+    async fn test_handler_resource() {
+        let resource = ResourceBuilder::new("memory://counter")
+            .name("Counter")
+            .handler(|| async {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri: "memory://counter".to_string(),
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some("42".to_string()),
+                        blob: None,
+                    }],
+                })
+            });
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents[0].text.as_deref(), Some("42"));
+    }
+
+    #[tokio::test]
+    async fn test_trait_resource() {
+        struct TestResource;
+
+        impl McpResource for TestResource {
+            const URI: &'static str = "test://resource";
+            const NAME: &'static str = "Test";
+            const DESCRIPTION: Option<&'static str> = Some("A test resource");
+            const MIME_TYPE: Option<&'static str> = Some("text/plain");
+
+            async fn read(&self) -> Result<ReadResourceResult> {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri: Self::URI.to_string(),
+                        mime_type: Self::MIME_TYPE.map(|s| s.to_string()),
+                        text: Some("test content".to_string()),
+                        blob: None,
+                    }],
+                })
+            }
+        }
+
+        let resource = TestResource.into_resource();
+        assert_eq!(resource.uri, "test://resource");
+        assert_eq!(resource.name, "Test");
+
+        let result = resource.read().await.unwrap();
+        assert_eq!(result.contents[0].text.as_deref(), Some("test content"));
+    }
+
+    #[test]
+    fn test_resource_definition() {
+        let resource = ResourceBuilder::new("file:///test.txt")
+            .name("Test")
+            .description("Description")
+            .mime_type("text/plain")
+            .text("content");
+
+        let def = resource.definition();
+        assert_eq!(def.uri, "file:///test.txt");
+        assert_eq!(def.name, "Test");
+        assert_eq!(def.description.as_deref(), Some("Description"));
+        assert_eq!(def.mime_type.as_deref(), Some("text/plain"));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `ResourceBuilder` and `McpResource` trait for defining resources
- Add `PromptBuilder` and `McpPrompt` trait for defining prompts
- Update `McpRouter` with `.resource()` and `.prompt()` builder methods
- Implement `resources/list`, `resources/read` handlers
- Implement `prompts/list`, `prompts/get` handlers
- Update capabilities to reflect registered resources/prompts

## New APIs

### Resources
```rust
// Builder pattern
let resource = ResourceBuilder::new("file:///config.json")
    .name("Configuration")
    .description("App config")
    .json(serde_json::json!({"key": "value"}));

// Trait-based
impl McpResource for MyResource {
    const URI: &'static str = "memory://data";
    const NAME: &'static str = "Data";
    // ...
}
```

### Prompts
```rust
// Builder pattern
let prompt = PromptBuilder::new("greet")
    .description("Generate a greeting")
    .required_arg("name", "The name to greet")
    .handler(|args| async move { /* ... */ });

// Trait-based
impl McpPrompt for MyPrompt {
    const NAME: &'static str = "review";
    const DESCRIPTION: &'static str = "Code review";
    // ...
}
```

## Test plan

- [x] Unit tests for ResourceBuilder and McpResource trait
- [x] Unit tests for PromptBuilder and McpPrompt trait  
- [x] Integration tests for resources/list and resources/read
- [x] Integration tests for prompts/list and prompts/get
- [x] Capability negotiation tests
- [x] Error handling tests (not found, etc.)
- [x] All 29 integration tests pass
- [x] All 22 unit tests pass
- [x] All 9 doc tests pass

Closes #7, closes #8