### PR TITLE
feat: SEP-1442 stateless MCP mode (experimental)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,8 @@ oauth = ["dep:jsonwebtoken", "http"]
 jwks = ["oauth", "dep:reqwest"]
 # Test utilities for MCP servers
 testing = []
+# SEP-1442 stateless mode (experimental)
+stateless = []
 
 [dependencies.axum]
 version = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -260,6 +260,8 @@ pub mod protocol;
 pub mod resource;
 pub mod router;
 pub mod session;
+#[cfg(feature = "stateless")]
+pub mod stateless;
 #[cfg(feature = "testing")]
 pub mod testing;
 pub mod tool;

--- a/src/session.rs
+++ b/src/session.rs
@@ -169,9 +169,14 @@ impl SessionState {
     /// Per spec:
     /// - Before initialization: only `initialize` and `ping` are valid
     /// - During all phases: `ping` is always valid
+    /// - With SEP-1442 stateless mode: `server/discover` is also valid before init
     pub fn is_request_allowed(&self, method: &str) -> bool {
         match self.phase() {
             SessionPhase::Uninitialized => {
+                #[cfg(feature = "stateless")]
+                if method == "server/discover" {
+                    return true;
+                }
                 matches!(method, "initialize" | "ping")
             }
             SessionPhase::Initializing | SessionPhase::Initialized => true,

--- a/src/stateless.rs
+++ b/src/stateless.rs
@@ -1,0 +1,405 @@
+//! SEP-1442 Stateless MCP support (experimental)
+//!
+//! This module provides experimental support for stateless MCP as defined in
+//! [SEP-1442](https://github.com/modelcontextprotocol/specification/issues/1442).
+//!
+//! ## Feature Flag
+//!
+//! This module is gated behind the `stateless` feature flag:
+//!
+//! ```toml
+//! tower-mcp = { version = "0.2", features = ["stateless"] }
+//! ```
+//!
+//! ## Key Changes from Standard MCP
+//!
+//! 1. **Per-request protocol version**: Every request includes the protocol version
+//! 2. **Optional discovery**: `server/discover` RPC for capability discovery
+//! 3. **Optional sessions**: Sessions are no longer mandatory
+//! 4. **Per-request client capabilities**: Clients can specify capabilities per-request
+//!
+//! ## Warning
+//!
+//! SEP-1442 is still in draft status. The API may change as the specification evolves.
+
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::{
+    ClientCapabilities, Implementation, ProgressToken, Root, ServerCapabilities,
+};
+
+// =============================================================================
+// Extended _meta fields for stateless mode
+// =============================================================================
+
+/// Extended request metadata for stateless MCP (SEP-1442).
+///
+/// In stateless mode, each request must be self-contained. This extended metadata
+/// allows passing protocol version, session ID, and client capabilities per-request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatelessRequestMeta {
+    /// Progress token for receiving progress notifications
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<ProgressToken>,
+
+    /// The MCP protocol version for this request (SEP-1442).
+    ///
+    /// For HTTP transport, this must match the `MCP-Protocol-Version` header.
+    #[serde(
+        rename = "modelcontextprotocol.io/mcpProtocolVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub protocol_version: Option<String>,
+
+    /// Optional session ID for requests that need session affinity (SEP-1442).
+    ///
+    /// For HTTP transport, this must match the `MCP-Session-Id` header.
+    #[serde(
+        rename = "modelcontextprotocol.io/sessionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub session_id: Option<String>,
+
+    /// Client capabilities for this specific request (SEP-1442).
+    ///
+    /// Allows the server to know what optional features the client can handle
+    /// for this specific transaction.
+    #[serde(
+        rename = "modelcontextprotocol.io/clientCapabilities",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_capabilities: Option<ClientCapabilities>,
+
+    /// Client roots for this request (SEP-1442).
+    #[serde(
+        rename = "modelcontextprotocol.io/roots",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub roots: Option<Vec<Root>>,
+
+    /// Log level for this request (SEP-1442).
+    ///
+    /// Replaces the deprecated `logging/setLevel` RPC.
+    #[serde(
+        rename = "modelcontextprotocol.io/logLevel",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub log_level: Option<LogLevel>,
+}
+
+/// Log levels (matches existing MCP log levels)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+    Critical,
+    Alert,
+    Emergency,
+}
+
+// =============================================================================
+// server/discover RPC
+// =============================================================================
+
+/// Request for the `server/discover` RPC (SEP-1442).
+///
+/// Allows clients to query server capabilities without establishing a session.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiscoverParams {}
+
+/// Response for the `server/discover` RPC (SEP-1442).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    /// Protocol versions supported by this server.
+    pub supported_versions: Vec<String>,
+
+    /// Server capabilities.
+    pub capabilities: ServerCapabilities,
+
+    /// Server implementation info.
+    pub server_info: Implementation,
+
+    /// Optional instructions for using this server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+// =============================================================================
+// messages/listen RPC
+// =============================================================================
+
+/// Request for the `messages/listen` RPC (SEP-1442).
+///
+/// Opens a persistent SSE stream for receiving server notifications.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessagesListenParams {
+    /// Extended metadata for stateless mode
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    pub meta: Option<StatelessRequestMeta>,
+}
+
+/// Notification sent as first event on a `messages/listen` SSE stream (SEP-1442).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessagesListenNotification {
+    // Empty for now - just signals the stream is ready
+}
+
+// =============================================================================
+// Error codes (SEP-1442)
+// =============================================================================
+
+/// SEP-1442 error codes.
+///
+/// Note: These overlap with some existing MCP error codes. When stateless mode
+/// is enabled, these take precedence.
+pub mod error_codes {
+    /// Unsupported protocol version (-32000)
+    ///
+    /// The error data MUST include `supportedVersions` array.
+    pub const UNSUPPORTED_VERSION: i32 = -32000;
+
+    /// Invalid or missing required session ID (-32001)
+    pub const INVALID_SESSION: i32 = -32001;
+}
+
+/// Error data for unsupported protocol version errors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedVersionData {
+    /// Protocol versions supported by this server.
+    pub supported_versions: Vec<String>,
+}
+
+// =============================================================================
+// Stateless mode configuration
+// =============================================================================
+
+/// Configuration for stateless MCP mode.
+#[derive(Debug, Clone, Default)]
+pub struct StatelessConfig {
+    /// Whether to require protocol version in every request.
+    ///
+    /// Default: true (as per SEP-1442)
+    pub require_protocol_version: bool,
+
+    /// Whether sessions are optional.
+    ///
+    /// When true, requests without session IDs are allowed.
+    /// When false, behaves like standard MCP (sessions required after init).
+    ///
+    /// Default: true
+    pub optional_sessions: bool,
+
+    /// Whether to enable the `server/discover` RPC.
+    ///
+    /// Default: true
+    pub enable_discover: bool,
+
+    /// Whether to enable the `messages/listen` RPC.
+    ///
+    /// Default: true
+    pub enable_messages_listen: bool,
+}
+
+impl StatelessConfig {
+    /// Create a new stateless configuration with SEP-1442 defaults.
+    pub fn new() -> Self {
+        Self {
+            require_protocol_version: true,
+            optional_sessions: true,
+            enable_discover: true,
+            enable_messages_listen: true,
+        }
+    }
+
+    /// Create a configuration that maintains backward compatibility.
+    ///
+    /// This enables stateless features but doesn't require them,
+    /// allowing gradual migration.
+    pub fn backward_compatible() -> Self {
+        Self {
+            require_protocol_version: false,
+            optional_sessions: true,
+            enable_discover: true,
+            enable_messages_listen: true,
+        }
+    }
+}
+
+// =============================================================================
+// Helper functions for extracting stateless metadata
+// =============================================================================
+
+impl StatelessRequestMeta {
+    /// Extract stateless request metadata from JSON-RPC request params.
+    ///
+    /// The metadata is expected to be in the `_meta` field of the params object.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::stateless::StatelessRequestMeta;
+    /// use serde_json::json;
+    ///
+    /// let params = json!({
+    ///     "name": "my-tool",
+    ///     "_meta": {
+    ///         "modelcontextprotocol.io/mcpProtocolVersion": "2025-06-18",
+    ///         "modelcontextprotocol.io/sessionId": "abc123"
+    ///     }
+    /// });
+    ///
+    /// let meta = StatelessRequestMeta::from_params(&params);
+    /// assert!(meta.is_some());
+    /// let meta = meta.unwrap();
+    /// assert_eq!(meta.protocol_version, Some("2025-06-18".to_string()));
+    /// ```
+    pub fn from_params(params: &serde_json::Value) -> Option<Self> {
+        params
+            .get("_meta")
+            .and_then(|meta| serde_json::from_value(meta.clone()).ok())
+    }
+
+    /// Check if this request includes client capabilities.
+    pub fn has_client_capabilities(&self) -> bool {
+        self.client_capabilities.is_some()
+    }
+
+    /// Check if this request includes roots.
+    pub fn has_roots(&self) -> bool {
+        self.roots.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stateless_meta_serialization() {
+        let meta = StatelessRequestMeta {
+            progress_token: None,
+            protocol_version: Some("2025-06-18".to_string()),
+            session_id: Some("abc123".to_string()),
+            client_capabilities: None,
+            roots: None,
+            log_level: Some(LogLevel::Info),
+        };
+
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("modelcontextprotocol.io/mcpProtocolVersion"));
+        assert!(json.contains("modelcontextprotocol.io/sessionId"));
+        assert!(json.contains("modelcontextprotocol.io/logLevel"));
+    }
+
+    #[test]
+    fn test_stateless_meta_deserialization() {
+        let json = r#"{
+            "modelcontextprotocol.io/mcpProtocolVersion": "2025-06-18",
+            "modelcontextprotocol.io/sessionId": "test-session",
+            "modelcontextprotocol.io/logLevel": "debug"
+        }"#;
+
+        let meta: StatelessRequestMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.protocol_version, Some("2025-06-18".to_string()));
+        assert_eq!(meta.session_id, Some("test-session".to_string()));
+        assert_eq!(meta.log_level, Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_discover_result_serialization() {
+        let result = DiscoverResult {
+            supported_versions: vec!["2025-06-18".to_string(), "2025-03-26".to_string()],
+            capabilities: ServerCapabilities::default(),
+            server_info: Implementation {
+                name: "test-server".to_string(),
+                version: "1.0.0".to_string(),
+                title: None,
+                description: None,
+                icons: None,
+                website_url: None,
+            },
+            instructions: Some("Test instructions".to_string()),
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        assert!(json["supportedVersions"].is_array());
+        assert_eq!(json["serverInfo"]["name"], "test-server");
+    }
+
+    #[test]
+    fn test_unsupported_version_data() {
+        let data = UnsupportedVersionData {
+            supported_versions: vec!["2025-06-18".to_string()],
+        };
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["supportedVersions"][0], "2025-06-18");
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = StatelessConfig::new();
+        assert!(config.require_protocol_version);
+        assert!(config.optional_sessions);
+        assert!(config.enable_discover);
+        assert!(config.enable_messages_listen);
+    }
+
+    #[test]
+    fn test_config_backward_compatible() {
+        let config = StatelessConfig::backward_compatible();
+        assert!(!config.require_protocol_version);
+        assert!(config.optional_sessions);
+    }
+
+    #[test]
+    fn test_from_params() {
+        let params = serde_json::json!({
+            "name": "test-tool",
+            "_meta": {
+                "modelcontextprotocol.io/mcpProtocolVersion": "2025-06-18",
+                "modelcontextprotocol.io/sessionId": "session-123",
+                "modelcontextprotocol.io/logLevel": "debug"
+            }
+        });
+
+        let meta = StatelessRequestMeta::from_params(&params).unwrap();
+        assert_eq!(meta.protocol_version, Some("2025-06-18".to_string()));
+        assert_eq!(meta.session_id, Some("session-123".to_string()));
+        assert_eq!(meta.log_level, Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_from_params_no_meta() {
+        let params = serde_json::json!({
+            "name": "test-tool"
+        });
+
+        let meta = StatelessRequestMeta::from_params(&params);
+        assert!(meta.is_none());
+    }
+
+    #[test]
+    fn test_has_client_capabilities() {
+        let meta = StatelessRequestMeta {
+            progress_token: None,
+            protocol_version: None,
+            session_id: None,
+            client_capabilities: Some(ClientCapabilities::default()),
+            roots: None,
+            log_level: None,
+        };
+        assert!(meta.has_client_capabilities());
+
+        let meta_without = StatelessRequestMeta::default();
+        assert!(!meta_without.has_client_capabilities());
+    }
+}

--- a/src/tracing_layer.rs
+++ b/src/tracing_layer.rs
@@ -222,6 +222,10 @@ fn extract_operation_details(req: &McpRequest) -> (Option<&'static str>, Option<
         }
         McpRequest::Initialize(_) => (Some("init"), None),
         McpRequest::Ping => (Some("ping"), None),
+        #[cfg(feature = "stateless")]
+        McpRequest::Discover => (Some("discover"), None),
+        #[cfg(feature = "stateless")]
+        McpRequest::MessagesListen(_) => (Some("messages_listen"), None),
         McpRequest::Unknown { method, .. } => (Some("unknown"), Some(method.clone())),
     }
 }

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -178,6 +178,8 @@ pub struct WebSocketTransport {
     service_factory: ServiceFactory,
     #[cfg(feature = "oauth")]
     oauth_config: Option<crate::oauth::ProtectedResourceMetadata>,
+    #[cfg(feature = "stateless")]
+    stateless_config: Option<crate::stateless::StatelessConfig>,
 }
 
 impl WebSocketTransport {
@@ -189,6 +191,8 @@ impl WebSocketTransport {
             service_factory: identity_factory(),
             #[cfg(feature = "oauth")]
             oauth_config: None,
+            #[cfg(feature = "stateless")]
+            stateless_config: None,
         }
     }
 
