### PR TITLE
fix(crates-mcp): add --minimal flag to workaround Claude Code MCP issues

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,17 @@
       "env": {
         "RUST_LOG": "tower_mcp=debug"
       }
+    },
+    "crates-mcp-local": {
+      "command": "cargo",
+      "args": ["run", "--manifest-path", "examples/crates-mcp/Cargo.toml", "--", "--transport", "stdio", "--minimal"],
+      "env": {
+        "RUST_LOG": "crates_mcp=info"
+      }
+    },
+    "crates-mcp-remote": {
+      "type": "http",
+      "url": "https://crates-mcp-demo.fly.dev/"
     }
   }
 }


### PR DESCRIPTION
## Summary

Claude Code has a known issue where MCP servers with certain capability combinations don't expose their tools to the assistant, despite connecting successfully.

Related issues:
- https://github.com/anthropics/claude-code/issues/2682
- https://github.com/anthropics/claude-code/issues/12164

## Root Cause Analysis

Investigation found that the `completions` capability (added in PR #170) appears to trigger this issue:

| Capabilities | Tools Exposed |
|-------------|---------------|
| completions, prompts, resources, tasks, tools | No |
| prompts, resources, tasks, tools (main branch) | Yes |
| tasks, tools only (tower-mcp-example, project-tracker) | Yes |

Claude Code shows "Capabilities: resources / prompts" but NOT "tools" even though the initialize response correctly includes the tools capability.

## Solution

Adds a `--minimal` flag to crates-mcp that disables resources, prompts, and completions, leaving only tools registered. This matches the capability set of working servers.

```bash
crates-mcp --transport stdio --minimal
```

Also updates `.mcp.json` to use minimal mode for `crates-mcp-local` by default.

## Test Plan

- [x] Build and test locally
- [x] Verify minimal mode only advertises tasks + tools capabilities
- [x] Verify all 10 tools still work in minimal mode
- [ ] User testing: reconnect crates-mcp-local with minimal mode and verify tools appear

## Note

This is a workaround, not a fix. The underlying issue is in Claude Code's MCP client. The bug should be reported/tracked in the Claude Code repository.