### PR TITLE
feat!: make ToolBuilder::build() infallible

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -125,7 +125,7 @@ let echo = ToolBuilder::new("echo")
     .handler(|input: EchoInput| async move {
         Ok(CallToolResult::text(input.message))
     })
-    .build()?;
+    .build();
 ```
 
 And the input type with automatic JSON Schema generation:

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: GreetInput| async move {
             Ok(CallToolResult::text(format!("Hello, {}!", input.name)))
         })
-        .build()?;
+        .build();
 
     // Demonstrates returning structured JSON using from_serialize
     let add = ToolBuilder::new("add")
@@ -76,7 +76,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             // Use from_serialize for structured JSON output from any Serialize type
             CallToolResult::from_serialize(&output)
         })
-        .build()?;
+        .build();
 
     let echo = ToolBuilder::new("echo")
         .description("Echo a message back, optionally repeated")
@@ -87,7 +87,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 .collect();
             Ok(CallToolResult::text(repeated.join(" ")))
         })
-        .build()?;
+        .build();
 
     // Create the router with our tools.
     // auto_instructions() generates instructions from tool descriptions at init time.

--- a/examples/capability_filtering.rs
+++ b/examples/capability_filtering.rs
@@ -157,7 +157,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: EchoInput| async move {
             Ok(CallToolResult::text(format!("Echo: {}", input.message)))
         })
-        .build()?;
+        .build();
 
     let get_time = ToolBuilder::new("get_time")
         .description("Get the current server time")
@@ -168,7 +168,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 .as_secs();
             Ok(CallToolResult::text(format!("Current timestamp: {}", now)))
         })
-        .build()?;
+        .build();
 
     // === ADMIN TOOLS (visible to Admin and Developer roles) ===
 
@@ -179,7 +179,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 "System Stats: CPU: 45%, Memory: 2.1GB, Active Users: 1,234",
             ))
         })
-        .build()?;
+        .build();
 
     let admin_delete = ToolBuilder::new("admin_delete_user")
         .description("Delete a user account (admin only)")
@@ -189,7 +189,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 input.user_id
             )))
         })
-        .build()?;
+        .build();
 
     // === INTERNAL TOOLS (visible only to Developer role) ===
 
@@ -198,7 +198,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|_: tower_mcp::NoParams| async move {
             Ok(CallToolResult::text("Debug: memory_pools=12, gc_runs=847"))
         })
-        .build()?;
+        .build();
 
     // === RESOURCES ===
 

--- a/examples/codegen-mcp/src/codegen.rs
+++ b/examples/codegen-mcp/src/codegen.rs
@@ -578,7 +578,7 @@ fn generate_tool_builder(tool: &ToolDef, _has_state: bool) -> String {
         }
     }
 
-    code.push_str("        .build()?;\n");
+    code.push_str("        .build();\n");
     code
 }
 
@@ -870,7 +870,7 @@ fn generate_component_tool_builder(builder: &ToolBuilderState) -> String {
         code.push_str(&generate_layer_code(layer));
     }
 
-    code.push_str("    .build()?;\n");
+    code.push_str("    .build();\n");
     code
 }
 

--- a/examples/codegen-mcp/src/tools.rs
+++ b/examples/codegen-mcp/src/tools.rs
@@ -200,7 +200,6 @@ fn build_init_project(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_add_tool(state: Arc<CodegenState>) -> Tool {
@@ -270,7 +269,6 @@ fn build_add_tool(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -312,7 +310,6 @@ fn build_remove_tool(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_get_project(state: Arc<CodegenState>) -> Tool {
@@ -327,7 +324,6 @@ fn build_get_project(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_generate(state: Arc<CodegenState>) -> Tool {
@@ -352,7 +348,6 @@ fn build_generate(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_validate(state: Arc<CodegenState>) -> Tool {
@@ -437,7 +432,6 @@ fn build_validate(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_reset(state: Arc<CodegenState>) -> Tool {
@@ -454,7 +448,6 @@ fn build_reset(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================
@@ -488,7 +481,6 @@ fn build_list_handler_types() -> Tool {
             )))
         })
         .build()
-        .expect("valid tool")
 }
 
 fn build_list_layer_types() -> Tool {
@@ -514,7 +506,6 @@ fn build_list_layer_types() -> Tool {
             )))
         })
         .build()
-        .expect("valid tool")
 }
 
 fn build_list_input_types() -> Tool {
@@ -533,7 +524,6 @@ fn build_list_input_types() -> Tool {
             )))
         })
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================
@@ -565,7 +555,6 @@ fn build_tool_new(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -601,7 +590,6 @@ fn build_tool_set_description(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -657,7 +645,6 @@ fn build_tool_add_input(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -710,7 +697,6 @@ fn build_tool_set_handler(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -758,7 +744,6 @@ fn build_tool_set_annotation(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -816,7 +801,6 @@ fn build_tool_add_layer(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -844,7 +828,6 @@ fn build_tool_get(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_tool_build(state: Arc<CodegenState>) -> Tool {
@@ -876,7 +859,6 @@ fn build_tool_build(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_tool_add_to_project(state: Arc<CodegenState>) -> Tool {
@@ -921,7 +903,6 @@ fn build_tool_add_to_project(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_tool_list(state: Arc<CodegenState>) -> Tool {
@@ -959,7 +940,6 @@ fn build_tool_list(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 fn build_tool_discard(state: Arc<CodegenState>) -> Tool {
@@ -983,5 +963,4 @@ fn build_tool_discard(state: Arc<CodegenState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -69,7 +69,6 @@ fn build_simple_text() -> Tool {
             ))
         })
         .build()
-        .expect("failed to build test_simple_text")
 }
 
 fn build_image_content() -> Tool {
@@ -79,7 +78,6 @@ fn build_image_content() -> Tool {
             Ok(CallToolResult::image(red_pixel_base64(), "image/png"))
         })
         .build()
-        .expect("failed to build test_image_content")
 }
 
 fn build_audio_content() -> Tool {
@@ -89,7 +87,6 @@ fn build_audio_content() -> Tool {
             Ok(CallToolResult::audio(minimal_wav_base64(), "audio/wav"))
         })
         .build()
-        .expect("failed to build test_audio_content")
 }
 
 fn build_embedded_resource() -> Tool {
@@ -104,7 +101,6 @@ fn build_embedded_resource() -> Tool {
             }))
         })
         .build()
-        .expect("failed to build test_embedded_resource")
 }
 
 fn build_multiple_content_types() -> Tool {
@@ -137,7 +133,6 @@ fn build_multiple_content_types() -> Tool {
             })
         })
         .build()
-        .expect("failed to build test_multiple_content_types")
 }
 
 fn build_tool_with_logging() -> Tool {
@@ -164,7 +159,6 @@ fn build_tool_with_logging() -> Tool {
             Ok(CallToolResult::text("Logging complete"))
         })
         .build()
-        .expect("failed to build test_tool_with_logging")
 }
 
 fn build_tool_with_progress() -> Tool {
@@ -185,7 +179,6 @@ fn build_tool_with_progress() -> Tool {
             Ok(CallToolResult::text("Progress complete"))
         })
         .build()
-        .expect("failed to build test_tool_with_progress")
 }
 
 fn build_error_handling() -> Tool {
@@ -195,7 +188,6 @@ fn build_error_handling() -> Tool {
             Ok(CallToolResult::error("This is an error response"))
         })
         .build()
-        .expect("failed to build test_error_handling")
 }
 
 fn build_sampling() -> Tool {
@@ -221,7 +213,6 @@ fn build_sampling() -> Tool {
             }
         })
         .build()
-        .expect("failed to build test_sampling")
 }
 
 fn build_elicitation() -> Tool {
@@ -250,7 +241,6 @@ fn build_elicitation() -> Tool {
             }
         })
         .build()
-        .expect("failed to build test_elicitation")
 }
 
 fn build_elicitation_sep1034_defaults() -> Tool {
@@ -286,7 +276,6 @@ fn build_elicitation_sep1034_defaults() -> Tool {
             }
         })
         .build()
-        .expect("failed to build test_elicitation_sep1034_defaults")
 }
 
 fn build_elicitation_sep1330_enums() -> Tool {
@@ -372,5 +361,4 @@ fn build_elicitation_sep1330_enums() -> Tool {
             }
         })
         .build()
-        .expect("failed to build test_elicitation_sep1330_enums")
 }

--- a/examples/crates-mcp/Cargo.toml
+++ b/examples/crates-mcp/Cargo.toml
@@ -14,8 +14,8 @@ name = "integration"
 path = "tests/integration.rs"
 
 [dependencies]
-# Core MCP (use version for Docker builds, path for local dev)
-tower-mcp = { version = "0.3", features = ["http"] }
+# Core MCP
+tower-mcp = { path = "../..", features = ["http"] }
 
 # Crates.io API client
 crates_io_api = "0.12"

--- a/examples/crates-mcp/src/tools/authors.rs
+++ b/examples/crates-mcp/src/tools/authors.rs
@@ -65,5 +65,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/dependencies.rs
+++ b/examples/crates-mcp/src/tools/dependencies.rs
@@ -100,5 +100,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/downloads.rs
+++ b/examples/crates-mcp/src/tools/downloads.rs
@@ -68,5 +68,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/info.rs
+++ b/examples/crates-mcp/src/tools/info.rs
@@ -90,5 +90,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/owners.rs
+++ b/examples/crates-mcp/src/tools/owners.rs
@@ -64,5 +64,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/reverse_deps.rs
+++ b/examples/crates-mcp/src/tools/reverse_deps.rs
@@ -90,5 +90,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/search.rs
+++ b/examples/crates-mcp/src/tools/search.rs
@@ -101,5 +101,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/summary.rs
+++ b/examples/crates-mcp/src/tools/summary.rs
@@ -77,5 +77,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/user.rs
+++ b/examples/crates-mcp/src/tools/user.rs
@@ -50,5 +50,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/crates-mcp/src/tools/versions.rs
+++ b/examples/crates-mcp/src/tools/versions.rs
@@ -74,5 +74,4 @@ pub fn build(state: Arc<AppState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }

--- a/examples/external_api_auth.rs
+++ b/examples/external_api_auth.rs
@@ -110,7 +110,6 @@ fn build_server_side_tool(client: Arc<ExternalApiClient>) -> tower_mcp::Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================
@@ -167,7 +166,6 @@ fn build_oauth_claims_tool() -> tower_mcp::Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================
@@ -240,7 +238,6 @@ fn build_elicitation_tool() -> tower_mcp::Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================
@@ -336,7 +333,6 @@ fn build_credential_store_tool(store: Arc<CredentialStore>) -> tower_mcp::Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -105,12 +105,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()?;
+        .build();
 
     let echo = ToolBuilder::new("echo")
         .description("Echo a message back")
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-        .build()?;
+        .build();
 
     // A tool that simulates work and sends progress notifications
     // Useful for demonstrating SSE event streaming and Last-Event-ID resumption
@@ -144,7 +144,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 )))
             },
         )
-        .build()?;
+        .build();
 
     // Create resources
     let config = ResourceBuilder::new("file:///config.json")

--- a/examples/http_server_with_auth.rs
+++ b/examples/http_server_with_auth.rs
@@ -164,7 +164,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()?;
+        .build();
 
     // Create the MCP router
     let mcp_router = McpRouter::new()

--- a/examples/http_server_with_middleware.rs
+++ b/examples/http_server_with_middleware.rs
@@ -63,7 +63,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()?;
+        .build();
 
     let slow = ToolBuilder::new("slow")
         .description("Sleep for a specified number of seconds, then respond")
@@ -74,7 +74,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 input.seconds
             )))
         })
-        .build()?;
+        .build();
 
     let router = McpRouter::new()
         .server_info("middleware-example", "1.0.0")

--- a/examples/http_server_with_oauth.rs
+++ b/examples/http_server_with_oauth.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()?;
+        .build();
 
     let router = McpRouter::new()
         .server_info("oauth-example", "1.0.0")

--- a/examples/markdownlint-mcp/src/tools.rs
+++ b/examples/markdownlint-mcp/src/tools.rs
@@ -19,7 +19,7 @@
 //!     .extractor_handler(state.clone(), |State(state), Json(input)| async move {
 //!         // Use state here
 //!     })
-//!     .build()?;
+//!     .build();
 //! ```
 //!
 //! ## Input Types with JsonSchema
