### PR TITLE
feat(filter): add session-specific prompt filtering

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,9 @@ pub use context::{
     RequestContext, RequestContextBuilder, ServerNotification, outgoing_request_channel,
 };
 pub use error::{BoxError, Error, Result, ToolError};
-pub use filter::{CapabilityFilter, DenialBehavior, Filterable, ResourceFilter, ToolFilter};
+pub use filter::{
+    CapabilityFilter, DenialBehavior, Filterable, PromptFilter, ResourceFilter, ToolFilter,
+};
 pub use jsonrpc::{JsonRpcLayer, JsonRpcService};
 pub use prompt::{Prompt, PromptBuilder, PromptHandler};
 pub use protocol::{


### PR DESCRIPTION
## Summary

Completes capability filtering by supporting prompts (third part of #262).

- Add `PromptFilter` type alias export
- Add `McpRouter::prompt_filter()` builder method
- Filter prompts from `prompts/list` based on session state
- Return appropriate errors on `prompts/get` for filtered prompts

## Design

Same pattern as tool and resource filtering:

```rust
let router = McpRouter::new()
    .prompt(public_prompt)
    .prompt(admin_prompt)
    .prompt_filter(CapabilityFilter::new(|session, prompt: &Prompt| {
        !prompt.name().contains("system")
    }));
```

## Test plan

- [x] Unit tests for prompt filtering (4 tests)
- [x] All existing tests pass (288 unit, 79 doc)

Closes #262