### PR TITLE
docs: show server protocol version response in http_server example

### DIFF
--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -4,11 +4,22 @@
 //!
 //! Test with curl:
 //! ```bash
-//! # Initialize session
+//! # Initialize session (client sends protocolVersion)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "Accept: application/json, text/event-stream" \
 //!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!
+//! # Server responds with negotiated protocolVersion and its capabilities:
+//! # {
+//! #   "jsonrpc": "2.0",
+//! #   "id": 1,
+//! #   "result": {
+//! #     "protocolVersion": "2025-11-25",
+//! #     "serverInfo": { "name": "http-example", "version": "1.0.0" },
+//! #     "capabilities": { "tools": {}, "resources": {}, "prompts": {} }
+//! #   }
+//! # }
 //!
 //! # List tools (use session ID from initialize response)
 //! curl -X POST http://localhost:3000/ \


### PR DESCRIPTION
## Summary

Add commented example of server's initialize response showing:
- protocolVersion negotiation (server echoes supported version)
- serverInfo with name and version
- capabilities object

## Context

Addresses MCP Scan feedback about protocol version negotiation not being visible in examples. The scanner noted:

> "there's no explicit mechanism shown for how the server would negotiate or report its supported protocol versions"

This shows the server's side of the negotiation in the curl example comments.

## Test plan

- [ ] Verify example still compiles: `cargo build --example http_server --features http`