### PR TITLE
feat: add Streamable HTTP transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = []
 # Transport features
 stdio = []
-http = ["dep:hyper", "dep:http", "dep:http-body-util"]
+http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = []
+
+[dependencies.axum]
+version = "0.8"
+optional = true
+features = ["json"]
 
 [dependencies.hyper]
 version = "1"
@@ -55,6 +60,16 @@ optional = true
 version = "0.1"
 optional = true
 
+[dependencies.tokio-stream]
+version = "0.1"
+optional = true
+features = ["sync"]
+
+[dependencies.uuid]
+version = "1"
+optional = true
+features = ["v4"]
+
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
@@ -62,3 +77,8 @@ path = "examples/basic.rs"
 [[example]]
 name = "stdio_server"
 path = "examples/stdio_server.rs"
+
+[[example]]
+name = "http_server"
+path = "examples/http_server.rs"
+required-features = ["http"]

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -1,0 +1,114 @@
+//! HTTP server example for tower-mcp
+//!
+//! Run with: cargo run --example http_server --features http
+//!
+//! Test with curl:
+//! ```bash
+//! # Initialize session
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "Accept: application/json, text/event-stream" \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!
+//! # List tools (use session ID from initialize response)
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id>" \
+//!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+//!
+//! # Call a tool
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id>" \
+//!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":10,"b":32}}}'
+//! ```
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder,
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EchoInput {
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=debug".parse()?),
+        )
+        .init();
+
+    // Create tools
+    let add = ToolBuilder::new("add")
+        .description("Add two numbers together")
+        .handler(|input: AddInput| async move {
+            Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+        })
+        .build()?;
+
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build()?;
+
+    // Create resources
+    let config = ResourceBuilder::new("file:///config.json")
+        .name("Configuration")
+        .description("Server configuration")
+        .json(serde_json::json!({
+            "version": "1.0.0",
+            "debug": true,
+            "features": ["add", "echo"]
+        }));
+
+    // Create prompts
+    let greet = PromptBuilder::new("greet")
+        .description("Generate a greeting")
+        .required_arg("name", "Name to greet")
+        .handler(|args| async move {
+            let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+            Ok(tower_mcp::GetPromptResult {
+                description: Some("A friendly greeting".to_string()),
+                messages: vec![tower_mcp::PromptMessage {
+                    role: tower_mcp::PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: format!("Please greet {} warmly.", name),
+                        annotations: None,
+                    },
+                }],
+            })
+        });
+
+    // Create the MCP router
+    let router = McpRouter::new()
+        .server_info("http-example", "1.0.0")
+        .instructions("A simple HTTP MCP server example with add and echo tools.")
+        .tool(add)
+        .tool(echo)
+        .resource(config)
+        .prompt(greet);
+
+    // Create and configure the HTTP transport
+    let transport = HttpTransport::new(router)
+        // For local development, disable origin validation
+        // In production, use .allowed_origins(vec!["https://your-domain.com".to_string()])
+        .disable_origin_validation();
+
+    // Serve on localhost:3000
+    tracing::info!("Starting HTTP MCP server on http://127.0.0.1:3000");
+    transport.serve("127.0.0.1:3000").await?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,6 @@ pub use router::{JsonRpcService, McpRouter};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};
 pub use transport::{StdioTransport, SyncStdioTransport};
+
+#[cfg(feature = "http")]
+pub use transport::HttpTransport;

--- a/src/router.rs
+++ b/src/router.rs
@@ -48,6 +48,19 @@ pub struct McpRouter {
     session: SessionState,
 }
 
