### PR TITLE
feat(examples): add markdownlint-mcp example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["mcp", "tower", "json-rpc", "ai", "llm"]
 categories = ["network-programming", "asynchronous"]
 
 [workspace]
-members = ["examples/crates-mcp", "examples/conformance-server"]
+members = ["examples/crates-mcp", "examples/conformance-server", "examples/markdownlint-mcp"]
 
 [workspace.dependencies]
 tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }

--- a/examples/markdownlint-mcp/Cargo.toml
+++ b/examples/markdownlint-mcp/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "markdownlint-mcp"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.88"  # Required by mdbook-lint
+description = "MCP server for markdown linting using mdbook-lint"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+# MCP server
+tower-mcp = { path = "../..", features = ["http"] }
+
+# Markdown linting
+mdbook-lint-core = "0.13"
+mdbook-lint-rulesets = "0.13"
+
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+schemars = "1.2"
+
+# HTTP client for URL fetching
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Error handling
+thiserror = "2"
+
+# CLI
+clap = { version = "4", features = ["derive"] }
+
+# Web server (for HTTP transport)
+axum = "0.8"

--- a/examples/markdownlint-mcp/README.md
+++ b/examples/markdownlint-mcp/README.md
@@ -1,0 +1,155 @@
+# markdownlint-mcp
+
+An MCP server for markdown linting, powered by [mdbook-lint](https://github.com/joshrotenberg/mdbook-lint).
+
+This example demonstrates building a full-featured MCP server with tower-mcp, including tools, resources, resource templates, and prompts.
+
+## Features
+
+- **66 lint rules** from mdbook-lint (standard markdown + mdBook-specific)
+- **Automatic fixes** for many common issues
+- **Multiple input sources**: direct content, local files, or URLs
+- **Rule browsing** via resources
+
+## Requirements
+
+- Rust 1.88+ (required by mdbook-lint)
+
+## Running
+
+### Stdio transport (for Claude Desktop, etc.)
+
+```bash
+cargo run -p markdownlint-mcp -- --transport stdio
+```
+
+### HTTP transport
+
+```bash
+cargo run -p markdownlint-mcp -- --transport http --port 3002
+```
+
+## Claude Desktop Configuration
+
+Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "markdownlint": {
+      "command": "cargo",
+      "args": ["run", "-p", "markdownlint-mcp", "--", "--transport", "stdio"],
+      "cwd": "/path/to/tower-mcp"
+    }
+  }
+}
+```
+
+Or if you've built the release binary:
+
+```json
+{
+  "mcpServers": {
+    "markdownlint": {
+      "command": "/path/to/markdownlint-mcp",
+      "args": ["--transport", "stdio"]
+    }
+  }
+}
+```
+
+## Tools
+
+### lint_content
+
+Lint markdown content directly.
+
+```json
+{
+  "content": "# Hello\n\n\n\nToo many blank lines",
+  "filename": "test.md"
+}
+```
+
+### lint_file
+
+Lint a local markdown file.
+
+```json
+{
+  "path": "/path/to/document.md"
+}
+```
+
+### lint_url
+
+Fetch and lint markdown from a URL.
+
+```json
+{
+  "url": "https://raw.githubusercontent.com/user/repo/main/README.md"
+}
+```
+
+### list_rules
+
+List all available lint rules with descriptions. No parameters required.
+
+### explain_rule
+
+Get detailed information about a specific rule.
+
+```json
+{
+  "rule_id": "MD001"
+}
+```
+
+### fix_content
+
+Apply automatic fixes to markdown content where possible.
+
+```json
+{
+  "content": "# Hello  \n\nTrailing spaces above",
+  "filename": "test.md"
+}
+```
+
+Returns the fixed content along with any remaining violations that couldn't be auto-fixed.
+
+## Resources
+
+### rules://overview
+
+JSON overview of all available lint rules, including:
+- Total rule count
+- Rule IDs, names, descriptions
+- Whether each rule supports auto-fix
+
+### rules://{rule_id}
+
+Resource template for individual rule details. Example: `rules://MD001`
+
+## Prompts
+
+### fix_suggestions
+
+Generate human-readable suggestions for fixing lint violations. Pass the JSON output from `lint_content` or `lint_file` as the `violations_json` argument.
+
+## Example Workflow
+
+1. **Lint a file**: Use `lint_file` to check a markdown document
+2. **Review violations**: The result includes rule IDs, line numbers, and messages
+3. **Auto-fix**: Use `fix_content` to apply automatic fixes
+4. **Get help**: Use `explain_rule` to understand specific violations
+5. **Manual fixes**: Use the `fix_suggestions` prompt for guidance on remaining issues
+
+## Rule Categories
+
+- **MD001-MD059**: Standard markdown rules (headings, lists, whitespace, links, code, emphasis)
+- **MDBOOK001-MDBOOK007**: mdBook-specific rules (code block languages, SUMMARY.md structure, internal links)
+
+## License
+
+MIT OR Apache-2.0

