### PR TITLE
fix(examples): add .build() calls to resource handlers

### DIFF
--- a/examples/codegen-mcp/src/resources.rs
+++ b/examples/codegen-mcp/src/resources.rs
@@ -48,6 +48,7 @@ fn build_cargo_toml_resource(state: Arc<CodegenState>) -> Resource {
                 })
             }
         })
+        .build()
 }
 
 fn build_main_rs_resource(state: Arc<CodegenState>) -> Resource {
@@ -79,6 +80,7 @@ fn build_main_rs_resource(state: Arc<CodegenState>) -> Resource {
                 })
             }
         })
+        .build()
 }
 
 fn build_readme_resource(state: Arc<CodegenState>) -> Resource {
@@ -110,6 +112,7 @@ fn build_readme_resource(state: Arc<CodegenState>) -> Resource {
                 })
             }
         })
+        .build()
 }
 
 fn build_state_resource(state: Arc<CodegenState>) -> Resource {
@@ -135,4 +138,5 @@ fn build_state_resource(state: Arc<CodegenState>) -> Resource {
                 })
             }
         })
+        .build()
 }

--- a/examples/crates-mcp/src/resources/recent_searches.rs
+++ b/examples/crates-mcp/src/resources/recent_searches.rs
@@ -28,4 +28,5 @@ pub fn build(state: Arc<AppState>) -> Resource {
                 })
             }
         })
+        .build()
 }

--- a/examples/markdownlint-mcp/src/resources.rs
+++ b/examples/markdownlint-mcp/src/resources.rs
@@ -87,6 +87,7 @@ fn build_rules_overview_resource() -> Resource {
                 }],
             })
         })
+        .build()
 }
 
 fn build_rule_detail_template() -> ResourceTemplate {


### PR DESCRIPTION
## Summary

The per-resource middleware API change (PR #298) requires `.build()` after `.handler()` to finalize resources. This updates all example servers that were missed:

- `codegen-mcp/src/resources.rs` - 4 resources
- `crates-mcp/src/resources/recent_searches.rs` - 1 resource
- `markdownlint-mcp/src/resources.rs` - 1 resource

## Test plan

- [x] `cargo build --all-targets --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-targets --all-features`