### PR TITLE
fix: add required-features for capability_filtering example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,3 +153,8 @@ path = "examples/weather_server.rs"
 name = "http_sse_client"
 path = "examples/http_sse_client.rs"
 required-features = ["http"]
+
+[[example]]
+name = "capability_filtering"
+path = "examples/capability_filtering.rs"
+required-features = ["http"]


### PR DESCRIPTION
## Summary
- Add `[[example]]` entry with `required-features = ["http"]` for capability_filtering example to fix compilation without http feature
- Remove unused `Extensions` import from tests/integration.rs

## Test plan
- [x] `cargo test` passes (was failing before this fix)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes