### PR TITLE
feat: add _meta field to all request params types (SEP-1319)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -234,8 +234,14 @@ impl<T: ClientTransport> McpClient<T> {
     /// List available tools
     pub async fn list_tools(&mut self) -> Result<ListToolsResult> {
         self.ensure_initialized()?;
-        self.request("tools/list", &ListToolsParams { cursor: None })
-            .await
+        self.request(
+            "tools/list",
+            &ListToolsParams {
+                cursor: None,
+                meta: None,
+            },
+        )
+        .await
     }
 
     /// Call a tool
@@ -257,8 +263,14 @@ impl<T: ClientTransport> McpClient<T> {
     /// List available resources
     pub async fn list_resources(&mut self) -> Result<ListResourcesResult> {
         self.ensure_initialized()?;
-        self.request("resources/list", &ListResourcesParams { cursor: None })
-            .await
+        self.request(
+            "resources/list",
+            &ListResourcesParams {
+                cursor: None,
+                meta: None,
+            },
+        )
+        .await
     }
 
     /// Read a resource
@@ -266,6 +278,7 @@ impl<T: ClientTransport> McpClient<T> {
         self.ensure_initialized()?;
         let params = ReadResourceParams {
             uri: uri.to_string(),
+            meta: None,
         };
         self.request("resources/read", &params).await
     }
@@ -273,8 +286,14 @@ impl<T: ClientTransport> McpClient<T> {
     /// List available prompts
     pub async fn list_prompts(&mut self) -> Result<ListPromptsResult> {
         self.ensure_initialized()?;
-        self.request("prompts/list", &ListPromptsParams { cursor: None })
-            .await
+        self.request(
+            "prompts/list",
+            &ListPromptsParams {
+                cursor: None,
+                meta: None,
+            },
+        )
+        .await
     }
 
     /// Get a prompt
@@ -287,6 +306,7 @@ impl<T: ClientTransport> McpClient<T> {
         let params = GetPromptParams {
             name: name.to_string(),
             arguments: arguments.unwrap_or_default(),
+            meta: None,
         };
         self.request("prompts/get", &params).await
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -299,6 +299,9 @@ impl LoggingMessageParams {
 pub struct SetLogLevelParams {
     /// Minimum log level to receive
     pub level: LogLevel,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Request ID - can be string or number per JSON-RPC spec
@@ -1521,6 +1524,9 @@ pub struct PromptsCapability {
 pub struct ListToolsParams {
     #[serde(default)]
     pub cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2218,6 +2224,9 @@ pub struct ResourceContent {
 pub struct ListResourcesParams {
     #[serde(default)]
     pub cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2260,6 +2269,9 @@ pub struct ResourceDefinition {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadResourceParams {
     pub uri: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2481,11 +2493,17 @@ impl ReadResourceResult {
 #[derive(Debug, Clone, Deserialize)]
 pub struct SubscribeResourceParams {
     pub uri: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct UnsubscribeResourceParams {
     pub uri: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Parameters for listing resource templates
@@ -2494,6 +2512,9 @@ pub struct ListResourceTemplatesParams {
     /// Pagination cursor from previous response
     #[serde(default)]
     pub cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Result of listing resource templates
@@ -2563,6 +2584,9 @@ pub struct ResourceTemplateDefinition {
 pub struct ListPromptsParams {
     #[serde(default)]
     pub cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2608,6 +2632,9 @@ pub struct GetPromptParams {
     pub name: String,
     #[serde(default)]
     pub arguments: std::collections::HashMap<String, String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2974,6 +3001,9 @@ pub struct ListTasksParams {
     /// Pagination cursor
     #[serde(default)]
     pub cursor: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Result of listing tasks
@@ -2993,6 +3023,9 @@ pub struct ListTasksResult {
 pub struct GetTaskInfoParams {
     /// Task ID to query
     pub task_id: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Parameters for getting task result
@@ -3001,6 +3034,9 @@ pub struct GetTaskInfoParams {
 pub struct GetTaskResultParams {
     /// Task ID to get result for
     pub task_id: String,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Parameters for cancelling a task
@@ -3012,6 +3048,9 @@ pub struct CancelTaskParams {
     /// Optional reason for cancellation
     #[serde(default)]
     pub reason: Option<String>,
+    /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
 }
 
 /// Notification params when task status changes

--- a/src/router.rs
+++ b/src/router.rs
@@ -2397,6 +2397,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "db://users/123".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2451,6 +2452,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "file:///README.md".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2499,6 +2501,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "db://posts/123".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2821,6 +2824,7 @@ mod tests {
             id: RequestId::Number(2),
             inner: McpRequest::GetTaskResult(GetTaskResultParams {
                 task_id: task_id.clone(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2880,6 +2884,7 @@ mod tests {
             inner: McpRequest::CancelTask(CancelTaskParams {
                 task_id: task_id.clone(),
                 reason: Some("Test cancellation".to_string()),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2930,6 +2935,7 @@ mod tests {
             id: RequestId::Number(2),
             inner: McpRequest::GetTaskInfo(GetTaskInfoParams {
                 task_id: task_id.clone(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -2987,6 +2993,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::GetTaskInfo(GetTaskInfoParams {
                 task_id: "task-999".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3021,6 +3028,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::SubscribeResource(SubscribeResourceParams {
                 uri: "file:///test.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3052,6 +3060,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::SubscribeResource(SubscribeResourceParams {
                 uri: "file:///test.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3063,6 +3072,7 @@ mod tests {
             id: RequestId::Number(2),
             inner: McpRequest::UnsubscribeResource(UnsubscribeResourceParams {
                 uri: "file:///test.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3087,6 +3097,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::SubscribeResource(SubscribeResourceParams {
                 uri: "file:///nonexistent.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3604,6 +3615,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "file:///secret.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3639,6 +3651,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "file:///public.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3675,6 +3688,7 @@ mod tests {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
                 uri: "file:///secret.txt".to_string(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3754,6 +3768,7 @@ mod tests {
             inner: McpRequest::GetPrompt(GetPromptParams {
                 name: "system_debug".to_string(),
                 arguments: HashMap::new(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3791,6 +3806,7 @@ mod tests {
             inner: McpRequest::GetPrompt(GetPromptParams {
                 name: "greeting".to_string(),
                 arguments: HashMap::new(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -3828,6 +3844,7 @@ mod tests {
             inner: McpRequest::GetPrompt(GetPromptParams {
                 name: "system_debug".to_string(),
                 arguments: HashMap::new(),
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -4742,6 +4759,7 @@ mod tests {
             id: RequestId::Number(99),
             inner: McpRequest::SetLoggingLevel(SetLogLevelParams {
                 level: LogLevel::Warning,
+                meta: None,
             }),
             extensions: crate::context::Extensions::new(),
         };
@@ -4865,7 +4883,10 @@ mod tests {
         // First page
         let req = RouterRequest {
             id: RequestId::Number(1),
-            inner: McpRequest::ListTools(ListToolsParams { cursor: None }),
+            inner: McpRequest::ListTools(ListToolsParams {
+                cursor: None,
+                meta: None,
+            }),
             extensions: Extensions::new(),
         };
         let resp = router.ready().await.unwrap().call(req).await.unwrap();
@@ -4883,6 +4904,7 @@ mod tests {
             id: RequestId::Number(2),
             inner: McpRequest::ListTools(ListToolsParams {
                 cursor: next_cursor,
+                meta: None,
             }),
             extensions: Extensions::new(),
         };
@@ -4916,7 +4938,10 @@ mod tests {
 
         let req = RouterRequest {
             id: RequestId::Number(1),
-            inner: McpRequest::ListTools(ListToolsParams { cursor: None }),
+            inner: McpRequest::ListTools(ListToolsParams {
+                cursor: None,
+                meta: None,
+            }),
             extensions: Extensions::new(),
         };
         let resp = router.ready().await.unwrap().call(req).await.unwrap();

--- a/src/tracing_layer.rs
+++ b/src/tracing_layer.rs
@@ -326,6 +326,7 @@ mod tests {
         // Test resource read
         let req = McpRequest::ReadResource(ReadResourceParams {
             uri: "file:///test.txt".to_string(),
+            meta: None,
         });
         let (name, target) = extract_operation_details(&req);
         assert_eq!(name, Some("resource"));
@@ -335,6 +336,7 @@ mod tests {
         let req = McpRequest::GetPrompt(GetPromptParams {
             name: "my_prompt".to_string(),
             arguments: HashMap::new(),
+            meta: None,
         });
         let (name, target) = extract_operation_details(&req);
         assert_eq!(name, Some("prompt"));


### PR DESCRIPTION
## Summary

- Adds `_meta: Option<RequestMeta>` to the 13 request params structs that were missing it, completing the decoupled request payloads alignment per SEP-1319
- PR #426 previously added `_meta` to result/response/definition types — this covers the **request side**
- All params can now carry a `progress_token` per the MCP spec

### Params updated:
`SetLogLevelParams`, `ListToolsParams`, `ListResourcesParams`, `ListResourceTemplatesParams`, `ReadResourceParams`, `SubscribeResourceParams`, `UnsubscribeResourceParams`, `ListPromptsParams`, `GetPromptParams`, `ListTasksParams`, `GetTaskInfoParams`, `GetTaskResultParams`, `CancelTaskParams`

### Params already correct (unchanged):
- `CallToolParams`, `ListRootsParams` — already use `Option<RequestMeta>`
- `InitializeParams`, `CompleteParams`, `CreateMessageParams` — use `Option<Value>` to preserve unknown metadata fields

Closes #438

## Test plan
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] All 656 tests pass (461 unit + 62 integration + 5 JWKS + 128 doctests)