### PR TITLE
feat: add tools and context sub-fields to SamplingCapability

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -397,9 +397,9 @@ pub use protocol::{
     JsonRpcResponse, JsonRpcResponseMessage, ListRootsParams, ListRootsResult, McpRequest,
     McpResponse, ModelHint, ModelPreferences, PrimitiveSchemaDefinition, PromptMessage,
     PromptReference, PromptRole, ReadResourceResult, ResourceContent, ResourceReference, Root,
-    RootsCapability, SamplingCapability, SamplingContent, SamplingContentOrArray, SamplingMessage,
-    SamplingTool, TaskInfo, TaskObject, TaskRequestParams, TaskSupportMode, ToolChoice,
-    ToolExecution,
+    RootsCapability, SamplingCapability, SamplingContent, SamplingContentOrArray,
+    SamplingContextCapability, SamplingMessage, SamplingTool, SamplingToolsCapability, TaskInfo,
+    TaskObject, TaskRequestParams, TaskSupportMode, ToolChoice, ToolExecution,
 };
 #[cfg(feature = "dynamic-tools")]
 pub use registry::DynamicToolRegistry;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -632,7 +632,22 @@ pub struct ListRootsResult {
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct SamplingCapability {}
+pub struct SamplingCapability {
+    /// Support for tool use within sampling
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools: Option<SamplingToolsCapability>,
+    /// Support for context inclusion within sampling
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<SamplingContextCapability>,
+}
+
+/// Marker capability for tool use within sampling
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct SamplingToolsCapability {}
+
+/// Marker capability for context inclusion within sampling
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct SamplingContextCapability {}
 
 /// Server capability for providing completions
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2018,3 +2018,29 @@ async fn test_client_tasks_capability_round_trip() {
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
     }
 }
+
+#[tokio::test]
+async fn test_sampling_capability_round_trip() {
+    let router = create_test_router();
+    let mut service = JsonRpcService::new(router);
+
+    let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {
+            "sampling": {
+                "tools": {},
+                "context": {}
+            }
+        },
+        "clientInfo": {
+            "name": "test-client",
+            "version": "1.0"
+        }
+    }));
+
+    let resp = service.call_single(init_req).await.unwrap();
+    match resp {
+        JsonRpcResponse::Result(_) => {}
+        JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional `tools` and `context` sub-capability fields to `SamplingCapability` per MCP spec (2025-11-25) (#391)
- Introduces `SamplingToolsCapability` and `SamplingContextCapability` marker structs, following the same pattern as `ElicitationCapability`
- Exports new types from `lib.rs`

## Test plan
- [x] Added `test_sampling_capability_round_trip` integration test verifying initialize with `"sampling": {"tools": {}, "context": {}}`
- [x] `cargo check --all-targets --all-features`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --all-features` (all 645 tests pass)