### PR TITLE
fix: dockerfile path relative to fly.toml

### DIFF
--- a/examples/crates-mcp/fly.toml
+++ b/examples/crates-mcp/fly.toml
@@ -6,7 +6,7 @@ primary_region = "sjc"
 
 [build]
   context = "../.."
-  dockerfile = "examples/crates-mcp/Dockerfile"
+  dockerfile = "Dockerfile"
 
 [http_service]
   internal_port = 3000


### PR DESCRIPTION
The dockerfile path in fly.toml should be relative to the fly.toml location, not the context. Changed from `examples/crates-mcp/Dockerfile` to `Dockerfile`.