### PR TITLE
feat: add Clone derive to RouterRequest and RouterResponse

### DIFF
--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -15,7 +15,7 @@ path = "tests/integration.rs"
 
 [dependencies]
 # Core MCP
-tower-mcp = { version = "0.3", features = ["http"] }
+tower-mcp = { version = "0.3.3", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"

--- a/src/router.rs
+++ b/src/router.rs
@@ -1413,7 +1413,7 @@ impl Default for McpRouter {
 pub use crate::context::Extensions;
 
 /// Request type for the tower Service implementation
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RouterRequest {
     pub id: RequestId,
     pub inner: McpRequest,
@@ -1422,7 +1422,7 @@ pub struct RouterRequest {
 }
 
 /// Response type for the tower Service implementation
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RouterResponse {
     pub id: RequestId,
     pub inner: std::result::Result<McpResponse, JsonRpcError>,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -378,6 +378,21 @@ impl std::fmt::Debug for Tool {
 unsafe impl Send for Tool {}
 unsafe impl Sync for Tool {}
 
+impl Clone for Tool {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            title: self.title.clone(),
+            description: self.description.clone(),
+            output_schema: self.output_schema.clone(),
+            icons: self.icons.clone(),
+            annotations: self.annotations.clone(),
+            service: self.service.clone(),
+            input_schema: self.input_schema.clone(),
+        }
+    }
+}
+
 impl Tool {
     /// Create a new tool builder
     pub fn builder(name: impl Into<String>) -> ToolBuilder {


### PR DESCRIPTION
## Summary

- Adds `Clone` to `RouterRequest` and `RouterResponse` (derive)
- Adds `Clone` to `Tool` (manual impl, matching `Resource` and `Prompt`)

All inner types already implement Clone, so these are low-risk additions.

## Motivation

Enables middleware that needs to clone requests/responses:
- **Response caching** (tower-resilience-cache) - cache layer requires `Response: Clone`
- **Request logging/tracing** - clone request for async logging
- **Retry middleware** - clone request for retries

`Tool` now has Clone for consistency with `Resource` and `Prompt`.

## Audit

Checked all public types - the only ones missing Clone that could have it were these three. Other types either:
- Already have Clone (most protocol types, service wrappers)
- Can't have Clone (error types with `BoxError`, builders that are consumed)

## Test plan

- [x] `cargo test --lib --all-features` passes (347 tests)
- [x] `cargo test --doc --all-features` passes (101 tests)
- [x] `cargo clippy --all-features` passes