### PR TITLE
fix(crates-mcp): configure Fly.io for single-instance MCP sessions

### DIFF
--- a/examples/crates-mcp/fly.toml
+++ b/examples/crates-mcp/fly.toml
@@ -13,8 +13,14 @@ primary_region = "sjc"
   force_https = true
   auto_stop_machines = "suspend"
   auto_start_machines = true
+  # MCP HTTP sessions are stored in-memory, so we need exactly 1 instance
+  # For multi-instance deployments, use sticky sessions or external session store
   min_machines_running = 1
   processes = ["app"]
+  [http_service.concurrency]
+    type = "requests"
+    hard_limit = 100
+    soft_limit = 80
 
 [[vm]]
   memory = "256mb"


### PR DESCRIPTION
## Summary

- Add concurrency configuration and documentation for Fly.io deployment
- MCP HTTP sessions are stored in-memory, requiring single-instance or sticky sessions
- Tested and confirmed caching works correctly with single instance (378ms -> 36ms on cache hit)

## Context

When Fly.io runs multiple instances, requests can hit different machines, causing "session not found" errors since session state is in-memory. This PR documents the requirement and adds concurrency limits.

For production multi-instance deployments, options include:
- Sticky sessions (route same client to same instance)
- External session store (Redis, etc.)

## Test plan

- [x] Scaled to 1 instance: `fly scale count 1 -a crates-mcp-demo`
- [x] Verified session persistence works
- [x] Confirmed cache hit/miss timing (10x speedup on cache hit)