### PR TITLE
ci: add deployment verification step

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -28,3 +28,47 @@ jobs:
         run: flyctl deploy --config examples/crates-mcp/fly.toml --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      - name: Verify deployment
+        run: |
+          echo "Waiting for server to be ready..."
+          sleep 10
+
+          echo "Sending initialize request..."
+          INIT_RESPONSE=$(curl -s -X POST https://crates-mcp-demo.fly.dev/ \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"deploy-check","version":"1.0"}}}')
+
+          echo "Init response: $INIT_RESPONSE"
+
+          # Extract session ID from response header (need to capture headers)
+          SESSION_ID=$(curl -s -i -X POST https://crates-mcp-demo.fly.dev/ \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -d '{"jsonrpc":"2.0","id":2,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"deploy-check","version":"1.0"}}}' \
+            | grep -i "mcp-session-id" | cut -d' ' -f2 | tr -d '\r')
+
+          echo "Session ID: $SESSION_ID"
+
+          if [ -z "$SESSION_ID" ]; then
+            echo "Failed to get session ID"
+            exit 1
+          fi
+
+          echo "Sending test tool call..."
+          TOOL_RESPONSE=$(curl -s -X POST https://crates-mcp-demo.fly.dev/ \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            -H "MCP-Session-Id: $SESSION_ID" \
+            -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"search_crates","arguments":{"query":"tower"}}}')
+
+          echo "Tool response: $TOOL_RESPONSE"
+
+          # Check for successful response (should contain "result" not "error")
+          if echo "$TOOL_RESPONSE" | grep -q '"result"'; then
+            echo "Deployment verification successful!"
+          else
+            echo "Deployment verification failed - unexpected response"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a verification step after Fly.io deployment that:
1. Waits 10 seconds for the server to be ready
2. Sends an MCP initialize request and captures the session ID
3. Sends a test `search_crates` tool call
4. Verifies the response contains a result (not an error)

This catches deployment issues before they go unnoticed.

## Test plan

- [ ] Merge and verify the workflow runs successfully
- [ ] Optionally trigger a manual workflow run to test