### PR TITLE
feat: add resource templates support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ thiserror = "2"
 # Tracing
 tracing = "0.1"
 
+# URI template matching
+regex = "1"
+
 [dev-dependencies]
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,10 @@ pub use protocol::{
     JsonRpcResponseMessage, McpRequest, McpResponse, PromptMessage, PromptRole, ReadResourceResult,
     ResourceContent,
 };
-pub use resource::{Resource, ResourceBuilder, ResourceHandler};
+pub use resource::{
+    Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,
+    ResourceTemplateHandler,
+};
 pub use router::{JsonRpcService, McpRouter};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -4,13 +4,44 @@
 //!
 //! 1. **Builder pattern** - Fluent API for defining resources
 //! 2. **Trait-based** - Implement `McpResource` for full control
+//! 3. **Resource templates** - Parameterized resources using URI templates (RFC 6570)
+//!
+//! # Resource Templates
+//!
+//! Resource templates allow servers to expose parameterized resources using URI templates.
+//! When a client requests `resources/read` with a URI matching a template, the server
+//! extracts the variables and passes them to the handler.
+//!
+//! ```rust
+//! use tower_mcp::resource::ResourceTemplateBuilder;
+//! use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+//! use std::collections::HashMap;
+//!
+//! let template = ResourceTemplateBuilder::new("file:///{path}")
+//!     .name("Project Files")
+//!     .description("Access files in the project directory")
+//!     .handler(|uri: String, vars: HashMap<String, String>| async move {
+//!         let path = vars.get("path").unwrap_or(&String::new()).clone();
+//!         Ok(ReadResourceResult {
+//!             contents: vec![ResourceContent {
+//!                 uri,
+//!                 mime_type: Some("text/plain".to_string()),
+//!                 text: Some(format!("Contents of {}", path)),
+//!                 blob: None,
+//!             }],
+//!         })
+//!     });
+//! ```
 
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
 use crate::error::Result;
-use crate::protocol::{ReadResourceResult, ResourceContent, ResourceDefinition};
+use crate::protocol::{
+    ReadResourceResult, ResourceContent, ResourceDefinition, ResourceTemplateDefinition,
+};
 
 /// A boxed future for resource handlers
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -299,6 +330,311 @@ impl<T: McpResource> ResourceHandler for McpResourceHandler<T> {
     }
 }
 
