### PR TITLE
feat: add MCP client support with stdio transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ schemars = "1.2"
 # Error handling
 thiserror = "2"
 
+# Async traits
+async-trait = "0.1"
+
 # Tracing
 tracing = "0.1"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,423 @@
+//! MCP Client implementation
+//!
+//! Provides client functionality for connecting to MCP servers.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::client::{McpClient, StdioClientTransport};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Connect to an MCP server via stdio
+//!     let transport = StdioClientTransport::spawn("my-mcp-server", &["--flag"]).await?;
+//!     let mut client = McpClient::new(transport);
+//!
+//!     // Initialize the connection
+//!     let server_info = client.initialize("my-client", "1.0.0").await?;
+//!     println!("Connected to: {}", server_info.server_info.name);
+//!
+//!     // List available tools
+//!     let tools = client.list_tools().await?;
+//!     for tool in &tools.tools {
+//!         println!("Tool: {}", tool.name);
+//!     }
+//!
+//!     // Call a tool
+//!     let result = client.call_tool("my-tool", serde_json::json!({"arg": "value"})).await?;
+//!     println!("Result: {:?}", result);
+//!
+//!     Ok(())
+//! }
+//! ```
+
+use std::process::Stdio;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+use async_trait::async_trait;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, Command};
+
+use crate::error::{Error, Result};
+use crate::protocol::{
+    CallToolParams, CallToolResult, ClientCapabilities, GetPromptParams, GetPromptResult,
+    Implementation, InitializeParams, InitializeResult, JsonRpcRequest, JsonRpcResponse,
+    ListPromptsParams, ListPromptsResult, ListResourcesParams, ListResourcesResult,
+    ListToolsParams, ListToolsResult, ReadResourceParams, ReadResourceResult,
+};
+
+/// Trait for MCP client transports
+#[async_trait]
+pub trait ClientTransport: Send {
+    /// Send a request and receive a response
+    async fn request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value>;
+
+    /// Send a notification (no response expected)
+    async fn notify(&mut self, method: &str, params: serde_json::Value) -> Result<()>;
+
+    /// Check if the transport is still connected
+    fn is_connected(&self) -> bool;
+
+    /// Close the transport
+    async fn close(self: Box<Self>) -> Result<()>;
+}
+
+/// MCP Client for connecting to MCP servers
+pub struct McpClient<T: ClientTransport> {
+    transport: T,
+    initialized: bool,
+    server_info: Option<InitializeResult>,
+}
+
+impl<T: ClientTransport> McpClient<T> {
+    /// Create a new MCP client with the given transport
+    pub fn new(transport: T) -> Self {
+        Self {
+            transport,
+            initialized: false,
+            server_info: None,
+        }
+    }
+
+    /// Get the server info (available after initialization)
+    pub fn server_info(&self) -> Option<&InitializeResult> {
+        self.server_info.as_ref()
+    }
+
+    /// Check if the client is initialized
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    /// Initialize the MCP connection
+    pub async fn initialize(
+        &mut self,
+        client_name: &str,
+        client_version: &str,
+    ) -> Result<&InitializeResult> {
+        let params = InitializeParams {
+            protocol_version: crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
+            capabilities: ClientCapabilities::default(),
+            client_info: Implementation {
+                name: client_name.to_string(),
+                version: client_version.to_string(),
+            },
+        };
+
+        let result: InitializeResult = self.request("initialize", &params).await?;
+        self.server_info = Some(result);
+
+        // Send initialized notification
+        self.transport
+            .notify("notifications/initialized", serde_json::json!({}))
+            .await?;
+
+        self.initialized = true;
+
+        Ok(self.server_info.as_ref().unwrap())
+    }
+
+    /// List available tools
+    pub async fn list_tools(&mut self) -> Result<ListToolsResult> {
+        self.ensure_initialized()?;
+        self.request("tools/list", &ListToolsParams { cursor: None })
+            .await
+    }
+
+    /// Call a tool
+    pub async fn call_tool(
+        &mut self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<CallToolResult> {
+        self.ensure_initialized()?;
+        let params = CallToolParams {
+            name: name.to_string(),
+            arguments,
+            meta: None,
+        };
+        self.request("tools/call", &params).await
+    }
+
+    /// List available resources
+    pub async fn list_resources(&mut self) -> Result<ListResourcesResult> {
+        self.ensure_initialized()?;
+        self.request("resources/list", &ListResourcesParams { cursor: None })
+            .await
+    }
+
+    /// Read a resource
+    pub async fn read_resource(&mut self, uri: &str) -> Result<ReadResourceResult> {
+        self.ensure_initialized()?;
+        let params = ReadResourceParams {
+            uri: uri.to_string(),
+        };
+        self.request("resources/read", &params).await
+    }
+
+    /// List available prompts
+    pub async fn list_prompts(&mut self) -> Result<ListPromptsResult> {
+        self.ensure_initialized()?;
+        self.request("prompts/list", &ListPromptsParams { cursor: None })
+            .await
+    }
+
+    /// Get a prompt
+    pub async fn get_prompt(
+        &mut self,
+        name: &str,
+        arguments: Option<std::collections::HashMap<String, String>>,
+    ) -> Result<GetPromptResult> {
+        self.ensure_initialized()?;
+        let params = GetPromptParams {
+            name: name.to_string(),
+            arguments: arguments.unwrap_or_default(),
+        };
+        self.request("prompts/get", &params).await
+    }
+
+    /// Ping the server
+    pub async fn ping(&mut self) -> Result<()> {
+        let _: serde_json::Value = self.request("ping", &serde_json::json!({})).await?;
+        Ok(())
+    }
+
+    /// Send a raw request
+    pub async fn request<P: serde::Serialize, R: serde::de::DeserializeOwned>(
+        &mut self,
+        method: &str,
+        params: &P,
+    ) -> Result<R> {
+        let params_value = serde_json::to_value(params)
+            .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
+
+        let result = self.transport.request(method, params_value).await?;
+
+        serde_json::from_value(result)
+            .map_err(|e| Error::Transport(format!("Failed to deserialize response: {}", e)))
+    }
+
+    /// Send a notification
+    pub async fn notify<P: serde::Serialize>(&mut self, method: &str, params: &P) -> Result<()> {
+        let params_value = serde_json::to_value(params)
+            .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
+
+        self.transport.notify(method, params_value).await
+    }
+
+    fn ensure_initialized(&self) -> Result<()> {
+        if !self.initialized {
+            return Err(Error::Transport("Client not initialized".to_string()));
+        }
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Stdio Client Transport
+// ============================================================================
+
+/// Client transport that communicates with a subprocess via stdio
+pub struct StdioClientTransport {
+    child: Option<Child>,
+    stdin: tokio::process::ChildStdin,
+    stdout: BufReader<tokio::process::ChildStdout>,
+    request_id: AtomicI64,
+}
+
+impl StdioClientTransport {
+    /// Spawn a new subprocess and connect to it
+    pub async fn spawn(program: &str, args: &[&str]) -> Result<Self> {
+        let mut cmd = Command::new(program);
+        cmd.args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let mut child = cmd
+            .spawn()
+            .map_err(|e| Error::Transport(format!("Failed to spawn {}: {}", program, e)))?;
+
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdout".to_string()))?;
+
+        tracing::info!(program = %program, "Spawned MCP server process");
+
+        Ok(Self {
+            child: Some(child),
+            stdin,
+            stdout: BufReader::new(stdout),
+            request_id: AtomicI64::new(1),
+        })
+    }
+
+    /// Create from an existing child process
+    pub fn from_child(mut child: Child) -> Result<Self> {
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdin".to_string()))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| Error::Transport("Failed to get child stdout".to_string()))?;
+
+        Ok(Self {
+            child: Some(child),
+            stdin,
+            stdout: BufReader::new(stdout),
+            request_id: AtomicI64::new(1),
+        })
+    }
+
+    async fn send_line(&mut self, line: &str) -> Result<()> {
+        self.stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write: {}", e)))?;
+        self.stdin
+            .write_all(b"\n")
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
+        self.stdin
+            .flush()
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to flush: {}", e)))?;
+        Ok(())
+    }
+
+    async fn read_line(&mut self) -> Result<String> {
+        let mut line = String::new();
+        self.stdout
+            .read_line(&mut line)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to read: {}", e)))?;
+
+        if line.is_empty() {
+            return Err(Error::Transport("Connection closed".to_string()));
+        }
+
+        Ok(line)
+    }
+}
+
+#[async_trait]
+impl ClientTransport for StdioClientTransport {
+    async fn request(
+        &mut self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let id = self.request_id.fetch_add(1, Ordering::Relaxed);
+        let request = JsonRpcRequest::new(id, method).with_params(params);
+
+        let request_json = serde_json::to_string(&request)
+            .map_err(|e| Error::Transport(format!("Failed to serialize: {}", e)))?;
+
+        tracing::debug!(method = %method, id = %id, "Sending request");
+        self.send_line(&request_json).await?;
+
+        let response_line = self.read_line().await?;
+        tracing::debug!(response = %response_line.trim(), "Received response");
+
+        let response: JsonRpcResponse = serde_json::from_str(response_line.trim())
+            .map_err(|e| Error::Transport(format!("Failed to parse response: {}", e)))?;
+
+        match response {
+            JsonRpcResponse::Result(r) => Ok(r.result),
+            JsonRpcResponse::Error(e) => Err(Error::JsonRpc(e.error)),
+        }
+    }
+
+    async fn notify(&mut self, method: &str, params: serde_json::Value) -> Result<()> {
+        let notification = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params
+        });
+
+        let json = serde_json::to_string(&notification)
+            .map_err(|e| Error::Transport(format!("Failed to serialize: {}", e)))?;
+
+        tracing::debug!(method = %method, "Sending notification");
+        self.send_line(&json).await
+    }
+
+    fn is_connected(&self) -> bool {
+        // Assume connected if we have a child process handle
+        self.child.is_some()
+    }
+
+    async fn close(mut self: Box<Self>) -> Result<()> {
+        // Close stdin to signal EOF
+        drop(self.stdin);
+
+        if let Some(mut child) = self.child.take() {
+            // Wait for process with timeout
+            let result =
+                tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await;
+
+            match result {
+                Ok(Ok(status)) => {
+                    tracing::info!(status = ?status, "Child process exited");
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(error = %e, "Error waiting for child");
+                }
+                Err(_) => {
+                    tracing::warn!("Timeout waiting for child, killing");
+                    let _ = child.kill().await;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_client_not_initialized() {
+        // Create a mock transport for testing
+        struct MockTransport;
+
+        #[async_trait]
+        impl ClientTransport for MockTransport {
+            async fn request(
+                &mut self,
+                _: &str,
+                _: serde_json::Value,
+            ) -> Result<serde_json::Value> {
+                Ok(serde_json::json!({}))
+            }
+            async fn notify(&mut self, _: &str, _: serde_json::Value) -> Result<()> {
+                Ok(())
+            }
+            fn is_connected(&self) -> bool {
+                true
+            }
+            async fn close(self: Box<Self>) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut client = McpClient::new(MockTransport);
+
+        // Should fail because not initialized
+        let result = client.list_tools().await;
+        assert!(result.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@
 //! ```
 
 pub mod async_task;
+pub mod client;
 pub mod context;
 pub mod error;
 pub mod jsonrpc;
@@ -56,6 +57,7 @@ pub mod transport;
 
 // Re-exports
 pub use async_task::{Task, TaskStore};
+pub use client::{ClientTransport, McpClient, StdioClientTransport};
 pub use context::{
     NotificationReceiver, NotificationSender, RequestContext, RequestContextBuilder,
     ServerNotification,

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -468,7 +468,7 @@ pub enum McpResponse {
 // Initialize
 // =============================================================================
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
     pub protocol_version: String,
@@ -476,7 +476,7 @@ pub struct InitializeParams {
     pub client_info: Implementation,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct ClientCapabilities {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub roots: Option<RootsCapability>,
@@ -500,7 +500,7 @@ pub struct Implementation {
     pub version: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InitializeResult {
     pub protocol_version: String,
@@ -512,28 +512,28 @@ pub struct InitializeResult {
     pub instructions: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerCapabilities {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tools: Option<ToolsCapability>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<ResourcesCapability>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompts: Option<PromptsCapability>,
     /// Logging capability - servers that emit log notifications declare this
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logging: Option<LoggingCapability>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tasks: Option<TasksCapability>,
 }
 
 /// Logging capability declaration
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct LoggingCapability {}
 
 /// Capability for async task management
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TasksCapability {
     /// Default poll interval suggestion in seconds
@@ -541,14 +541,14 @@ pub struct TasksCapability {
     pub default_poll_interval: Option<u64>,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolsCapability {
     #[serde(default)]
     pub list_changed: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourcesCapability {
     #[serde(default)]
@@ -557,7 +557,7 @@ pub struct ResourcesCapability {
     pub list_changed: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PromptsCapability {
     #[serde(default)]
@@ -568,17 +568,17 @@ pub struct PromptsCapability {
 // Tools
 // =============================================================================
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ListToolsParams {
     #[serde(default)]
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListToolsResult {
     pub tools: Vec<ToolDefinition>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
 
@@ -628,7 +628,7 @@ fn is_true(v: &bool) -> bool {
     *v
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CallToolParams {
     pub name: String,
     #[serde(default)]
@@ -638,13 +638,13 @@ pub struct CallToolParams {
     pub meta: Option<RequestMeta>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
     pub content: Vec<Content>,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_error: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub structured_content: Option<Value>,
 }
 
@@ -749,17 +749,17 @@ pub struct ResourceContent {
 // Resources
 // =============================================================================
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ListResourcesParams {
     #[serde(default)]
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListResourcesResult {
     pub resources: Vec<ResourceDefinition>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
 
@@ -774,12 +774,12 @@ pub struct ResourceDefinition {
     pub mime_type: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadResourceParams {
     pub uri: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadResourceResult {
     pub contents: Vec<ResourceContent>,
 }
@@ -847,17 +847,17 @@ pub struct ResourceTemplateDefinition {
 // Prompts
 // =============================================================================
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ListPromptsParams {
     #[serde(default)]
     pub cursor: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListPromptsResult {
     pub prompts: Vec<PromptDefinition>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
 }
 
@@ -879,16 +879,16 @@ pub struct PromptArgument {
     pub required: bool,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetPromptParams {
     pub name: String,
     #[serde(default)]
     pub arguments: std::collections::HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetPromptResult {
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub messages: Vec<PromptMessage>,
 }


### PR DESCRIPTION
## Summary
- Adds `McpClient` struct for connecting to MCP servers
- Implements `ClientTransport` trait for pluggable transports
- Provides `StdioClientTransport` for subprocess communication
- Adds client methods: `initialize`, `list_tools`, `call_tool`, `list_resources`, `read_resource`, `list_prompts`, `get_prompt`, `ping`
- Adds `Serialize`/`Deserialize` derives to protocol types for bidirectional communication

## Test plan
- [x] All 89 unit tests pass
- [x] All 29 integration tests pass
- [x] Clippy passes with no warnings
- [ ] Manual test with real MCP server (optional)

Closes #29