### PR TITLE
fix(crates-mcp): use explicit tower-resilience version for Docker build

### DIFF
--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -39,4 +39,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tower middleware
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
-tower-resilience.workspace = true
+tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }


### PR DESCRIPTION
## Summary

The Docker build fails because `tower-resilience.workspace = true` doesn't work when Fly.io builds from within the example directory (no workspace root available).

## Fix

Replace workspace inheritance with explicit version:
```toml
tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }
```

## Test Plan

- [x] Builds locally
- [ ] Deploy to Fly.io after merge