@@ -181,7 +181,6 @@ fn build_lint_content_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Build the `lint_file` tool.
@@ -209,7 +208,6 @@ fn build_lint_file_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Build the `lint_url` tool.
@@ -245,7 +243,6 @@ fn build_lint_url_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Build the `list_rules` tool.
@@ -269,7 +266,6 @@ fn build_list_rules_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Build the `explain_rule` tool.
@@ -292,7 +288,6 @@ fn build_explain_rule_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 /// Build the `fix_content` tool.
@@ -312,7 +307,6 @@ fn build_fix_content_tool(state: Arc<LintState>) -> Tool {
             },
         )
         .build()
-        .expect("valid tool")
 }
 
 // =============================================================================

--- a/examples/stdio_server.rs
+++ b/examples/stdio_server.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .description("Echo a message back")
         .read_only()
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-        .build()?;
+        .build();
 
     let add = ToolBuilder::new("add")
         .description("Add two numbers together")
@@ -54,7 +54,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             let result = input.a + input.b;
             Ok(CallToolResult::text(format!("{}", result)))
         })
-        .build()?;
+        .build();
 
     let reverse = ToolBuilder::new("reverse")
         .description("Reverse a string")
@@ -64,7 +64,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             let reversed: String = input.text.chars().rev().collect();
             Ok(CallToolResult::text(reversed))
         })
