### PR TITLE
refactor: migrate examples and docs to extractor_handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ let state = Arc::new(AppState { /* ... */ });
 
 // Tools access state via Extension<T> extractor
 let tool = ToolBuilder::new("query")
-    .extractor_handler_typed::<_, _, _, QueryInput>(
+    .extractor_handler(
         (),
         |Extension(app): Extension<Arc<AppState>>, Json(input): Json<QueryInput>| async move {
             let result = app.db.query(&input.sql).await?;

--- a/examples/codegen-mcp/src/codegen.rs
+++ b/examples/codegen-mcp/src/codegen.rs
@@ -467,7 +467,7 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, NoParams>((), |Json(_): Json<NoParams>| async move {{
+                    r#"        .extractor_handler((), |Json(_): Json<NoParams>| async move {{
             // TODO: implement {}
             // Example: Ok(CallToolResult::text("Done!"))
             Ok(CallToolResult::text("OK"))
@@ -481,17 +481,17 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
             if let Some(ref input) = input_type {
                 let example = generate_example_impl(tool, true, false);
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, {}>(state.clone(), |State(state): State<Arc<AppState>>, Json(input): Json<{}>| async move {{
+                    r#"        .extractor_handler(state.clone(), |State(state): State<Arc<AppState>>, Json(input): Json<{}>| async move {{
             // TODO: implement {}
 {}
             Ok(CallToolResult::text(format!("{{:?}}", input)))
         }})
 "#,
-                    input, input, tool.name, example
+                    input, tool.name, example
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, NoParams>(state.clone(), |State(state): State<Arc<AppState>>, Json(_): Json<NoParams>| async move {{
+                    r#"        .extractor_handler(state.clone(), |State(state): State<Arc<AppState>>, Json(_): Json<NoParams>| async move {{
             // TODO: implement {}
             // Example: let data = state.db.query(...).await?;
             Ok(CallToolResult::text("OK"))
@@ -505,17 +505,17 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
             if let Some(ref input) = input_type {
                 let example = generate_example_impl(tool, false, true);
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, {}>((), |ctx: Context, Json(input): Json<{}>| async move {{
+                    r#"        .extractor_handler((), |ctx: Context, Json(input): Json<{}>| async move {{
             // TODO: implement {}
 {}
             Ok(CallToolResult::text(format!("{{:?}}", input)))
         }})
 "#,
-                    input, input, tool.name, example
+                    input, tool.name, example
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, NoParams>((), |ctx: Context, Json(_): Json<NoParams>| async move {{
+                    r#"        .extractor_handler((), |ctx: Context, Json(_): Json<NoParams>| async move {{
             // TODO: implement {}
             // Example: ctx.report_progress(0.5, Some(1.0), Some("Halfway done")).await;
             Ok(CallToolResult::text("OK"))
@@ -529,17 +529,17 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
             if let Some(ref input) = input_type {
                 let example = generate_example_impl(tool, true, true);
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, {}>(state.clone(), |State(state): State<Arc<AppState>>, ctx: Context, Json(input): Json<{}>| async move {{
+                    r#"        .extractor_handler(state.clone(), |State(state): State<Arc<AppState>>, ctx: Context, Json(input): Json<{}>| async move {{
             // TODO: implement {}
 {}
             Ok(CallToolResult::text(format!("{{:?}}", input)))
         }})
 "#,
-                    input, input, tool.name, example
+                    input, tool.name, example
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"        .extractor_handler_typed::<_, _, _, NoParams>(state.clone(), |State(state): State<Arc<AppState>>, ctx: Context, Json(_): Json<NoParams>| async move {{
+                    r#"        .extractor_handler(state.clone(), |State(state): State<Arc<AppState>>, ctx: Context, Json(_): Json<NoParams>| async move {{
             // TODO: implement {}
             // Example:
             //   ctx.report_progress(0.0, Some(1.0), Some("Starting")).await;
@@ -567,7 +567,7 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
         }
         HandlerType::NoParams => {
             code.push_str(&format!(
-                r#"        .extractor_handler_typed::<_, _, _, NoParams>((), |Json(_): Json<NoParams>| async move {{
+                r#"        .extractor_handler((), |Json(_): Json<NoParams>| async move {{
             // TODO: implement {}
             // Example: Ok(CallToolResult::text("Done!"))
             Ok(CallToolResult::text("OK"))
@@ -765,18 +765,18 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         HandlerType::WithState => {
             if let Some(ref input) = input_type {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, {}>(
+                    r#"    .extractor_handler(
         state.clone(),  // TODO: pass your Arc<State> here
         |State(state): State<Arc<YourState>>, Json(input): Json<{}>| async move {{
             todo!("Implement {} handler with state")
         }},
     )
 "#,
-                    input, input, builder.name
+                    input, builder.name
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, NoParams>(
+                    r#"    .extractor_handler(
         state.clone(),  // TODO: pass your Arc<State> here
         |State(state): State<Arc<YourState>>, Json(_): Json<NoParams>| async move {{
             todo!("Implement {} handler with state")
@@ -790,7 +790,7 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         HandlerType::WithContext => {
             if let Some(ref input) = input_type {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, {}>(
+                    r#"    .extractor_handler(
         (),
         |ctx: Context, Json(input): Json<{}>| async move {{
             // ctx.report_progress(0.5, Some(1.0), Some("Working...")).await;
@@ -799,11 +799,11 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         }},
     )
 "#,
-                    input, input, builder.name
+                    input, builder.name
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, NoParams>(
+                    r#"    .extractor_handler(
         (),
         |ctx: Context, Json(_): Json<NoParams>| async move {{
             // ctx.report_progress(0.5, Some(1.0), Some("Working...")).await;
@@ -818,7 +818,7 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         HandlerType::WithStateAndContext => {
             if let Some(ref input) = input_type {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, {}>(
+                    r#"    .extractor_handler(
         state.clone(),  // TODO: pass your Arc<State> here
         |State(state): State<Arc<YourState>>, ctx: Context, Json(input): Json<{}>| async move {{
             // ctx.report_progress(0.5, Some(1.0), Some("Working...")).await;
@@ -826,11 +826,11 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         }},
     )
 "#,
-                    input, input, builder.name
+                    input, builder.name
                 ));
             } else {
                 code.push_str(&format!(
-                    r#"    .extractor_handler_typed::<_, _, _, NoParams>(
+                    r#"    .extractor_handler(
         state.clone(),  // TODO: pass your Arc<State> here
         |State(state): State<Arc<YourState>>, ctx: Context, Json(_): Json<NoParams>| async move {{
             todo!("Implement {} handler with state and context")

--- a/examples/codegen-mcp/src/tools.rs
+++ b/examples/codegen-mcp/src/tools.rs
@@ -158,7 +158,7 @@ pub fn build_tools(state: Arc<CodegenState>) -> Vec<Tool> {
 fn build_init_project(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("init_project")
         .description("Initialize a new tower-mcp server project")
-        .extractor_handler_typed::<_, _, _, InitProjectInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<InitProjectInput>| async move {
@@ -206,7 +206,7 @@ fn build_init_project(state: Arc<CodegenState>) -> Tool {
 fn build_add_tool(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("add_tool")
         .description("Add a tool to the project")
-        .extractor_handler_typed::<_, _, _, AddToolInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<AddToolInput>| async move {
                 let mut project = state.project.write().await;
@@ -282,7 +282,7 @@ pub struct RemoveToolInput {
 fn build_remove_tool(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("remove_tool")
         .description("Remove a tool from the project")
-        .extractor_handler_typed::<_, _, _, RemoveToolInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<RemoveToolInput>| async move {
@@ -319,7 +319,7 @@ fn build_get_project(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("get_project")
         .description("Get the current project state as JSON")
         .read_only()
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(_): Json<NoParams>| async move {
                 let project = state.project.read().await;
@@ -334,7 +334,7 @@ fn build_generate(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("generate")
         .description("Generate the complete Rust code for the project")
         .read_only()
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(_): Json<NoParams>| async move {
                 let project = state.project.read().await;
@@ -359,7 +359,7 @@ fn build_validate(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("validate")
         .description("Validate the generated code compiles (runs cargo check)")
         .read_only()
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(_): Json<NoParams>| async move {
                 let project = state.project.read().await;
@@ -443,7 +443,7 @@ fn build_validate(state: Arc<CodegenState>) -> Tool {
 fn build_reset(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("reset")
         .description("Reset the project state to start over")
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(_): Json<NoParams>| async move {
                 let mut project = state.project.write().await;
@@ -549,7 +549,7 @@ pub struct ToolNewInput {
 fn build_tool_new(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_new")
         .description("Start building a new tool. Returns an ID to use with other tool_* commands.")
-        .extractor_handler_typed::<_, _, _, ToolNewInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<ToolNewInput>| async move {
                 let id = state.next_id();
@@ -579,7 +579,7 @@ pub struct ToolSetDescriptionInput {
 fn build_tool_set_description(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_set_description")
         .description("Set the description for a tool being built")
-        .extractor_handler_typed::<_, _, _, ToolSetDescriptionInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<ToolSetDescriptionInput>| async move {
@@ -623,7 +623,7 @@ pub struct ToolAddInputInput {
 fn build_tool_add_input(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_add_input")
         .description("Add an input field to a tool being built. Use list_input_types to see available types.")
-        .extractor_handler_typed::<_, _, _, ToolAddInputInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<ToolAddInputInput>| async move {
@@ -671,7 +671,7 @@ pub struct ToolSetHandlerInput {
 fn build_tool_set_handler(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_set_handler")
         .description("Set the handler type for a tool. Use list_handler_types to see available types.")
-        .extractor_handler_typed::<_, _, _, ToolSetHandlerInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<ToolSetHandlerInput>| async move {
@@ -726,7 +726,7 @@ pub struct ToolSetAnnotationInput {
 fn build_tool_set_annotation(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_set_annotation")
         .description("Set an annotation on a tool. Annotations are hints about tool behavior.")
-        .extractor_handler_typed::<_, _, _, ToolSetAnnotationInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<ToolSetAnnotationInput>| async move {
@@ -775,7 +775,7 @@ pub struct ToolAddLayerInput {
 fn build_tool_add_layer(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_add_layer")
         .description("Add a middleware layer to a tool. Use list_layer_types to see available layers and their config.")
-        .extractor_handler_typed::<_, _, _, ToolAddLayerInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>,
              Json(input): Json<ToolAddLayerInput>| async move {
@@ -829,7 +829,7 @@ fn build_tool_get(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_get")
         .description("Get the current state of a tool being built")
         .read_only()
-        .extractor_handler_typed::<_, _, _, ToolIdInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<ToolIdInput>| async move {
                 let tools = state.building_tools.read().await;
@@ -851,7 +851,7 @@ fn build_tool_build(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_build")
         .description("Generate Rust code for the tool. Returns the code but keeps the builder for further modifications.")
         .read_only()
-        .extractor_handler_typed::<_, _, _, ToolIdInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<ToolIdInput>| async move {
                 let tools = state.building_tools.read().await;
@@ -882,7 +882,7 @@ fn build_tool_build(state: Arc<CodegenState>) -> Tool {
 fn build_tool_add_to_project(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_add_to_project")
         .description("Add the built tool to the project for full project generation")
-        .extractor_handler_typed::<_, _, _, ToolIdInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<ToolIdInput>| async move {
                 let mut tools = state.building_tools.write().await;
@@ -928,7 +928,7 @@ fn build_tool_list(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_list")
         .description("List all tools currently being built")
         .read_only()
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(_): Json<NoParams>| async move {
                 let tools = state.building_tools.read().await;
@@ -965,7 +965,7 @@ fn build_tool_list(state: Arc<CodegenState>) -> Tool {
 fn build_tool_discard(state: Arc<CodegenState>) -> Tool {
     ToolBuilder::new("tool_discard")
         .description("Discard a tool being built without adding it to the project")
-        .extractor_handler_typed::<_, _, _, ToolIdInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<CodegenState>>, Json(input): Json<ToolIdInput>| async move {
                 let mut tools = state.building_tools.write().await;

--- a/examples/external_api_auth.rs
+++ b/examples/external_api_auth.rs
@@ -100,7 +100,7 @@ fn build_server_side_tool(client: Arc<ExternalApiClient>) -> tower_mcp::Tool {
         .description(
             "Search using server-side API credentials (Pattern 1: best for stdio transport)",
         )
-        .extractor_handler_typed::<_, _, _, QueryInput>(
+        .extractor_handler(
             client,
             |State(client): State<Arc<ExternalApiClient>>, Json(input): Json<QueryInput>| async move {
                 match client.list_items(&input.query).await {
@@ -133,7 +133,7 @@ fn build_server_side_tool(client: Arc<ExternalApiClient>) -> tower_mcp::Tool {
 // In a real implementation with OAuth middleware configured:
 //
 // ```rust,ignore
-// .extractor_handler_typed::<_, _, _, QueryInput>((), |ctx: Context, Json(input): Json<QueryInput>| async move {
+// .extractor_handler((), |ctx: Context, Json(input): Json<QueryInput>| async move {
 //     let claims = ctx.extensions().get::<TokenClaims>()
 //         .ok_or_else(|| Error::tool("Not authenticated"))?;
 //     let api_token = claims.extra.get("external_api_token")
@@ -149,7 +149,7 @@ fn build_server_side_tool(client: Arc<ExternalApiClient>) -> tower_mcp::Tool {
 fn build_oauth_claims_tool() -> tower_mcp::Tool {
     ToolBuilder::new("search_with_user_token")
         .description("Search using per-user API token from OAuth claims (Pattern 2: best for HTTP)")
-        .extractor_handler_typed::<_, _, _, QueryInput>(
+        .extractor_handler(
             (),
             |_ctx: Context, Json(input): Json<QueryInput>| async move {
                 // In production with OAuth middleware, you would extract the token from claims.
@@ -189,7 +189,7 @@ fn build_oauth_claims_tool() -> tower_mcp::Tool {
 fn build_elicitation_tool() -> tower_mcp::Tool {
     ToolBuilder::new("search_with_elicitation")
         .description("Search by asking user for API key at runtime (Pattern 3: interactive)")
-        .extractor_handler_typed::<_, _, _, QueryInput>(
+        .extractor_handler(
             (),
             |ctx: Context, Json(input): Json<QueryInput>| async move {
                 // Check if elicitation is available (client supports it)
@@ -262,7 +262,7 @@ fn build_elicitation_tool() -> tower_mcp::Tool {
 // In production with OAuth middleware, you would get the user_id from claims:
 //
 // ```rust,ignore
-// .extractor_handler_typed::<_, _, _, QueryInput>(store, |State(store): State<Arc<CredentialStore>>, ctx: Context, Json(input): Json<QueryInput>| async move {
+// .extractor_handler(store, |State(store): State<Arc<CredentialStore>>, ctx: Context, Json(input): Json<QueryInput>| async move {
 //     let claims = ctx.extensions().get::<TokenClaims>()?;
 //     let user_id = claims.sub.as_ref()?;
 //     let token = store.get(user_id, "github").await?;
@@ -304,7 +304,7 @@ fn build_credential_store_tool(store: Arc<CredentialStore>) -> tower_mcp::Tool {
         .description(
             "Search using credentials from server-side store (Pattern 4: credential store)",
         )
-        .extractor_handler_typed::<_, _, _, QueryInput>(
+        .extractor_handler(
             store,
             |State(store): State<Arc<CredentialStore>>,
              _ctx: Context,

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -116,7 +116,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // Useful for demonstrating SSE event streaming and Last-Event-ID resumption
     let slow_task = ToolBuilder::new("slow_task")
         .description("Simulate a slow task that sends progress notifications (for SSE demo)")
-        .extractor_handler_typed::<_, _, _, SlowTaskInput>(
+        .extractor_handler(
             (),
             |ctx: Context, Json(input): Json<SlowTaskInput>| async move {
                 let steps = input.steps.min(20); // Cap at 20 steps

--- a/examples/markdownlint-mcp/src/tools.rs
+++ b/examples/markdownlint-mcp/src/tools.rs
@@ -16,7 +16,7 @@
 //!
 //! // Each tool gets a clone of the Arc
 //! let tool = ToolBuilder::new("lint_content")
-//!     .extractor_handler_typed::<_, _, _, LintContentInput>(state.clone(), |State(state), Json(input)| async move {
+//!     .extractor_handler(state.clone(), |State(state), Json(input)| async move {
 //!         // Use state here
 //!     })
 //!     .build()?;
@@ -171,7 +171,7 @@ pub fn build_tools() -> Vec<Tool> {
 fn build_lint_content_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("lint_content")
         .description("Lint markdown content and return violations")
-        .extractor_handler_typed::<_, _, _, LintContentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(input): Json<LintContentInput>| async move {
                 match state.lint_to_result(&input.content, &input.filename) {
@@ -191,7 +191,7 @@ fn build_lint_content_tool(state: Arc<LintState>) -> Tool {
 fn build_lint_file_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("lint_file")
         .description("Lint a local markdown file")
-        .extractor_handler_typed::<_, _, _, LintFileInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(input): Json<LintFileInput>| async move {
                 // Read the file asynchronously
@@ -219,7 +219,7 @@ fn build_lint_file_tool(state: Arc<LintState>) -> Tool {
 fn build_lint_url_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("lint_url")
         .description("Fetch markdown from a URL and lint it")
-        .extractor_handler_typed::<_, _, _, LintUrlInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(input): Json<LintUrlInput>| async move {
                 // Fetch the URL
@@ -257,7 +257,7 @@ fn build_lint_url_tool(state: Arc<LintState>) -> Tool {
 fn build_list_rules_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("list_rules")
         .description("List all available lint rules with their descriptions")
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(_): Json<NoParams>| async move {
                 let rules = state.rules();
@@ -279,7 +279,7 @@ fn build_list_rules_tool(state: Arc<LintState>) -> Tool {
 fn build_explain_rule_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("explain_rule")
         .description("Get detailed explanation of a specific lint rule")
-        .extractor_handler_typed::<_, _, _, ExplainRuleInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(input): Json<ExplainRuleInput>| async move {
                 match state.get_rule(&input.rule_id) {
@@ -302,7 +302,7 @@ fn build_explain_rule_tool(state: Arc<LintState>) -> Tool {
 fn build_fix_content_tool(state: Arc<LintState>) -> Tool {
     ToolBuilder::new("fix_content")
         .description("Apply automatic fixes to markdown content where possible")
-        .extractor_handler_typed::<_, _, _, FixContentInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<LintState>>, Json(input): Json<FixContentInput>| async move {
                 match state.fix_content(&input.content, &input.filename) {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -534,7 +534,7 @@ impl<S> FromToolRequest<S> for RawArgs {
 ///
 /// let tool = ToolBuilder::new("query")
 ///     .description("Run a query")
-///     .extractor_handler_typed::<_, _, _, QueryInput>(
+///     .extractor_handler(
 ///         (),
 ///         |Extension(db): Extension<Arc<DatabasePool>>, Json(input): Json<QueryInput>| async move {
 ///             Ok(CallToolResult::text(format!("Query on {}: {}", db.url, input.sql)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@
 //! // Looks just like an axum handler!
 //! let tool = ToolBuilder::new("search")
 //!     .description("Search the database")
-//!     .extractor_handler_typed::<_, _, _, SearchInput>(
+//!     .extractor_handler(
 //!         Arc::new(AppState { db_url: "postgres://...".into() }),
 //!         |State(app): State<Arc<AppState>>,
 //!          ctx: Context,

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -1470,7 +1470,7 @@ mod tests {
 
         let tool = ToolBuilder::new("process")
             .description("Process with context")
-            .extractor_handler_typed::<_, _, _, ProcessInput>(
+            .extractor_handler(
                 (),
                 |ctx: Context, Json(input): Json<ProcessInput>| async move {
                     // Simulate progress reporting
@@ -1527,7 +1527,7 @@ mod tests {
 
         let tool = ToolBuilder::new("long_running")
             .description("Long running task")
-            .extractor_handler_typed::<_, _, _, LongRunningInput>(
+            .extractor_handler(
                 (),
                 move |ctx: Context, Json(input): Json<LongRunningInput>| {
                     let completed = iterations_ref.clone();
@@ -1608,7 +1608,7 @@ mod tests {
 
         let tool = ToolBuilder::new("stateful")
             .description("Uses shared state")
-            .extractor_handler_typed::<_, _, _, GreetInput>(
+            .extractor_handler(
                 shared,
                 |State(state): State<Arc<String>>, Json(input): Json<GreetInput>| async move {
                     Ok(CallToolResult::text(format!(
@@ -1633,7 +1633,7 @@ mod tests {
         let tool =
             ToolBuilder::new("stateful_ctx")
                 .description("Uses state and context")
-                .extractor_handler_typed::<_, _, _, GreetInput>(
+                .extractor_handler(
                     shared,
                     |State(state): State<Arc<i32>>,
                      _ctx: Context,
@@ -1658,7 +1658,7 @@ mod tests {
     async fn test_handler_no_params() {
         let tool = ToolBuilder::new("no_params")
             .description("Takes no parameters")
-            .extractor_handler_typed::<_, _, _, NoParams>((), |Json(_): Json<NoParams>| async {
+            .extractor_handler((), |Json(_): Json<NoParams>| async {
                 Ok(CallToolResult::text("no params result"))
             })
             .build()
@@ -1685,7 +1685,7 @@ mod tests {
 
         let tool = ToolBuilder::new("with_state_no_params")
             .description("Takes no parameters but has state")
-            .extractor_handler_typed::<_, _, _, NoParams>(
+            .extractor_handler(
                 shared,
                 |State(state): State<Arc<String>>, Json(_): Json<NoParams>| async move {
                     Ok(CallToolResult::text(format!("state: {}", state)))
@@ -1710,12 +1710,9 @@ mod tests {
     async fn test_handler_no_params_with_context() {
         let tool = ToolBuilder::new("no_params_with_context")
             .description("Takes no parameters but has context")
-            .extractor_handler_typed::<_, _, _, NoParams>(
-                (),
-                |_ctx: Context, Json(_): Json<NoParams>| async move {
-                    Ok(CallToolResult::text("context available"))
-                },
-            )
+            .extractor_handler((), |_ctx: Context, Json(_): Json<NoParams>| async move {
+                Ok(CallToolResult::text("context available"))
+            })
             .build()
             .expect("valid tool name");
 
@@ -1732,7 +1729,7 @@ mod tests {
 
         let tool = ToolBuilder::new("state_context_no_params")
             .description("Has state and context, no params")
-            .extractor_handler_typed::<_, _, _, NoParams>(
+            .extractor_handler(
                 shared,
                 |State(state): State<Arc<String>>,
                  _ctx: Context,


### PR DESCRIPTION
## Summary

- Migrates all examples, doc comments, and tests from `extractor_handler_typed` (with turbofish) to `extractor_handler` (auto-detected schema)
- Follows up on #357 which added schema auto-detection

### Files updated

- `src/lib.rs`, `src/tool.rs`, `src/router.rs`, `src/extract.rs` -- doc examples and tests
- `README.md` -- usage example
- `examples/http_server.rs`, `examples/external_api_auth.rs` -- inline examples
- `examples/codegen-mcp/` -- both the tool definitions and the code generation templates
- `examples/markdownlint-mcp/` -- tool definitions

### Not updated (tracked separately)

- `examples/crates-mcp/` -- tracked in #359

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (366 passed)
- [x] `cargo test --doc --all-features` (109 passed)
- [x] `cargo test --test '*' --all-features` (52 passed)
- [x] All workspace examples build (`codegen-mcp`, `markdownlint-mcp`, `conformance-server`, `crates-mcp`)