### PR TITLE
fix(crates-mcp): use published tower-mcp for Docker builds

### DIFF
--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -15,7 +15,7 @@ path = "tests/integration.rs"
 
 [dependencies]
 # Core MCP
-tower-mcp = { path = "../..", features = ["http"] }
+tower-mcp = { version = "0.3", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"


### PR DESCRIPTION
Use version 0.3 instead of path dependency so Docker builds work when building from within the example directory.

After merge, `fly deploy` from `examples/crates-mcp/` will work.