### PR TITLE
docs: add live demo section to README and bump rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,27 @@ This means:
 - Same service can be exposed over multiple transports (stdio, HTTP, WebSocket)
 - Easy integration with existing tower-based applications (axum, tonic)
 
+## Live Demo
+
+A demo MCP server for querying [crates.io](https://crates.io) is deployed at:
+
+**https://crates-mcp-demo.fly.dev**
+
+Connect with any MCP client that supports HTTP transport, or add to Claude Code's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "crates": {
+      "type": "http",
+      "url": "https://crates-mcp-demo.fly.dev"
+    }
+  }
+}
+```
+
+The demo includes 7 tools (search, info, versions, dependencies, reverse deps, downloads, owners), 2 prompts (analyze, compare), and 1 resource (recent searches). See [`examples/crates-mcp`](examples/crates-mcp) for the full source.
+
 ## Status
 
 **Active development** - Core protocol, routing, and transports are implemented. Used in production for MCP server deployments.

--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -39,5 +39,5 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tower middleware
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
-tower-resilience-ratelimiter = "0.6"
 tower-resilience-bulkhead = "0.6"
+tower-resilience-ratelimiter = "0.6"

--- a/examples/crates-mcp/Dockerfile
+++ b/examples/crates-mcp/Dockerfile
@@ -34,4 +34,4 @@ USER app
 EXPOSE 3000
 
 # Run the server
-CMD ["crates-mcp", "--transport", "http", "--host", "0.0.0.0", "--port", "3000", "--max-concurrent", "5", "--request-timeout-secs", "30"]
+CMD ["crates-mcp", "--transport", "http", "--host", "0.0.0.0", "--port", "3000", "--max-concurrent", "10", "--request-timeout-secs", "30"]

--- a/examples/crates-mcp/src/main.rs
+++ b/examples/crates-mcp/src/main.rs
@@ -152,8 +152,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             // tower-resilience layers use composite error types that wrap both
             // the layer's own errors and the inner service error, making them
             // compatible with tower-mcp's Infallible error type.
+            //
+            // Note: CircuitBreakerLayer could be added for downstream service failures
+            // (e.g., crates.io API), but McpRouter returns Infallible so the breaker
+            // would need a custom failure classifier to inspect response content.
             let rate_limiter = RateLimiterLayer::builder()
-                .limit_for_period(5) // 5 requests per period
+                .limit_for_period(10) // 10 requests per second
                 .refresh_period(Duration::from_secs(1))
                 .timeout_duration(Duration::from_millis(500))
                 .build();


### PR DESCRIPTION
## Summary

- Add Live Demo section to README with Fly.io URL and Claude Code `.mcp.json` config example
- Increase rate limiter from 5 to 10 requests/second for more generous demo access
- Increase bulkhead from 5 to 10 concurrent requests in Dockerfile
- Add comment about CircuitBreakerLayer integration considerations (requires custom failure classifier since McpRouter uses Infallible)

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Deploy to Fly.io and confirm rate limits work as expected