### PR TITLE
fix: update SEP status label when issue is final

### DIFF
--- a/.github/scripts/sync-seps.js
+++ b/.github/scripts/sync-seps.js
@@ -82,6 +82,9 @@ module.exports = async ({ github, context, core }) => {
 
     // Check if SEP is closed/final upstream
     const isFinal = sep.state === 'closed' || upstreamLabels.includes('final');
+    if (isFinal) {
+      status = 'sep:final';
+    }
     const statusPrefix = isFinal ? '[final]' :
                          status === 'sep:accepted' ? '[accepted]' :
                          status === 'sep:in-review' ? '[in-review]' :


### PR DESCRIPTION
## Summary

Fixes a bug in the SEP sync script where the status label wasn't being updated when an upstream SEP was marked as final.

**Before:** Title showed `[final]` but label remained `sep:proposal` or `sep:draft`
**After:** Both title and label are updated to `[final]` / `sep:final`

## Also done in this session

Bulk-closed 27 SEP tracking issues:
- 12 as `not-applicable` (governance/process/client-only)
- 15 as `implemented` (already in tower-mcp)

Open SEP issues reduced from 84 to 51.