### PR TITLE
feat: add WebSocket and child process transports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,17 @@ default = []
 # Transport features
 stdio = []
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
-websocket = []
+websocket = ["dep:axum", "dep:tokio-tungstenite", "dep:uuid"]
+childproc = []
 
 [dependencies.axum]
 version = "0.8"
 optional = true
-features = ["json"]
+features = ["json", "ws"]
+
+[dependencies.tokio-tungstenite]
+version = "0.26"
+optional = true
 
 [dependencies.hyper]
 version = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,3 +79,9 @@ pub use transport::{StdioTransport, SyncStdioTransport};
 
 #[cfg(feature = "http")]
 pub use transport::HttpTransport;
+
+#[cfg(feature = "websocket")]
+pub use transport::WebSocketTransport;
+
+#[cfg(feature = "childproc")]
+pub use transport::{ChildProcessConnection, ChildProcessTransport};

--- a/src/transport/childproc.rs
+++ b/src/transport/childproc.rs
@@ -1,0 +1,332 @@
+//! Child process transport for MCP
+//!
+//! Spawns and communicates with subprocess MCP servers via stdio.
+//! Useful for:
+//! - Running untrusted MCP servers in isolation
+//! - Spawning tool-specific servers on demand
+//! - Testing
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::transport::childproc::ChildProcessTransport;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Spawn an MCP server as a child process
+//!     let mut transport = ChildProcessTransport::new("my-mcp-server")
+//!         .arg("--some-flag")
+//!         .spawn()
+//!         .await?;
+//!
+//!     // Send a request
+//!     let response = transport.send_request(
+//!         "initialize",
+//!         serde_json::json!({
+//!             "protocolVersion": "2025-03-26",
+//!             "capabilities": {},
+//!             "clientInfo": { "name": "my-client", "version": "1.0" }
+//!         })
+//!     ).await?;
+//!
+//!     // Shutdown
+//!     transport.shutdown().await?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+
+use crate::error::{Error, Result};
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+
+/// Builder for child process transport
+pub struct ChildProcessTransport {
+    program: String,
+    args: Vec<String>,
+    envs: Vec<(String, String)>,
+}
+
+impl ChildProcessTransport {
+    /// Create a new child process transport builder
+    pub fn new(program: impl Into<String>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            envs: Vec::new(),
+        }
+    }
+
+    /// Add a command-line argument
+    pub fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Add multiple command-line arguments
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(args.into_iter().map(|s| s.into()));
+        self
+    }
+
+    /// Set an environment variable
+    pub fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.envs.push((key.into(), value.into()));
+        self
+    }
+
+    /// Spawn the child process
+    pub async fn spawn(self) -> Result<ChildProcessConnection> {
+        let mut cmd = Command::new(&self.program);
+        cmd.args(&self.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        for (key, value) in &self.envs {
+            cmd.env(key, value);
+        }
+
+        let child = cmd
+            .spawn()
+            .map_err(|e| Error::Transport(format!("Failed to spawn {}: {}", self.program, e)))?;
+
+        tracing::info!(program = %self.program, "Spawned child process");
+
+        ChildProcessConnection::new(child)
+    }
+}
+
+/// Active connection to a child MCP server process
+pub struct ChildProcessConnection {
+    child: Child,
+    stdin: tokio::process::ChildStdin,
+    stdout: BufReader<tokio::process::ChildStdout>,
+    request_id: AtomicI64,
+}
+
+impl ChildProcessConnection {
+    fn new(mut child: Child) -> Result<Self> {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdout".to_string()))?;
+
+        Ok(Self {
+            child,
+            stdin,
+            stdout: BufReader::new(stdout),
+            request_id: AtomicI64::new(1),
+        })
+    }
+
+    /// Send a JSON-RPC request and wait for response
+    pub async fn send_request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let id = self.request_id.fetch_add(1, Ordering::Relaxed);
+        let request = JsonRpcRequest::new(id, method).with_params(params);
+
+        // Send request
+        let request_json = serde_json::to_string(&request)
+            .map_err(|e| Error::Transport(format!("Failed to serialize request: {}", e)))?;
+
+        tracing::debug!(method = %method, id = %id, "Sending request to child");
+
+        self.stdin
+            .write_all(request_json.as_bytes())
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write to child stdin: {}", e)))?;
+        self.stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to flush stdin: {}", e)))?;
+
+        // Read response
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to read from child stdout: {}", e)))?;
+
+        if line.is_empty() {
+            return Err(Error::Transport("Child process closed stdout".to_string()));
+        }
+
+        tracing::debug!(response = %line.trim(), "Received response from child");
+
+        let response: JsonRpcResponse = serde_json::from_str(line.trim())
+            .map_err(|e| Error::Transport(format!("Failed to parse response: {}", e)))?;
+
+        match response {
+            JsonRpcResponse::Result(r) => Ok(r.result),
+            JsonRpcResponse::Error(e) => Err(Error::JsonRpc(e.error)),
+        }
+    }
+
+    /// Send a notification (no response expected)
+    pub async fn send_notification(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<()> {
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        });
+
+        let json = serde_json::to_string(&notification)
+            .map_err(|e| Error::Transport(format!("Failed to serialize notification: {}", e)))?;
+
+        tracing::debug!(method = %method, "Sending notification to child");
+
+        self.stdin
+            .write_all(json.as_bytes())
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write notification: {}", e)))?;
+        self.stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to flush stdin: {}", e)))?;
+
+        Ok(())
+    }
+
+    /// Initialize the MCP connection
+    pub async fn initialize(
+        &mut self,
+        client_name: &str,
+        client_version: &str,
+    ) -> Result<serde_json::Value> {
+        self.send_request(
+            "initialize",
+            serde_json::json!({
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": client_name,
+                    "version": client_version
+                }
+            }),
+        )
+        .await
+    }
+
+    /// Send initialized notification
+    pub async fn send_initialized(&mut self) -> Result<()> {
+        self.send_notification("notifications/initialized", serde_json::json!({}))
+            .await
+    }
+
+    /// List available tools
+    pub async fn list_tools(&mut self) -> Result<serde_json::Value> {
+        self.send_request("tools/list", serde_json::json!({})).await
+    }
+
+    /// Call a tool
+    pub async fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        self.send_request(
+            "tools/call",
+            serde_json::json!({
+                "name": name,
+                "arguments": arguments
+            }),
+        )
+        .await
+    }
+
+    /// Check if the child process is still running
+    pub fn is_running(&mut self) -> bool {
+        matches!(self.child.try_wait(), Ok(None))
+    }
+
+    /// Gracefully shutdown the child process
+    pub async fn shutdown(mut self) -> Result<()> {
+        // Close stdin to signal EOF
+        drop(self.stdin);
+
+        // Wait for process to exit with timeout
+        let result =
+            tokio::time::timeout(std::time::Duration::from_secs(5), self.child.wait()).await;
+
+        match result {
+            Ok(Ok(status)) => {
+                tracing::info!(status = ?status, "Child process exited");
+                Ok(())
+            }
+            Ok(Err(e)) => {
+                tracing::error!(error = %e, "Error waiting for child process");
+                Err(Error::Transport(format!("Child process error: {}", e)))
+            }
+            Err(_) => {
+                // Timeout - kill the process
+                tracing::warn!("Child process did not exit gracefully, killing");
+                self.child
+                    .kill()
+                    .await
+                    .map_err(|e| Error::Transport(format!("Failed to kill child: {}", e)))?;
+                Ok(())
+            }
+        }
+    }
+
+    /// Kill the child process immediately
+    pub async fn kill(mut self) -> Result<()> {
+        self.child
+            .kill()
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to kill child: {}", e)))?;
+        tracing::info!("Child process killed");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_transport_builder() {
+        let transport = ChildProcessTransport::new("echo")
+            .arg("hello")
+            .env("FOO", "bar");
+
+        assert_eq!(transport.program, "echo");
+        assert_eq!(transport.args, vec!["hello"]);
+        assert_eq!(transport.envs, vec![("FOO".to_string(), "bar".to_string())]);
+    }
+
+    #[tokio::test]
+    async fn test_transport_args() {
+        let transport = ChildProcessTransport::new("cmd").args(["--flag1", "--flag2"]);
+
+        assert_eq!(transport.args, vec!["--flag1", "--flag2"]);
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -3,13 +3,27 @@
 //! Provides different transport layers for MCP communication:
 //! - `stdio` - Standard input/output for CLI usage
 //! - `http` - Streamable HTTP transport (requires `http` feature)
+//! - `websocket` - WebSocket transport for full-duplex communication (requires `websocket` feature)
+//! - `childproc` - Child process transport for subprocess MCP servers (requires `childproc` feature)
 
 pub mod stdio;
 
 #[cfg(feature = "http")]
 pub mod http;
 
+#[cfg(feature = "websocket")]
+pub mod websocket;
+
+#[cfg(feature = "childproc")]
+pub mod childproc;
+
 pub use stdio::{StdioTransport, SyncStdioTransport};
 
 #[cfg(feature = "http")]
 pub use http::HttpTransport;
+
+#[cfg(feature = "websocket")]
+pub use websocket::WebSocketTransport;
+
+#[cfg(feature = "childproc")]
+pub use childproc::{ChildProcessConnection, ChildProcessTransport};

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -1,0 +1,297 @@
+//! WebSocket transport for MCP
+//!
+//! Provides full-duplex communication over WebSocket, ideal for:
+//! - Bidirectional notifications
+//! - Long-lived connections
+//! - Lower latency than HTTP polling
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+//! use tower_mcp::transport::websocket::WebSocketTransport;
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//!
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct Input { value: String }
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let tool = ToolBuilder::new("echo")
+//!         .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
+//!         .build()?;
+//!
+//!     let router = McpRouter::new()
+//!         .server_info("my-server", "1.0.0")
+//!         .tool(tool);
+//!
+//!     let transport = WebSocketTransport::new(router);
+//!     transport.serve("127.0.0.1:3000").await?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::{
+    Router,
+    extract::{
+        State, WebSocketUpgrade,
+        ws::{Message, WebSocket},
+    },
+    response::Response,
+    routing::get,
+};
+use futures::{SinkExt, StreamExt};
+use tokio::sync::RwLock;
+
+use crate::error::{Error, JsonRpcError, Result};
+use crate::jsonrpc::JsonRpcService;
+use crate::protocol::{JsonRpcMessage, JsonRpcNotification, JsonRpcResponse, McpNotification};
+use crate::router::McpRouter;
+
+/// Session state for WebSocket transport
+#[derive(Debug)]
+struct Session {
+    id: String,
+    router: McpRouter,
+}
+
+impl Session {
+    fn new(router: McpRouter) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            router,
+        }
+    }
+}
+
+/// Session store for WebSocket connections
+#[derive(Debug, Default)]
+struct SessionStore {
+    sessions: RwLock<HashMap<String, Arc<Session>>>,
+}
+
+impl SessionStore {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    async fn create(&self, router: McpRouter) -> Arc<Session> {
+        let session = Arc::new(Session::new(router));
+        let mut sessions = self.sessions.write().await;
+        sessions.insert(session.id.clone(), session.clone());
+        tracing::debug!(session_id = %session.id, "Created WebSocket session");
+        session
+    }
+
+    async fn remove(&self, id: &str) -> bool {
+        let mut sessions = self.sessions.write().await;
+        let removed = sessions.remove(id).is_some();
+        if removed {
+            tracing::debug!(session_id = %id, "Removed WebSocket session");
+        }
+        removed
+    }
+}
+
+/// Shared state for WebSocket transport
+struct AppState {
+    router_template: McpRouter,
+    sessions: SessionStore,
+}
+
+/// WebSocket transport for MCP servers
+///
+/// Provides full-duplex communication over WebSocket.
+pub struct WebSocketTransport {
+    router: McpRouter,
+}
+
+impl WebSocketTransport {
+    /// Create a new WebSocket transport
+    pub fn new(router: McpRouter) -> Self {
+        Self { router }
+    }
+
+    /// Build the axum router for this transport
+    pub fn into_router(self) -> Router {
+        let state = Arc::new(AppState {
+            router_template: self.router,
+            sessions: SessionStore::new(),
+        });
+
+        Router::new()
+            .route("/", get(handle_websocket))
+            .with_state(state)
+    }
+
+    /// Build an axum router mounted at a specific path
+    pub fn into_router_at(self, path: &str) -> Router {
+        let state = Arc::new(AppState {
+            router_template: self.router,
+            sessions: SessionStore::new(),
+        });
+
+        let ws_router = Router::new()
+            .route("/", get(handle_websocket))
+            .with_state(state);
+
+        Router::new().nest(path, ws_router)
+    }
+
+    /// Serve the transport on the given address
+    pub async fn serve(self, addr: &str) -> Result<()> {
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to bind to {}: {}", addr, e)))?;
+
+        tracing::info!("MCP WebSocket transport listening on {}", addr);
+
+        let router = self.into_router();
+        axum::serve(listener, router)
+            .await
+            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
+
+        Ok(())
+    }
+}
+
+/// Handle WebSocket upgrade
+async fn handle_websocket(State(state): State<Arc<AppState>>, ws: WebSocketUpgrade) -> Response {
+    ws.on_upgrade(move |socket| handle_socket(socket, state))
+}
+
+/// Handle an individual WebSocket connection
+async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
+    let session = state.sessions.create(state.router_template.clone()).await;
+    let session_id = session.id.clone();
+
+    tracing::info!(session_id = %session_id, "WebSocket connection established");
+
+    let mut service = JsonRpcService::new(session.router.clone());
+    let (mut sender, mut receiver) = socket.split();
+
+    // Process incoming messages
+    while let Some(msg) = receiver.next().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::error!(error = %e, "WebSocket receive error");
+                break;
+            }
+        };
+
+        match msg {
+            Message::Text(text) => {
+                match process_message(&mut service, &session.router, &text).await {
+                    Ok(Some(response)) => {
+                        let response_json = match serde_json::to_string(&response) {
+                            Ok(json) => json,
+                            Err(e) => {
+                                tracing::error!(error = %e, "Failed to serialize response");
+                                continue;
+                            }
+                        };
+
+                        if let Err(e) = sender.send(Message::Text(response_json.into())).await {
+                            tracing::error!(error = %e, "Failed to send response");
+                            break;
+                        }
+                    }
+                    Ok(None) => {
+                        // Notification, no response needed
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Error processing message");
+                        let error_response = JsonRpcResponse::error(
+                            None,
+                            JsonRpcError::internal_error(e.to_string()),
+                        );
+                        if let Ok(json) = serde_json::to_string(&error_response) {
+                            let _ = sender.send(Message::Text(json.into())).await;
+                        }
+                    }
+                }
+            }
+            Message::Binary(data) => {
+                // Try to parse binary as UTF-8 text
+                if let Ok(text) = String::from_utf8(data.to_vec()) {
+                    match process_message(&mut service, &session.router, &text).await {
+                        Ok(Some(response)) => {
+                            if let Ok(json) = serde_json::to_string(&response) {
+                                let _ = sender.send(Message::Text(json.into())).await;
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(e) => {
+                            tracing::error!(error = %e, "Error processing binary message");
+                        }
+                    }
+                }
+            }
+            Message::Ping(data) => {
+                if let Err(e) = sender.send(Message::Pong(data)).await {
+                    tracing::error!(error = %e, "Failed to send pong");
+                    break;
+                }
+            }
+            Message::Pong(_) => {
+                // Ignore pongs
+            }
+            Message::Close(_) => {
+                tracing::info!(session_id = %session_id, "WebSocket close received");
+                break;
+            }
+        }
+    }
+
+    // Cleanup session
+    state.sessions.remove(&session_id).await;
+    tracing::info!(session_id = %session_id, "WebSocket connection closed");
+}
+
+/// Process a JSON-RPC message
+async fn process_message(
+    service: &mut JsonRpcService<McpRouter>,
+    router: &McpRouter,
+    text: &str,
+) -> Result<Option<crate::protocol::JsonRpcResponseMessage>> {
+    // Check if it's a notification (no id field)
+    let parsed: serde_json::Value = serde_json::from_str(text)?;
+    if parsed.get("id").is_none()
+        && let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text)
+    {
+        let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
+        router.handle_notification(mcp_notification);
+        return Ok(None);
+    }
+
+    // Parse and process as a request
+    let message: JsonRpcMessage = serde_json::from_str(text)?;
+    let response = service.call_message(message).await?;
+    Ok(Some(response))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_router() -> McpRouter {
+        McpRouter::new().server_info("test-server", "1.0.0")
+    }
+
+    #[tokio::test]
+    async fn test_websocket_transport_builds() {
+        let transport = WebSocketTransport::new(create_test_router());
+        let _router = transport.into_router();
+    }
+
+    #[tokio::test]
+    async fn test_websocket_transport_at_path() {
+        let transport = WebSocketTransport::new(create_test_router());
+        let _router = transport.into_router_at("/mcp");
+    }
+}


### PR DESCRIPTION
## Summary

Add two new transport types for MCP communication.

### WebSocket Transport (#31)

Full-duplex WebSocket communication, ideal for bidirectional notifications and long-lived connections.

```rust
let transport = WebSocketTransport::new(router);
transport.serve("127.0.0.1:3000").await?;
```

Features:
- Session per WebSocket connection
- Text and binary message support
- Automatic ping/pong handling
- Session cleanup on disconnect

### Child Process Transport (#35)

Spawn and communicate with subprocess MCP servers via stdio.

```rust
let mut conn = ChildProcessTransport::new("my-mcp-server")
    .arg("--flag")
    .spawn()
    .await?;

conn.initialize("my-client", "1.0").await?;
conn.send_initialized().await?;
let tools = conn.list_tools().await?;
conn.shutdown().await?;
```

Features:
- Builder pattern for process configuration
- Helper methods: `initialize()`, `list_tools()`, `call_tool()`
- Graceful shutdown with timeout
- Process lifecycle management

## Test plan

- [x] All 88 library tests pass
- [x] All 29 integration tests pass
- [x] cargo clippy passes

Closes #31, closes #35