-        .build()?;
+        .build();
 
     // Create a resource that serves this file's own source code
     let source = ResourceBuilder::new("source://stdio_server.rs")

--- a/examples/stdio_server_with_middleware.rs
+++ b/examples/stdio_server_with_middleware.rs
@@ -47,7 +47,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()?;
+        .build();
 
     let slow = ToolBuilder::new("slow")
         .description("Sleep for a specified number of seconds, then respond")
@@ -58,7 +58,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 input.seconds
             )))
         })
-        .build()?;
+        .build();
 
     let router = McpRouter::new()
         .server_info("middleware-stdio-example", "1.0.0")

--- a/examples/tool_middleware.rs
+++ b/examples/tool_middleware.rs
@@ -59,7 +59,7 @@ async fn main() -> Result<(), BoxError> {
             )))
         })
         .layer(TimeoutLayer::new(Duration::from_secs(2)))
-        .build()?;
+        .build();
 
     // Tool 2: Slow search with long (30-second) timeout
     let slow_search = ToolBuilder::new("slow_search")
@@ -73,7 +73,7 @@ async fn main() -> Result<(), BoxError> {
             )))
         })
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
-        .build()?;
+        .build();
 
     // Tool 3: Expensive operation with concurrency limit
     // Only 5 concurrent calls allowed; additional calls will wait
