### PR TITLE
chore(ci): add examples build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,18 @@ jobs:
       - run: cargo doc --no-deps --all-features
         env:
           RUSTDOCFLAGS: -Dwarnings
+
+  examples:
+    name: Examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build all examples
+        run: |
+          cargo build --examples --all-features
+          cargo build --manifest-path examples/crates-mcp/Cargo.toml
+          cargo build --manifest-path examples/conformance-server/Cargo.toml
+          cargo build --manifest-path examples/codegen-mcp/Cargo.toml
+          cargo build --manifest-path examples/markdownlint-mcp/Cargo.toml


### PR DESCRIPTION
## Summary

- Add CI job to verify all examples compile on every PR/push
- Covers both `examples/*.rs` and workspace examples (`crates-mcp`, `conformance-server`, `codegen-mcp`, `markdownlint-mcp`)

## Test plan

- [x] Verified examples build locally
- [x] CI will run on this PR

This ensures examples stay in sync with API changes (especially important for 0.3.0 breaking changes).