### PR TITLE
feat: bump MCP protocol version to 2025-11-25

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,24 +250,28 @@ let app = transport.into_router()
 
 ## Protocol Compliance
 
-tower-mcp targets the [MCP specification 2025-03-26](https://modelcontextprotocol.io/specification/2025-03-26). Current compliance:
+tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25). Current compliance:
 
-- [x] [JSON-RPC 2.0 message format](https://modelcontextprotocol.io/specification/2025-03-26/basic#messages)
-- [x] [Protocol version negotiation](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#version-negotiation)
-- [x] [Capability negotiation](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#capability-negotiation)
-- [x] [Initialize/initialized lifecycle](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle)
-- [x] [tools/list and tools/call](https://modelcontextprotocol.io/specification/2025-03-26/server/tools)
-- [x] [Tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools)
-- [x] [Batch requests](https://modelcontextprotocol.io/specification/2025-03-26/basic#batching)
-- [x] [resources/list, resources/read, resources/subscribe](https://modelcontextprotocol.io/specification/2025-03-26/server/resources)
-- [x] [prompts/list, prompts/get](https://modelcontextprotocol.io/specification/2025-03-26/server/prompts)
+- [x] [JSON-RPC 2.0 message format](https://modelcontextprotocol.io/specification/2025-11-25/basic#messages)
+- [x] [Protocol version negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation)
+- [x] [Capability negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#capability-negotiation)
+- [x] [Initialize/initialized lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+- [x] [tools/list and tools/call](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [x] [Tool annotations](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
+- [x] [Batch requests](https://modelcontextprotocol.io/specification/2025-11-25/basic#batching)
+- [x] [resources/list, resources/read, resources/subscribe](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)
+- [x] [prompts/list, prompts/get](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts)
+- [x] [Icons on tools/resources/prompts (SEP-973)](https://modelcontextprotocol.io/specification/2025-11-25)
+- [x] [Implementation metadata](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+- [x] [Sampling with tools/toolChoice (SEP-1577)](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling)
 - [x] [Elicitation (user input requests)](https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation)
-- [x] [Session management](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management)
-- [x] [Progress notifications](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/progress)
-- [x] [Request cancellation](https://modelcontextprotocol.io/specification/2025-03-26/basic/utilities/cancellation)
-- [x] [Completion (autocomplete)](https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/completion)
-- [x] [Roots (filesystem discovery)](https://modelcontextprotocol.io/specification/2025-03-26/client/roots)
-- [x] [Sampling](https://modelcontextprotocol.io/specification/2025-03-26/client/sampling) (stdio transport)
+- [x] [Session management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management)
+- [x] [Progress notifications](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress)
+- [x] [Request cancellation](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation)
+- [x] [Completion (autocomplete)](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/completion)
+- [x] [Roots (filesystem discovery)](https://modelcontextprotocol.io/specification/2025-11-25/client/roots)
+- [x] [Sampling](https://modelcontextprotocol.io/specification/2025-11-25/client/sampling) (all transports)
+- [ ] SSE event IDs and stream resumption (SEP-1699) - future work
 
 ## Development
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // 1. Initialize
     println!("1. Initialize request:");
     let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
-        "protocolVersion": "2025-03-26",
+        "protocolVersion": "2025-11-25",
         "capabilities": {},
         "clientInfo": {
             "name": "example-client",

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -199,9 +199,11 @@ fn build_sampling() -> Tool {
                 CreateMessageParams::new(vec![SamplingMessage::user("Test sampling request")], 100);
             match ctx.sample(params).await {
                 Ok(result) => {
-                    let text = match &result.content {
-                        tower_mcp::SamplingContent::Text { text } => text.clone(),
-                        _ => format!("{:?}", result.content),
+                    // Get the first content item
+                    let text = match result.content_items().first() {
+                        Some(tower_mcp::SamplingContent::Text { text }) => text.clone(),
+                        Some(content) => format!("{:?}", content),
+                        None => "No content".to_string(),
                     };
                     Ok(CallToolResult::text(text))
                 }

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -8,7 +8,7 @@
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "Accept: application/json, text/event-stream" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //!
 //! # List tools (use session ID from initialize response)
 //! curl -X POST http://localhost:3000/ \

--- a/examples/http_server_with_auth.rs
+++ b/examples/http_server_with_auth.rs
@@ -9,19 +9,19 @@
 //! # Without auth (fails)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //!
 //! # With valid API key
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "Authorization: Bearer sk-test-key-123" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //!
 //! # With X-API-Key header
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "X-API-Key: sk-test-key-123" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //! ```
 
 use axum::{

--- a/examples/http_server_with_middleware.rs
+++ b/examples/http_server_with_middleware.rs
@@ -13,7 +13,7 @@
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "Accept: application/json, text/event-stream" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //!
 //! # Call the slow tool (will timeout after 2 seconds)
 //! curl -X POST http://localhost:3000/ \

--- a/examples/http_server_with_oauth.rs
+++ b/examples/http_server_with_oauth.rs
@@ -16,7 +16,7 @@
 //! # 2. Attempt without token (returns 401 with WWW-Authenticate header)
 //! curl -v -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //!
 //! # 3. Generate a test JWT (in a real app, obtained from the auth server):
 //! #    The example uses the shared secret "demo-secret-do-not-use-in-production"
@@ -29,7 +29,7 @@
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "Authorization: Bearer <your-jwt-here>" \
-//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //! ```
 
 use schemars::JsonSchema;

--- a/examples/stdio_server.rs
+++ b/examples/stdio_server.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with: cargo run --example stdio_server
 //!
-//! Test with: echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | cargo run --example stdio_server
+//! Test with: echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | cargo run --example stdio_server
 
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/examples/stdio_server_with_middleware.rs
+++ b/examples/stdio_server_with_middleware.rs
@@ -8,7 +8,7 @@
 //!
 //! Test with:
 //! ```bash
-//! echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
+//! echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' \
 //!   | cargo run --example stdio_server_with_middleware
 //! ```
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -192,6 +192,7 @@ impl<T: ClientTransport> McpClient<T> {
             client_info: Implementation {
                 name: client_name.to_string(),
                 version: client_version.to_string(),
+                ..Default::default()
             },
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@ pub use protocol::{
     ListRootsResult, McpRequest, McpResponse, ModelHint, ModelPreferences,
     PrimitiveSchemaDefinition, PromptMessage, PromptReference, PromptRole, ReadResourceResult,
     ResourceContent, ResourceReference, Root, RootsCapability, SamplingCapability, SamplingContent,
-    SamplingMessage,
+    SamplingContentOrArray, SamplingMessage, SamplingTool, ToolChoice,
 };
 pub use resource::{
     Resource, ResourceBuilder, ResourceHandler, ResourceTemplate, ResourceTemplateBuilder,

--- a/src/router.rs
+++ b/src/router.rs
@@ -79,6 +79,14 @@ impl std::fmt::Debug for McpRouter {
 struct McpRouterInner {
     server_name: String,
     server_version: String,
+    /// Human-readable title for the server
+    server_title: Option<String>,
+    /// Description of the server
+    server_description: Option<String>,
+    /// Icons for the server
+    server_icons: Option<Vec<ToolIcon>>,
+    /// URL of the server's website
+    server_website_url: Option<String>,
     instructions: Option<String>,
     tools: HashMap<String, Arc<Tool>>,
     resources: HashMap<String, Arc<Resource>>,
@@ -106,6 +114,10 @@ impl McpRouter {
             inner: Arc::new(McpRouterInner {
                 server_name: "tower-mcp".to_string(),
                 server_version: env!("CARGO_PKG_VERSION").to_string(),
+                server_title: None,
+                server_description: None,
+                server_icons: None,
+                server_website_url: None,
                 instructions: None,
                 tools: HashMap::new(),
                 resources: HashMap::new(),
@@ -224,6 +236,30 @@ impl McpRouter {
     /// Set instructions for LLMs describing how to use this server
     pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
         Arc::make_mut(&mut self.inner).instructions = Some(instructions.into());
+        self
+    }
+
+    /// Set a human-readable title for the server
+    pub fn server_title(mut self, title: impl Into<String>) -> Self {
+        Arc::make_mut(&mut self.inner).server_title = Some(title.into());
+        self
+    }
+
+    /// Set the server description
+    pub fn server_description(mut self, description: impl Into<String>) -> Self {
+        Arc::make_mut(&mut self.inner).server_description = Some(description.into());
+        self
+    }
+
+    /// Set icons for the server
+    pub fn server_icons(mut self, icons: Vec<ToolIcon>) -> Self {
+        Arc::make_mut(&mut self.inner).server_icons = Some(icons);
+        self
+    }
+
+    /// Set the server's website URL
+    pub fn server_website_url(mut self, url: impl Into<String>) -> Self {
+        Arc::make_mut(&mut self.inner).server_website_url = Some(url.into());
         self
     }
 
@@ -624,6 +660,10 @@ impl McpRouter {
                     server_info: Implementation {
                         name: self.inner.server_name.clone(),
                         version: self.inner.server_version.clone(),
+                        title: self.inner.server_title.clone(),
+                        description: self.inner.server_description.clone(),
+                        icons: self.inner.server_icons.clone(),
+                        website_url: self.inner.server_website_url.clone(),
                     },
                     instructions: self.inner.instructions.clone(),
                 }))
@@ -1131,6 +1171,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -1725,6 +1766,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -1835,6 +1877,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -1867,6 +1910,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -2370,6 +2414,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -2410,6 +2455,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),
@@ -2473,6 +2519,7 @@ mod tests {
                 client_info: Implementation {
                     name: "test".to_string(),
                     version: "1.0".to_string(),
+                    ..Default::default()
                 },
             }),
             extensions: Extensions::new(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -457,7 +457,7 @@ async fn test_protocol_version_negotiation_unsupported() {
         JsonRpcResponse::Result(r) => {
             // Server responds with its latest supported version
             let version = r.result.get("protocolVersion").unwrap().as_str().unwrap();
-            assert_eq!(version, "2025-03-26");
+            assert_eq!(version, "2025-11-25");
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
     }


### PR DESCRIPTION
## Summary

Bumps the advertised protocol version from 2025-03-26 to 2025-11-25 by implementing the remaining schema gaps.

### Changes

- **Icons/title/size on resources and prompts (SEP-973)**
  - `ResourceDefinition`: added `title`, `icons`, `size` fields
  - `ResourceTemplateDefinition`: added `title`, `icons` fields  
  - `PromptDefinition`: added `title`, `icons` fields
  - Added builder methods to ResourceBuilder, ResourceTemplateBuilder, PromptBuilder

- **Implementation metadata**
  - Added `title`, `description`, `icons`, `website_url` fields to `Implementation`
  - Added `McpRouter` builder methods: `server_title()`, `server_description()`, `server_icons()`, `server_website_url()`

- **Sampling tools and toolChoice (SEP-1577)**
  - Added `SamplingTool`, `ToolChoice`, `SamplingContentOrArray` types
  - Added `ToolUse` and `ToolResult` variants to `SamplingContent`
  - Updated `CreateMessageParams` with `tools` and `tool_choice` fields

- **Protocol version bump**
  - `LATEST_PROTOCOL_VERSION` = "2025-11-25"
  - `SUPPORTED_PROTOCOL_VERSIONS` = ["2025-11-25", "2025-03-26"]

### Breaking Changes

- `CreateMessageResult.content` is now `SamplingContentOrArray` instead of `SamplingContent`. Use `content_items()` to get `Vec<&SamplingContent>`.

### Deferred

- SSE event IDs and stream resumption (SEP-1699) - spec optional ("MAY"), tracking issue to follow

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (251 tests)
- [x] `cargo test --test '*' --all-features` (52 tests)
- [x] `cargo test --doc --all-features` (71 tests)

Closes #131