### PR TITLE
feat(filter): add session-specific resource filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ pub use context::{
     RequestContext, RequestContextBuilder, ServerNotification, outgoing_request_channel,
 };
 pub use error::{BoxError, Error, Result, ToolError};
-pub use filter::{CapabilityFilter, DenialBehavior, Filterable, ToolFilter};
+pub use filter::{CapabilityFilter, DenialBehavior, Filterable, ResourceFilter, ToolFilter};
 pub use jsonrpc::{JsonRpcLayer, JsonRpcService};
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{


### PR DESCRIPTION
## Summary

Extends capability filtering to support resources (second part of #262).

- Add `ResourceFilter` type alias export
- Add `McpRouter::resource_filter()` builder method
- Filter resources from `resources/list` based on session state
- Return appropriate errors on `resources/read` for filtered resources

## Design

Same pattern as tool filtering:

```rust
let router = McpRouter::new()
    .resource(public_resource)
    .resource(secret_resource)
    .resource_filter(CapabilityFilter::new(|session, resource: &Resource| {
        !resource.name().contains("Secret")
    }));
```

## Test plan

- [x] Unit tests for resource filtering (4 tests)
- [x] All existing tests pass (284 unit, 47 integration, 78 doc)

Partial fix for #262 (prompt filtering to follow in PR 3)