+// =============================================================================
+// Resource Templates
+// =============================================================================
+
+/// Handler trait for resource templates
+///
+/// Unlike [`ResourceHandler`], template handlers receive the extracted
+/// URI variables as a parameter.
+pub trait ResourceTemplateHandler: Send + Sync {
+    /// Read a resource with the given URI variables extracted from the template
+    fn read(
+        &self,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<ReadResourceResult>>;
+}
+
+/// A parameterized resource template
+///
+/// Resource templates use URI template syntax (RFC 6570) to match multiple URIs
+/// and extract variable values. This allows servers to expose dynamic resources
+/// like file systems or database records.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::resource::ResourceTemplateBuilder;
+/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+/// use std::collections::HashMap;
+///
+/// let template = ResourceTemplateBuilder::new("file:///{path}")
+///     .name("Project Files")
+///     .handler(|uri: String, vars: HashMap<String, String>| async move {
+///         let path = vars.get("path").unwrap_or(&String::new()).clone();
+///         Ok(ReadResourceResult {
+///             contents: vec![ResourceContent {
+///                 uri,
+///                 mime_type: Some("text/plain".to_string()),
+///                 text: Some(format!("Contents of {}", path)),
+///                 blob: None,
+///             }],
+///         })
+///     });
+/// ```
+pub struct ResourceTemplate {
+    /// The URI template pattern (e.g., `file:///{path}`)
+    pub uri_template: String,
+    /// Human-readable name
+    pub name: String,
+    /// Optional description
+    pub description: Option<String>,
+    /// Optional MIME type hint
+    pub mime_type: Option<String>,
+    /// Compiled regex for matching URIs
+    pattern: regex::Regex,
+    /// Variable names in order of appearance
+    variables: Vec<String>,
+    /// Handler for reading matched resources
+    handler: Arc<dyn ResourceTemplateHandler>,
+}
+
+impl Clone for ResourceTemplate {
+    fn clone(&self) -> Self {
+        Self {
+            uri_template: self.uri_template.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            mime_type: self.mime_type.clone(),
+            pattern: self.pattern.clone(),
+            variables: self.variables.clone(),
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for ResourceTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceTemplate")
+            .field("uri_template", &self.uri_template)
+            .field("name", &self.name)
+            .field("description", &self.description)
+            .field("mime_type", &self.mime_type)
+            .field("variables", &self.variables)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ResourceTemplate {
+    /// Create a new resource template builder
+    pub fn builder(uri_template: impl Into<String>) -> ResourceTemplateBuilder {
+        ResourceTemplateBuilder::new(uri_template)
+    }
+
+    /// Get the template definition for resources/templates/list
+    pub fn definition(&self) -> ResourceTemplateDefinition {
+        ResourceTemplateDefinition {
+            uri_template: self.uri_template.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            mime_type: self.mime_type.clone(),
+        }
+    }
+
+    /// Check if a URI matches this template and extract variables
+    ///
+    /// Returns `Some(HashMap)` with extracted variables if the URI matches,
+    /// `None` if it doesn't match.
+    pub fn match_uri(&self, uri: &str) -> Option<HashMap<String, String>> {
+        self.pattern.captures(uri).map(|caps| {
+            self.variables
+                .iter()
+                .enumerate()
+                .filter_map(|(i, name)| {
+                    caps.get(i + 1)
+                        .map(|m| (name.clone(), m.as_str().to_string()))
+                })
+                .collect()
+        })
+    }
+
+    /// Read a resource at the given URI using this template's handler
+    ///
+    /// # Arguments
+    ///
+    /// * `uri` - The actual URI being read
+    /// * `variables` - Variables extracted from matching the URI against the template
+    pub fn read(
+        &self,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<ReadResourceResult>> {
+        self.handler.read(uri, variables)
+    }
+}
+
+/// Builder for creating resource templates
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::resource::ResourceTemplateBuilder;
+/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+/// use std::collections::HashMap;
+///
+/// let template = ResourceTemplateBuilder::new("db://users/{id}")
+///     .name("User Records")
+///     .description("Access user records by ID")
+///     .handler(|uri: String, vars: HashMap<String, String>| async move {
+///         let id = vars.get("id").unwrap();
+///         Ok(ReadResourceResult {
+///             contents: vec![ResourceContent {
+///                 uri,
+///                 mime_type: Some("application/json".to_string()),
+///                 text: Some(format!(r#"{{"id": "{}"}}"#, id)),
+///                 blob: None,
+///             }],
+///         })
+///     });
+/// ```
+pub struct ResourceTemplateBuilder {
+    uri_template: String,
+    name: Option<String>,
+    description: Option<String>,
+    mime_type: Option<String>,
+}
+
+impl ResourceTemplateBuilder {
+    /// Create a new builder with the given URI template
+    ///
+    /// # URI Template Syntax
+    ///
+    /// Templates use RFC 6570 Level 1 syntax with simple variable expansion:
+    /// - `{varname}` - Matches any non-slash characters
+    ///
+    /// # Examples
+    ///
+    /// - `file:///{path}` - Matches `file:///README.md`
+    /// - `db://users/{id}` - Matches `db://users/123`
+    /// - `api://v1/{resource}/{id}` - Matches `api://v1/posts/456`
+    pub fn new(uri_template: impl Into<String>) -> Self {
+        Self {
+            uri_template: uri_template.into(),
+            name: None,
+            description: None,
+            mime_type: None,
+        }
+    }
+
+    /// Set the human-readable name for this template
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Set the description for this template
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the MIME type hint for resources from this template
+    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
+        self.mime_type = Some(mime_type.into());
+        self
+    }
+
+    /// Set the handler function for reading template resources
+    ///
+    /// The handler receives:
+    /// - `uri`: The full URI being read
+    /// - `variables`: A map of variable names to their values extracted from the URI
+    pub fn handler<F, Fut>(self, handler: F) -> ResourceTemplate
+    where
+        F: Fn(String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
+    {
+        let (pattern, variables) = compile_uri_template(&self.uri_template);
+        let name = self.name.unwrap_or_else(|| self.uri_template.clone());
+
+        ResourceTemplate {
+            uri_template: self.uri_template,
+            name,
+            description: self.description,
+            mime_type: self.mime_type,
+            pattern,
+            variables,
+            handler: Arc::new(FnTemplateHandler { handler }),
+        }
+    }
+}
+
+/// Handler wrapping a function for templates
+struct FnTemplateHandler<F> {
+    handler: F,
+}
+
+impl<F, Fut> ResourceTemplateHandler for FnTemplateHandler<F>
+where
+    F: Fn(String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
+{
+    fn read(
+        &self,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<ReadResourceResult>> {
+        let uri = uri.to_string();
+        Box::pin((self.handler)(uri, variables))
+    }
+}
+
+/// Compile a URI template into a regex pattern and extract variable names
+///
+/// Supports RFC 6570 Level 1 (simple expansion):
+/// - `{var}` matches any characters except `/`
+/// - `{+var}` matches any characters including `/` (reserved expansion)
+///
+/// Returns the compiled regex and a list of variable names in order.
+fn compile_uri_template(template: &str) -> (regex::Regex, Vec<String>) {
+    let mut pattern = String::from("^");
+    let mut variables = Vec::new();
+
+    let mut chars = template.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '{' {
+            // Check for + prefix (reserved expansion)
+            let is_reserved = chars.peek() == Some(&'+');
+            if is_reserved {
+                chars.next();
+            }
+
+            // Collect variable name
+            let var_name: String = chars.by_ref().take_while(|&c| c != '}').collect();
+            variables.push(var_name);
+
+            // Choose pattern based on expansion type
+            if is_reserved {
+                // Reserved expansion - match anything
+                pattern.push_str("(.+)");
+            } else {
+                // Simple expansion - match non-slash characters
+                pattern.push_str("([^/]+)");
+            }
+        } else {
+            // Escape regex special characters
+            match c {
+                '.' | '+' | '*' | '?' | '^' | '$' | '(' | ')' | '[' | ']' | '{' | '}' | '|'
+                | '\\' => {
+                    pattern.push('\\');
+                    pattern.push(c);
+                }
+                _ => pattern.push(c),
+            }
+        }
+    }
+
+    pattern.push('$');
+
+    // Compile the regex - panic if template is malformed
+    let regex = regex::Regex::new(&pattern)
+        .unwrap_or_else(|e| panic!("Invalid URI template '{}': {}", template, e));
+
+    (regex, variables)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -393,5 +729,161 @@ mod tests {
         assert_eq!(def.name, "Test");
         assert_eq!(def.description.as_deref(), Some("Description"));
         assert_eq!(def.mime_type.as_deref(), Some("text/plain"));
+    }
+
+    // =========================================================================
+    // Resource Template Tests
+    // =========================================================================
+
+    #[test]
+    fn test_compile_uri_template_simple() {
+        let (regex, vars) = compile_uri_template("file:///{path}");
+        assert_eq!(vars, vec!["path"]);
+        assert!(regex.is_match("file:///README.md"));
+        assert!(!regex.is_match("file:///foo/bar")); // no slashes in simple expansion
+    }
+
+    #[test]
+    fn test_compile_uri_template_multiple_vars() {
+        let (regex, vars) = compile_uri_template("api://v1/{resource}/{id}");
+        assert_eq!(vars, vec!["resource", "id"]);
+        assert!(regex.is_match("api://v1/users/123"));
+        assert!(regex.is_match("api://v1/posts/abc"));
+        assert!(!regex.is_match("api://v1/users")); // missing id
+    }
+
+    #[test]
+    fn test_compile_uri_template_reserved_expansion() {
+        let (regex, vars) = compile_uri_template("file:///{+path}");
+        assert_eq!(vars, vec!["path"]);
+        assert!(regex.is_match("file:///README.md"));
+        assert!(regex.is_match("file:///foo/bar/baz.txt")); // slashes allowed
+    }
+
+    #[test]
+    fn test_compile_uri_template_special_chars() {
+        let (regex, vars) = compile_uri_template("http://example.com/api?query={q}");
+        assert_eq!(vars, vec!["q"]);
+        assert!(regex.is_match("http://example.com/api?query=hello"));
+    }
+
+    #[test]
+    fn test_resource_template_match_uri() {
+        let template = ResourceTemplateBuilder::new("db://users/{id}")
+            .name("User Records")
+            .handler(|uri: String, vars: HashMap<String, String>| async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: None,
+                        text: Some(format!("User {}", vars.get("id").unwrap())),
+                        blob: None,
+                    }],
+                })
+            });
+
+        // Test matching
+        let vars = template.match_uri("db://users/123").unwrap();
+        assert_eq!(vars.get("id"), Some(&"123".to_string()));
+
+        // Test non-matching
+        assert!(template.match_uri("db://posts/123").is_none());
+        assert!(template.match_uri("db://users").is_none());
+    }
+
+    #[test]
+    fn test_resource_template_match_multiple_vars() {
+        let template = ResourceTemplateBuilder::new("api://{version}/{resource}/{id}")
+            .name("API Resources")
+            .handler(|uri: String, _vars: HashMap<String, String>| async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: None,
+                        text: None,
+                        blob: None,
+                    }],
+                })
+            });
+
+        let vars = template.match_uri("api://v2/users/abc-123").unwrap();
+        assert_eq!(vars.get("version"), Some(&"v2".to_string()));
+        assert_eq!(vars.get("resource"), Some(&"users".to_string()));
+        assert_eq!(vars.get("id"), Some(&"abc-123".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_resource_template_read() {
+        let template = ResourceTemplateBuilder::new("file:///{path}")
+            .name("Files")
+            .mime_type("text/plain")
+            .handler(|uri: String, vars: HashMap<String, String>| async move {
+                let path = vars.get("path").unwrap().clone();
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some(format!("Contents of {}", path)),
+                        blob: None,
+                    }],
+                })
+            });
+
+        let vars = template.match_uri("file:///README.md").unwrap();
+        let result = template.read("file:///README.md", vars).await.unwrap();
+
+        assert_eq!(result.contents.len(), 1);
+        assert_eq!(result.contents[0].uri, "file:///README.md");
+        assert_eq!(
+            result.contents[0].text.as_deref(),
+            Some("Contents of README.md")
+        );
+    }
+
+    #[test]
+    fn test_resource_template_definition() {
+        let template = ResourceTemplateBuilder::new("db://records/{id}")
+            .name("Database Records")
+            .description("Access database records by ID")
+            .mime_type("application/json")
+            .handler(|uri: String, _vars: HashMap<String, String>| async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: None,
+                        text: None,
+                        blob: None,
+                    }],
+                })
+            });
+
+        let def = template.definition();
+        assert_eq!(def.uri_template, "db://records/{id}");
+        assert_eq!(def.name, "Database Records");
+        assert_eq!(
+            def.description.as_deref(),
+            Some("Access database records by ID")
+        );
+        assert_eq!(def.mime_type.as_deref(), Some("application/json"));
+    }
+
+    #[test]
+    fn test_resource_template_reserved_path() {
+        let template = ResourceTemplateBuilder::new("file:///{+path}")
+            .name("Files with subpaths")
+            .handler(|uri: String, _vars: HashMap<String, String>| async move {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: None,
+                        text: None,
+                        blob: None,
+                    }],
+                })
+            });
+
+        // Reserved expansion should match slashes
+        let vars = template.match_uri("file:///src/lib/utils.rs").unwrap();
+        assert_eq!(vars.get("path"), Some(&"src/lib/utils.rs".to_string()));
     }
 }


