### PR TITLE
feat: add HTTP transport and Fly.io deployment for crates-mcp demo

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,30 @@
+name: Deploy Demo Server
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'examples/crates-mcp/**'
+      - 'src/**'
+      - 'Cargo.toml'
+      - '.github/workflows/deploy-demo.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to Fly.io
+    runs-on: ubuntu-latest
+    # Only deploy if FLY_API_TOKEN is set
+    if: github.repository == 'joshrotenberg/tower-mcp'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Fly CLI
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly.io
+        run: flyctl deploy --config examples/crates-mcp/fly.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -15,7 +15,7 @@ path = "tests/integration.rs"
 
 [dependencies]
 # Core MCP
-tower-mcp = { path = "../.." }
+tower-mcp = { path = "../..", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"
@@ -38,9 +38,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tower middleware
-tower = { version = "0.5", features = ["util"] }
-tower-resilience-ratelimiter = "0.5"
-tower-resilience-bulkhead = "0.5"
-
-# For rate limiting display
-humantime = "2"
+tower = { version = "0.5", features = ["util", "timeout", "limit"] }
+tower-resilience-ratelimiter = "0.6"
+tower-resilience-bulkhead = "0.6"

--- a/examples/crates-mcp/Dockerfile
+++ b/examples/crates-mcp/Dockerfile
@@ -1,0 +1,37 @@
+# Build stage
+FROM rust:1.85-slim-bookworm AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the workspace
+COPY . .
+
+# Build the release binary
+RUN cargo build --release -p crates-mcp
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy the binary from builder
+COPY --from=builder /app/target/release/crates-mcp /usr/local/bin/crates-mcp
+
+# Create non-root user
+RUN useradd -m -u 1000 app
+USER app
+
+# Expose port
+EXPOSE 3000
+
+# Run the server
+CMD ["crates-mcp", "--transport", "http", "--host", "0.0.0.0", "--port", "3000", "--max-concurrent", "5", "--request-timeout-secs", "30"]

--- a/examples/crates-mcp/fly.toml
+++ b/examples/crates-mcp/fly.toml
@@ -1,0 +1,21 @@
+# Fly.io configuration for crates-mcp demo server
+# Deploy with: fly deploy --config examples/crates-mcp/fly.toml
+
+app = "crates-mcp-demo"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "examples/crates-mcp/Dockerfile"
+
+[http_service]
+  internal_port = 3000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ["app"]
+
+[[vm]]
+  memory = "256mb"
+  cpu_kind = "shared"
+  cpus = 1


### PR DESCRIPTION
## Summary

Adds HTTP transport support and deployment infrastructure for the crates-mcp example server to serve as a public demo.

## Changes

**HTTP Transport:**
- Add `--transport http` CLI option with `--host` and `--port` flags
- Tower middleware stack: TimeoutLayer + RateLimiterLayer + BulkheadLayer
- Rate limiting (5 req/sec) and concurrency limiting (10 concurrent) for public demo protection

**Deployment Infrastructure:**
- `Dockerfile` - Multi-stage build for containerized deployment
- `fly.toml` - Fly.io configuration (sjc region, auto-suspend for cost savings)
- `.github/workflows/deploy-demo.yml` - Auto-deploy on push to main

**Dependencies:**
- `tower-resilience-ratelimiter = "0.6"` - Token bucket rate limiting
- `tower-resilience-bulkhead = "0.6"` - Concurrency isolation

## To Deploy

1. Add `FLY_API_TOKEN` secret to GitHub repo settings
2. Merge this PR
3. Push to main triggers auto-deploy

## Testing

```bash
# Local HTTP test
cargo run -p crates-mcp -- --transport http --port 3000

# Initialize
curl -X POST http://localhost:3000/ \
  -H "Content-Type: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}'
```

Closes #113