@@ -107,7 +107,7 @@ async fn main() -> Result<(), BoxError> {
             }
         })
         .layer(ConcurrencyLimitLayer::new(5))
-        .build()?;
+        .build();
 
     // Tool 4: Combined layers - both timeout AND concurrency limit
     let rate_limited_api = ToolBuilder::new("rate_limited_api")
@@ -122,7 +122,7 @@ async fn main() -> Result<(), BoxError> {
         // Multiple layers can be chained; outer layers wrap inner layers
         .layer(TimeoutLayer::new(Duration::from_secs(10)))
         .layer(ConcurrencyLimitLayer::new(3))
-        .build()?;
+        .build();
 
     // Tool 5: No middleware - direct handler for comparison
     let simple_tool = ToolBuilder::new("simple_tool")
@@ -133,7 +133,7 @@ async fn main() -> Result<(), BoxError> {
                 input.query
             )))
         })
-        .build()?;
+        .build();
 
     let router = McpRouter::new()
         .server_info("tool-middleware-example", "1.0.0")

--- a/examples/weather_server.rs
+++ b/examples/weather_server.rs
@@ -196,7 +196,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
             Ok(CallToolResult::text(forecast))
         })
-        .build()?;
+        .build();
 
     let get_alerts = ToolBuilder::new("get_alerts")
         .description("Get weather alerts for a US state (use two-letter state code)")
@@ -227,7 +227,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 ))),
             }
         })
-        .build()?;
+        .build();
 
     // Create router
     let router = McpRouter::new()

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -17,14 +17,12 @@
 //! let public_tool = ToolBuilder::new("public")
 //!     .description("Available to everyone")
 //!     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-//!     .build()
-//!     .unwrap();
+//!     .build();
 //!
 //! let admin_tool = ToolBuilder::new("admin")
 //!     .description("Admin only")
 //!     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-//!     .build()
-//!     .unwrap();
+//!     .build();
 //!
 //! let router = McpRouter::new()
 //!     .tool(public_tool)
@@ -241,7 +239,6 @@ mod tests {
             .description("Test tool")
             .handler(|_: serde_json::Value| async { Ok(CallToolResult::text("ok")) })
             .build()
-            .unwrap()
     }
 
     #[test]

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -373,8 +373,7 @@ mod tests {
                     input.a + input.b
                 )))
             })
-            .build()
-            .unwrap();
+            .build();
 
         McpRouter::new()
             .server_info("test-server", "1.0.0")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,8 +52,7 @@
 //!             Ok(CallToolResult::text(format!("Found results for: {}", input.query)))
 //!         },
 //!     )
-//!     .build()
-//!     .unwrap();
+//!     .build();
 //! ```
 //!
 //! ## Quick Start: Server
@@ -78,7 +77,7 @@
 //!         .handler(|input: GreetInput| async move {
 //!             Ok(CallToolResult::text(format!("Hello, {}!", input.name)))
 //!         })
-//!         .build()?;
+//!         .build();
 //!
 //!     // Create router and run over stdio
 //!     let router = McpRouter::new()
@@ -197,8 +196,7 @@
 //!         Ok(CallToolResult::text("results"))
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(60)))  // 60s for this tool
-//!     .build()
-//!     .unwrap();
+//!     .build();
 //!
 //! let router = McpRouter::new()
 //!     .server_info("example", "1.0.0")
