### PR TITLE
feat: add API convenience methods

### DIFF
--- a/examples/crates-mcp/README.md
+++ b/examples/crates-mcp/README.md
@@ -129,6 +129,26 @@ curl -X POST http://localhost:3000/ \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"search_crates","arguments":{"query":"async http"}}}'
 ```
 
+### MCP Inspector
+
+For interactive testing, use the MCP Inspector:
+
+```bash
+# Start the server with HTTP transport
+cargo run -p crates-mcp -- --transport http --port 3000
+
+# In another terminal, connect with Inspector
+npx @modelcontextprotocol/inspector --transport http --server-url http://127.0.0.1:3000
+```
+
+The Inspector opens at `http://localhost:6274` where you can:
+
+- Browse and call tools interactively
+- View resources and resource templates
+- Execute prompts with arguments
+- Monitor server notifications and progress updates
+- Test completions
+
 ## Deployment
 
 ### Docker


### PR DESCRIPTION
## Summary

- Add `ToolBuilder::no_params_handler()` for tools without input parameters (#331)
- Add `CreateMessageResult::first_text()` and `SamplingContent::as_text()` for sampling results (#332)
- Add `RequestContext::confirm()` for simple yes/no elicitation dialogs (#333)
- Add MCP Inspector setup instructions to crates-mcp README

## Details

### `no_params_handler` (#331)

Convenience method for tools that take no input:

```rust
let tool = ToolBuilder::new("get_status")
    .description("Get current status")
    .no_params_handler(|| async { Ok(CallToolResult::text("OK")) })
    .build()
    .unwrap();
```

Eliminates the need for `handler(|_: NoParams| async { ... })`.

### `first_text()` (#332)

Extract text from sampling results:

```rust
let result = ctx.sample(params).await?;
if let Some(text) = result.first_text() {
    // Use the text response
}
```

### `confirm()` (#333)

Simple yes/no confirmation dialogs:

```rust
let confirmed = ctx.confirm("Are you sure?").await?;
if confirmed {
    // Proceed with action
}
```

## Test plan

- [x] All 358 library tests pass
- [x] All 52 integration tests pass
- [x] All 104 doc tests pass
- [x] Clippy and formatting checks pass

Closes #331
Closes #332
Closes #333