### PR TITLE
fix: use latest stable Rust in Dockerfile

### DIFF
--- a/examples/crates-mcp/Dockerfile
+++ b/examples/crates-mcp/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:slim-bookworm AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
The crates-mcp example uses let-chains which aren't stable until Rust 1.88+. Changed from `rust:1.85-slim-bookworm` to `rust:slim-bookworm` (latest stable).