### PR TITLE
feat: add JsonRpcLayer for ServiceBuilder composition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use context::{
     RequestContext, RequestContextBuilder, ServerNotification, outgoing_request_channel,
 };
 pub use error::{Error, Result, ToolError};
-pub use jsonrpc::JsonRpcService;
+pub use jsonrpc::{JsonRpcLayer, JsonRpcService};
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{
     CallToolResult, CompleteParams, CompleteResult, Completion, CompletionArgument,


### PR DESCRIPTION
## Summary

- Add `JsonRpcLayer` implementing `tower::Layer<S>` that produces `JsonRpcService<S>`
- Enables idiomatic middleware composition via `ServiceBuilder`
- Implements `Debug`, `Clone`, `Copy`, and `Default`
- Re-export `JsonRpcLayer` from crate root
- Update module docs to document both the layer and service

## Example

```rust
use tower::ServiceBuilder;
use tower_mcp::{McpRouter, JsonRpcLayer};

let router = McpRouter::new().server_info("my-server", "1.0.0");

let service = ServiceBuilder::new()
    .layer(JsonRpcLayer::new())
    .service(router);
```

This follows the standard tower convention of `FooLayer`/`Foo` pairs (e.g., `TimeoutLayer`/`Timeout`, `TraceLayer`/`Trace`).

Closes #105

## Test plan

- [x] New test: `test_jsonrpc_layer` - builds service via `ServiceBuilder`, initializes, and lists tools
- [x] New test: `test_jsonrpc_layer_default` - verifies `Default` impl
- [x] New test: `test_jsonrpc_layer_clone` - verifies `Clone` and `Copy` impls
- [x] All 169 lib tests pass
- [x] All 39 doc tests pass
- [x] `cargo clippy` clean