### PR DESCRIPTION
## Summary

- Add resource templates support using RFC 6570 URI templates (fixes #27)
- Templates allow parameterized resource access like `file:///{path}` or `db://users/{id}`
- Static resources take precedence over template matching

## Changes

### Protocol Types
- `ResourceTemplateDefinition` - definition as returned by `resources/templates/list`
- `ListResourceTemplatesParams` and `ListResourceTemplatesResult`
- `ListResourceTemplates` variant for `McpRequest` and `McpResponse`

### Resource Module
- `ResourceTemplate` - complete template with handler and compiled matcher
- `ResourceTemplateBuilder` - fluent API for building templates
- `ResourceTemplateHandler` trait - receives URI and extracted variables
- `compile_uri_template()` - compiles template to regex with variable extraction

### Router
- `resource_template()` method to register templates
- `resources/templates/list` handler
- `resources/read` fallback to template matching
- Updated `capabilities()` to include resources when only templates registered

### URI Template Support
- Level 1 simple expansion: `{var}` matches non-slash characters
- Reserved expansion: `{+var}` matches any characters including slashes

## Test Plan

- [x] 14 new unit tests for template compilation and matching
- [x] 5 new router integration tests for template list/read/precedence
- [x] 45 total lib tests pass
- [x] 29 integration tests pass
- [x] 16 doc tests pass
- [x] clippy passes
- [x] cargo fmt passes