### PR TITLE
fix(crates-mcp): use published tower-mcp for Docker builds

### DIFF
--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -14,8 +14,8 @@ name = "integration"
 path = "tests/integration.rs"
 
 [dependencies]
-# Core MCP (use path for development, version for release)
-tower-mcp = { path = "../..", features = ["http"] }
+# Core MCP (use version for Docker builds, path for local dev)
+tower-mcp = { version = "0.3", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"


### PR DESCRIPTION
## Summary

- Fixes Docker build failure caused by path dependency
- The caching PR (#327) inadvertently reverted the dependency back to `path = "../.."`
- Changed to `version = "0.3"` for Docker builds

## Context

Docker builds from `examples/crates-mcp/` directory don't have access to the parent workspace, so path dependencies fail with:
```
error: failed to get `tower-mcp` as a dependency of package `crates-mcp v0.1.0 (/app)`
Caused by: failed to read `/Cargo.toml`
```

## Test plan

- [ ] Docker build succeeds: `fly deploy` from examples/crates-mcp/