--- a/examples/markdownlint-mcp/src/engine.rs
+++ b/examples/markdownlint-mcp/src/engine.rs
@@ -1,0 +1,381 @@
+//! Markdown linting engine wrapper.
+//!
+//! This module provides a high-level wrapper around mdbook-lint's linting capabilities.
+//! It encapsulates the complexity of setting up the plugin registry and lint engine,
+//! exposing a simple API for linting content and managing rules.
+//!
+//! # Architecture
+//!
+//! The [`LintState`] struct serves as the main interface to the linting system:
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │                      LintState                          │
+//! │  ┌─────────────────────────────────────────────────┐   │
+//! │  │               LintEngine                         │   │
+//! │  │  ┌─────────────────────────────────────────┐    │   │
+//! │  │  │           RuleRegistry                   │    │   │
+//! │  │  │  - StandardRuleProvider (MD001-MD059)   │    │   │
+//! │  │  │  - MdBookRuleProvider (MDBOOK001-007)   │    │   │
+//! │  │  └─────────────────────────────────────────┘    │   │
+//! │  └─────────────────────────────────────────────────┘   │
+//! └─────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use markdownlint_mcp::engine::LintState;
+//!
+//! let state = LintState::new().expect("Failed to create lint state");
+//!
+//! // Lint some content
+//! let violations = state.lint("# Hello\n\n\n\nWorld", "test.md")?;
+//!
+//! // List available rules
+//! let rules = state.rules();
+//!
+//! // Get info about a specific rule
+//! if let Some(rule) = state.get_rule("MD012") {
+//!     println!("{}: {}", rule.id, rule.description);
+//! }
+//! ```
+
+use mdbook_lint_core::{LintEngine, PluginRegistry, Severity, Violation};
+use mdbook_lint_rulesets::{MdBookRuleProvider, StandardRuleProvider};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// Information about a lint rule.
+///
+/// This is a serializable representation of rule metadata, suitable for
+/// returning from MCP tools and resources.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RuleInfo {
+    /// Unique rule identifier (e.g., "MD001", "MDBOOK003")
+    pub id: String,
+
+    /// Human-readable rule name (e.g., "heading-increment")
+    pub name: String,
+
+    /// Description of what the rule checks for
+    pub description: String,
+
+    /// Whether this rule supports automatic fixes
+    pub can_fix: bool,
+}
+
+/// Result of linting a document.
+///
+/// Contains the list of violations along with summary counts by severity.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LintResult {
+    /// The filename or identifier of the linted content
+    pub filename: String,
+
+    /// List of violations found
+    pub violations: Vec<ViolationInfo>,
+
+    /// Count of error-severity violations
+    pub total_errors: usize,
+
+    /// Count of warning-severity violations
+    pub total_warnings: usize,
+
+    /// Count of info-severity violations
+    pub total_info: usize,
+}
+
+/// Information about a single lint violation.
+///
+/// This is a serializable representation of a violation, suitable for
+/// JSON output from MCP tools.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct ViolationInfo {
+    /// The rule that was violated (e.g., "MD001")
+    pub rule_id: String,
+
+    /// Human-readable rule name
+    pub rule_name: String,
+
+    /// Description of the specific violation
+    pub message: String,
+
+    /// Line number where the violation occurred (1-indexed)
+    pub line: usize,
+
+    /// Column number where the violation occurred (1-indexed)
+    pub column: usize,
+
+    /// Severity level: "error", "warning", or "info"
+    pub severity: String,
+
+    /// Whether an automatic fix is available for this violation
+    pub has_fix: bool,
+}
+
+impl From<Violation> for ViolationInfo {
+    fn from(v: Violation) -> Self {
+        Self {
+            rule_id: v.rule_id,
+            rule_name: v.rule_name,
+            message: v.message,
+            line: v.line,
+            column: v.column,
+            severity: match v.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "info",
+            }
+            .to_string(),
+            has_fix: v.fix.is_some(),
+        }
+    }
+}
+
+/// Result of applying automatic fixes to content.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct FixResult {
+    /// The filename or identifier of the content
+    pub filename: String,
+
+    /// The original content before fixes
+    pub original_content: String,
+
+    /// The content after applying fixes
+    pub fixed_content: String,
+
+    /// Whether any changes were made
+    pub content_changed: bool,
+
+    /// Violations that could not be automatically fixed
+    pub remaining_violations: Vec<ViolationInfo>,
+}
+
+/// Shared linting engine state.
+///
+/// This struct wraps the mdbook-lint engine and provides a simplified API
+/// for linting operations. It's designed to be shared across multiple
+/// MCP tool handlers using `Arc<LintState>`.
+///
+/// # Thread Safety
+///
+/// `LintState` is `Send + Sync` and can be safely shared across threads.
+/// The underlying `LintEngine` performs read-only operations during linting.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use markdownlint_mcp::engine::LintState;
+///
+/// // Create shared state
+/// let state = Arc::new(LintState::new()?);
+///
+/// // Use from multiple handlers
+/// let state_clone = state.clone();
+/// let violations = state_clone.lint("# Test", "test.md")?;
+/// ```
+pub struct LintState {
+    engine: LintEngine,
+}
+
+impl LintState {
+    /// Create a new lint state with all available rules.
+    ///
+    /// This initializes the mdbook-lint engine with:
+    /// - Standard markdown rules (MD001-MD059)
+    /// - mdBook-specific rules (MDBOOK001-MDBOOK007)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the plugin registry or engine fails to initialize.
+    pub fn new() -> Result<Self, mdbook_lint_core::MdBookLintError> {
+        let mut registry = PluginRegistry::new();
+        registry.register_provider(Box::new(StandardRuleProvider))?;
+        registry.register_provider(Box::new(MdBookRuleProvider))?;
+        let engine = registry.create_engine()?;
+        Ok(Self { engine })
+    }
+
+    /// Lint markdown content.
+    ///
+    /// # Arguments
+    ///
+    /// * `content` - The markdown content to lint
+    /// * `path` - A filename or identifier for error reporting
+    ///
+    /// # Returns
+    ///
+    /// A list of violations found in the content.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let violations = state.lint("# Title\n\n\n\nToo many blanks", "doc.md")?;
+    /// for v in &violations {
+    ///     println!("{}:{} - {} ({})", v.line, v.column, v.message, v.rule_id);
+    /// }
+    /// ```
+    pub fn lint(&self, content: &str, path: &str) -> Result<Vec<Violation>, String> {
+        self.engine
+            .lint_content(content, path)
+            .map_err(|e| format!("Lint failed: {}", e))
+    }
+
+    /// Lint content and return a structured result.
+    ///
+    /// This is a convenience method that wraps [`lint`](Self::lint) and
+    /// converts the result to a [`LintResult`] with summary counts.
+    pub fn lint_to_result(&self, content: &str, path: &str) -> Result<LintResult, String> {
+        let violations = self.lint(content, path)?;
+        Ok(Self::violations_to_result(path, violations))
+    }
+
+    /// Get information about all available rules.
+    ///
+    /// Returns a list of [`RuleInfo`] structs describing each rule's
+    /// ID, name, description, and fix capability.
+    pub fn rules(&self) -> Vec<RuleInfo> {
+        self.engine
+            .registry()
+            .rules()
+            .iter()
+            .map(|rule| RuleInfo {
+                id: rule.id().to_string(),
+                name: rule.name().to_string(),
+                description: rule.description().to_string(),
+                can_fix: rule.can_fix(),
+            })
+            .collect()
+    }
+
+    /// Get information about a specific rule by ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `rule_id` - The rule identifier (e.g., "MD001", "MDBOOK003")
+    ///
+    /// # Returns
+    ///
+    /// `Some(RuleInfo)` if the rule exists, `None` otherwise.
+    pub fn get_rule(&self, rule_id: &str) -> Option<RuleInfo> {
+        self.engine
+            .registry()
+            .get_rule(rule_id)
+            .map(|rule| RuleInfo {
+                id: rule.id().to_string(),
+                name: rule.name().to_string(),
+                description: rule.description().to_string(),
+                can_fix: rule.can_fix(),
+            })
+    }
+
+    /// Apply automatic fixes to content.
+    ///
+    /// Iterates through the provided violations and applies fixes where
+    /// available. Returns the fixed content and any violations that
+    /// could not be automatically fixed.
+    ///
+    /// # Arguments
+    ///
+    /// * `content` - The original markdown content
+    /// * `violations` - Violations to attempt to fix
+    ///
+    /// # Returns
+    ///
+    /// A tuple of (fixed_content, remaining_violations).
+    ///
+    /// # Note
+    ///
+    /// Fixes are applied sequentially. If a fix changes line numbers,
+    /// subsequent fixes may not apply correctly. For best results,
+    /// run lint-fix cycles iteratively until no more fixes are available.
+    pub fn fix_violations(
+        &self,
+        content: &str,
+        violations: &[Violation],
+    ) -> (String, Vec<Violation>) {
+        let mut fixed_content = content.to_string();
+        let mut remaining = Vec::new();
+
+        for violation in violations {
+            if let Some(rule) = self.engine.registry().get_rule(&violation.rule_id) {
+                if let Some(fixed) = rule.fix(&fixed_content, violation) {
+                    fixed_content = fixed;
+                } else {
+                    remaining.push(violation.clone());
+                }
+            } else {
+                remaining.push(violation.clone());
+            }
+        }
+
+        (fixed_content, remaining)
+    }
+
+    /// Apply fixes and return a structured result.
+    ///
+    /// Convenience method that lints content, applies fixes, and returns
+    /// a [`FixResult`] with both original and fixed content.
+    pub fn fix_content(&self, content: &str, filename: &str) -> Result<FixResult, String> {
+        let violations = self.lint(content, filename)?;
+        let (fixed_content, remaining) = self.fix_violations(content, &violations);
+
+        Ok(FixResult {
+            filename: filename.to_string(),
+            original_content: content.to_string(),
+            fixed_content: fixed_content.clone(),
+            content_changed: content != fixed_content,
+            remaining_violations: remaining.into_iter().map(ViolationInfo::from).collect(),
+        })
+    }
+
+    /// Convert a list of violations to a [`LintResult`].
+    ///
+    /// This is a utility function for creating structured lint results
+    /// with severity counts.
+    pub fn violations_to_result(filename: &str, violations: Vec<Violation>) -> LintResult {
+        let total_errors = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Error)
+            .count();
+        let total_warnings = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Warning)
+            .count();
+        let total_info = violations
+            .iter()
+            .filter(|v| v.severity == Severity::Info)
+            .count();
+
+        LintResult {
+            filename: filename.to_string(),
+            violations: violations.into_iter().map(ViolationInfo::from).collect(),
+            total_errors,
+            total_warnings,
+            total_info,
+        }
+    }
+}
+
+/// Create a standalone lint engine.
+///
+/// This is useful for resources that need their own engine instance
+/// rather than sharing state with tools.
+///
+/// # Errors
+///
+/// Returns a tower_mcp error if engine creation fails.
+pub fn create_engine() -> Result<LintEngine, tower_mcp::Error> {
+    let mut registry = PluginRegistry::new();
+    registry
+        .register_provider(Box::new(StandardRuleProvider))
+        .map_err(|e| tower_mcp::Error::internal(format!("Failed to register provider: {}", e)))?;
+    registry
+        .register_provider(Box::new(MdBookRuleProvider))
+        .map_err(|e| tower_mcp::Error::internal(format!("Failed to register provider: {}", e)))?;
+    registry
+        .create_engine()
+        .map_err(|e| tower_mcp::Error::internal(format!("Failed to create engine: {}", e)))
+}

