### PR TITLE
docs: use handler_with_state in crates-mcp example

### DIFF
--- a/examples/crates-mcp/src/tools/dependencies.rs
+++ b/examples/crates-mcp/src/tools/dependencies.rs
@@ -28,9 +28,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: DependenciesInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: DependenciesInput| async move {
                 // Get crate info first to find version
                 let crate_response = state
                     .client
@@ -93,8 +93,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 output.push_str(&format!("**Total: {} dependencies**\n", total));
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/downloads.rs
+++ b/examples/crates-mcp/src/tools/downloads.rs
@@ -24,9 +24,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: DownloadsInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: DownloadsInput| async move {
                 let response = state
                     .client
                     .crate_downloads(&input.name)
@@ -61,8 +61,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/info.rs
+++ b/examples/crates-mcp/src/tools/info.rs
@@ -23,67 +23,64 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: InfoInput| {
-            let state = state.clone();
-            async move {
-                let response = state
-                    .client
-                    .get_crate(&input.name)
-                    .await
-                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+        .handler_with_state(state, |state: Arc<AppState>, input: InfoInput| async move {
+            let response = state
+                .client
+                .get_crate(&input.name)
+                .await
+                .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
 
-                let c = &response.crate_data;
+            let c = &response.crate_data;
 
-                let mut output = format!("# {}\n\n", c.name);
+            let mut output = format!("# {}\n\n", c.name);
 
-                if let Some(desc) = &c.description {
-                    output.push_str(&format!("{}\n\n", desc.trim()));
-                }
-
-                output.push_str("## Versions\n\n");
-                output.push_str(&format!("- Latest: **{}**\n", c.max_version));
-                if let Some(stable) = &c.max_stable_version
-                    && stable != &c.max_version
-                {
-                    output.push_str(&format!("- Latest Stable: **{}**\n", stable));
-                }
-
-                output.push_str("\n## Stats\n\n");
-                output.push_str(&format!(
-                    "- Total Downloads: {}\n",
-                    format_number(c.downloads)
-                ));
-                if let Some(recent) = c.recent_downloads {
-                    output.push_str(&format!("- Recent Downloads: {}\n", format_number(recent)));
-                }
-                output.push_str(&format!("- Created: {}\n", c.created_at.date_naive()));
-                output.push_str(&format!("- Updated: {}\n", c.updated_at.date_naive()));
-
-                output.push_str("\n## Links\n\n");
-                if let Some(repo) = &c.repository {
-                    output.push_str(&format!("- Repository: {}\n", repo));
-                }
-                if let Some(docs) = &c.documentation {
-                    output.push_str(&format!("- Documentation: {}\n", docs));
-                }
-                if let Some(home) = &c.homepage {
-                    output.push_str(&format!("- Homepage: {}\n", home));
-                }
-
-                if let Some(keywords) = &c.keywords
-                    && !keywords.is_empty()
-                {
-                    output.push_str(&format!("\n## Keywords\n\n{}\n", keywords.join(", ")));
-                }
-
-                if let Some(categories) = &c.categories
-                    && !categories.is_empty()
-                {
-                    output.push_str(&format!("\n## Categories\n\n{}\n", categories.join(", ")));
-                }
-
-                Ok(CallToolResult::text(output))
+            if let Some(desc) = &c.description {
+                output.push_str(&format!("{}\n\n", desc.trim()));
             }
+
+            output.push_str("## Versions\n\n");
+            output.push_str(&format!("- Latest: **{}**\n", c.max_version));
+            if let Some(stable) = &c.max_stable_version
+                && stable != &c.max_version
+            {
+                output.push_str(&format!("- Latest Stable: **{}**\n", stable));
+            }
+
+            output.push_str("\n## Stats\n\n");
+            output.push_str(&format!(
+                "- Total Downloads: {}\n",
+                format_number(c.downloads)
+            ));
+            if let Some(recent) = c.recent_downloads {
+                output.push_str(&format!("- Recent Downloads: {}\n", format_number(recent)));
+            }
+            output.push_str(&format!("- Created: {}\n", c.created_at.date_naive()));
+            output.push_str(&format!("- Updated: {}\n", c.updated_at.date_naive()));
+
+            output.push_str("\n## Links\n\n");
+            if let Some(repo) = &c.repository {
+                output.push_str(&format!("- Repository: {}\n", repo));
+            }
+            if let Some(docs) = &c.documentation {
+                output.push_str(&format!("- Documentation: {}\n", docs));
+            }
+            if let Some(home) = &c.homepage {
+                output.push_str(&format!("- Homepage: {}\n", home));
+            }
+
+            if let Some(keywords) = &c.keywords
+                && !keywords.is_empty()
+            {
+                output.push_str(&format!("\n## Keywords\n\n{}\n", keywords.join(", ")));
+            }
+
+            if let Some(categories) = &c.categories
+                && !categories.is_empty()
+            {
+                output.push_str(&format!("\n## Categories\n\n{}\n", categories.join(", ")));
+            }
+
+            Ok(CallToolResult::text(output))
         })
         .build()
         .expect("valid tool")

--- a/examples/crates-mcp/src/tools/owners.rs
+++ b/examples/crates-mcp/src/tools/owners.rs
@@ -23,9 +23,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: OwnersInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: OwnersInput| async move {
                 let owners = state
                     .client
                     .crate_owners(&input.name)
@@ -57,8 +57,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/reverse_deps.rs
+++ b/examples/crates-mcp/src/tools/reverse_deps.rs
@@ -23,9 +23,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: ReverseDepsInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: ReverseDepsInput| async move {
                 let response = state
                     .client
                     .crate_reverse_dependencies(&input.name)
@@ -48,8 +48,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/search.rs
+++ b/examples/crates-mcp/src/tools/search.rs
@@ -41,9 +41,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: SearchInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: SearchInput| async move {
                 let sort = parse_sort(&input.sort);
                 let query = CratesQuery::builder()
                     .search(&input.query)
@@ -94,8 +94,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/versions.rs
+++ b/examples/crates-mcp/src/tools/versions.rs
@@ -33,9 +33,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler(move |input: VersionsInput| {
-            let state = state.clone();
-            async move {
+        .handler_with_state(
+            state,
+            |state: Arc<AppState>, input: VersionsInput| async move {
                 let response = state
                     .client
                     .get_crate(&input.name)
@@ -67,8 +67,8 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 }
 
                 Ok(CallToolResult::text(output))
-            }
-        })
+            },
+        )
         .build()
         .expect("valid tool")
 }


### PR DESCRIPTION
## Summary

- Convert all 7 tools in `examples/crates-mcp` from the manual `move |input| { let state = state.clone(); async move { ... } }` pattern to `handler_with_state(state, |state, input| async move { ... })` from #134
- Demonstrates the boilerplate reduction for anyone using shared state (DB clients, API clients, etc.)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] All tests pass (235 lib, 47 integration, 70 doc)