### PR TITLE
feat: add roots/discovery support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,9 @@ pub use protocol::{
     CallToolResult, ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitFormSchema, ElicitMode,
     ElicitRequestParams, ElicitResult, ElicitUrlParams, ElicitationCapability,
     ElicitationCompleteParams, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
-    JsonRpcResponseMessage, McpRequest, McpResponse, PrimitiveSchemaDefinition, PromptMessage,
-    PromptRole, ReadResourceResult, ResourceContent,
+    JsonRpcResponseMessage, ListRootsParams, ListRootsResult, McpRequest, McpResponse,
+    PrimitiveSchemaDefinition, PromptMessage, PromptRole, ReadResourceResult, ResourceContent,
+    Root, RootsCapability,
 };
 pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,

--- a/src/router.rs
+++ b/src/router.rs
@@ -784,6 +784,11 @@ impl McpRouter {
                 );
                 // Progress notifications from client are unusual but valid
             }
+            McpNotification::RootsListChanged => {
+                tracing::info!("Client roots list changed");
+                // Server should re-request roots if needed
+                // This is handled by the application layer
+            }
             McpNotification::Unknown { method, .. } => {
                 tracing::debug!(method = %method, "Unknown notification received");
             }


### PR DESCRIPTION
## Summary

Add support for MCP roots, allowing clients to expose filesystem roots to servers for scoped file access and workspace awareness.

### Protocol types
- `Root` type with `uri` (required) and `name` (optional)
- `ListRootsParams` and `ListRootsResult` for `roots/list` request
- `RootsCapability` with `list_changed` flag
- `ROOTS_LIST_CHANGED` notification constant
- `RootsListChanged` variant in `McpNotification` enum

### Client support
- `McpClient::with_roots()` to create client with roots capability
- `McpClient::with_capabilities()` for custom capability configuration
- `set_roots()`, `add_root()`, `remove_root()` methods with auto-notification
- `list_roots()` method for responding to server's `roots/list` request

## Test plan
- [x] Root type serialization/deserialization tests
- [x] ListRootsResult serialization test
- [x] RootsCapability serialization test
- [x] ClientCapabilities with roots test
- [x] RootsListChanged notification parsing test
- [x] All existing tests pass (117 total)

Closes #34