### PR TITLE
feat: add sampling support for HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This means:
 - **Request cancellation**: Via `CancellationToken` in tool handlers
 - **Completion**: Autocomplete for prompt arguments and resource URIs
 - **Sampling types**: `CreateMessageParams`/`CreateMessageResult` for LLM requests
-- **Sampling runtime**: Via `BidirectionalStdioTransport` for stdio (WebSocket/HTTP coming soon)
+- **Sampling runtime**: Full support on stdio, WebSocket, and HTTP transports
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Implements MCP-spec-compliant server-to-client requests (sampling) over HTTP/SSE:

- Server sends sampling requests on the SSE stream
- Client receives them and responds via POST to the MCP endpoint
- Server routes responses back to waiting tool handlers

This follows the MCP spec which states:
> "The server MAY send JSON-RPC requests and notifications before sending the JSON-RPC response."

## Changes

- Add `HttpTransport::with_sampling()` constructor
- Add `PendingRequest` tracking per session
- Configure router with `ClientRequester` when sampling enabled
- Send outgoing requests on SSE stream via `handle_get_bidirectional()`
- Accept and route responses in `handle_post()` (detect response vs request)
- Update README to reflect full sampling support on all transports

## Usage

```rust
let transport = HttpTransport::with_sampling(router);
transport.serve("127.0.0.1:3000").await?;
```

Tool handlers can then use `ctx.sample()` to request LLM completions from connected clients.

## Test plan

- [x] All existing tests pass
- [x] Clippy clean
- [x] Documentation examples compile

Closes #74