### PR TITLE
fix: correct tasks capability nesting, add TaskStatusParams fields, emit null for ttl

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -99,6 +99,8 @@ pub enum ServerNotification {
     ToolsListChanged,
     /// The list of available prompts has changed
     PromptsListChanged,
+    /// Task status has changed
+    TaskStatusChanged(crate::protocol::TaskStatusParams),
 }
 
 /// Sender for server notifications

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,7 +399,8 @@ pub use protocol::{
     PromptReference, PromptRole, ReadResourceResult, ResourceContent, ResourceReference, Root,
     RootsCapability, SamplingCapability, SamplingContent, SamplingContentOrArray,
     SamplingContextCapability, SamplingMessage, SamplingTool, SamplingToolsCapability, TaskInfo,
-    TaskObject, TaskRequestParams, TaskSupportMode, ToolChoice, ToolExecution,
+    TaskObject, TaskRequestParams, TaskStatusParams, TaskSupportMode, TasksToolsRequestsCapability,
+    ToolChoice, ToolExecution,
 };
 #[cfg(feature = "dynamic-tools")]
 pub use registry::DynamicToolRegistry;

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -564,21 +564,39 @@ pub struct ClientTasksCancelCapability {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientTasksRequestsCapability {
-    /// Support for task-augmented sampling/createMessage
+    /// Task support for sampling-related requests
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sampling_create_message: Option<ClientTasksSamplingCapability>,
-    /// Support for task-augmented elicitation/create
+    pub sampling: Option<ClientTasksSamplingCapability>,
+    /// Task support for elicitation-related requests
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub elicitation_create: Option<ClientTasksElicitationCapability>,
+    pub elicitation: Option<ClientTasksElicitationCapability>,
+}
+
+/// Nested capability for task-augmented sampling requests
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTasksSamplingCapability {
+    /// Whether the client supports task-augmented sampling/createMessage requests
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create_message: Option<ClientTasksSamplingCreateMessageCapability>,
 }
 
 /// Marker capability for task-augmented sampling/createMessage support
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ClientTasksSamplingCapability {}
+pub struct ClientTasksSamplingCreateMessageCapability {}
+
+/// Nested capability for task-augmented elicitation requests
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientTasksElicitationCapability {
+    /// Whether the client supports task-augmented elicitation/create requests
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub create: Option<ClientTasksElicitationCreateCapability>,
+}
 
 /// Marker capability for task-augmented elicitation/create support
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ClientTasksElicitationCapability {}
+pub struct ClientTasksElicitationCreateCapability {}
 
 /// Client capability for roots (filesystem access)
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -1381,9 +1399,18 @@ pub struct TasksCancelCapability {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TasksRequestsCapability {
-    /// Support for task-augmented tools/call
+    /// Task support for tool-related requests
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tools: Option<TasksToolsCallCapability>,
+    pub tools: Option<TasksToolsRequestsCapability>,
+}
+
+/// Nested capability for task-augmented tool requests
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TasksToolsRequestsCapability {
+    /// Whether the server supports task-augmented tools/call requests
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub call: Option<TasksToolsCallCapability>,
 }
 
 /// Marker capability for task-augmented tools/call support
@@ -2741,8 +2768,7 @@ pub struct TaskObject {
     pub created_at: String,
     /// ISO 8601 timestamp when the task was last updated
     pub last_updated_at: String,
-    /// Time-to-live in milliseconds
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Time-to-live in milliseconds, null for unlimited
     pub ttl: Option<u64>,
     /// Suggested polling interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2812,6 +2838,9 @@ pub struct CancelTaskParams {
 }
 
 /// Notification params when task status changes
+///
+/// Per the spec, `TaskStatusNotificationParams = NotificationParams & Task`,
+/// so this includes all fields from the Task object.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskStatusParams {
@@ -2822,6 +2851,15 @@ pub struct TaskStatusParams {
     /// Human-readable status message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status_message: Option<String>,
+    /// ISO 8601 timestamp when the task was created
+    pub created_at: String,
+    /// ISO 8601 timestamp when the task was last updated
+    pub last_updated_at: String,
+    /// Time-to-live in milliseconds, null for unlimited
+    pub ttl: Option<u64>,
+    /// Suggested polling interval in milliseconds
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub poll_interval: Option<u64>,
 }
 
 /// Backwards-compatible alias

--- a/src/router.rs
+++ b/src/router.rs
@@ -1261,7 +1261,9 @@ impl McpRouter {
                         list: Some(TasksListCapability {}),
                         cancel: Some(TasksCancelCapability {}),
                         requests: Some(TasksRequestsCapability {
-                            tools: Some(TasksToolsCallCapability {}),
+                            tools: Some(TasksToolsRequestsCapability {
+                                call: Some(TasksToolsCallCapability {}),
+                            }),
                         }),
                     })
                 } else {

--- a/src/transport/stdio.rs
+++ b/src/transport/stdio.rs
@@ -100,6 +100,11 @@ pub(crate) fn serialize_notification(notification: &ServerNotification) -> Optio
             let notif = JsonRpcNotification::new(notifications::PROMPTS_LIST_CHANGED);
             serde_json::to_string(&notif).ok()
         }
+        ServerNotification::TaskStatusChanged(params) => {
+            let notif = JsonRpcNotification::new(notifications::TASK_STATUS_CHANGED)
+                .with_params(serde_json::to_value(params).unwrap_or_default());
+            serde_json::to_string(&notif).ok()
+        }
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2001,8 +2001,8 @@ async fn test_client_tasks_capability_round_trip() {
                 "list": {},
                 "cancel": {},
                 "requests": {
-                    "samplingCreateMessage": {},
-                    "elicitationCreate": {}
+                    "sampling": { "createMessage": {} },
+                    "elicitation": { "create": {} }
                 }
             }
         },


### PR DESCRIPTION
## Summary
- **#406**: Restructured `ClientTasksRequestsCapability` and `TasksRequestsCapability` to use properly nested JSON. Client side now serializes as `{ "sampling": { "createMessage": {} } }` instead of `{ "samplingCreateMessage": {} }`. Server side now serializes as `{ "tools": { "call": {} } }` instead of `{ "tools": {} }`.
- **#408**: Added missing fields to `TaskStatusParams` (`createdAt`, `lastUpdatedAt`, `ttl`, `pollInterval`) matching the spec's `TaskStatusNotificationParams = NotificationParams & Task`. Added `ServerNotification::TaskStatusChanged` variant with serialization support.
- **#417**: Removed `skip_serializing_if` from `TaskObject.ttl` so it serializes as `null` when `None`, matching the spec's `ttl: number | null`.

## Test plan
- [x] Updated integration test `test_client_tasks_capability_round_trip` with correct nesting
- [x] Updated `router.rs` capability construction with new intermediate `TasksToolsRequestsCapability` struct
- [x] Added `TaskStatusChanged` handling in `serialize_notification`
- [x] Exported `TaskStatusParams` and `TasksToolsRequestsCapability` from `lib.rs`
- [x] `cargo check --workspace --all-targets --all-features` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test --all-features` — 451 + 62 + 5 + 128 tests pass

Closes #406
Closes #408
Closes #417