### PR TITLE
feat: add sampling support for WebSocket transport

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -8,7 +8,7 @@
 //! ## API Key Authentication
 //!
 //! ```rust,no_run
-//! use tower_mcp::auth::{ApiKeyLayer, ApiKeyValidator};
+//! use tower_mcp::auth::{AuthConfig, ApiKeyValidator};
 //! use tower_mcp::{McpRouter, HttpTransport};
 //! use std::sync::Arc;
 //!
@@ -19,7 +19,7 @@
 //! let router = McpRouter::new().server_info("my-server", "1.0.0");
 //! let transport = HttpTransport::new(router);
 //!
-//! // The ApiKeyLayer extracts the key from the Authorization header
+//! // The auth layer extracts the key from the Authorization header
 //! // and validates it using the provided validator
 //! ```
 //!

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -283,7 +283,7 @@ struct PendingRequest {
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let tool = ToolBuilder::new("ai-tool")
 ///         .description("A tool that uses LLM")
-///         .context_handler(|ctx: RequestContext, input: serde_json::Value| async move {
+///         .handler_with_context(|ctx: RequestContext, input: serde_json::Value| async move {
 ///             // Request LLM completion from the client
 ///             let params = CreateMessageParams::new(
 ///                 vec![SamplingMessage::user("Help me with: ...")],

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -4,6 +4,7 @@
 //! - Bidirectional notifications
 //! - Long-lived connections
 //! - Lower latency than HTTP polling
+//! - Server-to-client requests (sampling)
 //!
 //! # Example
 //!
@@ -31,6 +32,40 @@
 //!     Ok(())
 //! }
 //! ```
+//!
+//! # Sampling Support
+//!
+//! The WebSocket transport supports server-to-client requests like sampling.
+//! Use [`WebSocketTransport::with_sampling`] to enable this feature:
+//!
+//! ```rust,no_run
+//! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult, CreateMessageParams, SamplingMessage};
+//! use tower_mcp::context::RequestContext;
+//! use tower_mcp::transport::websocket::WebSocketTransport;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let tool = ToolBuilder::new("ai-tool")
+//!         .handler_with_context(|ctx: RequestContext, _: serde_json::Value| async move {
+//!             // Request LLM completion from client
+//!             let params = CreateMessageParams::new(
+//!                 vec![SamplingMessage::user("Summarize this...")],
+//!                 500,
+//!             );
+//!             let result = ctx.sample(params).await?;
+//!             Ok(CallToolResult::text(format!("{:?}", result.content)))
+//!         })
+//!         .build()?;
+//!
+//!     let router = McpRouter::new()
+//!         .server_info("my-server", "1.0.0")
+//!         .tool(tool);
+//!
+//!     let transport = WebSocketTransport::with_sampling(router);
+//!     transport.serve("127.0.0.1:3000").await?;
+//!     Ok(())
+//! }
+//! ```
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -45,11 +80,18 @@ use axum::{
     routing::get,
 };
 use futures::{SinkExt, StreamExt};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
+use crate::context::{
+    ChannelClientRequester, ClientRequesterHandle, OutgoingRequest, OutgoingRequestReceiver,
+    OutgoingRequestSender, outgoing_request_channel,
+};
 use crate::error::{Error, JsonRpcError, Result};
 use crate::jsonrpc::JsonRpcService;
-use crate::protocol::{JsonRpcMessage, JsonRpcNotification, JsonRpcResponse, McpNotification};
+use crate::protocol::{
+    JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, McpNotification,
+    RequestId,
+};
 use crate::router::McpRouter;
 
 /// Session state for WebSocket transport
@@ -97,10 +139,17 @@ impl SessionStore {
     }
 }
 
+/// Pending request waiting for a response
+struct PendingRequest {
+    response_tx: tokio::sync::oneshot::Sender<Result<serde_json::Value>>,
+}
+
 /// Shared state for WebSocket transport
 struct AppState {
     router_template: McpRouter,
     sessions: SessionStore,
+    /// Whether sampling is enabled
+    sampling_enabled: bool,
 }
 
 /// WebSocket transport for MCP servers
