### PR TITLE
feat(codegen-mcp): add example comments and README generation

### DIFF
--- a/examples/codegen-mcp/src/tools.rs
+++ b/examples/codegen-mcp/src/tools.rs
@@ -287,8 +287,8 @@ fn build_generate(state: Arc<CodegenState>) -> Tool {
             match generate_code(&project) {
                 Ok(code) => {
                     let output = format!(
-                        "# Generated Code\n\n## Cargo.toml\n\n```toml\n{}\n```\n\n## src/main.rs\n\n```rust\n{}\n```",
-                        code.cargo_toml, code.main_rs
+                        "# Generated Code\n\n## Cargo.toml\n\n```toml\n{}\n```\n\n## src/main.rs\n\n```rust\n{}\n```\n\n## README.md\n\n{}\n\n---\n\n**What's next?** You can stop here and implement the handlers manually, or keep using codegen-mcp to add more tools. Read `project://README.md` for details.",
+                        code.cargo_toml, code.main_rs, code.readme_md
                     );
                     Ok(CallToolResult::text(output))
                 }


### PR DESCRIPTION
## Summary

Improves codegen-mcp to be a better teaching/scaffolding tool:

- **Example comments in handlers** - Generated handlers now include contextual example comments showing how to use input fields, state, and context
- **README.md generation** - New `project://README.md` resource with getting started instructions, tool list, and implementation patterns
- **"What's Next?" section** - Explains users can stop and implement manually or continue using codegen-mcp

## Example Generated Handler (before)

```rust
.handler(|input: GreetInput| async move {
    // TODO: implement greet
    Ok(CallToolResult::text(format!("{:?}", input)))
})
```

## Example Generated Handler (after)

```rust
.handler(|input: GreetInput| async move {
    // TODO: implement greet
    // Example:
    //   let result = format!("Got: {}", input.name);
    //   Ok(CallToolResult::text(result))
    Ok(CallToolResult::text(format!("{:?}", input)))
})
```

## Test plan

- [ ] Run `cargo test -p codegen-mcp`
- [ ] Test README generation via `resources/read` for `project://README.md`
- [ ] Verify example comments appear in generated handlers