### PR TITLE
chore: remove unused tokio-tungstenite direct dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,17 +54,13 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 default = []
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
-websocket = ["dep:axum", "dep:tokio-tungstenite", "dep:uuid"]
+websocket = ["dep:axum", "dep:uuid"]
 childproc = []
 
 [dependencies.axum]
 version = "0.8"
 optional = true
 features = ["json", "ws"]
-
-[dependencies.tokio-tungstenite]
-version = "0.26"
-optional = true
 
 [dependencies.hyper]
 version = "1"


### PR DESCRIPTION
## Summary

- Remove direct `tokio-tungstenite = "0.26"` dependency from `Cargo.toml`
- The WebSocket transport uses axum's built-in WebSocket types (`axum::extract::ws`), not tokio-tungstenite directly
- Axum already pulls in `tokio-tungstenite v0.28` via its `ws` feature, so our direct dep on v0.26 was unused and caused two versions of tungstenite in the dependency tree

Before: `tokio-tungstenite v0.26.2` + `tokio-tungstenite v0.28.0`
After: `tokio-tungstenite v0.28.0` (via axum only)

## Test plan

- [x] `cargo clippy --all-targets --all-features` passes
- [x] `cargo test --lib --all-features` passes (166 tests)
- [x] `cargo test --doc --all-features` passes (38 tests)
- [x] `cargo tree` confirms single tungstenite version