### PR TITLE
feat: add Content::text() shorthand and improve documentation

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -72,13 +72,23 @@ impl Filterable for Prompt {
 /// Behavior when a filtered capability is accessed directly.
 #[derive(Clone, Default)]
 pub enum DenialBehavior {
-    /// Return "method not found" error - don't reveal the capability exists.
-    /// This is the default and recommended for security.
+    /// Return "method not found" error -- hides the capability entirely.
+    ///
+    /// This is the default and recommended for security. Use this in
+    /// multi-tenant scenarios where tools should not be discoverable by
+    /// unauthorized users.
     #[default]
     NotFound,
     /// Return an "unauthorized" error, revealing the capability exists.
+    ///
+    /// Use this when the client should know about the capability but is
+    /// not permitted to invoke it (e.g., premium features behind an
+    /// upgrade prompt).
     Unauthorized,
-    /// Use a custom error generator.
+    /// Use a custom error generator for application-specific responses.
+    ///
+    /// Use this when you need custom status codes, domain-specific error
+    /// messages, or structured error payloads.
     Custom(Arc<dyn Fn(&str) -> Error + Send + Sync>),
 }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1747,6 +1747,38 @@ impl Content {
     /// let content = Content::Text { text: "hello".into(), annotations: None };
     /// assert_eq!(content.as_text(), Some("hello"));
     /// ```
+    /// Create a [`Content::Text`] variant with no annotations.
+    ///
+    /// This is a shorthand for the common case of creating text content
+    /// without annotations.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::Content;
+    ///
+    /// let content = Content::text("hello world");
+    /// assert_eq!(content.as_text(), Some("hello world"));
+    /// ```
+    pub fn text(text: impl Into<String>) -> Self {
+        Content::Text {
+            text: text.into(),
+            annotations: None,
+        }
+    }
+
+    /// Extract the text from a [`Content::Text`] variant.
+    ///
+    /// Returns `None` for non-text content variants.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::Content;
+    ///
+    /// let content = Content::Text { text: "hello".into(), annotations: None };
+    /// assert_eq!(content.as_text(), Some("hello"));
+    /// ```
     pub fn as_text(&self) -> Option<&str> {
         match self {
             Content::Text { text, .. } => Some(text),
@@ -3101,6 +3133,25 @@ impl McpNotification {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_content_text_constructor() {
+        let content = Content::text("hello world");
+        assert_eq!(content.as_text(), Some("hello world"));
+
+        // Verify it creates a Text variant with no annotations
+        match &content {
+            Content::Text { text, annotations } => {
+                assert_eq!(text, "hello world");
+                assert!(annotations.is_none());
+            }
+            _ => panic!("expected Content::Text"),
+        }
+
+        // Works with String too
+        let content = Content::text(String::from("owned"));
+        assert_eq!(content.as_text(), Some("owned"));
+    }
 
     #[test]
     fn test_elicit_form_schema_builder() {


### PR DESCRIPTION
## Summary

- Add `Content::text(s)` constructor that creates `Content::Text` with no annotations, replacing the verbose `Content::Text { text: "...".into(), annotations: None }` pattern
- Expand `DenialBehavior` variant docs with usage guidance (multi-tenant hiding, upgrade prompts, custom error payloads)
- Add state-sharing doc examples to `ResourceBuilder::handler()` and `PromptBuilder::handler()` showing `Arc` capture pattern

## Test plan

- [x] `test_content_text_constructor` unit test covers constructor with `&str` and `String` inputs
- [x] Doc tests on `Content::text()`, `ResourceBuilder::handler()` state example, `PromptBuilder::handler()` state example
- [x] All existing tests pass

Closes #353