### PR TITLE
feat!: API consistency audit - add missing handler variants

### DIFF
--- a/examples/conformance-server/src/main.rs
+++ b/examples/conformance-server/src/main.rs
@@ -34,7 +34,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         router = router.prompt(prompt);
     }
 
-    let transport = HttpTransport::with_sampling(router);
+    let transport = HttpTransport::new(router).with_sampling();
 
     let app = transport.into_router_at("/mcp");
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -13,7 +13,7 @@
 //!
 //! ## Sampling (Server-to-Client Requests)
 //!
-//! When using `HttpTransport::with_sampling()`, tool handlers can request
+//! When using `HttpTransport::new(router).with_sampling()`, tool handlers can request
 //! LLM completions from the client. The flow is:
 //!
 //! 1. Tool handler calls `ctx.sample(params)`
@@ -538,7 +538,7 @@ impl HttpTransport {
         }
     }
 
-    /// Create a new HTTP transport with sampling support enabled
+    /// Enable sampling support for this transport.
     ///
     /// When sampling is enabled, tool handlers can use `ctx.sample()` to
     /// request LLM completions from connected clients. The server sends
@@ -569,22 +569,14 @@ impl HttpTransport {
     ///         .server_info("my-server", "1.0.0")
     ///         .tool(tool);
     ///
-    ///     let transport = HttpTransport::with_sampling(router);
+    ///     let transport = HttpTransport::new(router).with_sampling();
     ///     transport.serve("127.0.0.1:3000").await?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn with_sampling(router: McpRouter) -> Self {
-        Self {
-            router,
-            validate_origin: true,
-            allowed_origins: vec![],
-            session_config: SessionConfig::default(),
-            sampling_enabled: true,
-            service_factory: identity_factory(),
-            #[cfg(feature = "oauth")]
-            oauth_config: None,
-        }
+    pub fn with_sampling(mut self) -> Self {
+        self.sampling_enabled = true;
+        self
     }
 
     /// Disable Origin header validation (not recommended for production)

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -36,7 +36,7 @@
 //! # Sampling Support
 //!
 //! The WebSocket transport supports server-to-client requests like sampling.
-//! Use [`WebSocketTransport::with_sampling`] to enable this feature:
+//! Use [`WebSocketTransport::new`] with [`with_sampling`](WebSocketTransport::with_sampling) to enable:
 //!
 //! ```rust,no_run
 //! use tower_mcp::{BoxError, McpRouter, ToolBuilder, CallToolResult, CreateMessageParams, SamplingMessage};
@@ -61,7 +61,7 @@
 //!         .server_info("my-server", "1.0.0")
 //!         .tool(tool);
 //!
-//!     let transport = WebSocketTransport::with_sampling(router);
+//!     let transport = WebSocketTransport::new(router).with_sampling();
 //!     transport.serve("127.0.0.1:3000").await?;
 //!     Ok(())
 //! }
@@ -192,18 +192,13 @@ impl WebSocketTransport {
         }
     }
 
-    /// Create a new WebSocket transport with sampling support enabled
+    /// Enable sampling support for this transport.
     ///
     /// When sampling is enabled, tool handlers can use `ctx.sample()` to
     /// request LLM completions from connected clients.
-    pub fn with_sampling(router: McpRouter) -> Self {
-        Self {
-            router,
-            sampling_enabled: true,
-            service_factory: identity_factory(),
-            #[cfg(feature = "oauth")]
-            oauth_config: None,
-        }
+    pub fn with_sampling(mut self) -> Self {
+        self.sampling_enabled = true;
+        self
     }
 
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.


### PR DESCRIPTION
## Summary

API consistency audit for 0.3.0 release. Multiple breaking changes to improve API ergonomics and consistency.

## Changes

### 1. ToolBuilder Handler Naming Fix

Renamed `handler_no_params_with_state` to `handler_with_state_no_params` for consistency with:
- `handler_with_state`
- `handler_with_state_and_context`

The old name is kept as a deprecated alias.

### 2. New ToolBuilder Handler Variants

Complete the handler matrix:

| Handler | Params | State | Context |
|---------|--------|-------|---------|
| `handler_no_params_with_context` | - | - | Y |
| `handler_with_state_and_context_no_params` | - | Y | Y |
| `raw_handler_with_state` | raw | Y | - |
| `raw_handler_with_state_and_context` | raw | Y | Y |

### 3. Builder Pattern Refactors

Convert static constructor variants to chainable builder methods across multiple types:

**McpClient:**
```rust
// Before
McpClient::with_roots(transport, roots)
McpClient::with_capabilities(transport, caps)

// After
McpClient::new(transport)
    .with_roots(roots)
    .with_capabilities(caps)
```

**HttpTransport / WebSocketTransport:**
```rust
// Before
HttpTransport::with_sampling(router)
WebSocketTransport::with_sampling(router)

// After
HttpTransport::new(router).with_sampling()
WebSocketTransport::new(router).with_sampling()
```

## Breaking Changes

1. `handler_no_params_with_state` renamed to `handler_with_state_no_params` (deprecated alias available)
2. `McpClient::with_roots(transport, roots)` -> `McpClient::new(transport).with_roots(roots)`
3. `McpClient::with_capabilities(transport, caps)` -> `McpClient::new(transport).with_capabilities(caps)`
4. `HttpTransport::with_sampling(router)` -> `HttpTransport::new(router).with_sampling()`
5. `WebSocketTransport::with_sampling(router)` -> `WebSocketTransport::new(router).with_sampling()`

## Test Plan

- [x] All 298 library tests pass
- [x] All 89 doc tests pass
- [x] All integration tests pass
- [x] Conformance server example compiles
- [x] Clippy clean

Closes #277