### PR TITLE
feat(codegen-mcp): add component builder workflow for incremental tool construction

### DIFF
--- a/examples/codegen-mcp/src/main.rs
+++ b/examples/codegen-mcp/src/main.rs
@@ -1,35 +1,49 @@
 //! tower-mcp-codegen: An MCP server that helps build tower-mcp servers.
 //!
-//! This server provides tools for AI agents to incrementally define and generate
-//! tower-mcp server code. The workflow is:
+//! This server provides two workflows for AI agents:
 //!
-//! 1. `init_project` - Initialize a new project with name and transports
-//! 2. `add_tool` - Add tools with input fields and handler types
-//! 3. `get_project` - Inspect the current project state (or read project:// resources)
-//! 4. `validate` - Verify the generated code compiles
-//! 5. `generate` - Generate complete, compilable Rust code
-//! 6. `reset` - Start over with a new project
+//! ## Workflow 1: Component Builder (Recommended for agents)
+//!
+//! Build individual tools/resources/prompts incrementally with explicit variant discovery:
+//!
+//! ```text
+//! 1. list_handler_types()  -> Learn available handler types
+//! 2. list_input_types()    -> Learn available input types
+//! 3. tool_new("search")    -> Start building, get an ID
+//! 4. tool_set_description(id, "Search the database")
+//! 5. tool_add_input(id, "query", "String", "Search term", true)
+//! 6. tool_set_handler(id, "with_state")
+//! 7. tool_add_layer(id, "timeout", {"secs": 30})
+//! 8. tool_build(id)        -> Get Rust code for this tool
+//! ```
+//!
+//! Benefits:
+//! - Explicit variant discovery (no guessing what options exist)
+//! - Incremental construction (one decision at a time)
+//! - Immediate feedback at each step
+//! - Can generate code for individual components
+//!
+//! ## Workflow 2: Project Builder (Original)
+//!
+//! Build a complete project with all tools at once:
+//!
+//! ```text
+//! 1. init_project(name="echo-server", transports=["stdio"])
+//! 2. add_tool(name="echo", description="...", input_fields=[...])
+//! 3. validate() -> Check it compiles
+//! 4. generate() -> Complete Cargo.toml and main.rs
+//! ```
+//!
+//! ## Combining Workflows
+//!
+//! Use `tool_add_to_project(id)` to add a component-built tool to the project,
+//! then use `generate()` for full project code.
 //!
 //! ## Resources
 //!
 //! - `project://Cargo.toml` - Generated Cargo.toml content
 //! - `project://src/main.rs` - Generated main.rs content
 //! - `project://state.json` - Current project state as JSON
-//!
-//! ## Example
-//!
-//! ```text
-//! Agent: "Create an MCP server that echoes messages"
-//!
-//! 1. init_project(name="echo-server", transports=["stdio"])
-//! 2. add_tool(
-//!      name="echo",
-//!      description="Echo a message back",
-//!      input_fields=[{name: "message", type: "String", description: "Message to echo"}]
-//!    )
-//! 3. validate() -> Check it compiles
-//! 4. generate() -> Complete Cargo.toml and main.rs
-//! ```
 
 mod codegen;
 mod resources;
