### PR TITLE
chore: bump jsonwebtoken to v10 and reqwest to v0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,14 +94,16 @@ optional = true
 features = ["v4"]
 
 [dependencies.jsonwebtoken]
-version = "9"
-optional = true
-
-[dependencies.reqwest]
-version = "0.12"
+version = "10"
 optional = true
 default-features = false
-features = ["rustls-tls", "json"]
+features = ["aws_lc_rs", "use_pem"]
+
+[dependencies.reqwest]
+version = "0.13"
+optional = true
+default-features = false
+features = ["rustls", "json"]
 
 [[example]]
 name = "basic"


### PR DESCRIPTION
## Summary

- **jsonwebtoken** 9.3.1 -> 10.3.0: major version bump, selects `aws_lc_rs` crypto backend and enables `use_pem` feature (PEM methods moved behind a feature gate in v10)
- **reqwest** 0.12.28 -> 0.13.1: major version bump, renames `rustls-tls` feature to `rustls` (rustls is now the default TLS backend)

No source changes required -- the API surface we use is fully compatible across both major bumps.

The two transitive deps (`generic-array` 0.14.7 and `matchit` 0.8.4) are patch-level behind and will update when their parent crates bump them.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (243 passed)
- [x] `cargo test --test '*' --all-features` (52 passed)
- [x] `cargo test --doc --all-features` (71 passed)
- [x] `cargo check --workspace --all-features` (crates-mcp + conformance-server)