### PR TITLE
refactor(crates-mcp): adopt extractor_handler and ResultExt

### DIFF
--- a/examples/crates-mcp/src/tools/downloads.rs
+++ b/examples/crates-mcp/src/tools/downloads.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, Error, Tool, ToolBuilder,
+    CallToolResult, ResultExt, Tool, ToolBuilder,
     extract::{Json, State},
 };
 
@@ -28,14 +28,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .extractor_handler_typed::<_, _, _, DownloadsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<DownloadsInput>| async move {
                 let response = state
                     .client
                     .crate_downloads(&input.name)
                     .await
-                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+                    .tool_context("Crates.io API error")?;
 
                 let mut output = format!("# {} - Download Statistics\n\n", input.name);
 

--- a/examples/crates-mcp/src/tools/owners.rs
+++ b/examples/crates-mcp/src/tools/owners.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, Error, Tool, ToolBuilder,
+    CallToolResult, ResultExt, Tool, ToolBuilder,
     extract::{Json, State},
 };
 
@@ -27,14 +27,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .extractor_handler_typed::<_, _, _, OwnersInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<OwnersInput>| async move {
                 let owners = state
                     .client
                     .crate_owners(&input.name)
                     .await
-                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+                    .tool_context("Crates.io API error")?;
 
                 let mut output = format!("# {} - Owners\n\n", input.name);
 

--- a/examples/crates-mcp/src/tools/summary.rs
+++ b/examples/crates-mcp/src/tools/summary.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use tower_mcp::{
-    CallToolResult, Error, NoParams, Tool, ToolBuilder,
+    CallToolResult, NoParams, ResultExt, Tool, ToolBuilder,
     extract::{Json, State},
 };
 
@@ -18,14 +18,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .extractor_handler_typed::<_, _, _, NoParams>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(_input): Json<NoParams>| async move {
                 let summary = state
                     .client
                     .summary()
                     .await
-                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+                    .tool_context("Crates.io API error")?;
 
                 let mut output = String::from("# Crates.io Summary\n\n");
 

--- a/examples/crates-mcp/src/tools/versions.rs
+++ b/examples/crates-mcp/src/tools/versions.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, Error, Tool, ToolBuilder,
+    CallToolResult, ResultExt, Tool, ToolBuilder,
     extract::{Json, State},
 };
 
@@ -37,14 +37,14 @@ pub fn build(state: Arc<AppState>) -> Tool {
         .read_only()
         .idempotent()
         .icon("https://crates.io/assets/cargo.png")
-        .extractor_handler_typed::<_, _, _, VersionsInput>(
+        .extractor_handler(
             state,
             |State(state): State<Arc<AppState>>, Json(input): Json<VersionsInput>| async move {
                 let response = state
                     .client
                     .get_crate(&input.name)
                     .await
-                    .map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?;
+                    .tool_context("Crates.io API error")?;
 
                 let versions: Vec<_> = response
                     .versions


### PR DESCRIPTION
## Summary

- Migrate all 10 tool handlers from `extractor_handler_typed::<_, _, _, T>` to `extractor_handler` (schema auto-detection from #357)
- Replace `.map_err(|e| Error::tool(format!("Crates.io API error: {}", e)))?` with `.tool_context("Crates.io API error")?` (`ResultExt` from #346)

Mechanical changes only -- no behavior change.

## Test plan

- [x] `cargo build --manifest-path examples/crates-mcp/Cargo.toml` builds clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] 417 lib tests pass

Closes #355, closes #359