@@ -266,7 +264,7 @@
 //!         let text = result.first_text().unwrap_or("No response");
 //!         Ok(CallToolResult::text(text))
 //!     })
-//!     .build()?;
+//!     .build();
 //! ```
 //!
 //! ### Elicitation (User Input)
@@ -288,7 +286,7 @@
 //!         // ... perform deletion ...
 //!         Ok(CallToolResult::text("Deleted"))
 //!     })
-//!     .build()?;
+//!     .build();
 //! ```
 //!
 //! For complex forms, use [`ElicitFormSchema`] to define multiple fields.
@@ -314,7 +312,7 @@
 //!
 //!         Ok(CallToolResult::text("Done"))
 //!     })
-//!     .build()?;
+//!     .build();
 //! ```
 //!
 //! ### Router Composition

--- a/src/oauth/mod.rs
+++ b/src/oauth/mod.rs
@@ -38,7 +38,7 @@
 //!         .handler(|input: serde_json::Value| async move {
 //!             Ok(CallToolResult::text(format!("{}", input)))
 //!         })
-//!         .build()?;
+//!         .build();
 //!
 //!     let router = McpRouter::new()
 //!         .server_info("oauth-server", "1.0.0")

--- a/src/router.rs
+++ b/src/router.rs
@@ -48,8 +48,7 @@ pub type CompletionHandler = Arc<
 /// let tool = ToolBuilder::new("echo")
 ///     .description("Echo input")
 ///     .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
-///     .build()
-///     .unwrap();
+///     .build();
 ///
 /// let router = McpRouter::new()
 ///     .server_info("my-server", "1.0.0")
