### PR TITLE
chore(deps): update tower-resilience to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["network-programming", "asynchronous"]
 [workspace]
 members = ["examples/crates-mcp", "examples/conformance-server"]
 
+[workspace.dependencies]
+tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }
+
 [dependencies]
 # Tower ecosystem
 tower = { version = "0.5", features = ["util"] }

--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -39,5 +39,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tower middleware
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
-tower-resilience-bulkhead = "0.6"
-tower-resilience-ratelimiter = "0.6"
+tower-resilience.workspace = true

--- a/examples/crates-mcp/src/main.rs
+++ b/examples/crates-mcp/src/main.rs
@@ -15,8 +15,8 @@ use tower::ServiceBuilder;
 use tower::timeout::TimeoutLayer;
 use tower_mcp::protocol::{CompleteParams, CompleteResult, Completion, CompletionReference};
 use tower_mcp::{HttpTransport, McpRouter, StdioTransport};
-use tower_resilience_bulkhead::BulkheadLayer;
-use tower_resilience_ratelimiter::RateLimiterLayer;
+use tower_resilience::bulkhead::BulkheadLayer;
+use tower_resilience::ratelimiter::RateLimiterLayer;
 
 use crate::state::AppState;
 


### PR DESCRIPTION
## Summary

- Update tower-resilience from 0.6 to 0.7
- Switch from individual crates (`tower-resilience-bulkhead`, `tower-resilience-ratelimiter`) to main crate with feature flags
- Add as workspace dependency for consistent versioning across workspace members

## Changes

- `Cargo.toml`: Add `tower-resilience` as workspace dependency with `bulkhead` and `ratelimiter` features
- `examples/crates-mcp/Cargo.toml`: Use workspace dependency
- `examples/crates-mcp/src/main.rs`: Update imports to use `tower_resilience::{bulkhead, ratelimiter}`

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (293 tests pass)
- [x] `cargo test --test '*' --all-features` (52 tests pass)