### PR TITLE
feat: add resource subscriptions support

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -35,6 +35,13 @@ use crate::protocol::{ProgressParams, ProgressToken, RequestId};
 pub enum ServerNotification {
     /// Progress update for a request
     Progress(ProgressParams),
+    /// A subscribed resource has been updated
+    ResourceUpdated {
+        /// The URI of the updated resource
+        uri: String,
+    },
+    /// The list of available resources has changed
+    ResourcesListChanged,
 }
 
 /// Sender for server notifications
@@ -265,6 +272,7 @@ mod tests {
                 assert_eq!(params.total, Some(100.0));
                 assert_eq!(params.message.as_deref(), Some("Halfway"));
             }
+            _ => panic!("Expected Progress notification"),
         }
     }
 


### PR DESCRIPTION
## Summary

- Add resource subscriptions support (fixes #28)
- Clients can subscribe to resource URIs to receive update notifications
- Server advertises subscription support in capabilities

## Changes

### Context Module
- Add `ResourceUpdated { uri }` variant to `ServerNotification`
- Add `ResourcesListChanged` variant to `ServerNotification`

### Router
- Add `subscriptions: HashSet<String>` to track subscribed URIs per session
- Implement `resources/subscribe` handler - verifies resource exists, adds to subscriptions
- Implement `resources/unsubscribe` handler - removes from subscriptions
- Add `is_subscribed(uri)` - check if a URI is subscribed
- Add `subscribed_uris()` - get all subscribed URIs
- Add `notify_resource_updated(uri)` - send notification to subscribers
- Add `notify_resources_list_changed()` - send list changed notification
- Update `ResourcesCapability` to set `subscribe: true`

## Usage

```rust
let router = McpRouter::new()
    .resource(my_resource)
    .with_notification_sender(tx);

// Client subscribes via resources/subscribe request
// ...

// When resource changes, notify subscribers:
if router.notify_resource_updated("file:///my-resource") {
    println!("Notification sent!");
}
```

## Test Plan

- [x] 6 new unit tests for subscription behavior
- [x] 37 total lib tests pass
- [x] 29 integration tests pass
- [x] clippy passes
- [x] cargo fmt passes