@@ -73,10 +87,17 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let mut router = McpRouter::new()
         .server_info("codegen-mcp", env!("CARGO_PKG_VERSION"))
         .instructions(
-            "This server helps you build tower-mcp servers. Use init_project to start, \
-             add_tool to define tools, and generate to get the code. Read project:// \
-             resources to see generated files, or call get_project for the full state. \
-             Use validate to check the code compiles, or reset to start over.",
+            "This server helps you build tower-mcp servers.\n\n\
+             **Recommended workflow (component builder):**\n\
+             1. Call list_handler_types, list_input_types, list_layer_types to learn available options\n\
+             2. Call tool_new(name) to start building a tool\n\
+             3. Use tool_set_description, tool_add_input, tool_set_handler, tool_add_layer to configure\n\
+             4. Call tool_build(id) to generate code for just that tool\n\n\
+             **Alternative workflow (full project):**\n\
+             1. init_project(name, transports) to start\n\
+             2. add_tool(...) to add tools\n\
+             3. generate() for complete project code\n\n\
+             Use tool_list to see tools being built, tool_add_to_project to add to project.",
         );
 
     for tool in tools {

--- a/examples/codegen-mcp/src/state.rs
+++ b/examples/codegen-mcp/src/state.rs
@@ -2,9 +2,23 @@
 //!
 //! This module defines the data structures that accumulate project
 //! configuration as the agent calls tools like `init_project`, `add_tool`, etc.
+//!
+//! ## Component Builder Pattern
+//!
+//! In addition to project-level state, this module supports incremental
+//! component building where tools/resources/prompts are constructed step-by-step:
+//!
+//! ```text
+//! tool_new("search") -> id
+//! tool_set_description(id, "...")
+//! tool_add_input(id, "query", "String", ...)
+//! tool_set_handler(id, "with_state")
+//! tool_build(id) -> Rust code
+//! ```
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// The accumulated project state.
 ///
@@ -244,5 +258,183 @@ impl ProjectState {
     /// Reset the project state.
     pub fn reset(&mut self) {
         *self = Self::default();
+    }
+}
+
+// =============================================================================
+// Component Builder State
+// =============================================================================
+
+/// In-progress tool being built incrementally.
+///
+/// Created by `tool_new`, configured by `tool_set_*` and `tool_add_*`,
+/// finalized by `tool_build`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+pub struct ToolBuilderState {
+    /// Tool name (snake_case)
+    pub name: String,
+
+    /// Tool description
+    pub description: Option<String>,
+
+    /// Input fields
+    pub input_fields: Vec<InputField>,
+
+    /// Handler type
+    #[serde(default)]
+    pub handler_type: HandlerType,
+
+    /// Tool annotations
+    #[serde(default)]
+    pub annotations: ToolAnnotations,
+
+    /// Middleware layers to apply
+    #[serde(default)]
+    pub layers: Vec<LayerConfig>,
+}
+
+impl ToolBuilderState {
+    /// Create a new tool builder with the given name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Convert to a ToolDef (for adding to project).
+    pub fn into_tool_def(self) -> ToolDef {
+        ToolDef {
+            name: self.name,
+            description: self.description.unwrap_or_default(),
+            input_fields: self.input_fields,
+            handler_type: self.handler_type,
+            annotations: self.annotations,
+        }
+    }
+}
+
+/// Configuration for a middleware layer.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct LayerConfig {
+    /// Type of layer
+    pub layer_type: LayerType,
+
+    /// Layer-specific configuration
+    #[serde(default)]
+    pub config: Value,
+}
+
+/// Available middleware layer types.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum LayerType {
+    /// Timeout layer - fails if handler takes too long
+    Timeout,
+    /// Rate limit layer - limits requests per time window
+    RateLimit,
+    /// Concurrency limit layer - limits concurrent executions
+    ConcurrencyLimit,
+}
+
+impl LayerType {
+    /// Get all available layer types.
+    #[allow(dead_code)]
+    pub fn all() -> Vec<&'static str> {
+        vec!["timeout", "rate_limit", "concurrency_limit"]
+    }
+
+    /// Get description for a layer type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            LayerType::Timeout => {
+                "Fails the tool call if it takes longer than the specified duration"
+            }
+            LayerType::RateLimit => "Limits how often the tool can be called within a time window",
+            LayerType::ConcurrencyLimit => {
+                "Limits how many concurrent executions of this tool are allowed"
+            }
+        }
+    }
+
+    /// Get the config schema description for this layer.
+    pub fn config_schema(&self) -> &'static str {
+        match self {
+            LayerType::Timeout => r#"{"secs": <number>} - timeout in seconds"#,
+            LayerType::RateLimit => {
+                r#"{"requests": <number>, "per_secs": <number>} - max requests per time window"#
+            }
+            LayerType::ConcurrencyLimit => r#"{"max": <number>} - maximum concurrent executions"#,
+        }
+    }
+}
+
+impl std::fmt::Display for LayerType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LayerType::Timeout => write!(f, "timeout"),
+            LayerType::RateLimit => write!(f, "rate_limit"),
+            LayerType::ConcurrencyLimit => write!(f, "concurrency_limit"),
+        }
+    }
+}
+
+impl HandlerType {
+    /// Get all available handler types.
+    pub fn all() -> Vec<&'static str> {
+        vec![
+            "simple",
+            "with_state",
+            "with_context",
+            "with_state_and_context",
+            "raw",
+            "no_params",
+        ]
+    }
+
+    /// Get description for a handler type.
+    pub fn description(&self) -> &'static str {
+        match self {
+            HandlerType::Simple => {
+                "Basic handler that receives typed input: handler(|input: T| async { ... })"
+            }
+            HandlerType::WithState => {
+                "Handler with shared state: handler_with_state(|state: Arc<S>, input: T| async { ... })"
+            }
+            HandlerType::WithContext => {
+                "Handler with request context for progress/cancellation: handler_with_context(|ctx, input: T| async { ... })"
+            }
+            HandlerType::WithStateAndContext => {
+                "Handler with both state and context: handler_with_state_and_context(|state, ctx, input: T| async { ... })"
+            }
+            HandlerType::Raw => {
+                "Handler receiving raw JSON Value: raw_handler(|args: Value| async { ... })"
+            }
+            HandlerType::NoParams => {
+                "Handler with no input parameters: no_params_handler(|| async { ... })"
+            }
+        }
+    }
+}
+
+/// Available input field types.
+pub struct InputTypes;
+
+impl InputTypes {
+    /// Get all available input types with descriptions.
+    pub fn all() -> Vec<(&'static str, &'static str)> {
+        vec![
+            ("String", "UTF-8 string"),
+            ("i64", "64-bit signed integer"),
+            ("f64", "64-bit floating point"),
+            ("bool", "Boolean true/false"),
+            ("Option<String>", "Optional string (can be null)"),
+            ("Option<i64>", "Optional integer"),
+            ("Option<f64>", "Optional float"),
+            ("Option<bool>", "Optional boolean"),
+            ("Vec<String>", "Array of strings"),
+            ("Vec<i64>", "Array of integers"),
+            ("Value", "Raw JSON value (any structure)"),
+        ]
     }
 }


