### PR TITLE
feat: add MCP test harness with TestClient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,15 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "childproc", "oauth"]
+full = ["http", "websocket", "childproc", "oauth", "testing"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
 childproc = []
 # OAuth 2.1 resource server support
 oauth = ["dep:jsonwebtoken", "http"]
+# Test utilities for MCP servers
+testing = []
 
 [dependencies.axum]
 version = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,6 +100,7 @@
 //! - `websocket` - WebSocket transport for bidirectional communication
 //! - `childproc` - Child process transport for subprocess management
 //! - `oauth` - OAuth 2.1 resource server support (token validation, metadata endpoint)
+//! - `testing` - Test utilities ([`TestClient`]) for ergonomic MCP server testing
 //!
 //! ## MCP Specification
 //!
@@ -119,6 +120,8 @@ pub mod protocol;
 pub mod resource;
 pub mod router;
 pub mod session;
+#[cfg(feature = "testing")]
+pub mod testing;
 pub mod tool;
 pub mod transport;
 
@@ -168,3 +171,6 @@ pub use transport::McpBoxService;
 
 #[cfg(feature = "childproc")]
 pub use transport::{ChildProcessConnection, ChildProcessTransport};
+
+#[cfg(feature = "testing")]
+pub use testing::TestClient;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -1,0 +1,447 @@
+//! Test utilities for MCP servers.
+//!
+//! This module provides [`TestClient`], an ergonomic wrapper around [`McpRouter`]
+//! for writing concise MCP server tests without manual JSON-RPC construction.
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use tower_mcp::{CallToolResult, McpRouter, ToolBuilder, TestClient};
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//! use serde_json::json;
+//!
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct EchoInput {
+//!     message: String,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! let echo = ToolBuilder::new("echo")
+//!     .description("Echo a message")
+//!     .handler(|input: EchoInput| async move {
+//!         Ok(CallToolResult::text(input.message))
+//!     })
+//!     .build()
+//!     .expect("valid tool");
+//!
+//! let router = McpRouter::new()
+//!     .server_info("test-server", "1.0.0")
+//!     .tool(echo);
+//!
+//! let mut client = TestClient::from_router(router);
+//! client.initialize().await;
+//!
+//! let result = client.call_tool("echo", json!({"message": "hello"})).await;
+//! assert_eq!(result.all_text(), "hello");
+//! # }
+//! ```
+//!
+//! # Full Example
+//!
+//! The following shows a complete test setup with tools, resources, and prompts:
+//!
+//! ```rust
+//! use std::collections::HashMap;
+//! use tower_mcp::{
+//!     CallToolResult, GetPromptResult, McpRouter, ReadResourceResult,
+//!     PromptBuilder, ResourceBuilder, TestClient, ToolBuilder,
+//! };
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//! use serde_json::json;
+//!
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct AddInput {
+//!     a: i64,
+//!     b: i64,
+//! }
+//!
+//! # #[tokio::main]
+//! # async fn main() {
+//! // -- Build the router ------------------------------------------------
+//! let add = ToolBuilder::new("add")
+//!     .description("Add two numbers")
+//!     .handler(|input: AddInput| async move {
+//!         Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+//!     })
+//!     .build()
+//!     .expect("valid tool");
+//!
+//! let readme = ResourceBuilder::new("file:///README.md")
+//!     .name("README")
+//!     .description("Project readme")
+//!     .text("# My Project");
+//!
+//! let greet = PromptBuilder::new("greet")
+//!     .description("Greet someone")
+//!     .required_arg("name", "Name to greet")
+//!     .handler(|args: HashMap<String, String>| async move {
+//!         let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+//!         Ok(GetPromptResult::user_message(
+//!             format!("Please greet {} warmly.", name),
+//!         ))
+//!     });
+//!
+//! let router = McpRouter::new()
+//!     .server_info("test-server", "1.0.0")
+//!     .tool(add)
+//!     .resource(readme)
+//!     .prompt(greet);
+//!
+//! // -- Create client and initialize ------------------------------------
+//! let mut client = TestClient::from_router(router);
+//! let init = client.initialize().await;
+//! assert!(init.get("protocolVersion").is_some());
+//!
+//! // -- Tools -----------------------------------------------------------
+//! let tools = client.list_tools().await;
+//! assert_eq!(tools.len(), 1);
+//!
+//! let result = client.call_tool("add", json!({"a": 2, "b": 3})).await;
+//! assert_eq!(result.all_text(), "5");
+//! assert_eq!(result.first_text(), Some("5"));
+//! assert!(!result.is_error);
+//!
+//! // -- Resources -------------------------------------------------------
+//! let resources = client.list_resources().await;
+//! assert_eq!(resources.len(), 1);
+//!
+//! let readme = client.read_resource("file:///README.md").await;
+//! assert_eq!(readme.first_text(), Some("# My Project"));
+//! assert_eq!(readme.first_uri(), Some("file:///README.md"));
+//!
+//! // -- Prompts ---------------------------------------------------------
+//! let prompts = client.list_prompts().await;
+//! assert_eq!(prompts.len(), 1);
+//!
+//! let mut args = HashMap::new();
+//! args.insert("name".to_string(), "Alice".to_string());
+//! let prompt = client.get_prompt("greet", args).await;
+//! assert!(prompt.first_message_text().unwrap().contains("Alice"));
+//!
+//! // -- Error handling --------------------------------------------------
+//! // Expect a JSON-RPC error for a non-existent tool:
+//! let error = client
+//!     .call_tool_expect_error("nonexistent", json!({}))
+//!     .await;
+//! assert!(error.get("code").is_some());
+//!
+//! // Expect a JSON-RPC error for an unknown method:
+//! let error = client
+//!     .send_request_expect_error("unknown/method", None)
+//!     .await;
+//! assert_eq!(error.get("code").and_then(|v| v.as_i64()), Some(-32601));
+//!
+//! // -- Raw escape hatch ------------------------------------------------
+//! // Use send_request for methods without typed helpers:
+//! let pong = client.send_request("ping", None).await;
+//! assert_eq!(pong, json!({}));
+//! # }
+//! ```
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::context::{NotificationReceiver, ServerNotification, notification_channel};
+use crate::jsonrpc::JsonRpcService;
+use crate::protocol::{
+    CallToolResult, GetPromptResult, JsonRpcRequest, JsonRpcResponse, McpNotification,
+    ReadResourceResult,
+};
+use crate::router::McpRouter;
+
+/// An ergonomic test client for MCP servers.
+///
+/// Wraps an [`McpRouter`] and [`JsonRpcService`] to provide typed, concise
+/// methods for testing MCP server behavior. All methods that expect successful
+/// responses will panic on JSON-RPC errors, which is appropriate for test code.
+///
+/// # Construction
+///
+/// Use [`TestClient::from_router`] to create a client from an existing router:
+///
+/// ```rust
+/// use tower_mcp::{McpRouter, TestClient};
+///
+/// let router = McpRouter::new().server_info("test", "1.0.0");
+/// let mut client = TestClient::from_router(router);
+/// ```
+pub struct TestClient {
+    service: JsonRpcService<McpRouter>,
+    router: McpRouter,
+    notification_rx: NotificationReceiver,
+    next_id: i64,
+}
+
+impl TestClient {
+    /// Create a new test client from an [`McpRouter`].
+    ///
+    /// Sets up a notification channel and wraps the router in a
+    /// [`JsonRpcService`] for JSON-RPC framing.
+    pub fn from_router(router: McpRouter) -> Self {
+        let (tx, rx) = notification_channel(256);
+        let router = router.with_notification_sender(tx);
+        let service = JsonRpcService::new(router.clone());
+        Self {
+            service,
+            router,
+            notification_rx: rx,
+            next_id: 1,
+        }
+    }
+
+    fn next_id(&mut self) -> i64 {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Send an initialize request and the initialized notification.
+    ///
+    /// Returns the raw JSON result from the initialize response.
+    /// Panics if initialization fails.
+    pub async fn initialize(&mut self) -> Value {
+        let id = self.next_id();
+        let req = JsonRpcRequest::new(id, "initialize").with_params(serde_json::json!({
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {
+                "name": "test-client",
+                "version": "1.0.0"
+            }
+        }));
+
+        let result = self.send_request_inner(req).await;
+        self.router
+            .handle_notification(McpNotification::Initialized);
+        result
+    }
+
+    /// List all tools registered on the server.
+    ///
+    /// Returns the tools array from the response. Panics on error.
+    pub async fn list_tools(&mut self) -> Vec<Value> {
+        let result = self.send_request("tools/list", None).await;
+        result
+            .get("tools")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Call a tool by name with the given arguments.
+    ///
+    /// Returns a typed [`CallToolResult`]. Panics on JSON-RPC errors.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use tower_mcp::TestClient;
+    /// # use serde_json::json;
+    /// # async fn example(client: &mut TestClient) {
+    /// let result = client.call_tool("echo", json!({"message": "hi"})).await;
+    /// assert_eq!(result.first_text(), Some("hi"));
+    /// # }
+    /// ```
+    pub async fn call_tool(&mut self, name: &str, args: Value) -> CallToolResult {
+        let raw = self.call_tool_raw(name, args).await;
+        serde_json::from_value(raw).expect("failed to deserialize CallToolResult")
+    }
+
+    /// Call a tool and return the raw JSON response.
+    ///
+    /// Useful when you need to inspect fields not covered by [`CallToolResult`].
+    pub async fn call_tool_raw(&mut self, name: &str, args: Value) -> Value {
+        self.send_request(
+            "tools/call",
+            Some(serde_json::json!({
+                "name": name,
+                "arguments": args,
+            })),
+        )
+        .await
+    }
+
+    /// Call a tool and assert that it returns an error.
+    ///
+    /// Panics if the tool call succeeds without an error. Returns the raw
+    /// JSON response body (which may be a `CallToolResult` with `isError: true`
+    /// or a JSON-RPC error).
+    pub async fn call_tool_expect_error(&mut self, name: &str, args: Value) -> Value {
+        let id = self.next_id();
+        let req = JsonRpcRequest::new(id, "tools/call").with_params(serde_json::json!({
+            "name": name,
+            "arguments": args,
+        }));
+
+        let resp = self
+            .service
+            .call_single(req)
+            .await
+            .expect("transport error");
+
+        match resp {
+            JsonRpcResponse::Error(e) => {
+                serde_json::to_value(&e.error).expect("failed to serialize error")
+            }
+            JsonRpcResponse::Result(r) => {
+                // Check for isError flag in CallToolResult
+                if r.result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+                    r.result
+                } else {
+                    panic!(
+                        "expected tool call to '{}' to fail, but it succeeded: {:?}",
+                        name, r.result
+                    );
+                }
+            }
+        }
+    }
+
+    /// List all resources registered on the server.
+    ///
+    /// Returns the resources array from the response. Panics on error.
+    pub async fn list_resources(&mut self) -> Vec<Value> {
+        let result = self.send_request("resources/list", None).await;
+        result
+            .get("resources")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Read a resource by URI.
+    ///
+    /// Returns a typed [`ReadResourceResult`]. Panics on JSON-RPC errors.
+    pub async fn read_resource(&mut self, uri: &str) -> ReadResourceResult {
+        let raw = self
+            .send_request("resources/read", Some(serde_json::json!({ "uri": uri })))
+            .await;
+        serde_json::from_value(raw).expect("failed to deserialize ReadResourceResult")
+    }
+
+    /// List all prompts registered on the server.
+    ///
+    /// Returns the prompts array from the response. Panics on error.
+    pub async fn list_prompts(&mut self) -> Vec<Value> {
+        let result = self.send_request("prompts/list", None).await;
+        result
+            .get("prompts")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Get a prompt by name with the given arguments.
+    ///
+    /// Returns a typed [`GetPromptResult`]. Panics on JSON-RPC errors.
+    pub async fn get_prompt(
+        &mut self,
+        name: &str,
+        args: HashMap<String, String>,
+    ) -> GetPromptResult {
+        let raw = self
+            .send_request(
+                "prompts/get",
+                Some(serde_json::json!({
+                    "name": name,
+                    "arguments": args,
+                })),
+            )
+            .await;
+        serde_json::from_value(raw).expect("failed to deserialize GetPromptResult")
+    }
+
+    /// Send a completion request with raw parameters.
+    ///
+    /// Returns the raw JSON result. Panics on error.
+    pub async fn complete(&mut self, params: Value) -> Value {
+        self.send_request("completion/complete", Some(params)).await
+    }
+
+    /// Send an arbitrary request and expect success.
+    ///
+    /// This is an escape hatch for methods not covered by the typed helpers.
+    /// Panics on JSON-RPC errors.
+    pub async fn send_request(&mut self, method: &str, params: Option<Value>) -> Value {
+        let id = self.next_id();
+        let mut req = JsonRpcRequest::new(id, method);
+        if let Some(p) = params {
+            req = req.with_params(p);
+        }
+        self.send_request_inner(req).await
+    }
+
+    /// Send an arbitrary request and expect a JSON-RPC error.
+    ///
+    /// Panics if the response is a success. Returns the error object as JSON.
+    pub async fn send_request_expect_error(
+        &mut self,
+        method: &str,
+        params: Option<Value>,
+    ) -> Value {
+        let id = self.next_id();
+        let mut req = JsonRpcRequest::new(id, method);
+        if let Some(p) = params {
+            req = req.with_params(p);
+        }
+
+        let resp = self
+            .service
+            .call_single(req)
+            .await
+            .expect("transport error");
+
+        match resp {
+            JsonRpcResponse::Error(e) => {
+                serde_json::to_value(&e.error).expect("failed to serialize error")
+            }
+            JsonRpcResponse::Result(r) => {
+                panic!(
+                    "expected request '{}' to fail, but it succeeded: {:?}",
+                    method, r.result
+                );
+            }
+        }
+    }
+
+    /// Try to receive a notification without blocking.
+    ///
+    /// Returns `None` if no notification is available.
+    pub fn try_recv_notification(&mut self) -> Option<ServerNotification> {
+        self.notification_rx.try_recv().ok()
+    }
+
+    /// Drain all pending notifications.
+    ///
+    /// Returns all notifications that have been sent since the last drain.
+    pub fn drain_notifications(&mut self) -> Vec<ServerNotification> {
+        let mut notifications = Vec::new();
+        while let Ok(n) = self.notification_rx.try_recv() {
+            notifications.push(n);
+        }
+        notifications
+    }
+
+    async fn send_request_inner(&mut self, req: JsonRpcRequest) -> Value {
+        let method = req.method.clone();
+        let resp = self
+            .service
+            .call_single(req)
+            .await
+            .expect("transport error");
+
+        match resp {
+            JsonRpcResponse::Result(r) => r.result,
+            JsonRpcResponse::Error(e) => {
+                panic!(
+                    "expected request '{}' to succeed, but got error: {} (code {})",
+                    method, e.error.message, e.error.code,
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #124.

- Add `testing` feature flag with `TestClient` struct that wraps `McpRouter` for ergonomic server testing
- Add accessor methods to protocol types (not feature-gated): `Content::as_text()`, `CallToolResult::all_text()`/`first_text()`, `ReadResourceResult::first_text()`/`first_uri()`, `GetPromptResult::first_message_text()`
- Add 14 integration tests demonstrating `TestClient` usage

No Rust MCP SDK currently ships test utilities -- this fills that gap. Reduces per-operation test boilerplate from ~20 lines of manual JSON-RPC construction to 1-2 lines:

```rust
// Before: manual JSON-RPC construction + raw JSON parsing
let req = JsonRpcRequest::new(3, "tools/call").with_params(json!({
    "name": "echo", "arguments": {"message": "hello"}
}));
let resp = service.call_single(req).await.unwrap();
match resp {
    JsonRpcResponse::Result(r) => {
        let content = r.result.get("content").unwrap().as_array().unwrap();
        let text = content[0].get("text").unwrap().as_str().unwrap();
        assert_eq!(text, "hello");
    }
    JsonRpcResponse::Error(e) => panic!("Expected success: {:?}", e),
}

// After: typed, concise
let result = client.call_tool("echo", json!({"message": "hello"})).await;
assert_eq!(result.all_text(), "hello");
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (232 passed)
- [x] `cargo test --test '*' --all-features` (41 passed, 14 new)
- [x] `cargo test --doc --all-features` (58 passed)