### PR TITLE
feat: add extensions field to capabilities and default to MultiSelectEnumSchema (#436, #441)

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -529,6 +529,9 @@ pub struct ClientCapabilities {
     /// Experimental, non-standard capabilities
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
+    /// Declared extension support (SEP-1724/SEP-2133)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Client capability for elicitation (requesting user input)
@@ -1433,6 +1436,9 @@ pub struct ServerCapabilities {
     /// Experimental, non-standard capabilities
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
+    /// Declared extension support (SEP-1724/SEP-2133)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Logging capability declaration
@@ -3497,6 +3503,9 @@ pub struct MultiSelectEnumSchema {
     pub items: MultiSelectEnumItems,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unique_items: Option<bool>,
+    /// Default value for this field
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default: Option<Vec<String>>,
 }
 
 /// Items definition for multi-select enum
@@ -3841,6 +3850,7 @@ mod tests {
             }),
             tasks: None,
             experimental: None,
+            extensions: None,
         };
 
         let json = serde_json::to_value(&caps).unwrap();
@@ -3949,6 +3959,7 @@ mod tests {
             elicitation: None,
             tasks: None,
             experimental: None,
+            extensions: None,
         };
 
         let json = serde_json::to_value(&caps).unwrap();

--- a/src/router.rs
+++ b/src/router.rs
@@ -1279,6 +1279,7 @@ impl McpRouter {
                 None
             },
             experimental: None,
+            extensions: None,
         }
     }
 
@@ -1942,6 +1943,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2544,6 +2546,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2660,6 +2663,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -2696,6 +2700,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -3209,6 +3214,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),
@@ -4621,6 +4627,7 @@ mod tests {
                     elicitation: None,
                     tasks: None,
                     experimental: None,
+                    extensions: None,
                 },
                 client_info: Implementation {
                     name: "test".to_string(),


### PR DESCRIPTION
## Summary

- **SEP-1724/SEP-2133 extensions field** (#436) — Add `extensions: Option<HashMap<String, Value>>` to both `ServerCapabilities` and `ClientCapabilities`. This enables extension capability negotiation per the MCP extensions framework (vendor-prefixed extension IDs like `io.modelcontextprotocol/oauth-client-credentials`). Matches rmcp SDK PR #643.
- **SEP-1034 elicitation defaults** (#441) — Add missing `default: Option<Vec<String>>` to `MultiSelectEnumSchema`. The other 5 schema types (`StringSchema`, `IntegerSchema`, `NumberSchema`, `BooleanSchema`, `SingleSelectEnumSchema`) already had `default` fields.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --workspace --all-features -- -D warnings` — clean
- [x] `cargo test --all-features` — 656 tests pass

Closes #436
Closes #441