@@ -224,6 +228,32 @@ impl WebSocketTransport {
     #[cfg(feature = "oauth")]
     pub fn oauth(mut self, metadata: crate::oauth::ProtectedResourceMetadata) -> Self {
         self.oauth_config = Some(metadata);
+        self
+    }
+
+    /// Enable SEP-1442 stateless mode features for WebSocket transport.
+    ///
+    /// **Note:** WebSocket connections are inherently stateful (persistent connection),
+    /// so the full stateless mode (optional sessions) doesn't apply. However, enabling
+    /// this allows:
+    ///
+    /// - `server/discover` RPC before initialization
+    /// - Per-request metadata in `_meta` fields
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tower_mcp::stateless::StatelessConfig;
+    /// use tower_mcp::transport::websocket::WebSocketTransport;
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new().server_info("my-server", "1.0.0");
+    /// let transport = WebSocketTransport::new(router)
+    ///     .stateless(StatelessConfig::new());
+    /// ```
+    #[cfg(feature = "stateless")]
+    pub fn stateless(mut self, config: crate::stateless::StatelessConfig) -> Self {
+        self.stateless_config = Some(config);
         self
     }
 


### PR DESCRIPTION
## Summary

Experimental implementation of [SEP-1442](https://github.com/modelcontextprotocol/specification/issues/1442) stateless MCP mode. This enables horizontal scaling without sticky sessions by making requests self-contained.

**Status:** WIP - SEP-1442 is still in draft. This implementation explores the API surface and feasibility.

### Features Implemented

- **New feature flag:** `stateless` (disabled by default)
- **`server/discover` RPC:** Query server capabilities without initialization
- **`messages/listen` RPC:** Client-initiated SSE stream for notifications
- **Optional sessions:** Requests without session ID create ephemeral sessions
- **Protocol version validation:** Via `MCP-Protocol-Version` header
- **Per-request metadata:** Extended `_meta` field with protocol version, session ID, client capabilities, roots, log level

### New Types

```rust
// Per-request metadata (in _meta field)
pub struct StatelessRequestMeta {
    pub protocol_version: Option<String>,      // modelcontextprotocol.io/mcpProtocolVersion
    pub session_id: Option<String>,            // modelcontextprotocol.io/sessionId
    pub client_capabilities: Option<ClientCapabilities>,
    pub roots: Option<Vec<Root>>,
    pub log_level: Option<LogLevel>,
}

// Configuration
pub struct StatelessConfig {
    pub require_protocol_version: bool,  // Require MCP-Protocol-Version header
    pub optional_sessions: bool,         // Allow requests without session ID
    pub enable_discover: bool,           // Enable server/discover RPC
    pub enable_messages_listen: bool,    // Enable messages/listen RPC
}
```

### Usage

```rust
use tower_mcp::stateless::StatelessConfig;
use tower_mcp::transport::http::HttpTransport;

let transport = HttpTransport::new(router)
    .stateless(StatelessConfig::new());  // Full SEP-1442 mode

// Or for gradual migration:
let transport = HttpTransport::new(router)
    .stateless(StatelessConfig::backward_compatible());
```

### Error Codes

| Code | Name | Description |
|------|------|-------------|
| -32000 | UnsupportedVersion | Protocol version not supported |
| -32001 | InvalidSession | Invalid or missing required session ID |

## Test plan

- [x] `cargo test --lib --all-features` (308 tests passing)
- [x] `cargo test --test '*' --all-features` (52 tests passing)
- [x] `cargo clippy --all-targets --all-features`
- [ ] Manual testing with MCP client (pending SEP-1442 client implementations)

## Notes

- SEP-1442 is targeting the June 2026 MCP spec version
- This PR will remain draft until the specification stabilizes
- WebSocket support is minimal (persistent connections are inherently stateful)

Closes #263