### PR TITLE
feat: add full feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [features]
 default = []
+# Enable all optional features
+full = ["http", "websocket", "childproc"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ tower-mcp = "0.1"
 
 | Feature | Description |
 |---------|-------------|
+| `full` | Enable all optional features |
 | `http` | HTTP transport with SSE support (adds axum, hyper dependencies) |
 | `websocket` | WebSocket transport for full-duplex communication |
 | `childproc` | Child process transport for spawning subprocess MCP servers |
@@ -65,7 +66,7 @@ Example with features:
 
 ```toml
 [dependencies]
-tower-mcp = { version = "0.1", features = ["http", "client"] }
+tower-mcp = { version = "0.1", features = ["full"] }
 ```
 
 ## Quick Start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 //!
 //! ## Feature Flags
 //!
+//! - `full` - Enable all optional features
 //! - `http` - HTTP/SSE transport for web servers
 //! - `websocket` - WebSocket transport for bidirectional communication
 //! - `childproc` - Child process transport for subprocess management


### PR DESCRIPTION
## Summary
- Add `full` feature flag that enables all optional features (`http`, `websocket`, `childproc`), following the tower ecosystem convention (tower-http, tokio, etc.)
- Document the new feature in `lib.rs` doc comments and README feature table
- Update README example to show `features = ["full"]`

Closes #109

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (189 passed)
- [x] `cargo test --test '*' --all-features` (29 passed)
- [x] `cargo test --doc --all-features` (42 passed)
- [x] Verified `--features full` produces same test count as `--all-features`