### PR TITLE
feat(http): add /health endpoint for deployment verification

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -29,11 +29,23 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-      - name: Verify deployment
+      - name: Verify deployment (health check)
         run: |
           echo "Waiting for server to be ready..."
           sleep 10
 
+          echo "Checking health endpoint..."
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://crates-mcp-demo.fly.dev/health)
+
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Health check passed!"
+          else
+            echo "Health check failed with status: $HTTP_STATUS"
+            exit 1
+          fi
+
+      - name: Verify deployment (MCP protocol)
+        run: |
           # Save response headers to a file so we can extract session ID
           echo "Sending initialize request..."
           INIT_RESPONSE=$(curl -s -D /tmp/headers.txt -X POST https://crates-mcp-demo.fly.dev/ \
@@ -72,8 +84,8 @@ jobs:
 
           # Check for successful response (should contain "result" not "error")
           if echo "$TOOL_RESPONSE" | grep -q '"result"'; then
-            echo "Deployment verification successful!"
+            echo "MCP protocol verification successful!"
           else
-            echo "Deployment verification failed - unexpected response"
+            echo "MCP protocol verification failed - unexpected response"
             exit 1
           fi

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -632,6 +632,7 @@ impl HttpTransport {
             .route("/", post(handle_post))
             .route("/", get(handle_get))
             .route("/", delete(handle_delete))
+            .route("/health", get(handle_health))
             .with_state(state);
 
         #[cfg(feature = "oauth")]
@@ -648,6 +649,7 @@ impl HttpTransport {
             .route("/", post(handle_post))
             .route("/", get(handle_get))
             .route("/", delete(handle_delete))
+            .route("/health", get(handle_health))
             .with_state(state);
 
         let router = Router::new().nest(path, mcp_router);
@@ -1171,6 +1173,14 @@ async fn handle_delete(State(state): State<Arc<AppState>>, headers: HeaderMap) -
         tracing::debug!(session_id = %session_id, "Session already removed or never existed");
         StatusCode::OK.into_response()
     }
+}
+
+/// Handle GET /health requests
+///
+/// Returns a simple 200 OK response for health checks.
+/// Does not require authentication or session state.
+async fn handle_health() -> Response {
+    StatusCode::OK.into_response()
 }
 
 /// Create a JSON-RPC error response


### PR DESCRIPTION
## Summary

Adds a simple `/health` endpoint to the HTTP transport that returns 200 OK without requiring authentication or session state. This provides a reliable way to verify deployments.

## Changes

1. **New `/health` endpoint** in HTTP transport
   - `GET /health` returns 200 OK
   - No session, auth, or MCP protocol required
   - Available on both `into_router()` and `into_router_at()`

2. **Updated deploy verification** (two steps now)
   - First: health check (`GET /health`)
   - Then: MCP protocol check (initialize -> initialized -> tool call)

If the MCP protocol check continues to fail, we can remove it and rely on the health check alone.

## Test plan

- [ ] Verify `/health` returns 200 locally
- [ ] Merge and check if deploy workflow passes
- [ ] If MCP check still fails, remove it in a follow-up