### PR TITLE
feat: add _meta field across all protocol types

### DIFF
--- a/examples/codegen-mcp/src/resources.rs
+++ b/examples/codegen-mcp/src/resources.rs
@@ -44,7 +44,9 @@ fn build_cargo_toml_resource(state: Arc<CodegenState>) -> Resource {
                         mime_type: Some("text/x-toml".to_string()),
                         text: Some(text),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -76,7 +78,9 @@ fn build_main_rs_resource(state: Arc<CodegenState>) -> Resource {
                         mime_type: Some("text/x-rust".to_string()),
                         text: Some(text),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -108,7 +112,9 @@ fn build_readme_resource(state: Arc<CodegenState>) -> Resource {
                         mime_type: Some("text/markdown".to_string()),
                         text: Some(text),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -134,7 +140,9 @@ fn build_state_resource(state: Arc<CodegenState>) -> Resource {
                         mime_type: Some("application/json".to_string()),
                         text: Some(json),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })

--- a/examples/conformance-server/src/prompts.rs
+++ b/examples/conformance-server/src/prompts.rs
@@ -55,8 +55,11 @@ fn build_exercise_conformance_prompt() -> Prompt {
 After testing each feature, summarize what worked and any issues found."#
                             .to_string(),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -73,8 +76,11 @@ fn build_simple_prompt() -> Prompt {
                     content: Content::Text {
                         text: "This is a simple prompt message".to_string(),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -95,8 +101,11 @@ fn build_prompt_with_arguments() -> Prompt {
                     content: Content::Text {
                         text: format!("arg1: {}, arg2: {}", arg1, arg2),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -121,10 +130,14 @@ fn build_prompt_with_embedded_resource() -> Prompt {
                             mime_type: Some("text/plain".to_string()),
                             text: Some("Embedded resource content".to_string()),
                             blob: None,
+                            meta: None,
                         },
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -142,8 +155,11 @@ fn build_prompt_with_image() -> Prompt {
                         data: red_pixel_base64(),
                         mime_type: "image/png".to_string(),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/examples/conformance-server/src/resources.rs
+++ b/examples/conformance-server/src/resources.rs
@@ -42,7 +42,9 @@ fn build_static_binary() -> Resource {
                         mime_type: Some("image/png".to_string()),
                         text: None,
                         blob: Some(png_base64),
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -78,7 +80,9 @@ fn build_template() -> ResourceTemplate {
                     mime_type: Some("text/plain".to_string()),
                     text: Some(format!("Template data for id: {}", id)),
                     blob: None,
+                    meta: None,
                 }],
+                meta: None,
             })
         })
 }

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -98,6 +98,7 @@ fn build_embedded_resource() -> Tool {
                 mime_type: Some("text/plain".to_string()),
                 text: Some("Embedded resource content".to_string()),
                 blob: None,
+                meta: None,
             }))
         })
         .build()
@@ -112,11 +113,13 @@ fn build_multiple_content_types() -> Tool {
                     Content::Text {
                         text: "This is text content".to_string(),
                         annotations: None,
+                        meta: None,
                     },
                     Content::Image {
                         data: red_pixel_base64(),
                         mime_type: "image/png".to_string(),
                         annotations: None,
+                        meta: None,
                     },
                     Content::Resource {
                         resource: ResourceContent {
@@ -124,8 +127,10 @@ fn build_multiple_content_types() -> Tool {
                             mime_type: Some("text/plain".to_string()),
                             text: Some("Embedded resource content".to_string()),
                             blob: None,
+                            meta: None,
                         },
                         annotations: None,
+                        meta: None,
                     },
                 ],
                 is_error: false,

--- a/examples/crates-mcp/src/main.rs
+++ b/examples/crates-mcp/src/main.rs
@@ -252,6 +252,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                             total: None,
                             has_more: Some(false),
                         },
+                        meta: None,
                     })
                 }
             });

--- a/examples/crates-mcp/src/prompts/analyze.rs
+++ b/examples/crates-mcp/src/prompts/analyze.rs
@@ -44,8 +44,11 @@ pub fn build() -> Prompt {
                     content: tower_mcp::protocol::Content::Text {
                         text: prompt,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/examples/crates-mcp/src/prompts/compare.rs
+++ b/examples/crates-mcp/src/prompts/compare.rs
@@ -39,8 +39,11 @@ pub fn build() -> Prompt {
                     content: tower_mcp::protocol::Content::Text {
                         text: prompt,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/examples/crates-mcp/src/resources/crate_info.rs
+++ b/examples/crates-mcp/src/resources/crate_info.rs
@@ -56,7 +56,9 @@ pub fn build(state: Arc<AppState>) -> ResourceTemplate {
                         mime_type: Some("text/markdown".to_string()),
                         text: Some(content),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })

--- a/examples/crates-mcp/src/resources/recent_searches.rs
+++ b/examples/crates-mcp/src/resources/recent_searches.rs
@@ -24,7 +24,9 @@ pub fn build(state: Arc<AppState>) -> Resource {
                         mime_type: Some("application/json".to_string()),
                         text: Some(json),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })

--- a/examples/crates-mcp/src/tools/reverse_deps.rs
+++ b/examples/crates-mcp/src/tools/reverse_deps.rs
@@ -41,6 +41,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
                         "action": "fetch_reverse_deps",
                         "crate": input.name
                     }),
+                    meta: None,
                 });
 
                 // Send initial progress
@@ -66,6 +67,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
                         "crate": input.name,
                         "count": response.meta.total
                     }),
