### PR TITLE
feat: add completion and sampling support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,12 +67,15 @@ pub use error::{Error, Result, ToolError};
 pub use jsonrpc::JsonRpcService;
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{
-    CallToolResult, ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitFormSchema, ElicitMode,
-    ElicitRequestParams, ElicitResult, ElicitUrlParams, ElicitationCapability,
-    ElicitationCompleteParams, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
-    JsonRpcResponseMessage, ListRootsParams, ListRootsResult, McpRequest, McpResponse,
-    PrimitiveSchemaDefinition, PromptMessage, PromptRole, ReadResourceResult, ResourceContent,
-    Root, RootsCapability,
+    CallToolResult, CompleteParams, CompleteResult, Completion, CompletionArgument,
+    CompletionReference, CompletionsCapability, ContentRole, CreateMessageParams,
+    CreateMessageResult, ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitFormSchema,
+    ElicitMode, ElicitRequestParams, ElicitResult, ElicitUrlParams, ElicitationCapability,
+    ElicitationCompleteParams, GetPromptResult, IncludeContext, JsonRpcMessage, JsonRpcRequest,
+    JsonRpcResponse, JsonRpcResponseMessage, ListRootsParams, ListRootsResult, McpRequest,
+    McpResponse, ModelHint, ModelPreferences, PrimitiveSchemaDefinition, PromptMessage,
+    PromptReference, PromptRole, ReadResourceResult, ResourceContent, ResourceReference, Root,
+    RootsCapability, SamplingCapability, SamplingContent, SamplingMessage,
 };
 pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,

--- a/src/router.rs
+++ b/src/router.rs
@@ -419,6 +419,8 @@ impl McpRouter {
             },
             // Tasks capability is always available
             tasks: Some(TasksCapability::default()),
+            // Completions: for now always None, completion handlers to be added
+            completions: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Add completion and sampling types for MCP protocol.

### Completion (server provides autocomplete suggestions)
- `PromptReference` and `ResourceReference` types
- `CompletionReference` enum (tagged union by `type` field)
- `CompletionArgument` for the value being completed
- `CompleteParams` and `CompleteResult` types
- `Completion` type with pagination support (`total`, `hasMore`)
- `CompletionsCapability` added to `ServerCapabilities`

### Sampling (server requests LLM completions from client)
- `SamplingMessage` with `user()` and `assistant()` constructors
- `SamplingContent` enum (text, image, audio)
- `ModelHint` and `ModelPreferences` with builder pattern
- `IncludeContext` enum (allServers, thisServer, none)
- `CreateMessageParams` with builder methods for optional fields
- `CreateMessageResult` for LLM responses

### Client methods
- `complete()` for raw completion requests
- `complete_prompt_arg()` for prompt argument completion
- `complete_resource_uri()` for resource URI completion

## Test plan
- [x] PromptReference serialization test
- [x] ResourceReference serialization test
- [x] CompletionReference prompt/resource tests
- [x] CompletionArgument test
- [x] CompleteParams serialization test
- [x] Completion with/without pagination tests
- [x] CompleteResult test
- [x] ModelHint test
- [x] ModelPreferences builder and clamping tests
- [x] IncludeContext serialization test
- [x] SamplingMessage user/assistant tests
- [x] SamplingContent text/image serialization tests
- [x] CreateMessageParams builder and serialization tests
- [x] CreateMessageResult deserialization test
- [x] CompletionsCapability and ServerCapabilities tests
- [x] All 139 tests pass

Closes #36