### PR TITLE
fix: ensure each HTTP/WebSocket session has independent state

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -146,6 +146,20 @@ impl McpRouter {
         }
     }
 
+    /// Create a clone with fresh session state.
+    ///
+    /// Use this when creating a new logical session (e.g., per HTTP connection).
+    /// The router configuration (tools, resources, prompts) is shared, but the
+    /// session state (phase, extensions) is independent.
+    ///
+    /// This is typically called by transports when establishing a new client session.
+    pub fn with_fresh_session(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            session: SessionState::new(),
+        }
+    }
+
     /// Get access to the task store for async operations
     pub fn task_store(&self) -> &TaskStore {
         &self.inner.task_store

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -947,9 +947,13 @@ async fn handle_post(
     // Get or create session
     let session = if is_init {
         // Create new session for initialize
+        // Use with_fresh_session() to ensure each session has its own state
         match state
             .sessions
-            .create(state.router_template.clone(), state.service_factory.clone())
+            .create(
+                state.router_template.with_fresh_session(),
+                state.service_factory.clone(),
+            )
             .await
         {
             Some(s) => s,

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -402,9 +402,13 @@ async fn handle_socket(
     state: Arc<AppState>,
     mcp_extensions: crate::router::Extensions,
 ) {
+    // Use with_fresh_session() to ensure each session has its own state
     let session = state
         .sessions
-        .create(state.router_template.clone(), state.service_factory.clone())
+        .create(
+            state.router_template.with_fresh_session(),
+            state.service_factory.clone(),
+        )
         .await;
     let session_id = session.id.clone();
 


### PR DESCRIPTION
## Summary

- SessionState uses Arc internally, so cloning McpRouter caused all sessions to share the same phase state
- This led to warnings like "Received initialized notification in unexpected state: Initialized" when multiple clients connected
- Add `McpRouter::with_fresh_session()` that creates a clone with fresh SessionState
- Use it in HTTP and WebSocket transports when creating new sessions

Fixes #323

## Test plan

- [ ] Deploy crates-mcp-demo with the new tower-mcp version
- [ ] Make multiple concurrent MCP tool calls
- [ ] Verify no "unexpected state" warnings in logs