### PR TITLE
feat: add DynamicToolRegistry for runtime tool registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ reqwest = { version = "0.13", default-features = false, features = ["rustls", "j
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "childproc", "oauth", "jwks", "testing"]
+full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
@@ -69,6 +69,8 @@ oauth = ["dep:jsonwebtoken", "http"]
 jwks = ["oauth", "dep:reqwest"]
 # Test utilities for MCP servers
 testing = []
+# Runtime tool (de)registration via DynamicToolRegistry
+dynamic-tools = []
 
 [dependencies.axum]
 version = "0.8"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@
 //! - `childproc` - Child process transport for subprocess management
 //! - `oauth` - OAuth 2.1 resource server support (token validation, metadata endpoint)
 //! - `testing` - Test utilities ([`TestClient`]) for ergonomic MCP server testing
+//! - `dynamic-tools` - Runtime tool (de)registration via [`DynamicToolRegistry`]
 //!
 //! ## Middleware Placement Guide
 //!
@@ -359,6 +360,8 @@ pub mod jsonrpc;
 pub mod oauth;
 pub mod prompt;
 pub mod protocol;
+#[cfg(feature = "dynamic-tools")]
+pub mod registry;
 pub mod resource;
 pub mod router;
 pub mod session;
@@ -395,6 +398,8 @@ pub use protocol::{
     ResourceContent, ResourceReference, Root, RootsCapability, SamplingCapability, SamplingContent,
     SamplingContentOrArray, SamplingMessage, SamplingTool, ToolChoice,
 };
+#[cfg(feature = "dynamic-tools")]
+pub use registry::DynamicToolRegistry;
 pub use resource::{
     BoxResourceService, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
     ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,0 +1,137 @@
+//! Dynamic tool registry for runtime tool (de)registration.
+//!
+//! The [`DynamicToolRegistry`] provides a thread-safe, cloneable handle for
+//! adding and removing tools at runtime. When tools change, all connected
+//! sessions are notified via `notifications/tools/list_changed`.
+//!
+//! # Example
+//!
+//! ```rust
+//! use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+//! use schemars::JsonSchema;
+//! use serde::Deserialize;
+//!
+//! #[derive(Debug, Deserialize, JsonSchema)]
+//! struct Input { value: String }
+//!
+//! let (router, registry) = McpRouter::new()
+//!     .server_info("my-server", "1.0.0")
+//!     .with_dynamic_tools();
+//!
+//! // Register a tool at runtime
+//! let tool = ToolBuilder::new("echo")
+//!     .description("Echo input")
+//!     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
+//!     .build();
+//!
+//! registry.register(tool);
+//! ```
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use crate::context::{NotificationSender, ServerNotification};
+use crate::tool::Tool;
+
+/// Inner state shared between the registry handle and the router.
+pub(crate) struct DynamicToolsInner {
+    tools: RwLock<HashMap<String, Arc<Tool>>>,
+    notification_senders: RwLock<Vec<NotificationSender>>,
+}
+
+impl DynamicToolsInner {
+    pub(crate) fn new() -> Self {
+        Self {
+            tools: RwLock::new(HashMap::new()),
+            notification_senders: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register a notification sender for a new session.
+    pub(crate) fn add_notification_sender(&self, sender: NotificationSender) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.push(sender);
+    }
+
+    /// Broadcast `ToolsListChanged` to all sessions, lazily cleaning up closed channels.
+    fn broadcast_tools_changed(&self) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.retain(|tx| !tx.is_closed());
+        for tx in senders.iter() {
+            let _ = tx.try_send(ServerNotification::ToolsListChanged);
+        }
+    }
+
+    /// Get a snapshot of all dynamic tools.
+    pub(crate) fn list(&self) -> Vec<Arc<Tool>> {
+        let tools = self.tools.read().unwrap();
+        tools.values().cloned().collect()
+    }
+
+    /// Look up a dynamic tool by name.
+    pub(crate) fn get(&self, name: &str) -> Option<Arc<Tool>> {
+        let tools = self.tools.read().unwrap();
+        tools.get(name).cloned()
+    }
+
+    /// Check if a dynamic tool exists.
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        let tools = self.tools.read().unwrap();
+        tools.contains_key(name)
+    }
+}
+
+/// A thread-safe, cloneable handle for runtime tool management.
+///
+/// Obtained from [`McpRouter::with_dynamic_tools()`](crate::McpRouter::with_dynamic_tools).
+/// Tools registered here are merged with the router's static tools when
+/// handling `tools/list` and `tools/call` requests.
+///
+/// When a tool is registered or unregistered, all connected sessions receive a
+/// `notifications/tools/list_changed` notification.
+#[derive(Clone)]
+pub struct DynamicToolRegistry {
+    inner: Arc<DynamicToolsInner>,
+}
+
+impl DynamicToolRegistry {
+    pub(crate) fn new(inner: Arc<DynamicToolsInner>) -> Self {
+        Self { inner }
+    }
+
+    /// Register a tool, replacing any existing tool with the same name.
+    ///
+    /// Broadcasts `ToolsListChanged` to all connected sessions.
+    pub fn register(&self, tool: Tool) {
+        {
+            let mut tools = self.inner.tools.write().unwrap();
+            tools.insert(tool.name.clone(), Arc::new(tool));
+        }
+        self.inner.broadcast_tools_changed();
+    }
+
+    /// Unregister a tool by name.
+    ///
+    /// Returns `true` if the tool existed and was removed.
+    /// Broadcasts `ToolsListChanged` only if the tool was actually removed.
+    pub fn unregister(&self, name: &str) -> bool {
+        let removed = {
+            let mut tools = self.inner.tools.write().unwrap();
+            tools.remove(name).is_some()
+        };
+        if removed {
+            self.inner.broadcast_tools_changed();
+        }
+        removed
+    }
+
+    /// List all currently registered dynamic tools.
+    pub fn list(&self) -> Vec<Arc<Tool>> {
+        self.inner.list()
+    }
+
+    /// Check if a tool with the given name is registered.
+    pub fn contains(&self, name: &str) -> bool {
+        self.inner.contains(name)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #370.

Adds runtime tool (de)registration behind the `dynamic-tools` feature flag:

```toml
[dependencies]
tower-mcp = { version = "0.5", features = ["dynamic-tools"] }
```

- `DynamicToolRegistry` — thread-safe, cloneable handle for runtime tool management
- `McpRouter::with_dynamic_tools()` builder returns `(Self, DynamicToolRegistry)`
- `register(tool)` / `unregister(name)` add/remove tools and broadcast `ToolsListChanged` to all connected sessions
- `tools/list` merges static + dynamic tools (static wins on name collision)
- `tools/call` falls through from static to dynamic tools
- Tool filters apply to both static and dynamic tools
- Capabilities advertise `tools` when dynamic tools are enabled, even with no static tools
- Multi-session notification broadcasting with lazy cleanup of closed channels
- Zero cost when feature is not enabled — all code is `#[cfg(feature = "dynamic-tools")]`

## Test plan

- [x] Register/unregister tools via registry
- [x] `tools/list` returns merged results (static + dynamic)
- [x] Static tools shadow dynamic tools on name collision
- [x] `tools/call` dispatches to dynamic tools
- [x] `ToolsListChanged` notification sent on register/unregister
- [x] No notification on empty unregister
- [x] Tool filter applies to dynamic tools
- [x] Capabilities advertise tools when only dynamic tools exist
- [x] Multi-session notification broadcasting
- [x] Call returns method-not-found for missing tools
- [x] Registry `list()`/`contains()` API
- [x] `cargo test` passes without feature (104 tests, dynamic tests excluded)
- [x] `cargo test --features dynamic-tools` passes (106 tests, all included)
- [x] `cargo clippy -- -D warnings` clean both with and without feature