### PR TITLE
feat: add elicitation support for user input requests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,11 @@ pub use error::{Error, Result, ToolError};
 pub use jsonrpc::JsonRpcService;
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{
-    CallToolResult, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
-    JsonRpcResponseMessage, McpRequest, McpResponse, PromptMessage, PromptRole, ReadResourceResult,
-    ResourceContent,
+    CallToolResult, ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitFormSchema, ElicitMode,
+    ElicitRequestParams, ElicitResult, ElicitUrlParams, ElicitationCapability,
+    ElicitationCompleteParams, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+    JsonRpcResponseMessage, McpRequest, McpResponse, PrimitiveSchemaDefinition, PromptMessage,
+    PromptRole, ReadResourceResult, ResourceContent,
 };
 pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,

--- a/src/router.rs
+++ b/src/router.rs
@@ -888,6 +888,7 @@ mod tests {
                 capabilities: ClientCapabilities {
                     roots: None,
                     sampling: None,
+                    elicitation: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -1474,6 +1475,7 @@ mod tests {
                 capabilities: ClientCapabilities {
                     roots: None,
                     sampling: None,
+                    elicitation: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -1582,6 +1584,7 @@ mod tests {
                 capabilities: ClientCapabilities {
                     roots: None,
                     sampling: None,
+                    elicitation: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -1612,6 +1615,7 @@ mod tests {
                 capabilities: ClientCapabilities {
                     roots: None,
                     sampling: None,
+                    elicitation: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2099,6 +2103,7 @@ mod tests {
                 capabilities: ClientCapabilities {
                     roots: None,
                     sampling: None,
+                    elicitation: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),


### PR DESCRIPTION
## Summary
- Adds `ElicitFormParams` and `ElicitUrlParams` for server-to-client user input requests
- Implements `ElicitFormSchema` builder for structured form definitions with string, number, boolean, and enum fields
- Adds `PrimitiveSchemaDefinition` types for JSON Schema field definitions
- Adds `ElicitResult` with accept/decline/cancel actions and form content
- Implements `ElicitationCapability` for client capability negotiation (form and URL modes)
- Adds `ElicitationCompleteParams` for URL-based completion notification
- Exports all elicitation types from lib.rs

## Test plan
- [x] 100 unit tests pass (11 new elicitation tests)
- [x] 29 integration tests pass
- [x] Clippy passes with no warnings

Closes #61