### PR TITLE
feat(crates-mcp): add response caching with tower-resilience-cache

### DIFF
--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -14,8 +14,8 @@ name = "integration"
 path = "tests/integration.rs"
 
 [dependencies]
-# Core MCP
-tower-mcp = { version = "0.3.3", features = ["http"] }
+# Core MCP (use path for development, version for release)
+tower-mcp = { path = "../..", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"
@@ -39,4 +39,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Tower middleware
 tower = { version = "0.5", features = ["util", "timeout", "limit"] }
-tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }
+tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter", "cache"] }


### PR DESCRIPTION
## Summary

Adds response caching for tool calls using `tower-resilience-cache`, demonstrating tower middleware composition with tower-mcp.

## Features

- **Selective caching**: Only caches `tools/call` responses, not list/initialize/ping
- **Cache key**: `tool:{name}:{serialized_args}` for deterministic matching  
- **Bypass pattern**: Non-tool requests use `nocache:{request_id}` keys (never match)
- **Configurable via CLI**:
  - `--cache-enabled` (default: true)
  - `--cache-ttl-secs` (default: 300 = 5 minutes)
  - `--cache-max-size` (default: 200 entries)

## Performance Impact

Based on the logs shared earlier, this would significantly improve response times for repeated queries:

| Tool | Uncached | Cached |
|------|----------|--------|
| `get_reverse_dependencies` | ~24s | <1ms |
| `get_crate_info` | ~700ms | <1ms |
| `get_downloads` | ~1.8s | <1ms |

## Dependencies

- Adds `cache` feature to `tower-resilience` dependency
- Uses path dependency for `tower-mcp` (requires #325 Clone changes)

## Note

The path dependency for tower-mcp should be updated to a version dependency once a release including #325 is published.

## Test plan

- [x] `cargo build` passes
- [x] `cargo clippy` passes  
- [x] Pre-existing test failures unrelated to this change
- [ ] Manual testing with HTTP transport