### PR TITLE
fix(markdownlint-mcp): implement fix_content to properly apply fixes

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -31,13 +31,6 @@
       "env": {
         "RUST_LOG": "tower_mcp=info"
       }
-    },
-    "conformance": {
-      "command": "cargo",
-      "args": ["run", "-p", "conformance-server", "--", "--transport", "stdio"],
-      "env": {
-        "RUST_LOG": "conformance_server=info"
-      }
     }
   }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,7 +1,7 @@
 # tower-mcp Examples Tour
 
-Welcome! This guide walks through the example MCP servers in tower-mcp.
 
+Welcome! This guide walks through the example MCP servers in tower-mcp.
 
 ## Getting Started
 
@@ -27,7 +27,7 @@ example, demonstrating tools, resources, and prompts.
 
 **Try these (tools):**
 
-- "Search for async HTTP client crates"
+-  "Search for async HTTP client crates"
 - "What are tokio's dependencies?"
 - "Get download stats for tower-mcp"
 
@@ -58,7 +58,7 @@ with different input types and auto-fix capabilities.
 
 **Try these:**
 
--  "Lint this file: examples/README.md"
+- "Lint this file: examples/README.md"
 - "What does rule MD001 check for?"
 - "List all available markdown lint rules"
 
@@ -77,28 +77,7 @@ example showing external API integration.
 
 **Source:** `examples/weather_server.rs`
 
-### 4. conformance
-
-Full MCP protocol conformance server that passes all 39 official tests.
-Demonstrates every protocol feature: tools, resources, prompts, progress
-notifications, sampling, and elicitation.
-
-**Try these:**
-
-- "Call test_simple_text from the conformance server"
-- "Call test_tool_with_progress to see progress notifications"
-- "Call test_tool_with_logging to see log notifications"
-- "Call test_embedded_resource to see resource content"
-
-**Note:** The conformance server includes `test_image_content` and
-`test_audio_content` tools that return binary content. These work
-correctly per the MCP spec but may cause API errors in some hosts
-(including Claude Code) that don't support displaying binary content
-in conversations.
-
-**Source:** `examples/conformance-server/`
-
-### 5. tower-mcp-example
+### 4. tower-mcp-example
 
 The simplest possible MCP server - echo, add, and reverse tools. Good
 starting point for understanding the basics. This server is


### PR DESCRIPTION
## Summary

Implements the `fix_content` tool in markdownlint-mcp to properly apply fixes from mdbook-lint violations.

## Changes

### markdownlint-mcp/src/engine.rs
- Implement `fix_violations()` to apply fixes from mdbook-lint violations
- Sort fixes in reverse order (bottom to top) to preserve line/column positions
- Handle newline deduplication when replacement ends with `\n` (see #378 on mdbook-lint)
- Add `apply_fix()` helper with position-to-offset conversion
- Add tests for:
  - Extra blank lines (MD012)
  - Heading level fixes (MD001)
  - List spacing fixes (MD030)

### .mcp.json
- Remove conformance server (causes Claude API errors when returning 1x1 PNG images)

### examples/README.md
- Add intentional markdown errors back for interactive demo
- Remove conformance server section (no longer in .mcp.json)

## Testing

```bash
cargo test -p markdownlint-mcp
```

All 4 tests pass. The fix_content MCP tool now correctly fixes:
- Multiple blank lines
- Heading level skips (h2 → h4 becomes h2 → h3)
- List marker spacing

## Related

- Filed mdbook-lint issue about fix API: https://github.com/joshrotenberg/mdbook-lint/issues/378