+                    meta: None,
                 });
 
                 let mut output = format!(

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -169,8 +169,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                     content: tower_mcp::protocol::Content::Text {
                         text: format!("Please greet {} warmly.", name),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build();

--- a/examples/markdownlint-mcp/src/resources.rs
+++ b/examples/markdownlint-mcp/src/resources.rs
@@ -84,7 +84,9 @@ fn build_rules_overview_resource() -> Resource {
                     mime_type: Some("application/json".to_string()),
                     text: Some(serde_json::to_string_pretty(&overview).unwrap_or_default()),
                     blob: None,
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()
@@ -117,7 +119,9 @@ fn build_rule_detail_template() -> ResourceTemplate {
                             mime_type: Some("application/json".to_string()),
                             text: Some(serde_json::to_string_pretty(&detail).unwrap_or_default()),
                             blob: None,
+                            meta: None,
                         }],
+                        meta: None,
                     })
                 }
                 None => Err(tower_mcp::Error::internal(format!(

--- a/examples/markdownlint-mcp/src/tools.rs
+++ b/examples/markdownlint-mcp/src/tools.rs
@@ -354,8 +354,11 @@ pub fn build_fix_suggestions_prompt() -> Prompt {
                     content: Content::Text {
                         text: prompt_text,
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build()

--- a/src/async_task.rs
+++ b/src/async_task.rs
@@ -105,6 +105,7 @@ impl Task {
             last_updated_at: self.last_updated_at_str.clone(),
             ttl: Some(self.ttl),
             poll_interval: Some(self.poll_interval),
+            meta: None,
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -105,7 +105,7 @@ impl<T: ClientTransport> McpClient<T> {
     /// # async fn example() -> Result<(), tower_mcp::BoxError> {
     /// let transport = StdioClientTransport::spawn("server", &[]).await?;
     /// let client = McpClient::new(transport)
-    ///     .with_roots(vec![Root { uri: "file:///project".into(), name: Some("Project".into()) }]);
+    ///     .with_roots(vec![Root { uri: "file:///project".into(), name: Some("Project".into()), meta: None }]);
     /// # Ok(())
     /// # }
     /// ```
@@ -197,6 +197,7 @@ impl<T: ClientTransport> McpClient<T> {
     pub fn list_roots(&self) -> ListRootsResult {
         ListRootsResult {
             roots: self.roots.clone(),
+            meta: None,
         }
     }
 
@@ -214,6 +215,7 @@ impl<T: ClientTransport> McpClient<T> {
                 version: client_version.to_string(),
                 ..Default::default()
             },
+            meta: None,
         };
 
         let result: InitializeResult = self.request("initialize", &params).await?;
@@ -309,6 +311,7 @@ impl<T: ClientTransport> McpClient<T> {
             reference,
             argument: CompletionArgument::new(argument_name, argument_value),
             context: None,
+            meta: None,
         };
         self.request("completion/complete", &params).await
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -452,6 +452,7 @@ impl RequestContext {
             progress,
             total,
             message: message.map(|s| s.to_string()),
+            meta: None,
         };
 
         // Best effort - don't block if channel is full
@@ -474,6 +475,7 @@ impl RequestContext {
             progress,
             total,
             message: message.map(|s| s.to_string()),
+            meta: None,
         };
 
         let _ = tx.try_send(ServerNotification::Progress(params));

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -30,8 +30,11 @@
 //!                 content: Content::Text {
 //!                     text: "Hello!".to_string(),
 //!                     annotations: None,
+//!                     meta: None,
 //!                 },
+//!                 meta: None,
 //!             }],
+//!             meta: None,
 //!         })
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(5)));
@@ -165,8 +168,11 @@ where
                             content: Content::Text {
                                 text: format!("Error generating prompt: {}", err),
                                 annotations: None,
+                                meta: None,
                             },
+                            meta: None,
                         }],
+                        meta: None,
                     })
                 }
             }
@@ -321,6 +327,7 @@ impl Prompt {
             description: self.description.clone(),
             icons: self.icons.clone(),
             arguments: self.arguments.clone(),
+            meta: None,
         }
     }
 
@@ -373,8 +380,11 @@ impl Prompt {
 ///                 content: Content::Text {
 ///                     text: format!("Please greet {}", name),
 ///                     annotations: None,
+///                     meta: None,
 ///                 },
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     })
 ///     .build();
@@ -502,7 +512,9 @@ impl PromptBuilder {
     ///                 messages: vec![PromptMessage {
     ///                     role: PromptRole::User,
     ///                     content: Content::text(text),
+    ///                     meta: None,
     ///                 }],
+    ///                 meta: None,
     ///             })
     ///         }
     ///     })
@@ -554,6 +566,7 @@ impl PromptBuilder {
                 Ok(GetPromptResult {
                     description,
                     messages,
+                    meta: None,
                 })
             }
         })
@@ -568,7 +581,9 @@ impl PromptBuilder {
             content: Content::Text {
                 text,
                 annotations: None,
+                meta: None,
             },
+            meta: None,
         }])
     }
 
@@ -641,8 +656,11 @@ where
     ///                 content: Content::Text {
     ///                     text: "Hello!".to_string(),
     ///                     annotations: None,
+    ///                     meta: None,
     ///                 },
+    ///                 meta: None,
     ///             }],
+    ///             meta: None,
     ///         })
     ///     })
     ///     .layer(TimeoutLayer::new(Duration::from_secs(5)));
@@ -894,8 +912,11 @@ impl PromptHandler for ServiceContextHandler {
 ///                 content: Content::Text {
 ///                     text: format!("Please review this {} code:\n\n```{}\n{}\n```", lang, lang, code),
 ///                     annotations: None,
+///                     meta: None,
 ///                 },
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     }
 /// }