--- a/examples/markdownlint-mcp/src/main.rs
+++ b/examples/markdownlint-mcp/src/main.rs
@@ -1,0 +1,99 @@
+//! markdownlint-mcp - MCP server for markdown linting
+//!
+//! This server provides markdown linting capabilities via MCP, powered by mdbook-lint.
+//!
+//! ## Tools
+//! - `lint_content` - Lint markdown content directly
+//! - `lint_file` - Lint a local markdown file
+//! - `lint_url` - Fetch and lint markdown from a URL
+//! - `list_rules` - List all available lint rules
+//! - `explain_rule` - Get detailed explanation of a rule
+//! - `fix_content` - Apply automatic fixes to markdown content
+//!
+//! ## Resources
+//! - `rules://{rule_id}` - Browse individual rule details
+//!
+//! ## Prompts
+//! - `fix_suggestions` - Generate fix suggestions for lint violations
+
+mod engine;
+mod resources;
+mod tools;
+
+use clap::Parser;
+use tower_mcp::context::notification_channel;
+use tower_mcp::{HttpTransport, McpRouter, StdioTransport};
+
+#[derive(Parser)]
+#[command(name = "markdownlint-mcp")]
+#[command(about = "MCP server for markdown linting")]
+struct Args {
+    /// Transport to use: stdio or http
+    #[arg(long, default_value = "stdio")]
+    transport: String,
+
+    /// Port for HTTP transport
+    #[arg(long, default_value = "3002")]
+    port: u16,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=debug".parse()?)
+                .add_directive("markdownlint_mcp=debug".parse()?),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    let (tx, _rx) = notification_channel(256);
+
+    let mut router = McpRouter::new()
+        .server_info("markdownlint-mcp", env!("CARGO_PKG_VERSION"))
+        .instructions(
+            "Markdown linting server powered by mdbook-lint. \
+             Use lint_content to check markdown text, lint_file for local files, \
+             or lint_url to fetch and lint from URLs. Use list_rules to see available \
+             rules and explain_rule for details. fix_content can auto-fix some issues.",
+        )
+        .with_notification_sender(tx);
+
+    // Register tools
+    for tool in tools::build_tools() {
+        router = router.tool(tool);
+    }
+
+    // Register resources
+    for resource in resources::build_resources() {
+        router = router.resource(resource);
+    }
+    for template in resources::build_resource_templates() {
+        router = router.resource_template(template);
+    }
+
+    // Register prompts
+    router = router.prompt(tools::build_fix_suggestions_prompt());
+
+    match args.transport.as_str() {
+        "stdio" => {
+            tracing::info!("Starting markdownlint-mcp server on stdio");
+            StdioTransport::new(router).run().await?;
+        }
+        "http" => {
+            let transport = HttpTransport::new(router);
+            let app = transport.into_router_at("/mcp");
+            let addr = format!("127.0.0.1:{}", args.port);
+            tracing::info!("Starting markdownlint-mcp server on http://{}/mcp", addr);
+            let listener = tokio::net::TcpListener::bind(&addr).await?;
+            axum::serve(listener, app).await?;
+        }
+        other => {
+            return Err(format!("Unknown transport: {}", other).into());
+        }
+    }
+
+    Ok(())
+}

