### PR TITLE
feat: add resource subscriptions support

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -37,6 +37,13 @@ pub enum ServerNotification {
     Progress(ProgressParams),
     /// Log message notification
     LogMessage(LoggingMessageParams),
+    /// A subscribed resource has been updated
+    ResourceUpdated {
+        /// The URI of the updated resource
+        uri: String,
+    },
+    /// The list of available resources has changed
+    ResourcesListChanged,
 }
 
 /// Sender for server notifications

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -447,6 +447,8 @@ pub enum McpResponse {
     ListResources(ListResourcesResult),
     ListResourceTemplates(ListResourceTemplatesResult),
     ReadResource(ReadResourceResult),
+    SubscribeResource(EmptyResult),
+    UnsubscribeResource(EmptyResult),
     ListPrompts(ListPromptsResult),
     GetPrompt(GetPromptResult),
     EnqueueTask(EnqueueTaskResult),


### PR DESCRIPTION
## Summary
- Add resource subscription support with subscribe/unsubscribe handlers
- Add subscription methods to McpRouter (is_subscribed, subscribed_uris, notify_resource_updated, notify_resources_list_changed)
- Enable subscription capability in resources capability advertisement
- Add comprehensive tests for subscription functionality

Replaces #40 which had merge conflicts.

## Test plan
- [x] All 59 unit tests pass
- [x] Clippy passes with no warnings
- [x] Code is formatted