### PR TITLE
fix: add lastModified field to ContentAnnotations

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1782,6 +1782,9 @@ pub struct ContentAnnotations {
     /// Priority hint from 0 (optional) to 1 (required)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<f64>,
+    /// ISO 8601 timestamp of when this content was last modified
+    #[serde(rename = "lastModified", skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
 }
 
 impl Content {

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -1807,6 +1807,7 @@ mod tests {
         let annotations = ContentAnnotations {
             audience: Some(vec![ContentRole::User]),
             priority: Some(0.8),
+            last_modified: None,
         };
 
         let resource = ResourceBuilder::new("file:///important.txt")
@@ -1828,6 +1829,7 @@ mod tests {
         let annotations = ContentAnnotations {
             audience: Some(vec![ContentRole::Assistant]),
             priority: Some(0.5),
+            last_modified: None,
         };
 
         let template = ResourceTemplateBuilder::new("db://users/{id}")


### PR DESCRIPTION
## Summary

- Adds optional `lastModified` (ISO 8601 timestamp) field to `ContentAnnotations` per the `2025-11-25` spec
- Affects content blocks, `ResourceDefinition`, and `ResourceTemplateDefinition` annotations

Closes #387

## Test plan

- [x] `cargo test --lib` — 349 tests pass
- [x] `cargo clippy --all-features -- -D warnings` — clean