--- a/examples/markdownlint-mcp/src/resources.rs
+++ b/examples/markdownlint-mcp/src/resources.rs
@@ -1,0 +1,128 @@
+//! MCP resources for browsing lint rules.
+//!
+//! This module provides resources for discovering and exploring available lint rules.
+//! Resources complement tools by providing read-only data that can be browsed or
+//! referenced by clients.
+//!
+//! # Resource Types
+//!
+//! ## Static Resources
+//!
+//! Static resources have fixed URIs and return data that doesn't depend on parameters:
+//!
+//! - `rules://overview` - JSON overview of all available rules
+//!
+//! ## Resource Templates
+//!
+//! Resource templates use URI templates with parameters for dynamic content:
+//!
+//! - `rules://{rule_id}` - Detailed information about a specific rule
+//!
+//! # Example Usage
+//!
+//! ```rust,ignore
+//! // In main.rs, register resources with the router
+//! let router = McpRouter::new("markdownlint")
+//!     .resources(build_resources())
+//!     .resource_templates(build_resource_templates());
+//! ```
+
+use std::collections::HashMap;
+use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+use tower_mcp::{Resource, ResourceBuilder, ResourceTemplate, ResourceTemplateBuilder};
+
+use crate::engine::create_engine;
+
+/// Build static resources.
+///
+/// Returns a list of static resources to register with the MCP router.
+/// Currently includes:
+/// - `rules://overview` - Overview of all available lint rules
+pub fn build_resources() -> Vec<Resource> {
+    vec![build_rules_overview_resource()]
+}
+
+/// Build resource templates.
+///
+/// Returns a list of resource templates to register with the MCP router.
+/// Currently includes:
+/// - `rules://{rule_id}` - Details for a specific rule
+pub fn build_resource_templates() -> Vec<ResourceTemplate> {
+    vec![build_rule_detail_template()]
+}
+
+fn build_rules_overview_resource() -> Resource {
+    ResourceBuilder::new("rules://overview")
+        .name("Lint Rules Overview")
+        .description("Overview of all available markdown lint rules")
+        .mime_type("application/json")
+        .handler(|| async {
+            let engine = create_engine()?;
+
+            let rules: Vec<_> = engine
+                .registry()
+                .rules()
+                .iter()
+                .map(|rule| {
+                    serde_json::json!({
+                        "id": rule.id(),
+                        "name": rule.name(),
+                        "description": rule.description(),
+                        "can_fix": rule.can_fix(),
+                    })
+                })
+                .collect();
+
+            let overview = serde_json::json!({
+                "total_rules": rules.len(),
+                "rules": rules,
+            });
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri: "rules://overview".to_string(),
+                    mime_type: Some("application/json".to_string()),
+                    text: Some(serde_json::to_string_pretty(&overview).unwrap_or_default()),
+                    blob: None,
+                }],
+            })
+        })
+}
+
+fn build_rule_detail_template() -> ResourceTemplate {
+    ResourceTemplateBuilder::new("rules://{rule_id}")
+        .name("Lint Rule Details")
+        .description("Detailed information about a specific lint rule")
+        .mime_type("application/json")
+        .handler(|uri: String, vars: HashMap<String, String>| async move {
+            let rule_id = vars.get("rule_id").cloned().unwrap_or_default();
+
+            let engine = create_engine()?;
+
+            let rule = engine.registry().get_rule(&rule_id);
+
+            match rule {
+                Some(rule) => {
+                    let detail = serde_json::json!({
+                        "id": rule.id(),
+                        "name": rule.name(),
+                        "description": rule.description(),
+                        "can_fix": rule.can_fix(),
+                    });
+
+                    Ok(ReadResourceResult {
+                        contents: vec![ResourceContent {
+                            uri,
+                            mime_type: Some("application/json".to_string()),
+                            text: Some(serde_json::to_string_pretty(&detail).unwrap_or_default()),
+                            blob: None,
+                        }],
+                    })
+                }
+                None => Err(tower_mcp::Error::internal(format!(
+                    "Rule '{}' not found",
+                    rule_id
+                ))),
+            }
+        })
+}

