### PR TITLE
fix: add annotations to ResourceDefinition and ResourceTemplateDefinition

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1904,6 +1904,9 @@ pub struct ResourceDefinition {
     /// Size of the resource in bytes (if known)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
+    /// Annotations for this resource (audience, priority hints)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ContentAnnotations>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2177,6 +2180,9 @@ pub struct ResourceTemplateDefinition {
     /// Optional icons for display in user interfaces
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<ToolIcon>>,
+    /// Annotations for this resource template (audience, priority hints)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ContentAnnotations>,
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- Add optional `annotations: Option<ContentAnnotations>` field to `ResourceDefinition` and `ResourceTemplateDefinition` per the MCP spec
- Add `annotations()` builder methods on `ResourceBuilder` and `ResourceTemplateBuilder`
- Thread annotations through all intermediate builder states (`ResourceBuilderWithHandler`, `ResourceBuilderWithLayer`, `ResourceBuilderWithContextHandler`, `ResourceBuilderWithContextLayer`)

## Changes
- **`src/protocol.rs`**: Added `annotations` field to both definition structs
- **`src/resource.rs`**: Added field to `Resource`, `ResourceTemplate`, all builder types, `Clone`/`Debug` impls, `from_handler()`, and `definition()` methods

## Test plan
- [x] Resource with annotations flows through to definition
- [x] Resource template with annotations flows through to definition
- [x] Resources without annotations default to None
- [x] Full test suite passes (349 unit + 29 integration + 104 doc tests)

Closes #378