### PR TITLE
feat: add logging notifications support

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -28,13 +28,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use tokio::sync::mpsc;
 
-use crate::protocol::{ProgressParams, ProgressToken, RequestId};
+use crate::protocol::{LoggingMessageParams, ProgressParams, ProgressToken, RequestId};
 
 /// A notification to be sent to the client
 #[derive(Debug, Clone)]
 pub enum ServerNotification {
     /// Progress update for a request
     Progress(ProgressParams),
+    /// Log message notification
+    LogMessage(LoggingMessageParams),
 }
 
 /// Sender for server notifications
@@ -265,6 +267,7 @@ mod tests {
                 assert_eq!(params.total, Some(100.0));
                 assert_eq!(params.message.as_deref(), Some("Halfway"));
             }
+            _ => panic!("Expected Progress notification"),
         }
     }
 


### PR DESCRIPTION
## Summary

Implements logging notifications support per MCP specification (#32).

- Add `LogLevel` enum with RFC 5424 syslog-style levels (emergency, alert, critical, error, warning, notice, info, debug)
- Add `LoggingMessageParams` struct for structured log data
- Add `LoggingCapability` to server capabilities
- Add `LogMessage` variant to `ServerNotification` enum
- Add convenience methods to `McpRouter`: `log()`, `log_info()`, `log_warning()`, `log_error()`, `log_debug()`
- Logging capability is automatically enabled when a notification channel is configured

## Test plan

- [x] Test `LogLevel` ordering (debug < info < ... < emergency)
- [x] Test `LogLevel` serialization/deserialization
- [x] Test `log()` method with full parameters
- [x] Test convenience methods (`log_info`, `log_warning`, etc.)
- [x] Test that logging returns false when no notification channel configured