### PR TITLE
fix(markdownlint-mcp): wrap list_rules result in object for MCP compatibility

### DIFF
--- a/examples/markdownlint-mcp/src/engine.rs
+++ b/examples/markdownlint-mcp/src/engine.rs
@@ -133,6 +133,18 @@ impl From<Violation> for ViolationInfo {
     }
 }
 
+/// Result of listing available rules.
+///
+/// Wraps the rules array in an object for MCP structuredContent compatibility.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct RulesListResult {
+    /// List of available lint rules
+    pub rules: Vec<RuleInfo>,
+
+    /// Total number of rules
+    pub total: usize,
+}
+
 /// Result of applying automatic fixes to content.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct FixResult {

--- a/examples/markdownlint-mcp/src/tools.rs
+++ b/examples/markdownlint-mcp/src/tools.rs
@@ -57,7 +57,7 @@ use serde::Deserialize;
 use tower_mcp::protocol::{Content, GetPromptResult, PromptMessage, PromptRole};
 use tower_mcp::{CallToolResult, Prompt, PromptBuilder, Tool, ToolBuilder};
 
-use crate::engine::LintState;
+use crate::engine::{LintState, RulesListResult};
 
 // =============================================================================
 // Tool Input Types
@@ -256,7 +256,11 @@ fn build_list_rules_tool(state: Arc<LintState>) -> Tool {
         .description("List all available lint rules with their descriptions")
         .handler_with_state_no_params(state, |state: Arc<LintState>| async move {
             let rules = state.rules();
-            CallToolResult::from_serialize(&rules)
+            let result = RulesListResult {
+                total: rules.len(),
+                rules,
+            };
+            CallToolResult::from_serialize(&result)
         })
         .expect("valid tool")
 }


### PR DESCRIPTION
## Summary

- MCP `structuredContent` requires an object, not an array
- The `list_rules` tool was returning `Vec<RuleInfo>` directly, causing validation errors when called via Claude Code
- Added `RulesListResult` wrapper struct with `rules` array and `total` count

## Test plan

- [x] `cargo test --lib --all-features`
- [x] `cargo test --test '*' --all-features`
- [x] `cargo clippy -p markdownlint-mcp --all-targets -- -D warnings`
- [ ] Verify `list_rules` works via Claude Code MCP integration