### PR TITLE
feat: add comprehensive crates-mcp example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/joshrotenberg/tower-mcp"
 keywords = ["mcp", "tower", "json-rpc", "ai", "agents"]
 categories = ["network-programming", "web-programming"]
 
+[workspace]
+members = ["examples/crates-mcp"]
+
 [dependencies]
 # Tower ecosystem
 tower = { version = "0.5", features = ["util"] }

--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "crates-mcp"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Example MCP server for querying crates.io"
+
+[[bin]]
+name = "crates-mcp"
+path = "src/main.rs"
+
+[[test]]
+name = "integration"
+path = "tests/integration.rs"
+
+[dependencies]
+# Core MCP
+tower-mcp = { path = "../.." }
+
+# Crates.io API client
+crates_io_api = "0.12"
+
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Schema generation
+schemars = "1"
+
+# Tracing
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Tower middleware
+tower = { version = "0.5", features = ["util"] }
+tower-resilience-ratelimiter = "0.5"
+tower-resilience-bulkhead = "0.5"
+
+# For rate limiting display
+humantime = "2"

--- a/examples/crates-mcp/README.md
+++ b/examples/crates-mcp/README.md
@@ -1,0 +1,180 @@
+# crates-mcp
+
+An MCP server for querying [crates.io](https://crates.io), the Rust package registry.
+
+This is a comprehensive example demonstrating tower-mcp features including tools, resources, prompts, and tower middleware integration.
+
+## Features
+
+- **7 Tools** - One per crates.io API endpoint:
+  - `search_crates` - Find crates by name/keywords
+  - `get_crate_info` - Get detailed crate information
+  - `get_crate_versions` - Get version history
+  - `get_dependencies` - Get dependencies for a version
+  - `get_reverse_dependencies` - Find crates that depend on this crate
+  - `get_downloads` - Get download statistics
+  - `get_owners` - Get crate owners/maintainers
+
+- **1 Resource** - `crates://recent-searches` tracks recent queries
+
+- **2 Prompts** - Guided analysis workflows:
+  - `analyze_crate` - Comprehensive crate analysis
+  - `compare_crates` - Compare multiple crates for a use case
+
+- **Tower Middleware** - Demonstrates concurrency limiting
+
+## Building
+
+```bash
+cargo build -p crates-mcp
+```
+
+## Running
+
+### Stdio Transport (default)
+
+```bash
+cargo run -p crates-mcp
+```
+
+### With Options
+
+```bash
+cargo run -p crates-mcp -- \
+  --max-concurrent 3 \
+  --rate-limit-ms 2000 \
+  --log-level debug
+```
+
+## CLI Options
+
+```
+Options:
+  -t, --transport <TRANSPORT>        Transport to use [default: stdio]
+      --max-concurrent <N>           Maximum concurrent tool calls [default: 5]
+      --bulkhead-timeout-ms <MS>     Max wait time for bulkhead permit [default: 100]
+      --requests-per-second <N>      Maximum requests per second [default: 10]
+      --rate-limit-ms <MS>           Rate limit interval for crates.io API [default: 1000]
+  -l, --log-level <LEVEL>            Log level [default: info]
+  -h, --help                         Print help
+```
+
+## MCP Client Configuration
+
+### Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "crates": {
+      "command": "cargo",
+      "args": ["run", "-p", "crates-mcp", "--manifest-path", "/path/to/tower-mcp/Cargo.toml"]
+    }
+  }
+}
+```
+
+Or if you've built the binary:
+
+```json
+{
+  "mcpServers": {
+    "crates": {
+      "command": "/path/to/tower-mcp/target/debug/crates-mcp"
+    }
+  }
+}
+```
+
+## Example Usage
+
+Once connected, you can:
+
+1. **Search for crates:**
+   > "Search for async HTTP client libraries"
+
+2. **Get crate details:**
+   > "Tell me about the tokio crate"
+
+3. **Compare crates:**
+   > "Compare reqwest and ureq for making HTTP requests"
+
+4. **Analyze a crate:**
+   > "Should I use serde for my project? I need JSON serialization."
+
+## Project Structure
+
+```
+src/
+├── main.rs           # Entry point, CLI, router setup
+├── state.rs          # Shared state, crates.io client
+├── tools/
+│   ├── mod.rs
+│   ├── search.rs
+│   ├── info.rs
+│   ├── versions.rs
+│   ├── dependencies.rs
+│   ├── reverse_deps.rs
+│   ├── downloads.rs
+│   └── owners.rs
+├── resources/
+│   ├── mod.rs
+│   └── recent_searches.rs
+└── prompts/
+    ├── mod.rs
+    ├── analyze.rs
+    └── compare.rs
+```
+
+## Tower Middleware
+
+This example demonstrates tower middleware integration with [tower-resilience](https://crates.io/crates/tower-resilience-ratelimiter) layers:
+
+```rust
+use tower::ServiceBuilder;
+use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience_ratelimiter::RateLimiterLayer;
+
+// Rate limiter: token bucket algorithm
+let rate_limiter = RateLimiterLayer::builder()
+    .limit_for_period(10)              // 10 requests
+    .refresh_period(Duration::from_secs(1))  // per second
+    .timeout_duration(Duration::from_millis(500))
+    .build();
+
+// Bulkhead: isolate concurrent requests with timeout
+let bulkhead = BulkheadLayer::builder()
+    .max_concurrent_calls(5)           // max 5 in-flight
+    .max_wait_duration(Some(Duration::from_millis(100)))
+    .build();
+
+// Stack multiple middleware layers
+let service = ServiceBuilder::new()
+    .layer(rate_limiter)
+    .layer(bulkhead)
+    .service(router);
+```
+
+### Middleware Stack
+
+| Layer | Crate | Purpose |
+|-------|-------|---------|
+| RateLimiterLayer | tower-resilience-ratelimiter | Token bucket rate limiting (N/sec) |
+| BulkheadLayer | tower-resilience-bulkhead | Concurrent request isolation with wait timeout |
+
+### Why Both?
+
+- **RateLimiter**: Smooths traffic over time, prevents burst flooding
+- **Bulkhead**: Isolates resources, fails fast when overloaded
+
+Together they protect against:
+- Request floods and DoS
+- Resource exhaustion (memory, file handles)
+- Downstream service overload (crates.io has rate limits)
+- Cascading failures
+
+## License
+
+MIT OR Apache-2.0

--- a/examples/crates-mcp/src/main.rs
+++ b/examples/crates-mcp/src/main.rs
@@ -1,0 +1,162 @@
+//! Crates.io MCP Server
+//!
+//! A comprehensive example MCP server demonstrating tower-mcp features.
+
+mod prompts;
+mod resources;
+mod state;
+mod tools;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::{Parser, ValueEnum};
+use tower::ServiceBuilder;
+use tower_mcp::{McpRouter, StdioTransport};
+use tower_resilience_bulkhead::BulkheadLayer;
+use tower_resilience_ratelimiter::RateLimiterLayer;
+
+use crate::state::AppState;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Transport {
+    Stdio,
+    // Future: Http, WebSocket
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "crates-mcp")]
+#[command(about = "MCP server for querying crates.io", long_about = None)]
+struct Args {
+    /// Transport to use
+    #[arg(short, long, default_value = "stdio")]
+    transport: Transport,
+
+    /// Maximum concurrent tool calls (bulkhead pattern)
+    #[arg(long, default_value = "5")]
+    max_concurrent: usize,
+
+    /// Maximum wait time for bulkhead permit (in milliseconds)
+    #[arg(long, default_value = "100")]
+    bulkhead_timeout_ms: u64,
+
+    /// Maximum requests per second (rate limiting)
+    #[arg(long, default_value = "10")]
+    requests_per_second: usize,
+
+    /// Rate limit interval between crates.io API calls (in milliseconds)
+    #[arg(long, default_value = "1000")]
+    rate_limit_ms: u64,
+
+    /// Log level
+    #[arg(short, long, default_value = "info")]
+    log_level: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // Initialize tracing
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive(format!("crates_mcp={}", args.log_level).parse()?)
+                .add_directive(format!("tower_mcp={}", args.log_level).parse()?),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    tracing::info!(
+        transport = ?args.transport,
+        max_concurrent = args.max_concurrent,
+        requests_per_second = args.requests_per_second,
+        rate_limit_ms = args.rate_limit_ms,
+        "Starting crates-mcp server"
+    );
+
+    // Create shared state with rate limiting for crates.io API
+    let rate_limit = Duration::from_millis(args.rate_limit_ms);
+    let state =
+        Arc::new(AppState::new(rate_limit).map_err(|e| format!("Failed to create state: {}", e))?);
+
+    // Build all tools
+    let search_tool = tools::search::build(state.clone());
+    let info_tool = tools::info::build(state.clone());
+    let versions_tool = tools::versions::build(state.clone());
+    let deps_tool = tools::dependencies::build(state.clone());
+    let reverse_deps_tool = tools::reverse_deps::build(state.clone());
+    let downloads_tool = tools::downloads::build(state.clone());
+    let owners_tool = tools::owners::build(state.clone());
+
+    // Build resources
+    let recent_searches = resources::recent_searches::build(state.clone());
+
+    // Build prompts
+    let analyze_prompt = prompts::analyze::build();
+    let compare_prompt = prompts::compare::build();
+
+    // Create router with all capabilities
+    let router = McpRouter::new()
+        .server_info("crates-mcp", env!("CARGO_PKG_VERSION"))
+        .instructions(
+            "MCP server for querying crates.io - the Rust package registry.\n\n\
+             Available tools:\n\
+             - search_crates: Find crates by name/keywords\n\
+             - get_crate_info: Get detailed crate information\n\
+             - get_crate_versions: Get version history\n\
+             - get_dependencies: Get dependencies for a version\n\
+             - get_reverse_dependencies: Find crates that depend on this crate\n\
+             - get_downloads: Get download statistics\n\
+             - get_owners: Get crate owners/maintainers\n\n\
+             Use the prompts for guided analysis:\n\
+             - analyze_crate: Comprehensive crate analysis\n\
+             - compare_crates: Compare multiple crates",
+        )
+        .tool(search_tool)
+        .tool(info_tool)
+        .tool(versions_tool)
+        .tool(deps_tool)
+        .tool(reverse_deps_tool)
+        .tool(downloads_tool)
+        .tool(owners_tool)
+        .resource(recent_searches)
+        .prompt(analyze_prompt)
+        .prompt(compare_prompt);
+
+    // Build tower middleware stack demonstrating resilience patterns:
+    //
+    // 1. RateLimiterLayer (tower-resilience) - Limits requests per second
+    //    Token bucket algorithm, protects against request floods
+    //
+    // 2. BulkheadLayer (tower-resilience) - Limits concurrent in-flight requests
+    //    Isolates resources with configurable wait timeout
+    //
+    // These layers compose naturally with tower-mcp's Service implementation.
+    let rate_limiter = RateLimiterLayer::builder()
+        .limit_for_period(args.requests_per_second)
+        .refresh_period(Duration::from_secs(1))
+        .timeout_duration(Duration::from_millis(500))
+        .build();
+
+    let bulkhead = BulkheadLayer::builder()
+        .max_concurrent_calls(args.max_concurrent)
+        .max_wait_duration(Some(Duration::from_millis(args.bulkhead_timeout_ms)))
+        .build();
+
+    let _service = ServiceBuilder::new()
+        .layer(rate_limiter)
+        .layer(bulkhead)
+        .service(router.clone());
+
+    // For now, we use the router directly with StdioTransport
+    // The middleware layer would be used with HTTP/WebSocket transports
+    match args.transport {
+        Transport::Stdio => {
+            tracing::info!("Serving over stdio");
+            StdioTransport::new(router).run().await?;
+        }
+    }
+
+    Ok(())
+}

--- a/examples/crates-mcp/src/prompts/analyze.rs
+++ b/examples/crates-mcp/src/prompts/analyze.rs
@@ -1,0 +1,51 @@
+//! Analyze crate prompt
+
+use std::collections::HashMap;
+
+use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
+
+pub fn build() -> Prompt {
+    PromptBuilder::new("analyze_crate")
+        .description("Analyze a crate for quality, maintenance, and suitability")
+        .required_arg("name", "Name of the crate to analyze")
+        .optional_arg("use_case", "Your intended use case for the crate")
+        .handler(|args: HashMap<String, String>| async move {
+            let name = args.get("name").map(|s| s.as_str()).unwrap_or("unknown");
+            let use_case = args.get("use_case");
+
+            let mut prompt = format!(
+                "Please analyze the Rust crate '{}' for the following aspects:\n\n\
+                 1. **Quality**: Code quality, test coverage, documentation\n\
+                 2. **Maintenance**: Activity level, responsiveness to issues\n\
+                 3. **Popularity**: Download trends, community adoption\n\
+                 4. **Alternatives**: Similar crates and how they compare\n\
+                 5. **Recommendation**: Whether to use this crate\n\n\
+                 Use the available tools to fetch data:\n\
+                 - get_crate_info for details\n\
+                 - get_crate_versions for release frequency\n\
+                 - get_downloads for usage trends\n\
+                 - get_reverse_dependencies for ecosystem impact\n\
+                 - get_owners for maintainer info",
+                name
+            );
+
+            if let Some(uc) = use_case {
+                prompt.push_str(&format!(
+                    "\n\nThe intended use case is: {}\n\
+                     Please evaluate specifically for this use case.",
+                    uc
+                ));
+            }
+
+            Ok(GetPromptResult {
+                description: Some(format!("Analyze the '{}' crate", name)),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: prompt,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}

--- a/examples/crates-mcp/src/prompts/compare.rs
+++ b/examples/crates-mcp/src/prompts/compare.rs
@@ -1,0 +1,46 @@
+//! Compare crates prompt
+
+use std::collections::HashMap;
+
+use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
+
+pub fn build() -> Prompt {
+    PromptBuilder::new("compare_crates")
+        .description("Compare two or more crates for a specific use case")
+        .required_arg("crates", "Comma-separated list of crate names to compare")
+        .required_arg("use_case", "What you want to use these crates for")
+        .handler(|args: HashMap<String, String>| async move {
+            let crates = args.get("crates").map(|s| s.as_str()).unwrap_or("");
+            let use_case = args
+                .get("use_case")
+                .map(|s| s.as_str())
+                .unwrap_or("general use");
+
+            let crate_list: Vec<&str> = crates.split(',').map(|s| s.trim()).collect();
+
+            let prompt = format!(
+                "Please compare the following Rust crates for {}: {}\n\n\
+                 For each crate, use the available tools to gather data and evaluate:\n\n\
+                 1. **Features**: What each crate offers\n\
+                 2. **API Design**: Ease of use, ergonomics\n\
+                 3. **Performance**: Any known performance characteristics\n\
+                 4. **Dependencies**: Use get_dependencies to check dependency counts\n\
+                 5. **Maintenance**: Use get_crate_versions and get_owners to assess\n\
+                 6. **Popularity**: Use get_downloads and get_reverse_dependencies\n\n\
+                 Provide a comparison table and a final recommendation with reasoning.",
+                use_case,
+                crate_list.join(", ")
+            );
+
+            Ok(GetPromptResult {
+                description: Some(format!("Compare crates: {}", crates)),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: prompt,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}

--- a/examples/crates-mcp/src/prompts/mod.rs
+++ b/examples/crates-mcp/src/prompts/mod.rs
@@ -1,0 +1,4 @@
+//! Prompt definitions
+
+pub mod analyze;
+pub mod compare;

--- a/examples/crates-mcp/src/resources/mod.rs
+++ b/examples/crates-mcp/src/resources/mod.rs
@@ -1,0 +1,3 @@
+//! Resource definitions
+
+pub mod recent_searches;

--- a/examples/crates-mcp/src/resources/recent_searches.rs
+++ b/examples/crates-mcp/src/resources/recent_searches.rs
@@ -1,0 +1,31 @@
+//! Recent searches resource
+
+use std::sync::Arc;
+
+use tower_mcp::{ReadResourceResult, Resource, ResourceBuilder, ResourceContent};
+
+use crate::state::AppState;
+
+pub fn build(state: Arc<AppState>) -> Resource {
+    ResourceBuilder::new("crates://recent-searches")
+        .name("Recent Searches")
+        .description("JSON list of recent crate searches performed in this session")
+        .mime_type("application/json")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let searches = state.recent_searches.read().await;
+                let json =
+                    serde_json::to_string_pretty(&*searches).unwrap_or_else(|_| "[]".to_string());
+
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri: "crates://recent-searches".to_string(),
+                        mime_type: Some("application/json".to_string()),
+                        text: Some(json),
+                        blob: None,
+                    }],
+                })
+            }
+        })
+}

--- a/examples/crates-mcp/src/state.rs
+++ b/examples/crates-mcp/src/state.rs
@@ -1,0 +1,63 @@
+//! Shared application state
+
+use std::time::Duration;
+
+use crates_io_api::AsyncClient;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// Summary of a crate from search results (for resource storage)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CrateSummary {
+    pub name: String,
+    pub description: Option<String>,
+    pub max_version: String,
+    pub downloads: u64,
+}
+
+/// Shared state for the MCP server
+pub struct AppState {
+    /// Crates.io API client (already rate-limited internally)
+    pub client: AsyncClient,
+    /// Recent search queries (exposed as a resource)
+    pub recent_searches: RwLock<Vec<(String, Vec<CrateSummary>)>>,
+}
+
+impl AppState {
+    /// Create new application state
+    ///
+    /// # Arguments
+    /// * `rate_limit` - Minimum interval between crates.io API calls
+    pub fn new(rate_limit: Duration) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let client = AsyncClient::new(
+            "crates-mcp (tower-mcp example; https://github.com/joshrotenberg/tower-mcp)",
+            rate_limit,
+        )?;
+
+        Ok(Self {
+            client,
+            recent_searches: RwLock::new(Vec::new()),
+        })
+    }
+
+    /// Save a search query and its results for the recent searches resource
+    pub async fn save_search(&self, query: String, results: Vec<CrateSummary>) {
+        let mut searches = self.recent_searches.write().await;
+        // Keep only last 10 searches
+        if searches.len() >= 10 {
+            searches.remove(0);
+        }
+        searches.push((query, results));
+    }
+}
+
+/// Helper to format large numbers in a human-readable way
+pub fn format_number(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}K", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
+    }
+}

--- a/examples/crates-mcp/src/tools/dependencies.rs
+++ b/examples/crates-mcp/src/tools/dependencies.rs
@@ -1,0 +1,100 @@
+//! Get dependencies tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::AppState;
+
+/// Input for getting dependencies
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DependenciesInput {
+    /// Crate name
+    name: String,
+    /// Version (default: latest)
+    version: Option<String>,
+    /// Include dev dependencies
+    #[serde(default)]
+    include_dev: bool,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_dependencies")
+        .description(
+            "Get dependencies for a crate version. Shows required and optional deps, \
+             version requirements, and whether they're build or dev dependencies.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: DependenciesInput| {
+            let state = state.clone();
+            async move {
+                // Get crate info first to find version
+                let crate_response = state
+                    .client
+                    .get_crate(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let version = input
+                    .version
+                    .as_deref()
+                    .unwrap_or(&crate_response.crate_data.max_version);
+
+                let deps = state
+                    .client
+                    .crate_dependencies(&input.name, version)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let (normal, dev, build): (Vec<_>, Vec<_>, Vec<_>) =
+                    deps.iter().fold((vec![], vec![], vec![]), |mut acc, d| {
+                        match d.kind.as_str() {
+                            "dev" => acc.1.push(d),
+                            "build" => acc.2.push(d),
+                            _ => acc.0.push(d),
+                        }
+                        acc
+                    });
+
+                let mut output = format!("# {} v{} - Dependencies\n\n", input.name, version);
+
+                if !normal.is_empty() {
+                    output.push_str("## Dependencies\n\n");
+                    for d in &normal {
+                        let optional = if d.optional { " (optional)" } else { "" };
+                        output.push_str(&format!("- **{}** {}{}\n", d.crate_id, d.req, optional));
+                    }
+                    output.push('\n');
+                }
+
+                if !build.is_empty() {
+                    output.push_str("## Build Dependencies\n\n");
+                    for d in &build {
+                        let optional = if d.optional { " (optional)" } else { "" };
+                        output.push_str(&format!("- **{}** {}{}\n", d.crate_id, d.req, optional));
+                    }
+                    output.push('\n');
+                }
+
+                if input.include_dev && !dev.is_empty() {
+                    output.push_str("## Dev Dependencies\n\n");
+                    for d in &dev {
+                        let optional = if d.optional { " (optional)" } else { "" };
+                        output.push_str(&format!("- **{}** {}{}\n", d.crate_id, d.req, optional));
+                    }
+                    output.push('\n');
+                }
+
+                let total =
+                    normal.len() + build.len() + if input.include_dev { dev.len() } else { 0 };
+                output.push_str(&format!("**Total: {} dependencies**\n", total));
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/src/tools/downloads.rs
+++ b/examples/crates-mcp/src/tools/downloads.rs
@@ -1,0 +1,68 @@
+//! Get downloads tool
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::{AppState, format_number};
+
+/// Input for getting downloads data
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DownloadsInput {
+    /// Crate name
+    name: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_downloads")
+        .description(
+            "Get download statistics for a crate including total downloads \
+             and recent download trends.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: DownloadsInput| {
+            let state = state.clone();
+            async move {
+                let response = state
+                    .client
+                    .crate_downloads(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let mut output = format!("# {} - Download Statistics\n\n", input.name);
+
+                // Get recent downloads (last 90 days from version_downloads)
+                let total: u64 = response.version_downloads.iter().map(|v| v.downloads).sum();
+                output.push_str(&format!(
+                    "**Recent downloads (90 days):** {}\n\n",
+                    format_number(total)
+                ));
+
+                // Show per-version breakdown
+                output.push_str("## By Version\n\n");
+                let mut version_totals: HashMap<u64, u64> = HashMap::new();
+                for vd in &response.version_downloads {
+                    *version_totals.entry(vd.version).or_default() += vd.downloads;
+                }
+
+                let mut versions: Vec<_> = version_totals.iter().collect();
+                versions.sort_by(|a, b| b.1.cmp(a.1));
+
+                for (version_id, downloads) in versions.iter().take(10) {
+                    output.push_str(&format!(
+                        "- Version {}: {}\n",
+                        version_id,
+                        format_number(**downloads)
+                    ));
+                }
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/src/tools/info.rs
+++ b/examples/crates-mcp/src/tools/info.rs
@@ -1,0 +1,90 @@
+//! Get crate info tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::{AppState, format_number};
+
+/// Input for getting crate info
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct InfoInput {
+    /// Crate name
+    name: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_crate_info")
+        .description(
+            "Get detailed information about a specific crate including description, \
+             links, download stats, keywords, and categories.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: InfoInput| {
+            let state = state.clone();
+            async move {
+                let response = state
+                    .client
+                    .get_crate(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let c = &response.crate_data;
+
+                let mut output = format!("# {}\n\n", c.name);
+
+                if let Some(desc) = &c.description {
+                    output.push_str(&format!("{}\n\n", desc.trim()));
+                }
+
+                output.push_str("## Versions\n\n");
+                output.push_str(&format!("- Latest: **{}**\n", c.max_version));
+                if let Some(stable) = &c.max_stable_version
+                    && stable != &c.max_version
+                {
+                    output.push_str(&format!("- Latest Stable: **{}**\n", stable));
+                }
+
+                output.push_str("\n## Stats\n\n");
+                output.push_str(&format!(
+                    "- Total Downloads: {}\n",
+                    format_number(c.downloads)
+                ));
+                if let Some(recent) = c.recent_downloads {
+                    output.push_str(&format!("- Recent Downloads: {}\n", format_number(recent)));
+                }
+                output.push_str(&format!("- Created: {}\n", c.created_at.date_naive()));
+                output.push_str(&format!("- Updated: {}\n", c.updated_at.date_naive()));
+
+                output.push_str("\n## Links\n\n");
+                if let Some(repo) = &c.repository {
+                    output.push_str(&format!("- Repository: {}\n", repo));
+                }
+                if let Some(docs) = &c.documentation {
+                    output.push_str(&format!("- Documentation: {}\n", docs));
+                }
+                if let Some(home) = &c.homepage {
+                    output.push_str(&format!("- Homepage: {}\n", home));
+                }
+
+                if let Some(keywords) = &c.keywords
+                    && !keywords.is_empty()
+                {
+                    output.push_str(&format!("\n## Keywords\n\n{}\n", keywords.join(", ")));
+                }
+
+                if let Some(categories) = &c.categories
+                    && !categories.is_empty()
+                {
+                    output.push_str(&format!("\n## Categories\n\n{}\n", categories.join(", ")));
+                }
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/src/tools/mod.rs
+++ b/examples/crates-mcp/src/tools/mod.rs
@@ -1,0 +1,11 @@
+//! Tool definitions for crates.io queries
+//!
+//! Each tool corresponds to a crates.io API endpoint.
+
+pub mod dependencies;
+pub mod downloads;
+pub mod info;
+pub mod owners;
+pub mod reverse_deps;
+pub mod search;
+pub mod versions;

--- a/examples/crates-mcp/src/tools/owners.rs
+++ b/examples/crates-mcp/src/tools/owners.rs
@@ -1,0 +1,64 @@
+//! Get owners tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::AppState;
+
+/// Input for getting owners
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct OwnersInput {
+    /// Crate name
+    name: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_owners")
+        .description(
+            "Get the owners/maintainers of a crate. Shows GitHub usernames \
+             and team memberships.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: OwnersInput| {
+            let state = state.clone();
+            async move {
+                let owners = state
+                    .client
+                    .crate_owners(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let mut output = format!("# {} - Owners\n\n", input.name);
+
+                let (users, teams): (Vec<_>, Vec<_>) = owners
+                    .iter()
+                    .partition(|o| o.kind.as_deref() == Some("user"));
+
+                if !users.is_empty() {
+                    output.push_str("## Users\n\n");
+                    for owner in &users {
+                        output.push_str(&format!("- **{}**", owner.login));
+                        if let Some(name) = &owner.name {
+                            output.push_str(&format!(" ({})", name));
+                        }
+                        output.push('\n');
+                    }
+                }
+
+                if !teams.is_empty() {
+                    output.push_str("\n## Teams\n\n");
+                    for owner in &teams {
+                        output.push_str(&format!("- **{}**\n", owner.login));
+                    }
+                }
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/src/tools/reverse_deps.rs
+++ b/examples/crates-mcp/src/tools/reverse_deps.rs
@@ -1,0 +1,55 @@
+//! Get reverse dependencies tool
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::AppState;
+
+/// Input for getting reverse dependencies
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReverseDepsInput {
+    /// Crate name
+    name: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("get_reverse_dependencies")
+        .description(
+            "Get crates that depend on the specified crate (reverse dependencies). \
+             Useful for understanding a crate's ecosystem impact.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: ReverseDepsInput| {
+            let state = state.clone();
+            async move {
+                let response = state
+                    .client
+                    .crate_reverse_dependencies(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                let mut output = format!(
+                    "# {} - Reverse Dependencies\n\n\
+                     {} crates depend on this crate (showing first {}):\n\n",
+                    input.name,
+                    response.meta.total,
+                    response.dependencies.len()
+                );
+
+                for dep in &response.dependencies {
+                    output.push_str(&format!(
+                        "- **{}** v{} ({})\n",
+                        dep.crate_version.crate_name, dep.crate_version.num, dep.dependency.req
+                    ));
+                }
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/src/tools/search.rs
+++ b/examples/crates-mcp/src/tools/search.rs
@@ -1,0 +1,101 @@
+//! Search crates tool
+
+use std::sync::Arc;
+
+use crates_io_api::{CratesQuery, Sort};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+
+use crate::state::{AppState, CrateSummary, format_number};
+
+/// Input for searching crates
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SearchInput {
+    /// Search query (crate name or keywords)
+    query: String,
+    /// Sort order: relevance, downloads, recent-downloads, recent-updates, new
+    #[serde(default = "default_sort")]
+    sort: String,
+}
+
+fn default_sort() -> String {
+    "relevance".to_string()
+}
+
+fn parse_sort(s: &str) -> Sort {
+    match s {
+        "downloads" => Sort::Downloads,
+        "recent-downloads" => Sort::RecentDownloads,
+        "recent-updates" => Sort::RecentUpdates,
+        "new" => Sort::NewlyAdded,
+        _ => Sort::Relevance,
+    }
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("search_crates")
+        .description(
+            "Search for Rust crates on crates.io. Returns crate names, descriptions, \
+             download counts, and repository links.",
+        )
+        .read_only()
+        .idempotent()
+        .handler(move |input: SearchInput| {
+            let state = state.clone();
+            async move {
+                let sort = parse_sort(&input.sort);
+                let query = CratesQuery::builder()
+                    .search(&input.query)
+                    .sort(sort)
+                    .build();
+
+                let response = state
+                    .client
+                    .crates(query)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+
+                // Save search for resources
+                let summaries: Vec<_> = response
+                    .crates
+                    .iter()
+                    .map(|c| CrateSummary {
+                        name: c.name.clone(),
+                        description: c.description.clone(),
+                        max_version: c.max_version.clone(),
+                        downloads: c.downloads,
+                    })
+                    .collect();
+                state.save_search(input.query.clone(), summaries).await;
+
+                // Format results
+                let mut output = format!(
+                    "Found {} crates matching '{}' (showing {}):\n\n",
+                    response.meta.total,
+                    input.query,
+                    response.crates.len()
+                );
+
+                for (i, c) in response.crates.iter().enumerate() {
+                    output.push_str(&format!("{}. **{}** v{}\n", i + 1, c.name, c.max_version));
+                    if let Some(desc) = &c.description {
+                        output.push_str(&format!("   {}\n", desc.trim()));
+                    }
+                    output.push_str(&format!(
+                        "   Downloads: {} | Recent: {}\n",
+                        format_number(c.downloads),
+                        c.recent_downloads.map(format_number).unwrap_or_default()
+                    ));
+                    if let Some(repo) = &c.repository {
+                        output.push_str(&format!("   Repo: {}\n", repo));
+                    }
+                    output.push('\n');
+                }
+
+                Ok(CallToolResult::text(output))
+            }
+        })
+        .build()
+        .expect("valid tool")
+}

--- a/examples/crates-mcp/tests/integration.rs
+++ b/examples/crates-mcp/tests/integration.rs
@@ -1,0 +1,220 @@
+//! Integration tests for crates-mcp using the tower-mcp client
+//!
+//! These tests spawn the crates-mcp server as a subprocess and test it
+//! using the MCP client protocol.
+
+use std::path::PathBuf;
+
+use tower_mcp::client::{McpClient, StdioClientTransport};
+
+/// Helper to get the path to the crates-mcp binary
+fn binary_path() -> String {
+    // The workspace root's target directory
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir.parent().unwrap().parent().unwrap();
+    let binary = workspace_root.join("target/debug/crates-mcp");
+    binary.to_string_lossy().to_string()
+}
+
+#[tokio::test]
+async fn test_initialize() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+
+    let result = client.initialize("test-client", "1.0.0").await;
+    assert!(result.is_ok(), "Initialize failed: {:?}", result.err());
+
+    let info = result.unwrap();
+    assert_eq!(info.server_info.name, "crates-mcp");
+}
+
+#[tokio::test]
+async fn test_list_tools() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let tools = client.list_tools().await.expect("Failed to list tools");
+
+    // Should have 7 tools
+    assert_eq!(tools.tools.len(), 7);
+
+    // Check for expected tool names
+    let tool_names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_str()).collect();
+    assert!(tool_names.contains(&"search_crates"));
+    assert!(tool_names.contains(&"get_crate_info"));
+    assert!(tool_names.contains(&"get_crate_versions"));
+    assert!(tool_names.contains(&"get_dependencies"));
+    assert!(tool_names.contains(&"get_reverse_dependencies"));
+    assert!(tool_names.contains(&"get_downloads"));
+    assert!(tool_names.contains(&"get_owners"));
+}
+
+#[tokio::test]
+async fn test_list_resources() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let resources = client
+        .list_resources()
+        .await
+        .expect("Failed to list resources");
+
+    // Should have 1 resource
+    assert_eq!(resources.resources.len(), 1);
+    assert_eq!(resources.resources[0].uri, "crates://recent-searches");
+}
+
+#[tokio::test]
+async fn test_list_prompts() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let prompts = client.list_prompts().await.expect("Failed to list prompts");
+
+    // Should have 2 prompts
+    assert_eq!(prompts.prompts.len(), 2);
+
+    let prompt_names: Vec<&str> = prompts.prompts.iter().map(|p| p.name.as_str()).collect();
+    assert!(prompt_names.contains(&"analyze_crate"));
+    assert!(prompt_names.contains(&"compare_crates"));
+}
+
+#[tokio::test]
+#[ignore = "requires network access to crates.io"]
+async fn test_search_crates() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let result = client
+        .call_tool(
+            "search_crates",
+            serde_json::json!({
+                "query": "serde"
+            }),
+        )
+        .await
+        .expect("Failed to call search_crates");
+
+    // Check that we got content back
+    assert!(!result.content.is_empty());
+
+    // The result should contain text mentioning "serde"
+    if let tower_mcp::protocol::Content::Text { text, .. } = &result.content[0] {
+        assert!(text.contains("serde"), "Result should mention serde");
+    } else {
+        panic!("Expected text content");
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires network access to crates.io"]
+async fn test_get_crate_info() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let result = client
+        .call_tool(
+            "get_crate_info",
+            serde_json::json!({
+                "name": "serde"
+            }),
+        )
+        .await
+        .expect("Failed to call get_crate_info");
+
+    assert!(!result.content.is_empty());
+
+    if let tower_mcp::protocol::Content::Text { text, .. } = &result.content[0] {
+        assert!(text.contains("serde"), "Result should contain crate name");
+        assert!(text.contains("Downloads"), "Result should contain stats");
+    } else {
+        panic!("Expected text content");
+    }
+}
+
+#[tokio::test]
+async fn test_tool_error_handling() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    // Call with missing required argument
+    let result = client
+        .call_tool("search_crates", serde_json::json!({}))
+        .await;
+
+    // Should return an error for missing argument
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_read_recent_searches_empty() {
+    let transport = StdioClientTransport::spawn(&binary_path(), &[])
+        .await
+        .expect("Failed to spawn server");
+
+    let mut client = McpClient::new(transport);
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("Failed to initialize");
+
+    let result = client
+        .read_resource("crates://recent-searches")
+        .await
+        .expect("Failed to read resource");
+
+    assert_eq!(result.contents.len(), 1);
+    assert_eq!(result.contents[0].uri, "crates://recent-searches");
+
+    // Should be empty JSON array initially
+    if let Some(text) = &result.contents[0].text {
+        assert!(text.contains("[]") || text.contains("[\n]"));
+    } else {
+        panic!("Expected text content");
+    }
+}

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,7 +1,7 @@
 //! MCP protocol types based on JSON-RPC 2.0
 //!
 //! These types follow the MCP specification (2025-03-26):
-//! https://modelcontextprotocol.io/specification/2025-03-26
+//! <https://modelcontextprotocol.io/specification/2025-03-26>
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;


### PR DESCRIPTION
## Summary

- Add a full-featured example MCP server that queries crates.io as a workspace member
- Demonstrates tools, resources, prompts, CLI args, and tower middleware integration
- Includes integration tests using the tower-mcp client

## Features

**Structure:**
- Workspace member with own `Cargo.toml`
- Modular organization: `tools/`, `resources/`, `prompts/`
- CLI with clap for runtime configuration

**MCP Capabilities:**
- 7 tools (search, info, versions, dependencies, reverse_deps, downloads, owners)
- 1 resource (recent searches as JSON)
- 2 prompts (analyze_crate, compare_crates)

**Tower Middleware:**
- `RateLimiterLayer` from tower-resilience-ratelimiter (token bucket)
- `BulkheadLayer` from tower-resilience-bulkhead (concurrent request isolation)

**Testing:**
- Integration tests that spawn the server and test via MCP client protocol

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features -p tower-mcp`
- [x] `cargo test -p crates-mcp`
- [x] `cargo build -p crates-mcp`