@@ -320,8 +319,7 @@ impl McpRouter {
     ///             Ok(CallToolResult::text(format!("Query on {}: {}", state.db_url, input.sql)))
     ///         },
     ///     )
-    ///     .build()
-    ///     .unwrap();
+    ///     .build();
     ///
     /// let router = McpRouter::new()
     ///     .with_state(state)  // State is now available to all handlers
@@ -448,8 +446,7 @@ impl McpRouter {
     ///     .handler(|input: QueryInput| async move {
     ///         Ok(CallToolResult::text("result"))
     ///     })
-    ///     .build()
-    ///     .unwrap();
+    ///     .build();
     ///
     /// let router = McpRouter::new()
     ///     .auto_instructions()
@@ -592,11 +589,11 @@ impl McpRouter {
     ///     ToolBuilder::new("a")
     ///         .description("Tool A")
     ///         .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-    ///         .build().unwrap(),
+    ///         .build(),
     ///     ToolBuilder::new("b")
     ///         .description("Tool B")
     ///         .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-    ///         .build().unwrap(),
+    ///         .build(),
     /// ];
     ///
     /// let router = McpRouter::new().tools(tools);
@@ -682,7 +679,6 @@ impl McpRouter {
     ///             .description("Query the database")
     ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
     ///             .build()
-    ///             .unwrap()
     ///     );
     ///
     /// // Create a router with API tools
@@ -692,7 +688,6 @@ impl McpRouter {
     ///             .description("Fetch from API")
     ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
     ///             .build()
-    ///             .unwrap()
     ///     );
     ///
     /// // Merge them together
@@ -755,14 +750,12 @@ impl McpRouter {
     ///             .description("Query the database")
     ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
     ///             .build()
-    ///             .unwrap()
     ///     )
     ///     .tool(
     ///         ToolBuilder::new("insert")
     ///             .description("Insert into database")
     ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
     ///             .build()
-    ///             .unwrap()
     ///     );
     ///
     /// // Nest under "db" prefix - tools become "db.query" and "db.insert"
@@ -856,14 +849,12 @@ impl McpRouter {
     /// let public_tool = ToolBuilder::new("public")
     ///     .description("Available to everyone")
     ///     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-    ///     .build()
-    ///     .unwrap();
+    ///     .build();
     ///
     /// let admin_tool = ToolBuilder::new("admin")
     ///     .description("Admin only")
     ///     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
-    ///     .build()
-    ///     .unwrap();
+    ///     .build();
     ///
     /// let router = McpRouter::new()
     ///     .tool(public_tool)
@@ -1692,8 +1683,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(add_tool);
 
@@ -1724,8 +1714,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(add_tool);
 
@@ -1775,8 +1764,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let router = McpRouter::new().tool(add_tool);
         let mut service = JsonRpcService::new(router.clone());
@@ -1805,8 +1793,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let router = McpRouter::new().tool(add_tool);
         let mut service = JsonRpcService::new(router.clone());
@@ -1895,8 +1882,7 @@ mod tests {
                     Ok(CallToolResult::text("done"))
                 }
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         // Set up notification channel
         let (tx, mut rx) = notification_channel(10);
@@ -1962,8 +1948,7 @@ mod tests {
                     Ok(CallToolResult::text("done"))
                 }
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let (tx, mut rx) = notification_channel(10);
         let router = McpRouter::new().with_notification_sender(tx).tool(tool);
@@ -1994,8 +1979,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let router = McpRouter::new().tool(add_tool);
         let mut service = JsonRpcService::new(router.clone());
@@ -2441,8 +2425,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(add_tool);
         init_router(&mut router).await;
@@ -2496,8 +2479,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(add_tool);
         init_router(&mut router).await;
@@ -2560,8 +2542,7 @@ mod tests {
                 tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
                 Ok(CallToolResult::text("done"))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(slow_tool);
         init_router(&mut router).await;
@@ -2611,8 +2592,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(add_tool);
         init_router(&mut router).await;
@@ -3082,14 +3062,12 @@ mod tests {
         let public_tool = ToolBuilder::new("public")
             .description("Public tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("public")) })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let admin_tool = ToolBuilder::new("admin")
             .description("Admin tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("admin")) })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new()
             .tool(public_tool)
@@ -3125,8 +3103,7 @@ mod tests {
         let admin_tool = ToolBuilder::new("admin")
             .description("Admin tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("admin")) })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new()
             .tool(admin_tool)
@@ -3166,8 +3143,7 @@ mod tests {
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new()
             .tool(public_tool)
@@ -3204,8 +3180,7 @@ mod tests {
         let admin_tool = ToolBuilder::new("admin")
             .description("Admin tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("admin")) })
-            .build()
-            .expect("valid tool name");
+            .build();
 
         let mut router = McpRouter::new().tool(admin_tool).tool_filter(
             CapabilityFilter::new(|_, _: &Tool| false)
@@ -3553,8 +3528,7 @@ mod tests {
         let tool_a = ToolBuilder::new("tool_a")
             .description("Tool A")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("A")) })
-            .build()
-            .unwrap();
+            .build();
 
         let router_a = McpRouter::new().tool(tool_a);
 
@@ -3562,13 +3536,11 @@ mod tests {
         let tool_b = ToolBuilder::new("tool_b")
             .description("Tool B")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("B")) })
-            .build()
-            .unwrap();
+            .build();
         let tool_c = ToolBuilder::new("tool_c")
             .description("Tool C")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("C")) })
-            .build()
-            .unwrap();
+            .build();
 
         let router_b = McpRouter::new().tool(tool_b).tool(tool_c);
 
@@ -3607,8 +3579,7 @@ mod tests {
         let tool_v1 = ToolBuilder::new("shared")
             .description("Version 1")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("v1")) })
-            .build()
-            .unwrap();
+            .build();
 
         let router_a = McpRouter::new().tool(tool_v1);
 
@@ -3616,8 +3587,7 @@ mod tests {
         let tool_v2 = ToolBuilder::new("shared")
             .description("Version 2")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("v2")) })
-            .build()
-            .unwrap();
+            .build();
 
         let router_b = McpRouter::new().tool(tool_v2);
 
@@ -3723,13 +3693,11 @@ mod tests {
         let tool_query = ToolBuilder::new("query")
             .description("Query the database")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("query result")) })
-            .build()
-            .unwrap();
+            .build();
         let tool_insert = ToolBuilder::new("insert")
             .description("Insert into database")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("insert result")) })
-            .build()
-            .unwrap();
+            .build();
 
         let db_router = McpRouter::new().tool(tool_query).tool(tool_insert);
 
@@ -3764,8 +3732,7 @@ mod tests {
         let tool = ToolBuilder::new("echo")
             .description("Echo input")
             .handler(|input: StringInput| async move { Ok(CallToolResult::text(&input.value)) })
-            .build()
-            .unwrap();
+            .build();
 
         let nested_router = McpRouter::new().tool(tool);
 
@@ -3803,14 +3770,12 @@ mod tests {
         let db_tool = ToolBuilder::new("query")
             .description("Database query")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("db")) })
-            .build()
-            .unwrap();
+            .build();
 
         let api_tool = ToolBuilder::new("fetch")
             .description("API fetch")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("api")) })
-            .build()
-            .unwrap();
+            .build();
 
         let db_router = McpRouter::new().tool(db_tool);
         let api_router = McpRouter::new().tool(api_tool);
@@ -3846,14 +3811,12 @@ mod tests {
         let tool_a = ToolBuilder::new("local")
             .description("Local tool")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("local")) })