@@ -965,8 +986,11 @@ mod tests {
                         content: Content::Text {
                             text: format!("Hello, {}!", name),
                             annotations: None,
+                            meta: None,
                         },
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .build();
@@ -1026,8 +1050,11 @@ mod tests {
                         content: Content::Text {
                             text: format!("Input: {}", input),
                             annotations: None,
+                            meta: None,
                         },
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         }
@@ -1077,8 +1104,11 @@ mod tests {
                         content: Content::Text {
                             text: format!("Hello, {}!", name),
                             annotations: None,
+                            meta: None,
                         },
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .build();
@@ -1113,8 +1143,11 @@ mod tests {
                         content: Content::Text {
                             text: format!("Hello, {}!", name),
                             annotations: None,
+                            meta: None,
                         },
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .layer(TimeoutLayer::new(Duration::from_secs(5)));
@@ -1148,8 +1181,11 @@ mod tests {
                         content: Content::Text {
                             text: "This should not appear".to_string(),
                             annotations: None,
+                            meta: None,
                         },
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .layer(TimeoutLayer::new(Duration::from_millis(50)));
@@ -1183,8 +1219,11 @@ mod tests {
                             content: Content::Text {
                                 text: format!("Hello, {}!", name),
                                 annotations: None,
+                                meta: None,
                             },
+                            meta: None,
                         }],
+                        meta: None,
                     })
                 },
             )
