### PR TITLE
fix: correct Dockerfile path in fly.toml

### DIFF
--- a/examples/crates-mcp/fly.toml
+++ b/examples/crates-mcp/fly.toml
@@ -5,6 +5,7 @@ app = "crates-mcp-demo"
 primary_region = "sjc"
 
 [build]
+  context = "../.."
   dockerfile = "examples/crates-mcp/Dockerfile"
 
 [http_service]


### PR DESCRIPTION
The dockerfile path was being resolved relative to fly.toml location, causing a double path. Added explicit build context to resolve paths from repo root.