### PR TITLE
feat!: simplify handler API with unified extractor pattern

### DIFF
--- a/examples/codegen-mcp/src/state.rs
+++ b/examples/codegen-mcp/src/state.rs
@@ -99,7 +99,7 @@ fn default_true() -> bool {
 }
 
 /// Handler type variants.
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum HandlerType {
     /// Simple handler: `handler(|input: T| async move { ... })`

--- a/examples/crates-mcp/src/tools/authors.rs
+++ b/examples/crates-mcp/src/tools/authors.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::AppState;
 
@@ -26,9 +29,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, AuthorsInput>(
             state,
-            |state: Arc<AppState>, input: AuthorsInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<AuthorsInput>| async move {
                 // If no version specified, get the latest
                 let version = match input.version {
                     Some(v) => v,

--- a/examples/crates-mcp/src/tools/dependencies.rs
+++ b/examples/crates-mcp/src/tools/dependencies.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::AppState;
 
@@ -29,9 +32,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, DependenciesInput>(
             state,
-            |state: Arc<AppState>, input: DependenciesInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<DependenciesInput>| async move {
                 // Get crate info first to find version
                 let crate_response = state
                     .client

--- a/examples/crates-mcp/src/tools/downloads.rs
+++ b/examples/crates-mcp/src/tools/downloads.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::{AppState, format_number};
 
@@ -25,9 +28,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, DownloadsInput>(
             state,
-            |state: Arc<AppState>, input: DownloadsInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<DownloadsInput>| async move {
                 let response = state
                     .client
                     .crate_downloads(&input.name)

--- a/examples/crates-mcp/src/tools/info.rs
+++ b/examples/crates-mcp/src/tools/info.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::{AppState, format_number};
 
@@ -24,65 +27,68 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(state, |state: Arc<AppState>, input: InfoInput| async move {
-            let response = state
-                .client
-                .get_crate(&input.name)
-                .await
-                .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+        .extractor_handler_typed::<_, _, _, InfoInput>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<InfoInput>| async move {
+                let response = state
+                    .client
+                    .get_crate(&input.name)
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
 
-            let c = &response.crate_data;
+                let c = &response.crate_data;
 
-            let mut output = format!("# {}\n\n", c.name);
+                let mut output = format!("# {}\n\n", c.name);
 
-            if let Some(desc) = &c.description {
-                output.push_str(&format!("{}\n\n", desc.trim()));
-            }
+                if let Some(desc) = &c.description {
+                    output.push_str(&format!("{}\n\n", desc.trim()));
+                }
 
-            output.push_str("## Versions\n\n");
-            output.push_str(&format!("- Latest: **{}**\n", c.max_version));
-            if let Some(stable) = &c.max_stable_version
-                && stable != &c.max_version
-            {
-                output.push_str(&format!("- Latest Stable: **{}**\n", stable));
-            }
+                output.push_str("## Versions\n\n");
+                output.push_str(&format!("- Latest: **{}**\n", c.max_version));
+                if let Some(stable) = &c.max_stable_version
+                    && stable != &c.max_version
+                {
+                    output.push_str(&format!("- Latest Stable: **{}**\n", stable));
+                }
 
-            output.push_str("\n## Stats\n\n");
-            output.push_str(&format!(
-                "- Total Downloads: {}\n",
-                format_number(c.downloads)
-            ));
-            if let Some(recent) = c.recent_downloads {
-                output.push_str(&format!("- Recent Downloads: {}\n", format_number(recent)));
-            }
-            output.push_str(&format!("- Created: {}\n", c.created_at.date_naive()));
-            output.push_str(&format!("- Updated: {}\n", c.updated_at.date_naive()));
+                output.push_str("\n## Stats\n\n");
+                output.push_str(&format!(
+                    "- Total Downloads: {}\n",
+                    format_number(c.downloads)
+                ));
+                if let Some(recent) = c.recent_downloads {
+                    output.push_str(&format!("- Recent Downloads: {}\n", format_number(recent)));
+                }
+                output.push_str(&format!("- Created: {}\n", c.created_at.date_naive()));
+                output.push_str(&format!("- Updated: {}\n", c.updated_at.date_naive()));
 
-            output.push_str("\n## Links\n\n");
-            if let Some(repo) = &c.repository {
-                output.push_str(&format!("- Repository: {}\n", repo));
-            }
-            if let Some(docs) = &c.documentation {
-                output.push_str(&format!("- Documentation: {}\n", docs));
-            }
-            if let Some(home) = &c.homepage {
-                output.push_str(&format!("- Homepage: {}\n", home));
-            }
+                output.push_str("\n## Links\n\n");
+                if let Some(repo) = &c.repository {
+                    output.push_str(&format!("- Repository: {}\n", repo));
+                }
+                if let Some(docs) = &c.documentation {
+                    output.push_str(&format!("- Documentation: {}\n", docs));
+                }
+                if let Some(home) = &c.homepage {
+                    output.push_str(&format!("- Homepage: {}\n", home));
+                }
 
-            if let Some(keywords) = &c.keywords
-                && !keywords.is_empty()
-            {
-                output.push_str(&format!("\n## Keywords\n\n{}\n", keywords.join(", ")));
-            }
+                if let Some(keywords) = &c.keywords
+                    && !keywords.is_empty()
+                {
+                    output.push_str(&format!("\n## Keywords\n\n{}\n", keywords.join(", ")));
+                }
 
-            if let Some(categories) = &c.categories
-                && !categories.is_empty()
-            {
-                output.push_str(&format!("\n## Categories\n\n{}\n", categories.join(", ")));
-            }
+                if let Some(categories) = &c.categories
+                    && !categories.is_empty()
+                {
+                    output.push_str(&format!("\n## Categories\n\n{}\n", categories.join(", ")));
+                }
 
-            Ok(CallToolResult::text(output))
-        })
+                Ok(CallToolResult::text(output))
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/owners.rs
+++ b/examples/crates-mcp/src/tools/owners.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::AppState;
 
@@ -24,9 +27,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, OwnersInput>(
             state,
-            |state: Arc<AppState>, input: OwnersInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<OwnersInput>| async move {
                 let owners = state
                     .client
                     .crate_owners(&input.name)

--- a/examples/crates-mcp/src/tools/search.rs
+++ b/examples/crates-mcp/src/tools/search.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use crates_io_api::{CratesQuery, Sort};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::{AppState, CrateSummary, format_number};
 
@@ -42,9 +45,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, SearchInput>(
             state,
-            |state: Arc<AppState>, input: SearchInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<SearchInput>| async move {
                 let sort = parse_sort(&input.sort);
                 let query = CratesQuery::builder()
                     .search(&input.query)

--- a/examples/crates-mcp/src/tools/summary.rs
+++ b/examples/crates-mcp/src/tools/summary.rs
@@ -2,7 +2,10 @@
 
 use std::sync::Arc;
 
-use tower_mcp::{CallToolResult, Error, NoParams, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, NoParams, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::{AppState, format_number};
 
@@ -15,61 +18,64 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(state, |state: Arc<AppState>, _input: NoParams| async move {
-            let summary = state
-                .client
-                .summary()
-                .await
-                .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+        .extractor_handler_typed::<_, _, _, NoParams>(
+            state,
+            |State(state): State<Arc<AppState>>, Json(_input): Json<NoParams>| async move {
+                let summary = state
+                    .client
+                    .summary()
+                    .await
+                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
 
-            let mut output = String::from("# Crates.io Summary\n\n");
+                let mut output = String::from("# Crates.io Summary\n\n");
 
-            output.push_str("## Statistics\n\n");
-            output.push_str(&format!(
-                "- Total Crates: {}\n",
-                format_number(summary.num_crates)
-            ));
-            output.push_str(&format!(
-                "- Total Downloads: {}\n",
-                format_number(summary.num_downloads)
-            ));
-
-            output.push_str("\n## New Crates\n\n");
-            for c in summary.new_crates.iter().take(10) {
-                let desc = c
-                    .description
-                    .as_ref()
-                    .map(|d| format!(" - {}", d.trim()))
-                    .unwrap_or_default();
-                output.push_str(&format!("- **{}** v{}{}\n", c.name, c.max_version, desc));
-            }
-
-            output.push_str("\n## Most Downloaded\n\n");
-            for c in summary.most_downloaded.iter().take(10) {
+                output.push_str("## Statistics\n\n");
                 output.push_str(&format!(
-                    "- **{}** ({} downloads)\n",
-                    c.name,
-                    format_number(c.downloads)
+                    "- Total Crates: {}\n",
+                    format_number(summary.num_crates)
                 ));
-            }
+                output.push_str(&format!(
+                    "- Total Downloads: {}\n",
+                    format_number(summary.num_downloads)
+                ));
 
-            output.push_str("\n## Most Recently Updated\n\n");
-            for c in summary.just_updated.iter().take(10) {
-                output.push_str(&format!("- **{}** v{}\n", c.name, c.max_version));
-            }
+                output.push_str("\n## New Crates\n\n");
+                for c in summary.new_crates.iter().take(10) {
+                    let desc = c
+                        .description
+                        .as_ref()
+                        .map(|d| format!(" - {}", d.trim()))
+                        .unwrap_or_default();
+                    output.push_str(&format!("- **{}** v{}{}\n", c.name, c.max_version, desc));
+                }
 
-            output.push_str("\n## Popular Keywords\n\n");
-            for kw in summary.popular_keywords.iter().take(10) {
-                output.push_str(&format!("- {} ({} crates)\n", kw.keyword, kw.crates_cnt));
-            }
+                output.push_str("\n## Most Downloaded\n\n");
+                for c in summary.most_downloaded.iter().take(10) {
+                    output.push_str(&format!(
+                        "- **{}** ({} downloads)\n",
+                        c.name,
+                        format_number(c.downloads)
+                    ));
+                }
 
-            output.push_str("\n## Popular Categories\n\n");
-            for cat in summary.popular_categories.iter().take(10) {
-                output.push_str(&format!("- {} ({} crates)\n", cat.category, cat.crates_cnt));
-            }
+                output.push_str("\n## Most Recently Updated\n\n");
+                for c in summary.just_updated.iter().take(10) {
+                    output.push_str(&format!("- **{}** v{}\n", c.name, c.max_version));
+                }
 
-            Ok(CallToolResult::text(output))
-        })
+                output.push_str("\n## Popular Keywords\n\n");
+                for kw in summary.popular_keywords.iter().take(10) {
+                    output.push_str(&format!("- {} ({} crates)\n", kw.keyword, kw.crates_cnt));
+                }
+
+                output.push_str("\n## Popular Categories\n\n");
+                for cat in summary.popular_categories.iter().take(10) {
+                    output.push_str(&format!("- {} ({} crates)\n", cat.category, cat.crates_cnt));
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
         .build()
         .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/versions.rs
+++ b/examples/crates-mcp/src/tools/versions.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, Error, Tool, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, Error, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
 use crate::state::{AppState, format_number};
 
@@ -34,9 +37,9 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .handler_with_state(
+        .extractor_handler_typed::<_, _, _, VersionsInput>(
             state,
-            |state: Arc<AppState>, input: VersionsInput| async move {
+            |State(state): State<Arc<AppState>>, Json(input): Json<VersionsInput>| async move {
                 let response = state
                     .client
                     .get_crate(&input.name)

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -548,13 +548,13 @@ impl HttpTransport {
     ///
     /// ```rust,no_run
     /// use tower_mcp::{BoxError, McpRouter, ToolBuilder, CallToolResult, CreateMessageParams, SamplingMessage};
-    /// use tower_mcp::context::RequestContext;
+    /// use tower_mcp::extract::{Context, RawArgs};
     /// use tower_mcp::transport::http::HttpTransport;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), BoxError> {
     ///     let tool = ToolBuilder::new("ai-tool")
-    ///         .handler_with_context(|ctx: RequestContext, _: serde_json::Value| async move {
+    ///         .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
     ///             // Request LLM completion from client
     ///             let params = CreateMessageParams::new(
     ///                 vec![SamplingMessage::user("Summarize this...")],

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -467,13 +467,13 @@ struct PendingRequest {
 /// use tower_mcp::{BoxError, McpRouter, ToolBuilder, CallToolResult};
 /// use tower_mcp::transport::stdio::BidirectionalStdioTransport;
 /// use tower_mcp::{CreateMessageParams, SamplingMessage};
-/// use tower_mcp::context::RequestContext;
+/// use tower_mcp::extract::{Context, RawArgs};
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), BoxError> {
 ///     let tool = ToolBuilder::new("ai-tool")
 ///         .description("A tool that uses LLM")
-///         .handler_with_context(|ctx: RequestContext, input: serde_json::Value| async move {
+///         .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
 ///             // Request LLM completion from the client
 ///             let params = CreateMessageParams::new(
 ///                 vec![SamplingMessage::user("Help me with: ...")],

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -40,13 +40,13 @@
 //!
 //! ```rust,no_run
 //! use tower_mcp::{BoxError, McpRouter, ToolBuilder, CallToolResult, CreateMessageParams, SamplingMessage};
-//! use tower_mcp::context::RequestContext;
+//! use tower_mcp::extract::{Context, RawArgs};
 //! use tower_mcp::transport::websocket::WebSocketTransport;
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), BoxError> {
 //!     let tool = ToolBuilder::new("ai-tool")
-//!         .handler_with_context(|ctx: RequestContext, _: serde_json::Value| async move {
+//!         .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
 //!             // Request LLM completion from client
 //!             let params = CreateMessageParams::new(
 //!                 vec![SamplingMessage::user("Summarize this...")],


### PR DESCRIPTION
## Summary

- Remove 11 handler method variants in favor of the unified extractor pattern from #306
- Add "Familiar to axum Users" section to lib.rs documentation highlighting the axum-inspired design
- Update all examples and tests to use the new pattern

## Breaking Changes

The following methods are removed from `ToolBuilder`:

| Removed Method | Replacement |
|----------------|-------------|
| `handler_with_state()` | `extractor_handler_typed()` with `State<T>` |
| `handler_with_context()` | `extractor_handler_typed()` with `Context` |
| `handler_with_state_and_context()` | `extractor_handler_typed()` with both |
| `handler_no_params()` | `extractor_handler_typed()` without `Json<T>` |
| `handler_with_state_no_params()` | `extractor_handler_typed()` with just `State<T>` |
| `handler_no_params_with_context()` | `extractor_handler_typed()` with just `Context` |
| `handler_with_state_and_context_no_params()` | `extractor_handler_typed()` with `State` + `Context` |
| `raw_handler()` | `extractor_handler()` with `RawArgs` |
| `raw_handler_with_context()` | `extractor_handler()` with `RawArgs` + `Context` |
| `raw_handler_with_state()` | `extractor_handler()` with `RawArgs` + `State` |
| `raw_handler_with_state_and_context()` | `extractor_handler()` with all three |

## Migration Guide

```rust
// Before: handler_with_state
.handler_with_state(state.clone(), |state, input: MyInput| async move { ... })

// After: extractor_handler_typed with State<T> and Json<T>
.extractor_handler_typed::<_, _, _, MyInput>(
    state.clone(),
    |State(state): State<Arc<MyState>>, Json(input): Json<MyInput>| async move { ... }
)

// Before: handler_with_context
.handler_with_context(|ctx, input: MyInput| async move { ... })

// After: extractor_handler_typed with Context
.extractor_handler_typed::<_, _, _, MyInput>(
    (),
    |ctx: Context, Json(input): Json<MyInput>| async move { ... }
)

// Before: raw_handler
.raw_handler(|args: Value| async move { ... })

// After: extractor_handler with RawArgs
.extractor_handler((), |RawArgs(args): RawArgs| async move { ... })

// Before: handler_no_params
.handler_no_params(|| async move { ... })

// After: extractor_handler_typed with NoParams
.extractor_handler_typed::<_, _, _, NoParams>((), |Json(_): Json<NoParams>| async move { ... })
```

## Why This Change

The extractor pattern is axum-inspired, making the API familiar to users of Rust's most popular web framework:

- **Composable**: Pick the extractors you need (`State<T>`, `Context`, `Json<T>`, `RawArgs`)
- **Less API surface**: One method instead of 11+ variants
- **Familiar**: Same patterns as axum handlers

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (340 tests)
- [x] `cargo test --test '*' --all-features` (52 tests)
- [x] `cargo test --doc --all-features` (98 tests)

Closes #307