### PR TITLE
feat: add ScopeEnforcementLayer for per-operation OAuth scope checks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@
 //! | -32004 | NotSubscribed   | Resource not subscribed (for unsubscribe)|
 //! | -32005 | SessionNotFound | Session not found or expired             |
 //! | -32006 | SessionRequired | MCP-Session-Id header is required        |
+//! | -32007 | Forbidden       | Access forbidden (insufficient scope)    |
 
 use serde::{Deserialize, Serialize};
 
@@ -70,6 +71,8 @@ pub enum McpErrorCode {
     SessionNotFound = -32005,
     /// Session ID is required but was not provided
     SessionRequired = -32006,
+    /// Access forbidden (insufficient scope or authorization)
+    Forbidden = -32007,
 }
 
 impl McpErrorCode {
@@ -201,6 +204,11 @@ impl JsonRpcError {
             McpErrorCode::SessionRequired,
             "MCP-Session-Id header is required for this request.",
         )
+    }
+
+    /// Access forbidden (insufficient scope or authorization)
+    pub fn forbidden(message: impl Into<String>) -> Self {
+        Self::mcp_error(McpErrorCode::Forbidden, message)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,
     ResourceTemplateHandler,
 };
-pub use router::{McpRouter, RouterRequest, RouterResponse};
+pub use router::{Extensions, McpRouter, RouterRequest, RouterResponse};
 pub use session::{SessionPhase, SessionState};
 pub use tool::{Tool, ToolBuilder, ToolHandler};
 pub use transport::{
@@ -171,6 +171,9 @@ pub use transport::McpBoxService;
 
 #[cfg(feature = "childproc")]
 pub use transport::{ChildProcessConnection, ChildProcessTransport};
+
+#[cfg(feature = "oauth")]
+pub use oauth::{ScopeEnforcementLayer, ScopeEnforcementService};
 
 #[cfg(feature = "testing")]
 pub use testing::TestClient;

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -94,5 +94,5 @@ pub mod token;
 pub use error::OAuthError;
 pub use metadata::ProtectedResourceMetadata;
 pub use middleware::{OAuthLayer, OAuthService};
-pub use scope::{ScopePolicy, ScopeRequirement};
+pub use scope::{ScopeEnforcementLayer, ScopeEnforcementService, ScopePolicy, ScopeRequirement};
 pub use token::{JwtValidator, TokenAudience, TokenClaims, TokenValidator, ValidateAdapter};

--- a/src/transport/service.rs
+++ b/src/transport/service.rs
@@ -139,6 +139,7 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: crate::protocol::McpRequest::Ping,
+            extensions: crate::router::Extensions::new(),
         };
 
         let result = Service::call(&mut service, req).await;


### PR DESCRIPTION
## Summary

Closes #127.

- Add `Extensions` type-map to `RouterRequest` for passing data through middleware (uses `Arc<dyn Any>` for cheap cloning in batch requests)
- Add `Forbidden` (`-32007`) error code to `McpErrorCode`
- Add `ScopeEnforcementLayer` / `ScopeEnforcementService` -- tower middleware operating at `RouterRequest` level with `Error = Infallible` (matching `McpRouter`'s contract)
- Bridge `TokenClaims` from HTTP/WebSocket request extensions into MCP `Extensions` via `JsonRpcService::with_extensions()`
- No claims = pass through, so the middleware composes gracefully without OAuth
- Re-export `Extensions` unconditionally and `ScopeEnforcementLayer` under `#[cfg(feature = "oauth")]`

## Design decisions

- **Extensions uses `Arc<dyn Any>`** so `Clone` is cheap (needed for batch requests that fan out one HTTP request into multiple `RouterRequest`s)
- **No claims = pass through** makes the middleware composable without OAuth enabled
- **`Error = Infallible`** matches `McpRouter`'s contract; scope errors are carried in `RouterResponse` as JSON-RPC forbidden errors
- **`-32007` Forbidden** code follows the existing MCP error code sequence (-32001 through -32006)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (232 passed)
- [x] `cargo test --test '*' --all-features` (47 passed, including 6 new scope enforcement tests)
- [x] `cargo test --doc --all-features` (61 passed)
- [x] Test scope enforcement blocks tool calls without required scope
- [x] Test scope enforcement allows tool calls with required scope
- [x] Test pass-through when no TokenClaims are present
- [x] Test per-resource scope checks
- [x] Test per-prompt scope checks
- [x] Test default scope enforcement