@@ -108,12 +157,27 @@ struct AppState {
 /// Provides full-duplex communication over WebSocket.
 pub struct WebSocketTransport {
     router: McpRouter,
+    sampling_enabled: bool,
 }
 
 impl WebSocketTransport {
     /// Create a new WebSocket transport
     pub fn new(router: McpRouter) -> Self {
-        Self { router }
+        Self {
+            router,
+            sampling_enabled: false,
+        }
+    }
+
+    /// Create a new WebSocket transport with sampling support enabled
+    ///
+    /// When sampling is enabled, tool handlers can use `ctx.sample()` to
+    /// request LLM completions from connected clients.
+    pub fn with_sampling(router: McpRouter) -> Self {
+        Self {
+            router,
+            sampling_enabled: true,
+        }
     }
 
     /// Build the axum router for this transport
@@ -121,6 +185,7 @@ impl WebSocketTransport {
         let state = Arc::new(AppState {
             router_template: self.router,
             sessions: SessionStore::new(),
+            sampling_enabled: self.sampling_enabled,
         });
 
         Router::new()
@@ -133,6 +198,7 @@ impl WebSocketTransport {
         let state = Arc::new(AppState {
             router_template: self.router,
             sessions: SessionStore::new(),
+            sampling_enabled: self.sampling_enabled,
         });
 
         let ws_router = Router::new()
@@ -171,6 +237,19 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
 
     tracing::info!(session_id = %session_id, "WebSocket connection established");
 
+    if state.sampling_enabled {
+        handle_socket_bidirectional(socket, session, &session_id).await;
+    } else {
+        handle_socket_simple(socket, session, &session_id).await;
+    }
+
+    // Cleanup session
+    state.sessions.remove(&session_id).await;
+    tracing::info!(session_id = %session_id, "WebSocket connection closed");
+}
+
+/// Handle WebSocket connection without sampling (simple mode)
+async fn handle_socket_simple(socket: WebSocket, session: Arc<Session>, session_id: &str) {
     let mut service = JsonRpcService::new(session.router.clone());
     let (mut sender, mut receiver) = socket.split();
 
@@ -247,10 +326,259 @@ async fn handle_socket(socket: WebSocket, state: Arc<AppState>) {
             }
         }
     }
+}
 
-    // Cleanup session
-    state.sessions.remove(&session_id).await;
-    tracing::info!(session_id = %session_id, "WebSocket connection closed");
+/// Handle WebSocket connection with sampling support (bidirectional mode)
+async fn handle_socket_bidirectional(socket: WebSocket, session: Arc<Session>, session_id: &str) {
+    // Create channels for outgoing requests
+    let (request_tx, mut request_rx): (OutgoingRequestSender, OutgoingRequestReceiver) =
+        outgoing_request_channel(32);
+
+    // Create client requester for the router
+    let client_requester: ClientRequesterHandle = Arc::new(ChannelClientRequester::new(request_tx));
+
+    // Clone router and configure with client requester
+    let router = session
+        .router
+        .clone()
+        .with_client_requester(client_requester);
+    let mut service = JsonRpcService::new(router.clone());
+
+    // Track pending outgoing requests
+    let pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+
+    let (sender, mut receiver) = socket.split();
+    let sender = Arc::new(Mutex::new(sender));
+
+    let session_id_owned = session_id.to_string();
+
+    loop {
+        tokio::select! {
+            // Handle incoming messages from client
+            msg = receiver.next() => {
+                let msg = match msg {
+                    Some(Ok(m)) => m,
+                    Some(Err(e)) => {
+                        tracing::error!(error = %e, "WebSocket receive error");
+                        break;
+                    }
+                    None => break,
+                };
+
+                match msg {
+                    Message::Text(text) => {
+                        let result = handle_incoming_message(
+                            &text,
+                            &mut service,
+                            &router,
+                            pending_requests.clone(),
+                            sender.clone(),
+                        ).await;
+                        if let Err(e) = result {
+                            tracing::error!(error = %e, "Error handling incoming message");
+                        }
+                    }
+                    Message::Binary(data) => {
+                        if let Ok(text) = String::from_utf8(data.to_vec()) {
+                            let result = handle_incoming_message(
+                                &text,
+                                &mut service,
+                                &router,
+                                pending_requests.clone(),
+                                sender.clone(),
+                            ).await;
+                            if let Err(e) = result {
+                                tracing::error!(error = %e, "Error handling binary message");
+                            }
+                        }
+                    }
+                    Message::Ping(data) => {
+                        let mut sender = sender.lock().await;
+                        if let Err(e) = sender.send(Message::Pong(data)).await {
+                            tracing::error!(error = %e, "Failed to send pong");
+                            break;
+                        }
+                    }
+                    Message::Pong(_) => {}
+                    Message::Close(_) => {
+                        tracing::info!(session_id = %session_id_owned, "WebSocket close received");
+                        break;
+                    }
+                }
+            }
+
+            // Handle outgoing requests to send to client
+            Some(outgoing) = request_rx.recv() => {
+                let result = send_outgoing_request(
+                    outgoing,
+                    pending_requests.clone(),
+                    sender.clone(),
+                ).await;
+                if let Err(e) = result {
+                    tracing::error!(error = %e, "Error sending outgoing request");
+                }
+            }
+        }
+    }
+}
+
+/// Handle an incoming WebSocket message (bidirectional mode)
+async fn handle_incoming_message<S>(
+    text: &str,
+    service: &mut JsonRpcService<McpRouter>,
+    router: &McpRouter,
+    pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
+    sender: Arc<Mutex<S>>,
+) -> Result<()>
+where
+    S: futures::Sink<Message> + Unpin,
+    S::Error: std::fmt::Display,
+{
+    let parsed: serde_json::Value = serde_json::from_str(text)?;
+
+    // Check if this is a response to one of our pending requests
+    if parsed.get("method").is_none()
+        && (parsed.get("result").is_some() || parsed.get("error").is_some())
+    {
+        return handle_response(&parsed, pending_requests).await;
+    }
+
+    // Check if it's a notification (no id field)
+    if parsed.get("id").is_none() {
+        if let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text) {
+            let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
+            router.handle_notification(mcp_notification);
+        }
+        return Ok(());
+    }
+
+    // Process as a request
+    let message: JsonRpcMessage = serde_json::from_str(text)?;
+    match service.call_message(message).await {
+        Ok(response) => {
+            let response_json = serde_json::to_string(&response)
+                .map_err(|e| Error::Transport(format!("Failed to serialize response: {}", e)))?;
+            let mut sender = sender.lock().await;
+            sender
+                .send(Message::Text(response_json.into()))
+                .await
+                .map_err(|e| Error::Transport(format!("Failed to send response: {}", e)))?;
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Error processing message");
+            let error_response =
+                JsonRpcResponse::error(None, JsonRpcError::internal_error(e.to_string()));
+            if let Ok(json) = serde_json::to_string(&error_response) {
+                let mut sender = sender.lock().await;
+                let _ = sender.send(Message::Text(json.into())).await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle a response to one of our pending requests
+async fn handle_response(
+    parsed: &serde_json::Value,
+    pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
+) -> Result<()> {
+    let id = match parsed.get("id") {
+        Some(id) => {
+            if let Some(n) = id.as_i64() {
+                RequestId::Number(n)
+            } else if let Some(s) = id.as_str() {
+                RequestId::String(s.to_string())
+            } else {
+                tracing::warn!("Response has invalid id type");
+                return Ok(());
+            }
+        }
+        None => {
+            tracing::warn!("Response missing id field");
+            return Ok(());
+        }
+    };
+
+    let pending = {
+        let mut pending_requests = pending_requests.lock().await;
+        pending_requests.remove(&id)
+    };
+
+    match pending {
+        Some(pending) => {
+            let result = if let Some(error) = parsed.get("error") {
+                let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(-1);
+                let message = error
+                    .get("message")
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("Unknown error");
+                Err(Error::Internal(format!(
+                    "Client error ({}): {}",
+                    code, message
+                )))
+            } else if let Some(result) = parsed.get("result") {
+                Ok(result.clone())
+            } else {
+                Err(Error::Internal(
+                    "Response has neither result nor error".to_string(),
+                ))
+            };
+
+            // Send result to waiter (ignore if they've dropped the receiver)
+            let _ = pending.response_tx.send(result);
+        }
+        None => {
+            tracing::warn!(id = ?id, "Received response for unknown request");
+        }
+    }
+
+    Ok(())
+}
+
+/// Send an outgoing request to the client
+async fn send_outgoing_request<S>(
+    outgoing: OutgoingRequest,
+    pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
+    sender: Arc<Mutex<S>>,
+) -> Result<()>
+where
+    S: futures::Sink<Message> + Unpin,
+    S::Error: std::fmt::Display,
+{
+    // Build JSON-RPC request
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0".to_string(),
+        id: outgoing.id.clone(),
+        method: outgoing.method,
+        params: Some(outgoing.params),
+    };
+
+    let request_json = serde_json::to_string(&request)
+        .map_err(|e| Error::Transport(format!("Failed to serialize request: {}", e)))?;
+
+    tracing::debug!(output = %request_json, "Sending request to client");
+
+    // Store pending request
+    {
+        let mut pending = pending_requests.lock().await;
+        pending.insert(
+            outgoing.id,
+            PendingRequest {
+                response_tx: outgoing.response_tx,
+            },
+        );
+    }
+
+    // Send the request
+    let mut sender = sender.lock().await;
+    sender
+        .send(Message::Text(request_json.into()))
+        .await
+        .map_err(|e| Error::Transport(format!("Failed to send request: {}", e)))?;
+
+    Ok(())
 }
 
 /// Process a JSON-RPC message


### PR DESCRIPTION
## Summary

- Adds `with_client_requester()` method to `McpRouter` for configuring server-to-client request capability
- Updates `create_context()` to include client requester in `RequestContext`, enabling sampling in tool handlers
- Implements bidirectional WebSocket handling with `handle_socket_bidirectional()` 
- Tracks pending outgoing requests and matches responses by ID
- Uses `tokio::select!` for concurrent handling of incoming messages and outgoing requests

## Usage

```rust
let transport = WebSocketTransport::with_sampling(router);
transport.serve("127.0.0.1:3000").await?;
```

Tool handlers can then use `ctx.sample()` to request LLM completions from connected clients.

## Test plan

- [x] All existing tests pass
- [x] Clippy clean
- [x] Documentation examples compile

Closes #73