### PR TITLE
docs: document safe synchronization patterns in transport layer

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -5,6 +5,32 @@
 //! - `http` - Streamable HTTP transport (requires `http` feature)
 //! - `websocket` - WebSocket transport for full-duplex communication (requires `websocket` feature)
 //! - `childproc` - Child process transport for subprocess MCP servers (requires `childproc` feature)
+//!
+//! ## Synchronization and Thread Safety
+//!
+//! All transports are designed to be safe for concurrent use:
+//!
+//! - **Session storage**: Uses `RwLock` for safe concurrent access
+//! - **SSE notifications**: Uses `broadcast` channels which deliver to all receivers
+//! - **Request IDs**: Uses `AtomicI64` for lock-free incrementing
+//!
+//! We deliberately avoid `tokio::sync::Notify` patterns that can miss signals
+//! if `notify_one()` is called before a task starts waiting. This prevents
+//! race conditions in serverless/Lambda cold-start scenarios.
+//!
+//! ## Serverless Considerations
+//!
+//! For serverless environments (AWS Lambda, Cloudflare Workers, etc.):
+//!
+//! - **HTTP transport**: Each request is handled independently; session state
+//!   is stored in memory and will be lost on cold starts. Consider using
+//!   external session storage for persistence across invocations.
+//!
+//! - **Stateless mode**: For truly stateless operation, see issue #51 which
+//!   tracks SEP-1442 (Make MCP Stateless) once the spec is finalized.
+//!
+//! - **Cold starts**: Our synchronization primitives don't have timing-dependent
+//!   race conditions, so cold starts should be reliable.
 
 pub mod stdio;
 


### PR DESCRIPTION
## Summary

After reviewing our transport implementations against rmcp issue #610 (race conditions in serverless/Lambda), I found that **tower-mcp is not affected** by these issues.

### Why we're safe

We use proper synchronization primitives that don't have timing-dependent race conditions:

| Pattern | rmcp (problematic) | tower-mcp (safe) |
|---------|-------------------|------------------|
| Session storage | Notify | RwLock |
| Event delivery | Notify (can miss) | broadcast (delivers to all) |
| Request IDs | - | AtomicI64 (lock-free) |

The problematic pattern in rmcp was using `tokio::sync::Notify` which can miss signals if `notify_one()` is called before a task starts waiting. We don't use this pattern.

### Changes

Added documentation to `src/transport/mod.rs` explaining:
- Our synchronization approach and why it's safe
- Serverless considerations (session state in memory)
- Reference to #51 for stateless mode (SEP-1442)

## Test plan
- [x] 108 unit tests pass
- [x] 29 integration tests pass
- [x] Clippy passes

Closes #47