--- a/examples/markdownlint-mcp/src/tools.rs
+++ b/examples/markdownlint-mcp/src/tools.rs
@@ -1,0 +1,356 @@
+//! MCP tool definitions for markdown linting.
+//!
+//! This module defines the MCP tools exposed by the markdownlint server.
+//! Each tool is built using tower-mcp's [`ToolBuilder`] API.
+//!
+//! # Tool Design Patterns
+//!
+//! This module demonstrates several tower-mcp patterns:
+//!
+//! ## Shared State
+//!
+//! Tools share a common [`LintState`] via `Arc`:
+//!
+//! ```rust,ignore
+//! let state = Arc::new(LintState::new()?);
+//!
+//! // Each tool gets a clone of the Arc
+//! let tool = ToolBuilder::new("lint_content")
+//!     .handler_with_state(state.clone(), |state, input| async move {
+//!         // Use state here
+//!     })
+//!     .build()?;
+//! ```
+//!
+//! ## Input Types with JsonSchema
+//!
+//! Tool inputs derive `JsonSchema` for automatic schema generation:
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! pub struct LintContentInput {
+//!     /// Markdown content to lint
+//!     pub content: String,
+//!
+//!     /// Optional filename for context
+//!     #[serde(default = "default_filename")]
+//!     pub filename: String,
+//! }
+//! ```
+//!
+//! ## Error Handling
+//!
+//! Tools return `CallToolResult::error()` for user-facing errors:
+//!
+//! ```rust,ignore
+//! match state.lint(&content, &path) {
+//!     Ok(violations) => CallToolResult::from_serialize(&result),
+//!     Err(e) => Ok(CallToolResult::error(format!("Lint failed: {}", e))),
+//! }
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::protocol::{Content, GetPromptResult, PromptMessage, PromptRole};
+use tower_mcp::{CallToolResult, Prompt, PromptBuilder, Tool, ToolBuilder};
+
+use crate::engine::LintState;
+
+// =============================================================================
+// Tool Input Types
+// =============================================================================
+
+/// Input for the `lint_content` tool.
+///
+/// Lints markdown content provided directly as a string.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LintContentInput {
+    /// Markdown content to lint.
+    ///
+    /// Can be any valid UTF-8 string containing markdown.
+    pub content: String,
+
+    /// Optional filename for context in error messages.
+    ///
+    /// Defaults to "input.md" if not provided. This doesn't need to be
+    /// a real file path - it's used for display purposes in violations.
+    #[serde(default = "default_filename")]
+    pub filename: String,
+}
+
+/// Input for the `lint_file` tool.
+///
+/// Lints a markdown file from the local filesystem.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LintFileInput {
+    /// Absolute or relative path to the markdown file.
+    ///
+    /// The file must be readable by the server process.
+    pub path: String,
+}
+
+/// Input for the `lint_url` tool.
+///
+/// Fetches markdown content from a URL and lints it.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct LintUrlInput {
+    /// URL to fetch markdown content from.
+    ///
+    /// Must be a valid HTTP or HTTPS URL. The response body is
+    /// treated as markdown content.
+    pub url: String,
+}
+
+/// Input for the `explain_rule` tool.
+///
+/// Gets detailed information about a specific lint rule.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExplainRuleInput {
+    /// Rule identifier to look up.
+    ///
+    /// Examples: "MD001", "MD012", "MDBOOK003"
+    pub rule_id: String,
+}
+
+/// Input for the `fix_content` tool.
+///
+/// Applies automatic fixes to markdown content.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct FixContentInput {
+    /// Markdown content to fix.
+    pub content: String,
+
+    /// Optional filename for context.
+    ///
+    /// Defaults to "input.md" if not provided.
+    #[serde(default = "default_filename")]
+    pub filename: String,
+}
+
+/// Default filename for content without an explicit path.
+fn default_filename() -> String {
+    "input.md".to_string()
+}
+
+// =============================================================================
+// Tool Builder Functions
+// =============================================================================
+
+/// Build all linting tools.
+///
+/// Creates the shared [`LintState`] and returns all tool definitions.
+/// This is the main entry point called from `main.rs`.
+///
+/// # Panics
+///
+/// Panics if the lint engine fails to initialize. This is intentional
+/// as the server cannot function without the linting engine.
+pub fn build_tools() -> Vec<Tool> {
+    let state = Arc::new(LintState::new().expect("Failed to create lint engine"));
+
+    vec![
+        build_lint_content_tool(state.clone()),
+        build_lint_file_tool(state.clone()),
+        build_lint_url_tool(state.clone()),
+        build_list_rules_tool(state.clone()),
+        build_explain_rule_tool(state.clone()),
+        build_fix_content_tool(state.clone()),
+    ]
+}
+
+/// Build the `lint_content` tool.
+///
+/// This tool lints markdown content provided directly as a string.
+/// It's useful for checking content that isn't saved to a file yet.
+fn build_lint_content_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("lint_content")
+        .description("Lint markdown content and return violations")
+        .handler_with_state(
+            state,
+            |state: Arc<LintState>, input: LintContentInput| async move {
+                match state.lint_to_result(&input.content, &input.filename) {
+                    Ok(result) => CallToolResult::from_serialize(&result),
+                    Err(e) => Ok(CallToolResult::error(e)),
+                }
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+/// Build the `lint_file` tool.
+///
+/// This tool reads a file from disk and lints its contents.
+/// Useful for checking files in a project.
+fn build_lint_file_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("lint_file")
+        .description("Lint a local markdown file")
+        .handler_with_state(
+            state,
+            |state: Arc<LintState>, input: LintFileInput| async move {
+                // Read the file asynchronously
+                let content = match tokio::fs::read_to_string(&input.path).await {
+                    Ok(c) => c,
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!("Failed to read file: {}", e)));
+                    }
+                };
+
+                match state.lint_to_result(&content, &input.path) {
+                    Ok(result) => CallToolResult::from_serialize(&result),
+                    Err(e) => Ok(CallToolResult::error(e)),
+                }
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+/// Build the `lint_url` tool.
+///
+/// This tool fetches content from a URL and lints it.
+/// Useful for checking remote documentation or README files.
+fn build_lint_url_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("lint_url")
+        .description("Fetch markdown from a URL and lint it")
+        .handler_with_state(
+            state,
+            |state: Arc<LintState>, input: LintUrlInput| async move {
+                // Fetch the URL
+                let content = match reqwest::get(&input.url).await {
+                    Ok(resp) => match resp.text().await {
+                        Ok(text) => text,
+                        Err(e) => {
+                            return Ok(CallToolResult::error(format!(
+                                "Failed to read response: {}",
+                                e
+                            )));
+                        }
+                    },
+                    Err(e) => {
+                        return Ok(CallToolResult::error(format!("Failed to fetch URL: {}", e)));
+                    }
+                };
+
+                match state.lint_to_result(&content, &input.url) {
+                    Ok(result) => CallToolResult::from_serialize(&result),
+                    Err(e) => Ok(CallToolResult::error(e)),
+                }
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+/// Build the `list_rules` tool.
+///
+/// This tool returns information about all available lint rules.
+/// Useful for discovering what checks are available.
+///
+/// Note: Uses `handler_with_state_no_params` since no input is needed.
+fn build_list_rules_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("list_rules")
+        .description("List all available lint rules with their descriptions")
+        .handler_with_state_no_params(state, |state: Arc<LintState>| async move {
+            let rules = state.rules();
+            CallToolResult::from_serialize(&rules)
+        })
+        .expect("valid tool")
+}
+
+/// Build the `explain_rule` tool.
+///
+/// This tool returns detailed information about a specific rule.
+/// Useful for understanding what a rule checks and whether it can auto-fix.
+fn build_explain_rule_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("explain_rule")
+        .description("Get detailed explanation of a specific lint rule")
+        .handler_with_state(
+            state,
+            |state: Arc<LintState>, input: ExplainRuleInput| async move {
+                match state.get_rule(&input.rule_id) {
+                    Some(rule) => CallToolResult::from_serialize(&rule),
+                    None => Ok(CallToolResult::error(format!(
+                        "Rule '{}' not found",
+                        input.rule_id
+                    ))),
+                }
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+/// Build the `fix_content` tool.
+///
+/// This tool applies automatic fixes to markdown content where possible.
+/// Returns both the fixed content and any remaining violations.
+fn build_fix_content_tool(state: Arc<LintState>) -> Tool {
+    ToolBuilder::new("fix_content")
+        .description("Apply automatic fixes to markdown content where possible")
+        .handler_with_state(
+            state,
+            |state: Arc<LintState>, input: FixContentInput| async move {
+                match state.fix_content(&input.content, &input.filename) {
+                    Ok(result) => CallToolResult::from_serialize(&result),
+                    Err(e) => Ok(CallToolResult::error(e)),
+                }
+            },
+        )
+        .build()
+        .expect("valid tool")
+}
+
+// =============================================================================
+// Prompts
+// =============================================================================
+
+/// Build the `fix_suggestions` prompt.
+///
+/// This prompt helps users understand how to fix lint violations.
+/// It takes JSON output from the linting tools and generates
+/// human-readable fix suggestions.
+///
+/// # Prompt Design
+///
+/// The prompt instructs the LLM to:
+/// 1. Explain what each violated rule checks for
+/// 2. Show the specific fix needed
+/// 3. Mention auto-fix availability where applicable
+pub fn build_fix_suggestions_prompt() -> Prompt {
+    PromptBuilder::new("fix_suggestions")
+        .description("Generate suggestions for fixing lint violations")
+        .required_arg(
+            "violations_json",
+            "JSON output from lint_content or lint_file",
+        )
+        .handler(|args: HashMap<String, String>| async move {
+            let violations_json = args.get("violations_json").cloned().unwrap_or_default();
+
+            let prompt_text = format!(
+                "Analyze the following markdown lint violations and provide specific \
+                 suggestions for fixing each one.\n\n\
+                 For each violation:\n\
+                 1. Explain what the rule checks for\n\
+                 2. Show the specific fix needed\n\
+                 3. If the violation has an automatic fix available (has_fix: true), \
+                    mention that the fix_content tool can be used\n\n\
+                 Lint results:\n```json\n{}\n```",
+                violations_json
+            );
+
+            Ok(GetPromptResult {
+                description: Some("Suggestions for fixing markdown lint violations".to_string()),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: Content::Text {
+                        text: prompt_text,
+                        annotations: None,
+                    },
+                }],
+            })
+        })
+}


### PR DESCRIPTION
## Summary

Full-featured MCP server example demonstrating tower-mcp best practices, powered by [mdbook-lint](https://github.com/joshrotenberg/mdbook-lint).

**Features:**
- 6 tools: `lint_content`, `lint_file`, `lint_url`, `list_rules`, `explain_rule`, `fix_content`
- Resources: `rules://overview` static resource, `rules://{rule_id}` template
- Prompts: `fix_suggestions` for guided violation remediation
- 66 markdown lint rules with auto-fix support
- Both stdio and HTTP transport support

**Architecture demonstrates:**
- Modular code organization (separate `engine.rs` for linting logic from `tools.rs` for MCP definitions)
- Shared state via `Arc<LintState>` pattern
- `handler_with_state` and `handler_with_state_no_params` patterns
- Comprehensive rustdoc as a usage guide for library consumers
- JsonSchema derivation for automatic input schema generation

**Note:** Requires Rust 1.88+ (mdbook-lint dependency), while tower-mcp MSRV remains 1.85.

## Test plan

- [x] `cargo build -p markdownlint-mcp`
- [x] `cargo clippy -p markdownlint-mcp --all-targets -- -D warnings`
- [x] `cargo test --lib --all-features` (304 tests pass)
- [ ] Manual test with Claude Desktop (stdio transport)