@@ -1226,6 +1265,7 @@ mod tests {
                 Ok::<GetPromptResult, Error>(GetPromptResult {
                     description: None,
                     messages: vec![],
+                    meta: None,
                 })
             },
         };

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -265,6 +265,9 @@ pub struct LoggingMessageParams {
     /// Structured data to be logged
     #[serde(default)]
     pub data: Value,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl LoggingMessageParams {
@@ -274,6 +277,7 @@ impl LoggingMessageParams {
             level,
             logger: None,
             data: data.into(),
+            meta: None,
         }
     }
 
@@ -431,6 +435,9 @@ pub struct CancelledParams {
     /// Optional reason for cancellation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Parameters for progress notification
@@ -447,6 +454,9 @@ pub struct ProgressParams {
     /// Human-readable progress message
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Progress token - can be string or number
@@ -501,6 +511,9 @@ pub struct InitializeParams {
     pub protocol_version: String,
     pub capabilities: ClientCapabilities,
     pub client_info: Implementation,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -620,6 +633,9 @@ pub struct Root {
     /// Optional human-readable name for the root
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl Root {
@@ -628,6 +644,7 @@ impl Root {
         Self {
             uri: uri.into(),
             name: None,
+            meta: None,
         }
     }
 
@@ -636,6 +653,7 @@ impl Root {
         Self {
             uri: uri.into(),
             name: Some(name.into()),
+            meta: None,
         }
     }
 }
@@ -653,6 +671,9 @@ pub struct ListRootsParams {
 pub struct ListRootsResult {
     /// The list of roots available to the server
     pub roots: Vec<Root>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
@@ -782,6 +803,9 @@ pub struct CompleteParams {
     /// Additional context for completion, such as previously resolved argument values
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<CompletionContext>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Context provided alongside a completion request
@@ -832,6 +856,9 @@ impl Completion {
 pub struct CompleteResult {
     /// The completion suggestions
     pub completion: Completion,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl CompleteResult {
@@ -839,6 +866,7 @@ impl CompleteResult {
     pub fn new(values: Vec<String>) -> Self {
         Self {
             completion: Completion::new(values),
+            meta: None,
         }
     }
 
@@ -846,6 +874,7 @@ impl CompleteResult {
     pub fn with_pagination(values: Vec<String>, total: u32, has_more: bool) -> Self {
         Self {
             completion: Completion::with_pagination(values, total, has_more),
+            meta: None,
         }
     }
 }
@@ -940,6 +969,9 @@ pub struct SamplingMessage {
     pub role: ContentRole,
     /// The content of the message (single item or array)
     pub content: SamplingContentOrArray,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl SamplingMessage {
@@ -950,7 +982,9 @@ impl SamplingMessage {
             content: SamplingContentOrArray::Single(SamplingContent::Text {
                 text: text.into(),
                 annotations: None,
+                meta: None,
             }),
+            meta: None,
         }
     }
 
@@ -961,7 +995,9 @@ impl SamplingMessage {
             content: SamplingContentOrArray::Single(SamplingContent::Text {
                 text: text.into(),
                 annotations: None,
+                meta: None,
             }),
+            meta: None,
         }
     }
 }
@@ -1054,6 +1090,9 @@ pub enum SamplingContent {
         /// Optional annotations for this content
         #[serde(default, skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Image content
     Image {
@@ -1065,6 +1104,9 @@ pub enum SamplingContent {
         /// Optional annotations for this content
         #[serde(default, skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Audio content (if supported)
     Audio {
@@ -1076,6 +1118,9 @@ pub enum SamplingContent {
         /// Optional annotations for this content
         #[serde(default, skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Tool use request from the model (SEP-1577)
     #[serde(rename = "tool_use")]
@@ -1086,6 +1131,9 @@ pub enum SamplingContent {
         name: String,
         /// Input arguments for the tool
         input: Value,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Result of a tool invocation (SEP-1577)
     #[serde(rename = "tool_result")]
@@ -1105,6 +1153,9 @@ pub enum SamplingContent {
         /// Whether the tool execution resulted in an error
         #[serde(default, rename = "isError", skip_serializing_if = "Option::is_none")]
         is_error: Option<bool>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
 }
 
@@ -1118,13 +1169,14 @@ impl SamplingContent {
     /// ```rust
     /// use tower_mcp::protocol::SamplingContent;
     ///
-    /// let text_content = SamplingContent::Text { text: "Hello".into(), annotations: None };
+    /// let text_content = SamplingContent::Text { text: "Hello".into(), annotations: None, meta: None };
     /// assert_eq!(text_content.as_text(), Some("Hello"));
     ///
     /// let image_content = SamplingContent::Image {
     ///     data: "base64...".into(),
     ///     mime_type: "image/png".into(),
     ///     annotations: None,
+    ///     meta: None,
     /// };
     /// assert_eq!(image_content.as_text(), None);
     /// ```
@@ -1202,6 +1254,9 @@ pub struct CreateMessageParams {
     /// Task parameters for async execution
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<TaskRequestParams>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl CreateMessageParams {
@@ -1219,6 +1274,7 @@ impl CreateMessageParams {
             tools: None,
             tool_choice: None,
             task: None,
+            meta: None,
         }
     }
 
@@ -1278,6 +1334,9 @@ pub struct CreateMessageResult {
     /// Why the generation stopped
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl CreateMessageResult {
@@ -1300,10 +1359,12 @@ impl CreateMessageResult {
     ///     content: SamplingContentOrArray::Single(SamplingContent::Text {
     ///         text: "Hello, world!".into(),
     ///         annotations: None,
+    ///         meta: None,
     ///     }),
     ///     model: "claude-3".into(),
     ///     role: ContentRole::Assistant,
     ///     stop_reason: None,
+    ///     meta: None,
     /// };
     /// assert_eq!(result.first_text(), Some("Hello, world!"));
     /// ```
@@ -1332,6 +1393,9 @@ pub struct Implementation {
     /// URL of the implementation's website
     #[serde(skip_serializing_if = "Option::is_none")]
     pub website_url: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1344,6 +1408,9 @@ pub struct InitializeResult {
     /// These hints help LLMs understand the server's features.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1456,6 +1523,9 @@ pub struct ListToolsResult {
     pub tools: Vec<ToolDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Tool definition as returned by tools/list
@@ -1482,6 +1552,9 @@ pub struct ToolDefinition {
     /// Optional execution configuration for task support
     #[serde(skip_serializing_if = "Option::is_none")]
     pub execution: Option<ToolExecution>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Icon theme context
@@ -1653,6 +1726,7 @@ impl CallToolResult {
             content: vec![Content::Text {
                 text: text.into(),
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1669,6 +1743,7 @@ impl CallToolResult {
             content: vec![Content::Text {
                 text: message.into(),
                 annotations: None,
+                meta: None,
             }],
             is_error: true,
             structured_content: None,
@@ -1689,6 +1764,7 @@ impl CallToolResult {
             content: vec![Content::Text {
                 text,
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: Some(value),
@@ -1775,6 +1851,7 @@ impl CallToolResult {
                 data: data.into(),
                 mime_type: mime_type.into(),
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1789,6 +1866,7 @@ impl CallToolResult {
                 data: data.into(),
                 mime_type: mime_type.into(),
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1808,6 +1886,7 @@ impl CallToolResult {
                 size: None,
                 icons: None,
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1832,6 +1911,7 @@ impl CallToolResult {
                 size: None,
                 icons: None,
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1845,6 +1925,7 @@ impl CallToolResult {
             content: vec![Content::Resource {
                 resource,
                 annotations: None,
+                meta: None,
             }],
             is_error: false,
             structured_content: None,
@@ -1949,6 +2030,9 @@ pub enum Content {
         /// Optional annotations for this content.
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Base64-encoded image content.
     Image {
@@ -1960,6 +2044,9 @@ pub enum Content {
         /// Optional annotations for this content.
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Base64-encoded audio content.
     Audio {
@@ -1971,6 +2058,9 @@ pub enum Content {
         /// Optional annotations for this content.
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Embedded resource content.
     Resource {
@@ -1979,6 +2069,9 @@ pub enum Content {
         /// Optional annotations for this content.
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
     /// Link to a resource (without embedding the content)
     ResourceLink {
@@ -2003,6 +2096,9 @@ pub enum Content {
         icons: Option<Vec<ToolIcon>>,
         #[serde(skip_serializing_if = "Option::is_none")]
         annotations: Option<ContentAnnotations>,
+        /// Optional protocol-level metadata
+        #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+        meta: Option<Value>,
     },
 }
 
@@ -2030,7 +2126,7 @@ impl Content {
     /// ```rust
     /// use tower_mcp::Content;
     ///
-    /// let content = Content::Text { text: "hello".into(), annotations: None };
+    /// let content = Content::Text { text: "hello".into(), annotations: None, meta: None };
     /// assert_eq!(content.as_text(), Some("hello"));
     /// ```
     /// Create a [`Content::Text`] variant with no annotations.
@@ -2050,6 +2146,7 @@ impl Content {
         Content::Text {
             text: text.into(),
             annotations: None,
+            meta: None,
         }
     }
 
@@ -2062,7 +2159,7 @@ impl Content {
     /// ```rust
     /// use tower_mcp::Content;
     ///
-    /// let content = Content::Text { text: "hello".into(), annotations: None };
+    /// let content = Content::Text { text: "hello".into(), annotations: None, meta: None };
     /// assert_eq!(content.as_text(), Some("hello"));
     /// ```
     pub fn as_text(&self) -> Option<&str> {
@@ -2102,6 +2199,9 @@ pub struct ResourceContent {
     /// Base64-encoded binary content (for binary resources).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 // =============================================================================
@@ -2120,6 +2220,9 @@ pub struct ListResourcesResult {
     pub resources: Vec<ResourceDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2143,6 +2246,9 @@ pub struct ResourceDefinition {
     /// Annotations for this resource (audience, priority hints)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2153,6 +2259,9 @@ pub struct ReadResourceParams {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadResourceResult {
     pub contents: Vec<ResourceContent>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl ReadResourceResult {
@@ -2172,7 +2281,9 @@ impl ReadResourceResult {
                 mime_type: Some("text/plain".to_string()),
                 text: Some(content.into()),
                 blob: None,
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2200,7 +2311,9 @@ impl ReadResourceResult {
                 mime_type: Some(mime_type.into()),
                 text: Some(content.into()),
                 blob: None,
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2226,7 +2339,9 @@ impl ReadResourceResult {
                 mime_type: Some("application/json".to_string()),
                 text: Some(json_string),
                 blob: None,
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2249,7 +2364,9 @@ impl ReadResourceResult {
                 mime_type: Some("application/octet-stream".to_string()),
                 text: None,
                 blob: Some(encoded),
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2276,7 +2393,9 @@ impl ReadResourceResult {
                 mime_type: Some(mime_type.into()),
                 text: None,
                 blob: Some(encoded),
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2380,6 +2499,9 @@ pub struct ListResourceTemplatesResult {
     /// Cursor for next page (if more templates available)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Definition of a resource template as returned by resources/templates/list
@@ -2422,6 +2544,9 @@ pub struct ResourceTemplateDefinition {
     /// Arguments accepted by this template for URI expansion
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub arguments: Vec<PromptArgument>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 // =============================================================================
@@ -2440,6 +2565,9 @@ pub struct ListPromptsResult {
     pub prompts: Vec<PromptDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2455,6 +2583,9 @@ pub struct PromptDefinition {
     pub icons: Option<Vec<ToolIcon>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub arguments: Vec<PromptArgument>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2478,6 +2609,9 @@ pub struct GetPromptResult {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     pub messages: Vec<PromptMessage>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl GetPromptResult {
@@ -2498,8 +2632,11 @@ impl GetPromptResult {
                 content: Content::Text {
                     text: text.into(),
                     annotations: None,
+                    meta: None,
                 },
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2526,8 +2663,11 @@ impl GetPromptResult {
                 content: Content::Text {
                     text: text.into(),
                     annotations: None,
+                    meta: None,
                 },
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2548,8 +2688,11 @@ impl GetPromptResult {
                 content: Content::Text {
                     text: text.into(),
                     annotations: None,
+                    meta: None,
                 },
+                meta: None,
             }],
+            meta: None,
         }
     }
 
@@ -2655,7 +2798,9 @@ impl GetPromptResultBuilder {
             content: Content::Text {
                 text: text.into(),
                 annotations: None,
+                meta: None,
             },
+            meta: None,
         });
         self
     }
@@ -2667,7 +2812,9 @@ impl GetPromptResultBuilder {
             content: Content::Text {
                 text: text.into(),
                 annotations: None,
+                meta: None,
             },
+            meta: None,
         });
         self
     }
@@ -2677,6 +2824,7 @@ impl GetPromptResultBuilder {
         GetPromptResult {
             description: self.description,
             messages: self.messages,
+            meta: None,
         }
     }
 }
@@ -2685,6 +2833,9 @@ impl GetPromptResultBuilder {
 pub struct PromptMessage {
     pub role: PromptRole,
     pub content: Content,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2787,6 +2938,9 @@ pub struct TaskObject {
     /// Suggested polling interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Backwards-compatible alias for TaskObject
@@ -2799,6 +2953,9 @@ pub type TaskInfo = TaskObject;
 pub struct CreateTaskResult {
     /// The created task object
     pub task: TaskObject,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Parameters for listing tasks
@@ -2874,6 +3031,9 @@ pub struct TaskStatusParams {
     /// Suggested polling interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 /// Backwards-compatible alias
@@ -3368,6 +3528,9 @@ pub struct ElicitResult {
     /// Submitted form data (only present when action is Accept and mode was Form)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content: Option<std::collections::HashMap<String, ElicitFieldValue>>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 impl ElicitResult {
@@ -3376,6 +3539,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Accept,
             content: Some(content),
+            meta: None,
         }
     }
 
@@ -3384,6 +3548,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Decline,
             content: None,
+            meta: None,
         }
     }
 
@@ -3392,6 +3557,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Cancel,
             content: None,
+            meta: None,
         }
     }
 }
@@ -3413,6 +3579,9 @@ pub enum ElicitFieldValue {
 pub struct ElicitationCompleteParams {
     /// The ID of the elicitation that completed
     pub elicitation_id: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
 }
 
 // =============================================================================
@@ -3547,7 +3716,9 @@ mod tests {
 
         // Verify it creates a Text variant with no annotations
         match &content {
-            Content::Text { text, annotations } => {
+            Content::Text {
+                text, annotations, ..
+            } => {
                 assert_eq!(text, "hello world");
                 assert!(annotations.is_none());
             }
@@ -3698,6 +3869,7 @@ mod tests {
     fn test_elicitation_complete_params() {
         let params = ElicitationCompleteParams {
             elicitation_id: "xyz789".to_string(),
+            meta: None,
         };
 
         let json = serde_json::to_value(&params).unwrap();
@@ -3752,6 +3924,7 @@ mod tests {
                 Root::new("file:///project1"),
                 Root::with_name("file:///project2", "Project 2"),
             ],
+            meta: None,
         };
 
         let json = serde_json::to_value(&result).unwrap();
@@ -3849,6 +4022,7 @@ mod tests {
             reference: CompletionReference::prompt("sql-prompt"),
             argument: CompletionArgument::new("query", "SEL"),
             context: None,
+            meta: None,
         };
 
         let json = serde_json::to_value(&params).unwrap();
@@ -3953,6 +4127,7 @@ mod tests {
         let content = SamplingContent::Text {
             text: "Hello".to_string(),
             annotations: None,
+            meta: None,
         };
         let json = serde_json::to_value(&content).unwrap();
         assert_eq!(json["type"], "text");
@@ -3965,6 +4140,7 @@ mod tests {
             data: "base64data".to_string(),
             mime_type: "image/png".to_string(),
             annotations: None,
+            meta: None,
         };
         let json = serde_json::to_value(&content).unwrap();
         assert_eq!(json["type"], "image");
@@ -4054,6 +4230,7 @@ mod tests {
             size: None,
             icons: None,
             annotations: None,
+            meta: None,
         };
         let json = serde_json::to_value(&content).unwrap();
         assert_eq!(json["type"], "resource_link");
@@ -4159,6 +4336,7 @@ mod tests {
             id: "tool_123".to_string(),
             name: "get_weather".to_string(),
             input: serde_json::json!({"location": "San Francisco"}),
+            meta: None,
         };
         let json = serde_json::to_value(&content).unwrap();
         assert_eq!(json["type"], "tool_use");
@@ -4174,9 +4352,11 @@ mod tests {
             content: vec![SamplingContent::Text {
                 text: "72F, sunny".to_string(),
                 annotations: None,
+                meta: None,
             }],
             structured_content: None,
             is_error: None,
+            meta: None,
         };
         let json = serde_json::to_value(&content).unwrap();
         assert_eq!(json["type"], "tool_result");
@@ -4239,15 +4419,18 @@ mod tests {
                 SamplingContent::Text {
                     text: "First".to_string(),
                     annotations: None,
+                    meta: None,
                 },
                 SamplingContent::Text {
                     text: "Second".to_string(),
                     annotations: None,
+                    meta: None,
                 },
             ]),
             model: "test".to_string(),
             role: ContentRole::Assistant,
             stop_reason: None,
+            meta: None,
         };
         let items = result.content_items();
         assert_eq!(items.len(), 2);
@@ -4258,6 +4441,7 @@ mod tests {
         let text_content = SamplingContent::Text {
             text: "Hello".to_string(),
             annotations: None,
+            meta: None,
         };
         assert_eq!(text_content.as_text(), Some("Hello"));
 
@@ -4265,6 +4449,7 @@ mod tests {
             data: "base64data".to_string(),
             mime_type: "image/png".to_string(),
             annotations: None,
+            meta: None,
         };
         assert_eq!(image_content.as_text(), None);
 
@@ -4272,6 +4457,7 @@ mod tests {
             data: "base64audio".to_string(),
             mime_type: "audio/wav".to_string(),
             annotations: None,
+            meta: None,
         };
         assert_eq!(audio_content.as_text(), None);
     }
@@ -4282,10 +4468,12 @@ mod tests {
             content: SamplingContentOrArray::Single(SamplingContent::Text {
                 text: "Hello, world!".to_string(),
                 annotations: None,
+                meta: None,
             }),
             model: "test".to_string(),
             role: ContentRole::Assistant,
             stop_reason: None,
+            meta: None,
         };
         assert_eq!(result.first_text(), Some("Hello, world!"));
     }
@@ -4297,15 +4485,18 @@ mod tests {
                 SamplingContent::Text {
                     text: "First".to_string(),
                     annotations: None,
+                    meta: None,
                 },
                 SamplingContent::Text {
                     text: "Second".to_string(),
                     annotations: None,
+                    meta: None,
                 },
             ]),
             model: "test".to_string(),
             role: ContentRole::Assistant,
             stop_reason: None,
+            meta: None,
         };
         assert_eq!(result.first_text(), Some("First"));
     }
@@ -4318,15 +4509,18 @@ mod tests {
                     data: "base64data".to_string(),
                     mime_type: "image/png".to_string(),
                     annotations: None,
+                    meta: None,
                 },
                 SamplingContent::Text {
                     text: "After image".to_string(),
                     annotations: None,
+                    meta: None,
                 },
             ]),
             model: "test".to_string(),
             role: ContentRole::Assistant,
             stop_reason: None,
+            meta: None,
         };
         assert_eq!(result.first_text(), Some("After image"));
     }
@@ -4338,10 +4532,12 @@ mod tests {
                 data: "base64data".to_string(),
                 mime_type: "image/png".to_string(),
                 annotations: None,
+                meta: None,
             }),
             model: "test".to_string(),
             role: ContentRole::Assistant,
             stop_reason: None,
+            meta: None,
         };
         assert_eq!(result.first_text(), None);
     }
@@ -4404,6 +4600,7 @@ mod tests {
                 ..Default::default()
             }),
             execution: None,
+            meta: None,
         };
 
         assert!(def.is_read_only());
@@ -4423,6 +4620,7 @@ mod tests {
             icons: None,
             annotations: None,
             execution: None,
+            meta: None,
         };
 
         // MCP spec defaults when no annotations present
@@ -4574,6 +4772,7 @@ mod tests {
         let result = GetPromptResult {
             description: None,
             messages: vec![],
+            meta: None,
         };
         assert!(result.as_json().is_none());
     }

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -28,7 +28,9 @@
 //!                 mime_type: Some("text/plain".to_string()),
 //!                 text: Some("content".to_string()),
 //!                 blob: None,
+//!                 meta: None,
 //!             }],
+//!             meta: None,
 //!         })
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(30)))
@@ -57,7 +59,9 @@
 //!                 mime_type: Some("text/plain".to_string()),
 //!                 text: Some(format!("Contents of {}", path)),
 //!                 blob: None,
+//!                 meta: None,
 //!             }],
+//!             meta: None,
 //!         })
 //!     });
 //! ```
@@ -176,7 +180,9 @@ where
                             mime_type: Some("text/plain".to_string()),
                             text: Some(format!("Error reading resource: {}", err)),
                             blob: None,
+                            meta: None,
                         }],
+                        meta: None,
                     })
                 }
             }
@@ -336,6 +342,7 @@ impl Resource {
             icons: self.icons.clone(),
             size: self.size,
             annotations: self.annotations.clone(),
+            meta: None,
         }
     }
 
@@ -426,7 +433,9 @@ impl Resource {
 ///                 mime_type: Some("application/json".to_string()),
 ///                 text: Some(r#"{"setting": "value"}"#.to_string()),
 ///                 blob: None,
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     })
 ///     .build();
@@ -552,7 +561,9 @@ impl ResourceBuilder {
     ///                     mime_type: Some("text/plain".to_string()),
     ///                     text: Some(entries.join("\n")),
     ///                     blob: None,
+    ///                     meta: None,
     ///                 }],
+    ///                 meta: None,
     ///             })
     ///         }
     ///     })
@@ -620,7 +631,9 @@ impl ResourceBuilder {
                         mime_type,
                         text: Some(content),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -643,7 +656,9 @@ impl ResourceBuilder {
                         mime_type: Some("application/json".to_string()),
                         text: Some(text),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         })
@@ -713,7 +728,9 @@ where
     ///                 mime_type: Some("text/plain".to_string()),
     ///                 text: Some("content".to_string()),
     ///                 blob: None,
+    ///                 meta: None,
     ///             }],
+    ///             meta: None,
     ///         })
     ///     })
     ///     .layer(TimeoutLayer::new(Duration::from_secs(30)))
@@ -1011,7 +1028,9 @@ where
 ///                 mime_type: Self::MIME_TYPE.map(|s| s.to_string()),
 ///                 text: Some(self.config.clone()),
 ///                 blob: None,
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     }
 /// }
@@ -1099,7 +1118,9 @@ pub trait ResourceTemplateHandler: Send + Sync {
 ///                 mime_type: Some("text/plain".to_string()),
 ///                 text: Some(format!("Contents of {}", path)),
 ///                 blob: None,
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     });
 /// ```
@@ -1174,6 +1195,7 @@ impl ResourceTemplate {
             icons: self.icons.clone(),
             annotations: self.annotations.clone(),
             arguments: Vec::new(),
+            meta: None,
         }
     }
 
@@ -1229,7 +1251,9 @@ impl ResourceTemplate {
 ///                 mime_type: Some("application/json".to_string()),
 ///                 text: Some(format!(r#"{{"id": "{}"}}"#, id)),
 ///                 blob: None,
+///                 meta: None,
 ///             }],
+///             meta: None,
 ///         })
 ///     });
 /// ```
@@ -1472,7 +1496,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some("42".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .build();
@@ -1492,7 +1518,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some("content".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .layer(TimeoutLayer::new(Duration::from_secs(30)))
@@ -1515,7 +1543,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some("content".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .layer(TimeoutLayer::new(Duration::from_millis(50)))
@@ -1543,7 +1573,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some("context aware".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .build();
@@ -1563,7 +1595,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some("context with layer".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             })
             .layer(TimeoutLayer::new(Duration::from_secs(30)))
@@ -1593,7 +1627,9 @@ mod tests {
                         mime_type: Self::MIME_TYPE.map(|s| s.to_string()),
                         text: Some("test content".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             }
         }
@@ -1631,7 +1667,12 @@ mod tests {
     #[test]
     fn test_resource_catch_error_clone() {
         let handler = FnHandler {
-            handler: || async { Ok::<_, Error>(ReadResourceResult { contents: vec![] }) },
+            handler: || async {
+                Ok::<_, Error>(ReadResourceResult {
+                    contents: vec![],
+                    meta: None,
+                })
+            },
         };
         let service = ResourceHandlerService::new(handler);
         let catch_error = ResourceCatchError::new(service);
@@ -1641,7 +1682,12 @@ mod tests {
     #[test]
     fn test_resource_catch_error_debug() {
         let handler = FnHandler {
-            handler: || async { Ok::<_, Error>(ReadResourceResult { contents: vec![] }) },
+            handler: || async {
+                Ok::<_, Error>(ReadResourceResult {
+                    contents: vec![],
+                    meta: None,
+                })
+            },
         };
         let service = ResourceHandlerService::new(handler);
         let catch_error = ResourceCatchError::new(service);
@@ -1696,7 +1742,9 @@ mod tests {
                         mime_type: None,
                         text: Some(format!("User {}", vars.get("id").unwrap())),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -1720,7 +1768,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -1743,7 +1793,9 @@ mod tests {
                         mime_type: Some("text/plain".to_string()),
                         text: Some(format!("Contents of {}", path)),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -1771,7 +1823,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -1796,7 +1850,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -1847,7 +1903,9 @@ mod tests {
                         mime_type: None,
                         text: Some("data".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -674,7 +674,9 @@ impl McpRouter {
     ///                 mime_type: Some("text/plain".to_string()),
     ///                 text: Some(format!("Contents of {}", path)),
     ///                 blob: None,
+    ///                 meta: None,
     ///             }],
+    ///             meta: None,
     ///         })
     ///     });
     ///
@@ -1327,12 +1329,14 @@ impl McpRouter {
                         description: self.inner.server_description.clone(),
                         icons: self.inner.server_icons.clone(),
                         website_url: self.inner.server_website_url.clone(),
+                        meta: None,
                     },
                     instructions: if let Some(config) = &self.inner.auto_instructions {
                         Some(self.inner.generate_instructions(config))
                     } else {
                         self.inner.instructions.clone()
                     },
+                    meta: None,
                 }))
             }
 
@@ -1373,6 +1377,7 @@ impl McpRouter {
                 Ok(McpResponse::ListTools(ListToolsResult {
                     tools,
                     next_cursor,
+                    meta: None,
                 }))
             }
 
@@ -1454,7 +1459,10 @@ impl McpRouter {
                         ))
                     })?;
 
-                    Ok(McpResponse::CreateTask(CreateTaskResult { task }))
+                    Ok(McpResponse::CreateTask(CreateTaskResult {
+                        task,
+                        meta: None,
+                    }))
                 } else {
                     // Synchronous request: validate task_support != Required
                     if matches!(tool.task_support, TaskSupportMode::Required) {
@@ -1498,6 +1506,7 @@ impl McpRouter {
                 Ok(McpResponse::ListResources(ListResourcesResult {
                     resources,
                     next_cursor,
+                    meta: None,
                 }))
             }
 
@@ -1520,6 +1529,7 @@ impl McpRouter {
                     ListResourceTemplatesResult {
                         resource_templates,
                         next_cursor,
+                        meta: None,
                     },
                 ))
             }
@@ -1609,6 +1619,7 @@ impl McpRouter {
                 Ok(McpResponse::ListPrompts(ListPromptsResult {
                     prompts,
                     next_cursor,
+                    meta: None,
                 }))
             }
 
@@ -1937,6 +1948,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2323,7 +2335,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -2365,7 +2379,9 @@ mod tests {
                         mime_type: Some("application/json".to_string()),
                         text: Some(format!(r#"{{"id": "{}"}}"#, id)),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -2410,7 +2426,9 @@ mod tests {
                         mime_type: None,
                         text: Some("from template".to_string()),
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -2463,7 +2481,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -2505,7 +2525,9 @@ mod tests {
                         mime_type: None,
                         text: None,
                         blob: None,
+                        meta: None,
                     }],
+                    meta: None,
                 })
             });
 
@@ -2528,6 +2550,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2643,6 +2666,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2678,6 +2702,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3190,6 +3215,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3231,6 +3257,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3261,6 +3288,7 @@ mod tests {
                 reference: CompletionReference::prompt("test-prompt"),
                 argument: CompletionArgument::new("query", "al"),
                 context: None,
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3296,6 +3324,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3326,6 +3355,7 @@ mod tests {
                 reference: CompletionReference::prompt("test-prompt"),
                 argument: CompletionArgument::new("query", "al"),
                 context: None,
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -4165,6 +4195,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -4596,6 +4627,7 @@ mod tests {
                     version: "1.0".to_string(),
                     ..Default::default()
                 },
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -5257,6 +5289,7 @@ mod tests {
                         version: "1.0".to_string(),
                         ..Default::default()
                     },
+                    meta: None,
                 }),
                 extensions: Extensions::new(),
             };

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -514,6 +514,7 @@ impl Tool {
             icons: self.icons.clone(),
             annotations: self.annotations.clone(),
             execution,
+            meta: None,
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -90,7 +90,9 @@ fn create_router_with_resources_and_prompts() -> McpRouter {
                     mime_type: Some("text/plain".to_string()),
                     text: Some("42".to_string()),
                     blob: None,
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build();
@@ -108,8 +110,11 @@ fn create_router_with_resources_and_prompts() -> McpRouter {
                     content: tower_mcp::protocol::Content::Text {
                         text: format!("Please greet {} warmly.", name),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build();
@@ -134,8 +139,11 @@ fn create_router_with_resources_and_prompts() -> McpRouter {
                             lang, lang, code
                         ),
                         annotations: None,
+                        meta: None,
                     },
+                    meta: None,
                 }],
+                meta: None,
             })
         })
         .build();
@@ -1274,6 +1282,7 @@ mod test_client_tests {
         let text_content = Content::Text {
             text: "hello".to_string(),
             annotations: None,
+            meta: None,
         };
         assert_eq!(text_content.as_text(), Some("hello"));
 
@@ -1281,6 +1290,7 @@ mod test_client_tests {
             data: "abc".to_string(),
             mime_type: "image/png".to_string(),
             annotations: None,
+            meta: None,
         };
         assert_eq!(image_content.as_text(), None);
     }


### PR DESCRIPTION
## Summary

Closes #419

- Adds optional `_meta: Option<serde_json::Value>` field to all protocol types per MCP spec 2025-11-25
- Field serializes as `_meta` with `#[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]`
- Fully backward compatible: `serde(default)` means existing JSON without `_meta` deserializes fine

### Types updated (30+ structs, 10 enum variants)

**Structs:** `LoggingMessageParams`, `CancelledParams`, `ProgressParams`, `Root`, `ListRootsResult`, `CompleteParams`, `CompleteResult`, `SamplingMessage`, `CreateMessageParams`, `CreateMessageResult`, `Implementation`, `InitializeResult`, `InitializeParams`, `ListToolsResult`, `ToolDefinition`, `ResourceContent`, `ListResourcesResult`, `ResourceDefinition`, `ReadResourceResult`, `ListResourceTemplatesResult`, `ResourceTemplateDefinition`, `ListPromptsResult`, `PromptDefinition`, `GetPromptResult`, `PromptMessage`, `TaskObject`, `CreateTaskResult`, `TaskStatusParams`, `ElicitResult`, `ElicitationCompleteParams`

**Enum variants:** `Content` (Text, Image, Audio, Resource, ResourceLink), `SamplingContent` (Text, Image, Audio, ToolUse, ToolResult)

### Files changed (22)
- `src/protocol.rs` — Struct/enum definitions + constructors + helper methods + tests
- `src/router.rs`, `src/prompt.rs`, `src/resource.rs`, `src/tool.rs` — Struct literal constructions
- `src/client.rs`, `src/context.rs`, `src/async_task.rs` — Struct literal constructions
- `tests/integration.rs` — Test struct literals
- All workspace examples (conformance-server, crates-mcp, codegen-mcp, markdownlint-mcp, http_server)

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo test --all-features` (128 passed, 0 failed)