### PR TITLE
feat: add per-tool guards for request-level access control

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -421,6 +421,12 @@ impl From<JsonRpcError> for Error {
     }
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(err: std::convert::Infallible) -> Self {
+        match err {}
+    }
+}
+
 /// Result type alias for tower-mcp
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,7 +403,7 @@ pub use resource::{
 };
 pub use router::{McpRouter, RouterRequest, RouterResponse};
 pub use session::{SessionPhase, SessionState};
-pub use tool::{BoxToolService, NoParams, Tool, ToolBuilder, ToolHandler, ToolRequest};
+pub use tool::{BoxToolService, GuardLayer, NoParams, Tool, ToolBuilder, ToolHandler, ToolRequest};
 pub use tracing_layer::{McpTracingLayer, McpTracingService};
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,


### PR DESCRIPTION
## Summary

Closes #350.

- **`GuardLayer<G>` / `GuardService<G, S>`** -- tower Layer/Service pair that runs a closure before the inner service, short-circuiting with a tool error on rejection
- **`.guard()`** on all builder types: `ToolBuilderWithHandler`, `ToolBuilderWithLayer`, `ToolBuilderWithNoParamsHandler`, `ToolBuilderWithNoParamsHandlerLayer`, `ToolBuilderWithExtractor`, `ToolBuilderWithExtractorLayer`
- **`Tool::with_guard()`** for post-build guarding, enabling the per-group pattern (apply the same guard to multiple tools after building)
- **`GuardLayer`** re-exported from crate root

Guards are syntactic sugar for `.layer(GuardLayer::new(f))` -- a closure that receives `&ToolRequest` and returns `Result<(), String>`. They differ from filters (which control visibility at the session level) and general layers (which can transform requests/responses). Guards are specifically for "yes or no" execution checks at the request level.

### Example: per-tool guard

```rust
let tool = ToolBuilder::new("delete")
    .handler(|input: DeleteInput| async move { ... })
    .guard(|req: &ToolRequest| {
        let confirm = req.args.get("confirm").and_then(|v| v.as_bool()).unwrap_or(false);
        if !confirm {
            return Err("Must set confirm=true to delete".to_string());
        }
        Ok(())
    })
    .build()?;
```

### Example: per-group guard

```rust
let require_auth = |req: &ToolRequest| {
    // check auth token in args, headers, etc.
    Ok(())
};

let tools: Vec<Tool> = admin_tools.into_iter()
    .map(|t| t.with_guard(require_auth))
    .collect();
```

## Test plan

- [x] Guard allows request through (typed handler)
- [x] Guard rejects request with error message (typed handler)
- [x] Guard + layer composition (handler with timeout + guard)
- [x] Guard on no-params handler (with dynamic allow/deny)
- [x] Guard on no-params handler + layer
- [x] Guard on extractor handler (with arg validation)
- [x] Guard on extractor handler + layer
- [x] `Tool::with_guard()` post-build (admin-only pattern)
- [x] `with_guard` preserves tool metadata
- [x] Group pattern: same guard applied to multiple tools
- [x] Doc test for `GuardLayer`
- [x] Doc test for `Tool::with_guard`