### PR DESCRIPTION
## Summary

- Adds component builder workflow for AI agents to construct tools incrementally with explicit variant discovery
- Discovery tools (`list_handler_types`, `list_layer_types`, `list_input_types`) let agents learn valid options before making choices
- Builder tools (`tool_new`, `tool_set_*`, `tool_add_*`, `tool_build`) enable step-by-step construction
- `tool_build` generates Rust code for individual tools; `tool_add_to_project` integrates with full project generation
- Original project-focused workflow (init_project, add_tool, generate) remains available

**Agent-driven development philosophy**: Agents work fast and can try many variants, so explicit option discovery is more valuable than memorizing APIs or guessing valid inputs.

## Example workflow

```
agent: list_handler_types()
server: simple, with_state, with_context, with_state_and_context, raw, no_params

agent: tool_new("search")
server: id="search"

agent: tool_set_description("search", "Search the database")
server: ok

agent: list_input_types()
server: String, i64, f64, bool, Option<T>, Vec<T>, Value

agent: tool_add_input("search", "query", "String", "Search term", true)
server: ok

agent: tool_set_handler("search", "with_state")
server: ok

agent: tool_build("search")
server: [generated Rust code for the tool]
```

## Test plan

- [ ] Verify codegen-mcp compiles: `cargo build -p codegen-mcp`
- [ ] Test discovery tools return expected variants
- [ ] Test component builder workflow creates valid tool state
- [ ] Test `tool_build` generates compilable Rust code