### PR TITLE
feat: add tower middleware composition examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,10 @@ name = "stdio_server"
 path = "examples/stdio_server.rs"
 
 [[example]]
+name = "stdio_server_with_middleware"
+path = "examples/stdio_server_with_middleware.rs"
+
+[[example]]
 name = "http_server"
 path = "examples/http_server.rs"
 required-features = ["http"]

--- a/examples/stdio_server_with_middleware.rs
+++ b/examples/stdio_server_with_middleware.rs
@@ -1,0 +1,94 @@
+//! Stdio server example with tower middleware
+//!
+//! Demonstrates applying standard tower middleware to MCP request processing
+//! using `GenericStdioTransport` with `ServiceBuilder`. This is the purest
+//! tower composition pattern -- no HTTP or axum involved.
+//!
+//! Run with: cargo run --example stdio_server_with_middleware
+//!
+//! Test with:
+//! ```bash
+//! echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
+//!   | cargo run --example stdio_server_with_middleware
+//! ```
+
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::ServiceBuilder;
+use tower::timeout::TimeoutLayer;
+use tower_mcp::{CallToolResult, CatchError, GenericStdioTransport, McpRouter, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    /// First number
+    a: i64,
+    /// Second number
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SlowInput {
+    /// How many seconds to sleep before responding
+    seconds: u64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    // Initialize tracing (to stderr so it doesn't interfere with JSON-RPC on stdout)
+    tracing_subscriber::fmt()
+        .with_env_filter("tower_mcp=debug")
+        .with_writer(std::io::stderr)
+        .init();
+
+    let add = ToolBuilder::new("add")
+        .description("Add two numbers together")
+        .handler(|input: AddInput| async move {
+            Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+        })
+        .build()?;
+
+    let slow = ToolBuilder::new("slow")
+        .description("Sleep for a specified number of seconds, then respond")
+        .handler(|input: SlowInput| async move {
+            tokio::time::sleep(Duration::from_secs(input.seconds)).await;
+            Ok(CallToolResult::text(format!(
+                "Slept for {} seconds",
+                input.seconds
+            )))
+        })
+        .build()?;
+
+    let router = McpRouter::new()
+        .server_info("middleware-stdio-example", "1.0.0")
+        .instructions("A stdio MCP server demonstrating tower middleware layers.")
+        .tool(add)
+        .tool(slow);
+
+    // Compose tower middleware with ServiceBuilder, then wrap in CatchError
+    // to convert middleware errors (like timeouts) into JSON-RPC error responses.
+    //
+    // Layer ordering in ServiceBuilder:
+    //   .layer(OuterLayer)    // runs first on request, last on response
+    //   .layer(InnerLayer)    // runs last on request, first on response
+    //   .service(router)      // the inner service
+    //
+    // CatchError preserves the Error = Infallible contract that
+    // GenericStdioTransport requires.
+    let service = CatchError::new(
+        ServiceBuilder::new()
+            // Timeout: fail MCP requests that take longer than 5 seconds
+            .layer(TimeoutLayer::new(Duration::from_secs(5)))
+            // Concurrency: process at most 10 MCP requests at a time
+            .concurrency_limit(10)
+            .service(router),
+    );
+
+    let mut transport = GenericStdioTransport::new(service);
+
+    tracing::info!("Starting stdio server with middleware");
+    transport.run().await?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,7 +150,8 @@ pub use router::{McpRouter, RouterRequest, RouterResponse};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};
 pub use transport::{
-    BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, SyncStdioTransport,
+    BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,
+    SyncStdioTransport,
 };
 
 #[cfg(feature = "http")]

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -487,13 +487,19 @@ impl HttpTransport {
     ///
     /// ```rust,no_run
     /// use std::time::Duration;
+    /// use tower::ServiceBuilder;
     /// use tower::timeout::TimeoutLayer;
     /// use tower_mcp::McpRouter;
     /// use tower_mcp::transport::http::HttpTransport;
     ///
     /// let router = McpRouter::new().server_info("my-server", "1.0.0");
     /// let transport = HttpTransport::new(router)
-    ///     .layer(TimeoutLayer::new(Duration::from_secs(30)));
+    ///     .layer(
+    ///         ServiceBuilder::new()
+    ///             .layer(TimeoutLayer::new(Duration::from_secs(30)))
+    ///             .concurrency_limit(10)
+    ///             .into_inner(),
+    ///     );
     /// ```
     pub fn layer<L>(mut self, layer: L) -> Self
     where

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,9 +17,9 @@ pub mod websocket;
 #[cfg(feature = "childproc")]
 pub mod childproc;
 
-#[cfg(any(feature = "http", feature = "websocket"))]
 pub mod service;
 
+pub use service::CatchError;
 pub use stdio::{
     BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, SyncStdioTransport,
 };

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -214,13 +214,19 @@ impl WebSocketTransport {
     ///
     /// ```rust,no_run
     /// use std::time::Duration;
+    /// use tower::ServiceBuilder;
     /// use tower::timeout::TimeoutLayer;
     /// use tower_mcp::McpRouter;
     /// use tower_mcp::transport::websocket::WebSocketTransport;
     ///
     /// let router = McpRouter::new().server_info("my-server", "1.0.0");
     /// let transport = WebSocketTransport::new(router)
-    ///     .layer(TimeoutLayer::new(Duration::from_secs(30)));
+    ///     .layer(
+    ///         ServiceBuilder::new()
+    ///             .layer(TimeoutLayer::new(Duration::from_secs(30)))
+    ///             .concurrency_limit(10)
+    ///             .into_inner(),
+    ///     );
     /// ```
     pub fn layer<L>(mut self, layer: L) -> Self
     where


### PR DESCRIPTION
## Summary
- Add `stdio_server_with_middleware` example showing `ServiceBuilder` + `TimeoutLayer` + `concurrency_limit` with `GenericStdioTransport` -- pure tower composition with no HTTP/axum
- Make `CatchError` unconditionally available (was gated behind `http`/`websocket` features) and re-export from crate root, so middleware error conversion works with any transport
- Update doc examples on `GenericStdioTransport`, `HttpTransport::layer()`, and `WebSocketTransport::layer()` to show `ServiceBuilder` multi-layer composition, matching the standalone examples

Closes #111

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (189 passed)
- [x] `cargo test --test '*' --all-features` (29 passed)
- [x] `cargo test --doc --all-features` (42 passed)
- [x] `cargo build --example stdio_server_with_middleware` compiles