### PR TITLE
docs: improve CallToolResult::json discoverability

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1359,10 +1359,13 @@ impl CallToolResult {
         }
     }
 
-    /// Create a JSON result with structured content.
+    /// Create a JSON result with structured content from a [`serde_json::Value`].
     ///
     /// The JSON value is serialized to pretty-printed text for display,
     /// and also stored in `structured_content` for programmatic access.
+    ///
+    /// If you have a type that implements [`serde::Serialize`], use
+    /// [`from_serialize`](Self::from_serialize) instead to avoid manual `to_value()` calls.
     pub fn json(value: Value) -> Self {
         let text = serde_json::to_string_pretty(&value).unwrap_or_default();
         Self {


### PR DESCRIPTION
## Summary
- Add a note in `CallToolResult::json()` docs pointing users to `from_serialize()`
- Update `basic.rs` example to demonstrate `from_serialize()` with structured output

## Context
Feedback from axiom-mcp: user wrote `CallToolResult::json(serde_json::to_value(output).unwrap())` when `CallToolResult::from_serialize(&output)?` already exists. This improves discoverability via docs and example.

## Example output
The `add` tool now returns structured JSON:
```json
{
  "content": [{"text": "{\"expression\": \"17 + 25 = 42\", \"result\": 42}", "type": "text"}],
  "structuredContent": {"expression": "17 + 25 = 42", "result": 42}
}
```

## Test plan
- [x] `cargo test --doc --all-features` passes
- [x] `cargo run --example basic` works