### PR TITLE
fix: improve deploy verification reliability

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -46,46 +46,72 @@ jobs:
 
       - name: Verify deployment (MCP protocol)
         run: |
-          # Save response headers to a file so we can extract session ID
-          echo "Sending initialize request..."
-          INIT_RESPONSE=$(curl -s -D /tmp/headers.txt -X POST https://crates-mcp-demo.fly.dev/ \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/json" \
-            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"deploy-check","version":"1.0"}}}')
+          # Retry logic for session-based verification
+          # Fly.io edge routing can sometimes cause requests to hit different instances
+          MAX_RETRIES=3
+          RETRY_DELAY=5
 
-          echo "Init response: $INIT_RESPONSE"
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            echo "=== Attempt $attempt of $MAX_RETRIES ==="
 
-          # Extract session ID from response headers
-          SESSION_ID=$(grep -i "mcp-session-id" /tmp/headers.txt | cut -d' ' -f2 | tr -d '\r')
+            # Save response headers to a file so we can extract session ID
+            echo "Sending initialize request..."
+            INIT_RESPONSE=$(curl -s -D /tmp/headers.txt -X POST https://crates-mcp-demo.fly.dev/ \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json" \
+              -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"deploy-check","version":"1.0"}}}')
 
-          echo "Session ID: $SESSION_ID"
+            echo "Init response: $INIT_RESPONSE"
 
-          if [ -z "$SESSION_ID" ]; then
-            echo "Failed to get session ID"
-            exit 1
-          fi
+            # Extract session ID from response headers
+            SESSION_ID=$(grep -i "mcp-session-id" /tmp/headers.txt | cut -d' ' -f2 | tr -d '\r')
 
-          # Send initialized notification (required by MCP protocol before other requests)
-          echo "Sending initialized notification..."
-          curl -s -X POST https://crates-mcp-demo.fly.dev/ \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/json" \
-            -H "MCP-Session-Id: $SESSION_ID" \
-            -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+            echo "Session ID: $SESSION_ID"
 
-          echo "Sending test tool call..."
-          TOOL_RESPONSE=$(curl -s -X POST https://crates-mcp-demo.fly.dev/ \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/json" \
-            -H "MCP-Session-Id: $SESSION_ID" \
-            -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_crates","arguments":{"query":"tower"}}}')
+            if [ -z "$SESSION_ID" ]; then
+              echo "Failed to get session ID"
+              if [ $attempt -lt $MAX_RETRIES ]; then
+                echo "Retrying in ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+                continue
+              fi
+              exit 1
+            fi
 
-          echo "Tool response: $TOOL_RESPONSE"
+            # Small delay to ensure session is fully registered
+            sleep 1
 
-          # Check for successful response (should contain "result" not "error")
-          if echo "$TOOL_RESPONSE" | grep -q '"result"'; then
-            echo "MCP protocol verification successful!"
-          else
-            echo "MCP protocol verification failed - unexpected response"
-            exit 1
-          fi
+            # Send initialized notification (required by MCP protocol before other requests)
+            echo "Sending initialized notification..."
+            curl -s -X POST https://crates-mcp-demo.fly.dev/ \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json" \
+              -H "MCP-Session-Id: $SESSION_ID" \
+              -d '{"jsonrpc":"2.0","method":"notifications/initialized"}'
+
+            # Small delay after initialized
+            sleep 1
+
+            echo "Sending test tool call..."
+            TOOL_RESPONSE=$(curl -s -X POST https://crates-mcp-demo.fly.dev/ \
+              -H "Content-Type: application/json" \
+              -H "Accept: application/json" \
+              -H "MCP-Session-Id: $SESSION_ID" \
+              -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_crates","arguments":{"query":"tower"}}}')
+
+            echo "Tool response: $TOOL_RESPONSE"
+
+            # Check for successful response (should contain "result" not "error")
+            if echo "$TOOL_RESPONSE" | grep -q '"result"'; then
+              echo "MCP protocol verification successful!"
+              exit 0
+            else
+              echo "MCP protocol verification failed - unexpected response"
+              if [ $attempt -lt $MAX_RETRIES ]; then
+                echo "Retrying in ${RETRY_DELAY}s..."
+                sleep $RETRY_DELAY
+                continue
+              fi
+              exit 1
+            fi
+          done

--- a/examples/crates-mcp/fly.toml
+++ b/examples/crates-mcp/fly.toml
@@ -13,7 +13,7 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = "suspend"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ["app"]
 
 [[vm]]


### PR DESCRIPTION
## Summary

Fixes intermittent deploy verification failures caused by Fly.io routing issues.

### Changes

1. **fly.toml**: Set `min_machines_running = 1` to ensure one machine is always available
2. **deploy-demo.yml**: Add retry logic (3 attempts with 5s delays) to handle transient routing
3. **deploy-demo.yml**: Add 1s delays between session requests to ensure registration

### Problem

The CI verification was failing with "Session not found" errors because:
- Fly.io edge routing can send requests to different instances
- With `min_machines_running = 0`, machines could suspend/restart between requests

### Test plan

- [x] Manual testing from local machine (works reliably)
- [ ] CI run on this PR (triggers deploy workflow)

## Notes

The verification works perfectly from a single client (tested locally). The issue is specific to GitHub Actions environment where Fly.io's anycast routing may send requests through different paths.