### PR TITLE
feat(tool): add NoParams type for parameterless tools

### DIFF
--- a/examples/crates-mcp/src/tools/summary.rs
+++ b/examples/crates-mcp/src/tools/summary.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{CallToolResult, Error, NoParams, Tool, ToolBuilder};
 
 use crate::state::{AppState, format_number};
 
@@ -15,7 +15,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(state, |state: Arc<AppState>, _input: ()| async move {
+        .handler_with_state(state, |state: Arc<AppState>, _input: NoParams| async move {
             let summary = state
                 .client
                 .summary()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub use resource::{
 };
 pub use router::{Extensions, McpRouter, RouterRequest, RouterResponse};
 pub use session::{SessionPhase, SessionState};
-pub use tool::{Tool, ToolBuilder, ToolHandler};
+pub use tool::{NoParams, Tool, ToolBuilder, ToolHandler};
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,
     SyncStdioTransport,


### PR DESCRIPTION
## Summary

- Add `NoParams` type for tools that take no parameters
- The unit type `()` generates `"type": "null"` in JSON Schema, which MCP clients reject
- `NoParams` generates `"type": "object"` which is the correct schema for parameterless tools
- Update crates-mcp `get_summary` tool to use `NoParams`

## Problem

When using `()` as a handler input type:
```rust
.handler_with_state(state, |state: Arc<AppState>, _input: ()| async move { ... })
```

The generated JSON Schema has `"type": "null"`, which Claude Code (and likely other MCP clients) rejects with:
```
"Invalid input: expected \"object\""
```

## Solution

Add a `NoParams` type that:
- Implements `JsonSchema` to produce `{"type": "object"}`
- Implements `Deserialize` to accept `{}`, `null`, or objects with ignored fields

Usage:
```rust
use tower_mcp::NoParams;

.handler_with_state(state, |state: Arc<AppState>, _input: NoParams| async move { ... })
```

## Test plan

- [x] `cargo test` passes (267 lib + 47 integration tests)
- [x] `cargo clippy` passes
- [x] Verified `get_summary` tool now produces `"type": "object"` schema