### PR TITLE
feat: add DX improvements for result types and middleware support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tracing = "0.1"
 
 # URI template matching
 regex = "1"
+base64 = "0.22.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/examples/crates-mcp/src/main.rs
+++ b/examples/crates-mcp/src/main.rs
@@ -144,13 +144,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .max_wait_duration(Some(Duration::from_millis(args.bulkhead_timeout_ms)))
         .build();
 
+    // Build middleware stack demonstrating tower-resilience integration.
+    // Note: These layers return custom error types (RateLimiterError, BulkheadError)
+    // which need error mapping for use with GenericStdioTransport. For stdio,
+    // we use the router directly. For HTTP/WebSocket transports, middleware
+    // can be applied at the transport layer where error handling is more flexible.
     let _service = ServiceBuilder::new()
         .layer(rate_limiter)
         .layer(bulkhead)
         .service(router.clone());
 
-    // For now, we use the router directly with StdioTransport
-    // The middleware layer would be used with HTTP/WebSocket transports
     match args.transport {
         Transport::Stdio => {
             tracing::info!("Serving over stdio");

--- a/src/error.rs
+++ b/src/error.rs
@@ -281,6 +281,38 @@ impl Error {
     pub fn tool_with_name(tool: impl Into<String>, message: impl Into<String>) -> Self {
         Error::Tool(ToolError::with_tool(tool, message))
     }
+
+    /// Create a tool error from any `Display` type.
+    ///
+    /// This is useful for converting errors in a `map_err` chain:
+    ///
+    /// ```rust
+    /// # use tower_mcp::Error;
+    /// # fn example() -> Result<(), Error> {
+    /// let result: Result<(), std::io::Error> = Err(std::io::Error::other("oops"));
+    /// result.map_err(Error::tool_from)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tool_from<E: std::fmt::Display>(err: E) -> Self {
+        Error::Tool(ToolError::new(err.to_string()))
+    }
+
+    /// Create a tool error with context prefix.
+    ///
+    /// This is useful for adding context when converting errors:
+    ///
+    /// ```rust
+    /// # use tower_mcp::Error;
+    /// # fn example() -> Result<(), Error> {
+    /// let result: Result<(), std::io::Error> = Err(std::io::Error::other("connection refused"));
+    /// result.map_err(|e| Error::tool_context("API request failed", e))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn tool_context<E: std::fmt::Display>(context: impl Into<String>, err: E) -> Self {
+        Error::Tool(ToolError::new(format!("{}: {}", context.into(), err)))
+    }
 }
 
 impl From<JsonRpcError> for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,23 +69,26 @@ pub use jsonrpc::JsonRpcService;
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{
     CallToolResult, CompleteParams, CompleteResult, Completion, CompletionArgument,
-    CompletionReference, CompletionsCapability, ContentRole, CreateMessageParams,
+    CompletionReference, CompletionsCapability, Content, ContentRole, CreateMessageParams,
     CreateMessageResult, ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitFormSchema,
     ElicitMode, ElicitRequestParams, ElicitResult, ElicitUrlParams, ElicitationCapability,
-    ElicitationCompleteParams, GetPromptResult, IncludeContext, JsonRpcMessage, JsonRpcRequest,
-    JsonRpcResponse, JsonRpcResponseMessage, ListRootsParams, ListRootsResult, McpRequest,
-    McpResponse, ModelHint, ModelPreferences, PrimitiveSchemaDefinition, PromptMessage,
-    PromptReference, PromptRole, ReadResourceResult, ResourceContent, ResourceReference, Root,
-    RootsCapability, SamplingCapability, SamplingContent, SamplingMessage,
+    ElicitationCompleteParams, GetPromptResult, GetPromptResultBuilder, IncludeContext,
+    JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage, ListRootsParams,
+    ListRootsResult, McpRequest, McpResponse, ModelHint, ModelPreferences,
+    PrimitiveSchemaDefinition, PromptMessage, PromptReference, PromptRole, ReadResourceResult,
+    ResourceContent, ResourceReference, Root, RootsCapability, SamplingCapability, SamplingContent,
+    SamplingMessage,
 };
 pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,
     ResourceTemplateHandler,
 };
-pub use router::McpRouter;
+pub use router::{McpRouter, RouterRequest, RouterResponse};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};
-pub use transport::{BidirectionalStdioTransport, StdioTransport, SyncStdioTransport};
+pub use transport::{
+    BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, SyncStdioTransport,
+};
 
 #[cfg(feature = "http")]
 pub use transport::HttpTransport;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,7 +17,9 @@ pub mod websocket;
 #[cfg(feature = "childproc")]
 pub mod childproc;
 
-pub use stdio::{BidirectionalStdioTransport, StdioTransport, SyncStdioTransport};
+pub use stdio::{
+    BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, SyncStdioTransport,
+};
 
 #[cfg(feature = "http")]
 pub use http::HttpTransport;


### PR DESCRIPTION
## Summary

This PR implements several developer experience improvements discovered while building the crates-mcp example:

- **Re-export Content type** (#90) - `tower_mcp::Content` now available directly
- **Error helpers** (#92) - `Error::tool_from` and `Error::tool_context` for cleaner error conversion
- **ReadResourceResult helpers** (#88) - `::text()`, `::json()`, `::blob()` convenience constructors
- **GetPromptResult helpers** (#89) - `::user_message()`, `::builder()` for easier prompt construction
- **State sharing docs** (#93) - Document the Arc clone pattern in `ToolBuilder::handler`
- **GenericStdioTransport** (#91) - Support middleware-wrapped services in stdio transport

## Example Usage

```rust
// Before
Ok(ReadResourceResult {
    contents: vec![ResourceContent {
        uri: "crates://data".to_string(),
        mime_type: Some("application/json".to_string()),
        text: Some(json),
        blob: None,
    }],
})

// After
Ok(ReadResourceResult::json("crates://data", &data))
```

```rust
// Before
.map_err(|e| Error::tool(format!("API error: {}", e)))?

// After
.map_err(|e| Error::tool_context("API error", e))?
```

## Test plan

- [x] All existing tests pass
- [x] New doc tests for helper methods
- [x] crates-mcp example still works
- [x] Clippy clean

Closes #88, #89, #90, #91, #92, #93