-            .build()
-            .unwrap();
+            .build();
 
         let nested_tool = ToolBuilder::new("remote")
             .description("Remote tool")
             .handler(|_: StringInput| async move { Ok(CallToolResult::text("remote")) })
-            .build()
-            .unwrap();
+            .build();
 
         let nested_router = McpRouter::new().tool(nested_tool);
 
@@ -3942,13 +3905,11 @@ mod tests {
         let tool_a = ToolBuilder::new("alpha")
             .description("Alpha tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let tool_b = ToolBuilder::new("beta")
             .description("Beta tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .auto_instructions()
@@ -3972,20 +3933,17 @@ mod tests {
             .description("Run a query")
             .read_only()
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let destructive_tool = ToolBuilder::new("delete")
             .description("Delete a record")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let idempotent_tool = ToolBuilder::new("upsert")
             .description("Upsert a record")
             .non_destructive()
             .idempotent()
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .auto_instructions()
@@ -4072,8 +4030,7 @@ mod tests {
             .description("Execute SQL")
             .read_only()
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let resource = ResourceBuilder::new("db://schema")
             .name("Schema")
             .description("Full database schema")
@@ -4109,8 +4066,7 @@ mod tests {
         let tool = ToolBuilder::new("echo")
             .description("Echo input")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .auto_instructions_with(
@@ -4133,8 +4089,7 @@ mod tests {
         let tool = ToolBuilder::new("echo")
             .description("Echo input")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .auto_instructions_with(Some("My server intro."), None::<String>)
@@ -4166,8 +4121,7 @@ mod tests {
         let tool = ToolBuilder::new("echo")
             .description("Echo input")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .instructions("This will be overridden")
@@ -4186,8 +4140,7 @@ mod tests {
         let tool = ToolBuilder::new("echo")
             .description("Echo input")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .instructions("Manual instructions here")
@@ -4203,8 +4156,7 @@ mod tests {
     async fn test_auto_instructions_no_description_fallback() {
         let tool = ToolBuilder::new("mystery")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new().auto_instructions().tool(tool);
 
@@ -4219,18 +4171,15 @@ mod tests {
         let tool_z = ToolBuilder::new("zebra")
             .description("Z tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let tool_a = ToolBuilder::new("alpha")
             .description("A tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
         let tool_m = ToolBuilder::new("middle")
             .description("M tool")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new()
             .auto_instructions()
@@ -4254,8 +4203,7 @@ mod tests {
             .description("Safe update operation")
             .idempotent()
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new().auto_instructions().tool(tool);
 
@@ -4278,8 +4226,7 @@ mod tests {
         let tool = ToolBuilder::new("late_tool")
             .description("Added after auto_instructions")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         router = router.tool(tool);
 
@@ -4299,8 +4246,7 @@ mod tests {
                 ..Default::default()
             })
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new().auto_instructions().tool(tool);
 
@@ -4320,8 +4266,7 @@ mod tests {
         let tool = ToolBuilder::new("fetch")
             .description("Fetch data")
             .handler(|_: AddInput| async move { Ok(CallToolResult::text("ok")) })
-            .build()
-            .unwrap();
+            .build();
 
         let mut router = McpRouter::new().auto_instructions().tool(tool);
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -23,8 +23,7 @@
 //!     .handler(|input: EchoInput| async move {
 //!         Ok(CallToolResult::text(input.message))
 //!     })
-//!     .build()
-//!     .expect("valid tool");
+//!     .build();
 //!
 //! let router = McpRouter::new()
 //!     .server_info("test-server", "1.0.0")
@@ -66,8 +65,7 @@
 //!     .handler(|input: AddInput| async move {
 //!         Ok(CallToolResult::text(format!("{}", input.a + input.b)))
 //!     })
-//!     .build()
-//!     .expect("valid tool");
+//!     .build();
 //!
 //! let readme = ResourceBuilder::new("file:///README.md")
 //!     .name("README")
@@ -535,16 +533,14 @@ mod tests {
         let echo = ToolBuilder::new("echo")
             .description("Echo a message")
             .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-            .build()
-            .unwrap();
+            .build();
 
         let add = ToolBuilder::new("add")
             .description("Add two numbers")
             .handler(|input: AddInput| async move {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
-            .build()
-            .unwrap();
+            .build();
 
         let add_json = ToolBuilder::new("add_json")
             .description("Add two numbers and return JSON")
@@ -554,8 +550,7 @@ mod tests {
                 })
                 .unwrap())
             })
-            .build()
-            .unwrap();
+            .build();
 
         let readme = ResourceBuilder::new("file:///README.md")
             .name("README")

--- a/src/tracing_layer.rs
+++ b/src/tracing_layer.rs
@@ -67,7 +67,7 @@ use crate::router::{RouterRequest, RouterResponse};
 /// let tool = ToolBuilder::new("search")
 ///     .handler(|input: SearchInput| async move { ... })
 ///     .layer(McpTracingLayer::new())
-///     .build()?;
+///     .build();
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct McpTracingLayer {

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -93,7 +93,7 @@
 //! async fn main() -> Result<(), BoxError> {
 //!     let tool = ToolBuilder::new("echo")
 //!         .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
-//!         .build()?;
+//!         .build();
 //!
 //!     let router = McpRouter::new()
 //!         .server_info("my-server", "1.0.0")
@@ -563,7 +563,7 @@ impl HttpTransport {
     ///             let result = ctx.sample(params).await?;
     ///             Ok(CallToolResult::text(format!("{:?}", result.content)))
     ///         })
-    ///         .build()?;
+    ///         .build();
     ///
     ///     let router = McpRouter::new()
     ///         .server_info("my-server", "1.0.0")
@@ -1703,8 +1703,7 @@ mod tests {
                 tokio::time::sleep(Duration::from_secs(10)).await;
                 Ok(crate::CallToolResult::text("done"))
             })
-            .build()
-            .unwrap();
+            .build();
 
         let router = McpRouter::new()
             .server_info("test-server", "1.0.0")

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -482,7 +482,7 @@ struct PendingRequest {
 ///             let result = ctx.sample(params).await?;
 ///             Ok(CallToolResult::text(format!("{:?}", result.content)))
 ///         })
-///         .build()?;
+///         .build();
 ///
 ///     let router = McpRouter::new()
 ///         .server_info("my-server", "1.0.0")

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -21,7 +21,7 @@
 //! async fn main() -> Result<(), BoxError> {
 //!     let tool = ToolBuilder::new("echo")
 //!         .handler(|i: Input| async move { Ok(CallToolResult::text(i.value)) })
-//!         .build()?;
+//!         .build();
 //!
 //!     let router = McpRouter::new()
 //!         .server_info("my-server", "1.0.0")
@@ -55,7 +55,7 @@
 //!             let result = ctx.sample(params).await?;
 //!             Ok(CallToolResult::text(format!("{:?}", result.content)))
 //!         })
-//!         .build()?;
+//!         .build();
 //!
 //!     let router = McpRouter::new()
 //!         .server_info("my-server", "1.0.0")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,8 +32,7 @@ fn create_test_router() -> McpRouter {
         .description("Echo a message")
         .read_only()
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-        .build()
-        .expect("valid tool");
+        .build();
 
     let add = ToolBuilder::new("add")
         .description("Add two numbers")
@@ -42,16 +41,14 @@ fn create_test_router() -> McpRouter {
         .handler(|input: AddInput| async move {
             Ok(CallToolResult::text(format!("{}", input.a + input.b)))
         })
-        .build()
-        .expect("valid tool");
+        .build();
 
     let failing = ToolBuilder::new("failing")
         .description("A tool that always fails")
         .handler(
             |_input: EchoInput| async move { Err(tower_mcp::Error::tool("Intentional failure")) },
         )
-        .build()
-        .expect("valid tool");
+        .build();
 
     McpRouter::new()
         .server_info("test-server", "1.0.0")
@@ -66,8 +63,7 @@ fn create_router_with_resources_and_prompts() -> McpRouter {
     let echo = ToolBuilder::new("echo")
         .description("Echo a message")
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-        .build()
-        .expect("valid tool");
+        .build();
 
     // Resources
     let config_resource = ResourceBuilder::new("file:///config.json")


### PR DESCRIPTION
## Summary

- Move tool name validation from `build()` to `new()`, which panics on invalid names
- Add `try_new()` as a fallible alternative for runtime-provided names
- All 7 `build()` methods now return `Tool` directly instead of `Result<Tool>`
- `McpTool::into_tool()` also returns `Tool` directly
- Eliminates `.unwrap()`/`.expect()`/`?` boilerplate at every callsite (net -168 lines)

**BREAKING CHANGE**: `ToolBuilder::build()` returns `Tool` instead of `Result<Tool>`. `ToolBuilder::new()` panics on invalid names. Use `try_new()` for fallible construction from runtime input.

## Test plan

- [x] 393 lib tests pass (including 3 new `#[should_panic]` tests for `new()`)
- [x] 47 integration tests pass
- [x] 112 doc tests pass
- [x] All examples build (`cargo build --examples --all-features`)
- [x] All workspace examples build (crates-mcp, conformance-server, codegen-mcp, markdownlint-mcp)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #352