### PR TITLE
feat: add experimental field to ServerCapabilities and ClientCapabilities

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -3,6 +3,8 @@
 //! These types follow the MCP specification (2025-11-25):
 //! <https://modelcontextprotocol.io/specification/2025-11-25>
 
+use std::collections::HashMap;
+
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -510,6 +512,9 @@ pub struct ClientCapabilities {
     pub elicitation: Option<ElicitationCapability>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tasks: Option<ClientTasksCapability>,
+    /// Experimental, non-standard capabilities
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Client capability for elicitation (requesting user input)
@@ -1282,6 +1287,9 @@ pub struct ServerCapabilities {
     /// Completion capability - server provides autocomplete suggestions
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completions: Option<CompletionsCapability>,
+    /// Experimental, non-standard capabilities
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub experimental: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Logging capability declaration
@@ -3499,6 +3507,7 @@ mod tests {
                 url: Some(ElicitationUrlCapability {}),
             }),
             tasks: None,
+            experimental: None,
         };
 
         let json = serde_json::to_value(&caps).unwrap();
@@ -3604,6 +3613,7 @@ mod tests {
             sampling: None,
             elicitation: None,
             tasks: None,
+            experimental: None,
         };
 
         let json = serde_json::to_value(&caps).unwrap();

--- a/src/router.rs
+++ b/src/router.rs
@@ -1274,6 +1274,7 @@ impl McpRouter {
             } else {
                 None
             },
+            experimental: None,
         }
     }
 
@@ -1920,6 +1921,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2510,6 +2512,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2622,6 +2625,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2656,6 +2660,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -3167,6 +3172,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -4572,6 +4578,7 @@ mod tests {
                     sampling: None,
                     elicitation: None,
                     tasks: None,
+                    experimental: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2044,3 +2044,30 @@ async fn test_sampling_capability_round_trip() {
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
     }
 }
+
+#[tokio::test]
+async fn test_experimental_capabilities_round_trip() {
+    let router = create_test_router();
+    let mut service = JsonRpcService::new(router);
+
+    let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+        "protocolVersion": "2025-03-26",
+        "capabilities": {
+            "experimental": {
+                "customFeature": {
+                    "enabled": true
+                }
+            }
+        },
+        "clientInfo": {
+            "name": "test-client",
+            "version": "1.0"
+        }
+    }));
+
+    let resp = service.call_single(init_req).await.unwrap();
+    match resp {
+        JsonRpcResponse::Result(_) => {}
+        JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+    }
+}


### PR DESCRIPTION
## Summary
- Adds optional `experimental: Option<HashMap<String, serde_json::Value>>` field to both `ServerCapabilities` and `ClientCapabilities` per MCP spec (2025-11-25)
- Enables clients and servers to declare non-standard capabilities via `Record<string, object>`
- Updates all existing struct literals to include the new field

Closes #390

## Test plan
- [x] Added `test_experimental_capabilities_round_trip` integration test
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-features -- -D warnings`
- [x] `cargo test --all-features` (646 tests pass)