### PR TITLE
feat: support single-or-array SamplingMessage content and add missing sampling fields

### DIFF
--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -210,7 +210,7 @@ fn build_sampling() -> Tool {
                 Ok(result) => {
                     // Get the first content item
                     let text = match result.content_items().first() {
-                        Some(tower_mcp::SamplingContent::Text { text }) => text.clone(),
+                        Some(tower_mcp::SamplingContent::Text { text, .. }) => text.clone(),
                         Some(content) => format!("{:?}", content),
                         None => "No content".to_string(),
                     };


### PR DESCRIPTION
## Summary
- **#407**: `SamplingMessage.content` now uses `SamplingContentOrArray` to accept both a single content object and an array, matching the MCP spec union type `SamplingMessageContentBlock | SamplingMessageContentBlock[]`.
- **#413**: Added missing fields to sampling types:
  - `SamplingContent::Text/Image/Audio`: Added `annotations: Option<ContentAnnotations>`
  - `SamplingContent::ToolResult`: Added `structured_content: Option<Value>`
  - `CreateMessageParams`: Added `task: Option<TaskRequestParams>`
  - `SamplingTool`: Added `title`, `output_schema`, `icons`, `annotations`, `execution` to match the full `Tool` spec type

## Test plan
- [x] Updated all `SamplingContent` construction sites with new `annotations` field
- [x] Updated pattern matches to use `..` syntax
- [x] Updated conformance-server `SamplingContent::Text` match
- [x] `cargo check --workspace --all-targets --all-features` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --all-features` — 451 + 62 + 5 + 128 tests pass

Closes #407
Closes #413