+impl std::fmt::Debug for McpRouter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpRouter")
+            .field("server_name", &self.inner.server_name)
+            .field("server_version", &self.inner.server_version)
+            .field("tools_count", &self.inner.tools.len())
+            .field("resources_count", &self.inner.resources.len())
+            .field("prompts_count", &self.inner.prompts.len())
+            .field("session_phase", &self.session.phase())
+            .finish()
+    }
+}
+
 /// Inner configuration that is shared across clones
 #[derive(Clone)]
 struct McpRouterInner {

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -1,0 +1,596 @@
+//! Streamable HTTP transport for MCP
+//!
+//! Implements the Streamable HTTP transport from MCP specification 2025-11-25.
+//!
+//! Features:
+//! - Single endpoint for POST (requests) and GET (SSE notifications)
+//! - Session management via `MCP-Session-Id` header
+//! - SSE streaming for server notifications and progress updates
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+//! use tower_mcp::transport::http::HttpTransport;
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//!
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct Input { value: String }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let tool = ToolBuilder::new("echo")
+//!         .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
+//!         .build()?;
+//!
+//!     let router = McpRouter::new()
+//!         .server_info("my-server", "1.0.0")
+//!         .tool(tool);
+//!
+//!     let transport = HttpTransport::new(router);
+//!
+//!     // Run on localhost:3000
+//!     transport.serve("127.0.0.1:3000").await?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::{
+    Router,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response, Sse, sse::Event},
+    routing::{delete, get, post},
+};
+use tokio::sync::{RwLock, broadcast};
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
+
+use crate::error::{Error, JsonRpcError, Result};
+use crate::protocol::{
+    JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, McpNotification,
+    SUPPORTED_PROTOCOL_VERSIONS,
+};
+use crate::router::{JsonRpcService, McpRouter};
+
+/// Header name for MCP session ID
+pub const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
+
+/// Header name for MCP protocol version
+pub const MCP_PROTOCOL_VERSION_HEADER: &str = "mcp-protocol-version";
+
+/// SSE event type for JSON-RPC messages
+const SSE_MESSAGE_EVENT: &str = "message";
+
+/// Session state for HTTP transport
+#[derive(Debug)]
+struct Session {
+    /// Session ID
+    id: String,
+    /// The MCP router for this session
+    router: McpRouter,
+    /// Broadcast channel for SSE notifications
+    notifications_tx: broadcast::Sender<String>,
+}
+
+impl Session {
+    fn new(router: McpRouter) -> Self {
+        let (notifications_tx, _) = broadcast::channel(100);
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            router,
+            notifications_tx,
+        }
+    }
+}
+
+/// Session store for managing multiple client sessions
+#[derive(Debug, Default)]
+struct SessionStore {
+    sessions: RwLock<HashMap<String, Arc<Session>>>,
+}
+
+impl SessionStore {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    async fn create(&self, router: McpRouter) -> Arc<Session> {
+        let session = Arc::new(Session::new(router));
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(session.id.clone(), session.clone());
+        session
+    }
+
+    async fn get(&self, id: &str) -> Option<Arc<Session>> {
+        let sessions = self.sessions.read().await;
+        sessions.get(id).cloned()
+    }
+
+    async fn remove(&self, id: &str) -> bool {
+        let mut sessions = self.sessions.write().await;
+        sessions.remove(id).is_some()
+    }
+}
+
+/// Shared state for the HTTP transport
+struct AppState {
+    /// Template router for creating new sessions
+    router_template: McpRouter,
+    /// Session store
+    sessions: SessionStore,
+    /// Whether to validate Origin header
+    validate_origin: bool,
+    /// Allowed origins (if validation is enabled)
+    allowed_origins: Vec<String>,
+}
+
+/// HTTP transport for MCP servers
+///
+/// Implements the Streamable HTTP transport from the MCP specification.
+pub struct HttpTransport {
+    router: McpRouter,
+    validate_origin: bool,
+    allowed_origins: Vec<String>,
+}
+
+impl HttpTransport {
+    /// Create a new HTTP transport wrapping an MCP router
+    pub fn new(router: McpRouter) -> Self {
+        Self {
+            router,
+            validate_origin: true,
+            allowed_origins: vec![],
+        }
+    }
+
+    /// Disable Origin header validation (not recommended for production)
+    pub fn disable_origin_validation(mut self) -> Self {
+        self.validate_origin = false;
+        self
+    }
+
+    /// Set allowed origins for CORS/security validation
+    pub fn allowed_origins(mut self, origins: Vec<String>) -> Self {
+        self.allowed_origins = origins;
+        self
+    }
+
+    /// Build the axum router for this transport
+    pub fn into_router(self) -> Router {
+        let state = Arc::new(AppState {
+            router_template: self.router,
+            sessions: SessionStore::new(),
+            validate_origin: self.validate_origin,
+            allowed_origins: self.allowed_origins,
+        });
+
+        Router::new()
+            .route("/", post(handle_post))
+            .route("/", get(handle_get))
+            .route("/", delete(handle_delete))
+            .with_state(state)
+    }
+
+    /// Build an axum router mounted at a specific path
+    pub fn into_router_at(self, path: &str) -> Router {
+        let state = Arc::new(AppState {
+            router_template: self.router,
+            sessions: SessionStore::new(),
+            validate_origin: self.validate_origin,
+            allowed_origins: self.allowed_origins,
+        });
+
+        let mcp_router = Router::new()
+            .route("/", post(handle_post))
+            .route("/", get(handle_get))
+            .route("/", delete(handle_delete))
+            .with_state(state);
+
+        Router::new().nest(path, mcp_router)
+    }
+
+    /// Serve the transport on the given address
+    ///
+    /// This is a convenience method that creates a TCP listener and serves the transport.
+    pub async fn serve(self, addr: &str) -> Result<()> {
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to bind to {}: {}", addr, e)))?;
+
+        tracing::info!("MCP HTTP transport listening on {}", addr);
+
+        let router = self.into_router();
+        axum::serve(listener, router)
+            .await
+            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
+
+        Ok(())
+    }
+}
+
+/// Validate Origin header for security.
+/// Returns Some(Response) if validation fails, None if it passes.
+fn validate_origin(headers: &HeaderMap, state: &AppState) -> Option<Response> {
+    if !state.validate_origin {
+        return None;
+    }
+
+    if let Some(origin) = headers.get(header::ORIGIN) {
+        let origin_str = origin.to_str().unwrap_or("");
+
+        // If allowed_origins is empty and we're validating, reject all cross-origin requests
+        if state.allowed_origins.is_empty() {
+            // Allow same-origin (no Origin header means same-origin in most cases)
+            // But if Origin is present and we have no whitelist, reject
+            return Some(
+                (StatusCode::FORBIDDEN, "Cross-origin requests not allowed").into_response(),
+            );
+        }
+
+        if !state
+            .allowed_origins
+            .iter()
+            .any(|o| o == origin_str || o == "*")
+        {
+            return Some((StatusCode::FORBIDDEN, "Origin not allowed").into_response());
+        }
+    }
+
+    None
+}
+
+/// Extract and validate session ID from headers
+fn get_session_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(MCP_SESSION_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// Extract protocol version from headers
+fn get_protocol_version(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(MCP_PROTOCOL_VERSION_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+}
+
+/// Check if the request is an initialize request
+fn is_initialize_request(body: &serde_json::Value) -> bool {
+    body.get("method")
+        .and_then(|m| m.as_str())
+        .map(|m| m == "initialize")
+        .unwrap_or(false)
+}
+
+/// Handle POST requests (JSON-RPC messages from client)
+async fn handle_post(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    // Validate Origin
+    if let Some(resp) = validate_origin(&headers, &state) {
+        return resp;
+    }
+
+    // Parse the request body
+    let parsed: serde_json::Value = match serde_json::from_str(&body) {
+        Ok(v) => v,
+        Err(e) => {
+            return json_rpc_error_response(
+                None,
+                JsonRpcError::parse_error(format!("Invalid JSON: {}", e)),
+            );
+        }
+    };
+
+    // Check if this is an initialize request (creates new session)
+    let is_init = is_initialize_request(&parsed);
+
+    // Get or create session
+    let session = if is_init {
+        // Create new session for initialize
+        state.sessions.create(state.router_template.clone()).await
+    } else {
+        // Require existing session
+        let session_id = match get_session_id(&headers) {
+            Some(id) => id,
+            None => {
+                return (StatusCode::BAD_REQUEST, "Missing MCP-Session-Id header").into_response();
+            }
+        };
+
+        match state.sessions.get(&session_id).await {
+            Some(s) => s,
+            None => {
+                return (StatusCode::NOT_FOUND, "Session not found or expired").into_response();
+            }
+        }
+    };
+
+    // Validate protocol version (if present and not init request)
+    if !is_init
+        && let Some(version) = get_protocol_version(&headers)
+        && !SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("Unsupported protocol version: {}", version),
+        )
+            .into_response();
+    }
+
+    // Check if this is a notification (no id field)
+    if parsed.get("id").is_none() {
+        // Handle notification
+        if let Ok(notification) = serde_json::from_value::<JsonRpcNotification>(parsed)
+            && let Ok(mcp_notification) = McpNotification::from_jsonrpc(&notification)
+        {
+            session.router.handle_notification(mcp_notification);
+        }
+        return StatusCode::ACCEPTED.into_response();
+    }
+
+    // Handle as JSON-RPC request
+    let request: JsonRpcRequest = match serde_json::from_value(parsed) {
+        Ok(r) => r,
+        Err(e) => {
+            return json_rpc_error_response(
+                None,
+                JsonRpcError::parse_error(format!("Invalid request: {}", e)),
+            );
+        }
+    };
+
+    // Process the request
+    let mut service = JsonRpcService::new(session.router.clone());
+    let response = match service.call_single(request).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            return json_rpc_error_response(None, JsonRpcError::internal_error(e.to_string()));
+        }
+    };
+
+    // Build response with session ID header for initialize
+    let mut resp = axum::Json(response).into_response();
+
+    if is_init {
+        resp.headers_mut().insert(
+            MCP_SESSION_ID_HEADER,
+            HeaderValue::from_str(&session.id).unwrap(),
+        );
+    }
+
+    resp
+}
+
+/// Handle GET requests (SSE stream for server notifications)
+async fn handle_get(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    // Validate Origin
+    if let Some(resp) = validate_origin(&headers, &state) {
+        return resp;
+    }
+
+    // Check Accept header
+    let accept = headers
+        .get(header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    if !accept.contains("text/event-stream") {
+        return (
+            StatusCode::NOT_ACCEPTABLE,
+            "Accept header must include text/event-stream",
+        )
+            .into_response();
+    }
+
+    // Get session
+    let session_id = match get_session_id(&headers) {
+        Some(id) => id,
+        None => {
+            return (StatusCode::BAD_REQUEST, "Missing MCP-Session-Id header").into_response();
+        }
+    };
+
+    let session = match state.sessions.get(&session_id).await {
+        Some(s) => s,
+        None => {
+            return (StatusCode::NOT_FOUND, "Session not found or expired").into_response();
+        }
+    };
+
+    // Create SSE stream from broadcast channel
+    let rx = session.notifications_tx.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|result: std::result::Result<String, _>| {
+        result
+            .ok()
+            .map(|msg| Ok::<_, Infallible>(Event::default().event(SSE_MESSAGE_EVENT).data(msg)))
+    });
+
+    Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(30))
+                .text("ping"),
+        )
+        .into_response()
+}
+
+/// Handle DELETE requests (session termination)
+async fn handle_delete(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    // Validate Origin
+    if let Some(resp) = validate_origin(&headers, &state) {
+        return resp;
+    }
+
+    let session_id = match get_session_id(&headers) {
+        Some(id) => id,
+        None => {
+            return (StatusCode::BAD_REQUEST, "Missing MCP-Session-Id header").into_response();
+        }
+    };
+
+    if state.sessions.remove(&session_id).await {
+        tracing::info!(session_id = %session_id, "Session terminated");
+        StatusCode::OK.into_response()
+    } else {
+        (StatusCode::NOT_FOUND, "Session not found").into_response()
+    }
+}
+
+/// Create a JSON-RPC error response
+fn json_rpc_error_response(
+    id: Option<crate::protocol::RequestId>,
+    error: JsonRpcError,
+) -> Response {
+    let response = JsonRpcResponse::error(id, error);
+    axum::Json(response).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn create_test_router() -> McpRouter {
+        McpRouter::new().server_info("test-server", "1.0.0")
+    }
+
+    #[tokio::test]
+    async fn test_initialize_creates_session() {
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "test-client",
+                            "version": "1.0.0"
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key(MCP_SESSION_ID_HEADER));
+    }
+
+    #[tokio::test]
+    async fn test_request_without_session_fails() {
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_delete_session() {
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        // First, initialize to get a session
+        let init_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-03-26",
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "test-client",
+                            "version": "1.0.0"
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.clone().oneshot(init_request).await.unwrap();
+        let session_id = response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Delete the session
+        let delete_request = Request::builder()
+            .method("DELETE")
+            .uri("/")
+            .header(MCP_SESSION_ID_HEADER, &session_id)
+            .body(Body::empty())
+            .unwrap();
+
+        let response = app.clone().oneshot(delete_request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Verify session is gone
+        let list_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header(MCP_SESSION_ID_HEADER, &session_id)
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(list_request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,7 +2,14 @@
 //!
 //! Provides different transport layers for MCP communication:
 //! - `stdio` - Standard input/output for CLI usage
+//! - `http` - Streamable HTTP transport (requires `http` feature)
 
 pub mod stdio;
 
+#[cfg(feature = "http")]
+pub mod http;
+
 pub use stdio::{StdioTransport, SyncStdioTransport};
+
+#[cfg(feature = "http")]
+pub use http::HttpTransport;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,8 +8,8 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use tower_mcp::{
     CallToolResult, GetPromptResult, JsonRpcRequest, JsonRpcResponse, JsonRpcService, McpRouter,
-    PromptBuilder, PromptMessage, PromptRole, ReadResourceResult, ResourceBuilder,
-    ResourceContent, ToolBuilder,
+    PromptBuilder, PromptMessage, PromptRole, ReadResourceResult, ResourceBuilder, ResourceContent,
+    ToolBuilder,
 };
 
 // =============================================================================
@@ -122,7 +122,10 @@ fn create_router_with_resources_and_prompts() -> McpRouter {
         .optional_arg("language", "Programming language")
         .handler(|args: HashMap<String, String>| async move {
             let code = args.get("code").map(|s| s.as_str()).unwrap_or("");
-            let lang = args.get("language").map(|s| s.as_str()).unwrap_or("unknown");
+            let lang = args
+                .get("language")
+                .map(|s| s.as_str())
+                .unwrap_or("unknown");
             Ok(GetPromptResult {
                 description: Some("Code review prompt".to_string()),
                 messages: vec![PromptMessage {
@@ -683,7 +686,10 @@ async fn test_resources_list() {
     match resp {
         JsonRpcResponse::Result(r) => {
             let caps = r.result.get("capabilities").unwrap();
-            assert!(caps.get("resources").is_some(), "Resources capability should be declared");
+            assert!(
+                caps.get("resources").is_some(),
+                "Resources capability should be declared"
+            );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
     }
@@ -735,7 +741,10 @@ async fn test_resources_read_json() {
             assert_eq!(contents.len(), 1);
 
             let content = &contents[0];
-            assert_eq!(content.get("uri").unwrap().as_str().unwrap(), "file:///config.json");
+            assert_eq!(
+                content.get("uri").unwrap().as_str().unwrap(),
+                "file:///config.json"
+            );
             assert_eq!(
                 content.get("mimeType").unwrap().as_str().unwrap(),
                 "application/json"
@@ -862,7 +871,10 @@ async fn test_prompts_list() {
     match resp {
         JsonRpcResponse::Result(r) => {
             let caps = r.result.get("capabilities").unwrap();
-            assert!(caps.get("prompts").is_some(), "Prompts capability should be declared");
+            assert!(
+                caps.get("prompts").is_some(),
+                "Prompts capability should be declared"
+            );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
     }
@@ -1041,9 +1053,18 @@ async fn test_capabilities_tools_only() {
     match resp {
         JsonRpcResponse::Result(r) => {
             let caps = r.result.get("capabilities").unwrap();
-            assert!(caps.get("tools").is_some(), "Tools capability should be present");
-            assert!(caps.get("resources").is_none(), "Resources capability should NOT be present");
-            assert!(caps.get("prompts").is_none(), "Prompts capability should NOT be present");
+            assert!(
+                caps.get("tools").is_some(),
+                "Tools capability should be present"
+            );
+            assert!(
+                caps.get("resources").is_none(),
+                "Resources capability should NOT be present"
+            );
+            assert!(
+                caps.get("prompts").is_none(),
+                "Prompts capability should NOT be present"
+            );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
     }
@@ -1064,9 +1085,18 @@ async fn test_capabilities_all() {
     match resp {
         JsonRpcResponse::Result(r) => {
             let caps = r.result.get("capabilities").unwrap();
-            assert!(caps.get("tools").is_some(), "Tools capability should be present");
-            assert!(caps.get("resources").is_some(), "Resources capability should be present");
-            assert!(caps.get("prompts").is_some(), "Prompts capability should be present");
+            assert!(
+                caps.get("tools").is_some(),
+                "Tools capability should be present"
+            );
+            assert!(
+                caps.get("resources").is_some(),
+                "Resources capability should be present"
+            );
+            assert!(
+                caps.get("prompts").is_some(),
+                "Prompts capability should be present"
+            );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
     }


### PR DESCRIPTION
## Summary

Implements the Streamable HTTP transport from MCP specification 2025-11-25.

### Features
- Single endpoint supporting POST (requests) and GET (SSE notifications)
- Session management via `MCP-Session-Id` header
- Protocol version validation via `MCP-Protocol-Version` header
- Origin header validation for security (DNS rebinding protection)
- SSE streaming for server-to-client notifications

### API

```rust
// Simple standalone server
let transport = HttpTransport::new(router)
    .disable_origin_validation();  // for local dev
transport.serve("127.0.0.1:3000").await?;

// Compose with existing axum app
let mcp_router = HttpTransport::new(router)
    .allowed_origins(vec!["https://example.com".to_string()])
    .into_router_at("/mcp");

let app = Router::new()
    .merge(mcp_router)
    .route("/health", get(health_check));
```

### New Dependencies (behind `http` feature)
- `axum 0.8` - tower-native web framework
- `tokio-stream` - SSE streaming support
- `uuid` - session ID generation

### Spec Compliance
Based on https://modelcontextprotocol.io/specification/2025-11-25/basic/transports:
- [x] POST for JSON-RPC requests/notifications/responses
- [x] GET for SSE stream (server notifications)
- [x] DELETE for session termination
- [x] `MCP-Session-Id` header for session management
- [x] `MCP-Protocol-Version` header validation
- [x] Origin header validation
- [x] Proper HTTP status codes (202 for notifications, 400/404/403 for errors)

## Test plan

- [x] Unit tests for HTTP transport (3 tests)
- [x] All existing tests pass (25 unit + 29 integration + 10 doc)
- [x] Example compiles and runs: `cargo run --example http_server --features http`
- [ ] Manual testing with curl (commands in example docs)

Closes #6