### PR TITLE
feat(notes-mcp): add CRUD tools, fix search bugs, add resource and prompt

### DIFF
--- a/examples/notes-mcp/src/main.rs
+++ b/examples/notes-mcp/src/main.rs
@@ -75,14 +75,20 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // Build tools
     let search_customers = tools::search_customers::build(state.clone());
     let search_notes = tools::search_notes::build(state.clone());
+    let list_customers = tools::list_customers::build(state.clone());
     let add_note = tools::add_note::build(state.clone());
     let get_customer = tools::get_customer::build(state.clone());
+    let update_customer = tools::update_customer::build(state.clone());
+    let update_note = tools::update_note::build(state.clone());
+    let delete_note = tools::delete_note::build(state.clone());
 
     // Build resources
     let customer_template = resources::customer::build(state.clone());
+    let recent_notes = resources::recent_notes::build(state.clone());
 
     // Build prompts
     let prep_meeting = prompts::prep_meeting::build();
+    let account_review = prompts::account_review::build();
 
     // Assemble router
     let router = McpRouter::new()
@@ -92,18 +98,30 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
              Available tools:\n\
              - search_customers: Find customers by name, company, or role\n\
              - search_notes: Search note content with optional filters\n\
+             - list_customers: List all customers with note counts\n\
              - get_customer: Get a customer's full profile and notes\n\
-             - add_note: Create a new note for a customer\n\n\
+             - add_note: Create a new note for a customer\n\
+             - update_customer: Update customer profile fields\n\
+             - update_note: Update note content or metadata\n\
+             - delete_note: Delete a note by ID\n\n\
              Resources:\n\
-             - notes://customers/{id}: Customer profile with notes\n\n\
-             Use the prep_meeting prompt for guided meeting preparation.",
+             - notes://customers/{id}: Customer profile with notes\n\
+             - notes://recent: 10 most recent notes across all customers\n\n\
+             Use the prep_meeting prompt for guided meeting preparation.\n\
+             Use the account_review prompt for tier-level portfolio analysis.",
         )
         .tool(search_customers)
         .tool(search_notes)
+        .tool(list_customers)
         .tool(add_note)
         .tool(get_customer)
+        .tool(update_customer)
+        .tool(update_note)
+        .tool(delete_note)
         .resource_template(customer_template)
-        .prompt(prep_meeting);
+        .resource(recent_notes)
+        .prompt(prep_meeting)
+        .prompt(account_review);
 
     match args.transport {
         Transport::Stdio => {

--- a/examples/notes-mcp/src/prompts/account_review.rs
+++ b/examples/notes-mcp/src/prompts/account_review.rs
@@ -1,0 +1,58 @@
+//! Account review prompt — tier-level portfolio analysis
+
+use std::collections::HashMap;
+
+use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
+
+pub fn build() -> Prompt {
+    PromptBuilder::new("account_review")
+        .description("Review all accounts in a specific tier with themes and action items")
+        .required_arg("tier", "Account tier to review: enterprise, startup, or smb")
+        .optional_arg("focus", "Specific area to focus on (e.g. renewals, onboarding, risk)")
+        .handler(|args: HashMap<String, String>| async move {
+            let tier = args
+                .get("tier")
+                .map(|s| s.as_str())
+                .unwrap_or("enterprise");
+            let focus = args.get("focus");
+
+            let mut prompt = format!(
+                "Please perform a portfolio-level review of all **{tier}** accounts.\n\n\
+                 Follow these steps using the available tools:\n\n\
+                 1. **List all customers**: Use `list_customers` to see every customer and their note counts\n\
+                 2. **Filter by tier**: Identify the {tier}-tier customers from the list\n\
+                 3. **Deep dive each account**: For each {tier} customer, use `get_customer` to pull their full profile and notes\n\
+                 4. **Search for themes**: Use `search_notes` to look for common themes across {tier} accounts \
+                    (e.g. renewals, escalations, feature requests)\n\
+                 5. **Produce a portfolio summary** that includes:\n\
+                    - Overview of the {tier} portfolio (number of accounts, key contacts)\n\
+                    - Account-by-account status summary\n\
+                    - Common themes and patterns across accounts\n\
+                    - Risk flags (unhappy customers, stalled deals, overdue follow-ups)\n\
+                    - Opportunities (upsell candidates, expansion signals, advocacy potential)\n\
+                    - Prioritized action items with specific next steps"
+            );
+
+            if let Some(topic) = focus {
+                prompt.push_str(&format!(
+                    "\n\n**Focus area:** Pay special attention to \"{topic}\" \
+                     when reviewing notes and summarizing themes."
+                ));
+            }
+
+            Ok(GetPromptResult {
+                description: Some(format!("Account review for {tier} tier")),
+                messages: vec![PromptMessage {
+                    role: PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: prompt,
+                        annotations: None,
+                        meta: None,
+                    },
+                    meta: None,
+                }],
+                meta: None,
+            })
+        })
+        .build()
+}

--- a/examples/notes-mcp/src/prompts/mod.rs
+++ b/examples/notes-mcp/src/prompts/mod.rs
@@ -1,1 +1,2 @@
+pub mod account_review;
 pub mod prep_meeting;

--- a/examples/notes-mcp/src/resources/customer.rs
+++ b/examples/notes-mcp/src/resources/customer.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
 
-use crate::state::{AppState, Customer, Note, parse_ft_search};
+use crate::state::{AppState, Customer, Note, escape_tag, parse_ft_search};
 
 pub fn build(state: Arc<AppState>) -> ResourceTemplate {
     ResourceTemplateBuilder::new("notes://customers/{id}")
@@ -42,7 +42,7 @@ pub fn build(state: Arc<AppState>) -> ResourceTemplate {
                 // Get their notes
                 let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
                     .arg("idx:notes")
-                    .arg(format!("@customerId:{{{id}}}"))
+                    .arg(format!("@customerId:{{{}}}", escape_tag(&id)))
                     .arg("RETURN")
                     .arg("1")
                     .arg("$")

--- a/examples/notes-mcp/src/resources/mod.rs
+++ b/examples/notes-mcp/src/resources/mod.rs
@@ -1,1 +1,2 @@
 pub mod customer;
+pub mod recent_notes;

--- a/examples/notes-mcp/src/resources/recent_notes.rs
+++ b/examples/notes-mcp/src/resources/recent_notes.rs
@@ -1,0 +1,70 @@
+//! Recent notes resource — 10 most recent notes across all customers
+
+use std::sync::Arc;
+
+use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+use tower_mcp::resource::{Resource, ResourceBuilder};
+
+use crate::state::{AppState, Note, parse_ft_search};
+
+pub fn build(state: Arc<AppState>) -> Resource {
+    ResourceBuilder::new("notes://recent")
+        .name("Recent Notes")
+        .description("The 10 most recent notes across all customers")
+        .mime_type("text/markdown")
+        .handler(move || {
+            let state = state.clone();
+            async move {
+                let mut conn = state.conn();
+
+                let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
+                    .arg("idx:notes")
+                    .arg("*")
+                    .arg("RETURN")
+                    .arg("1")
+                    .arg("$")
+                    .arg("SORTBY")
+                    .arg("createdAt")
+                    .arg("DESC")
+                    .arg("LIMIT")
+                    .arg("0")
+                    .arg("10")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
+
+                let (total, rows) = parse_ft_search(values)
+                    .map_err(|e| tower_mcp::Error::tool(format!("Parse error: {e}")))?;
+
+                let mut content = format!(
+                    "# Recent Notes\n\n{total} total note(s) in system. Showing most recent:\n\n"
+                );
+
+                for (_key, json_str) in &rows {
+                    let n: Note = serde_json::from_str(json_str)
+                        .map_err(|e| tower_mcp::Error::tool(format!("JSON parse error: {e}")))?;
+                    content.push_str(&format!(
+                        "### {} — {} ({})\n**Customer:** {} | **Tags:** {}\n\n{}\n\n---\n\n",
+                        n.id,
+                        n.note_type,
+                        n.created_at,
+                        n.customer_id,
+                        n.tags.join(", "),
+                        n.content
+                    ));
+                }
+
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri: "notes://recent".to_string(),
+                        mime_type: Some("text/markdown".to_string()),
+                        text: Some(content),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                })
+            }
+        })
+        .build()
+}

--- a/examples/notes-mcp/src/tools/delete_note.rs
+++ b/examples/notes-mcp/src/tools/delete_note.rs
@@ -1,0 +1,55 @@
+//! Delete note tool — DEL note:{id}
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteNoteInput {
+    /// Note ID to delete (UUID)
+    id: String,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("delete_note")
+        .description("Delete a note by its ID. This action is permanent.")
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<DeleteNoteInput>| async move {
+                let mut conn = state.conn();
+
+                let key = format!("note:{}", input.id);
+
+                // Verify note exists
+                let exists: Option<String> = redis::cmd("JSON.GET")
+                    .arg(&key)
+                    .arg("$.id")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+
+                if exists.is_none() {
+                    return Err(tower_mcp::Error::tool(format!(
+                        "Note '{}' not found",
+                        input.id
+                    )));
+                }
+
+                redis::cmd("DEL")
+                    .arg(&key)
+                    .query_async::<()>(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+
+                Ok(CallToolResult::text(format!("Deleted note {}.", input.id)))
+            },
+        )
+        .build()
+}

--- a/examples/notes-mcp/src/tools/get_customer.rs
+++ b/examples/notes-mcp/src/tools/get_customer.rs
@@ -9,7 +9,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::{AppState, Customer, Note, parse_ft_search};
+use crate::state::{AppState, Customer, Note, escape_tag, parse_ft_search};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct GetCustomerInput {
@@ -51,7 +51,7 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 // Search for their notes
                 let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
                     .arg("idx:notes")
-                    .arg(format!("@customerId:{{{}}}", input.id))
+                    .arg(format!("@customerId:{{{}}}", escape_tag(&input.id)))
                     .arg("RETURN")
                     .arg("1")
                     .arg("$")

--- a/examples/notes-mcp/src/tools/list_customers.rs
+++ b/examples/notes-mcp/src/tools/list_customers.rs
@@ -1,0 +1,75 @@
+//! List all customers tool — FT.SEARCH idx:customers *
+
+use std::sync::Arc;
+
+use tower_mcp::{CallToolResult, Tool, ToolBuilder, extract::State};
+
+use crate::state::{AppState, Customer, parse_ft_search};
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("list_customers")
+        .description(
+            "List all customers with their note counts. \
+             No parameters required — returns every customer in the system.",
+        )
+        .read_only()
+        .idempotent()
+        .extractor_handler(state, |State(state): State<Arc<AppState>>| async move {
+            let mut conn = state.conn();
+
+            // Get all customers
+            let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
+                .arg("idx:customers")
+                .arg("*")
+                .arg("RETURN")
+                .arg("1")
+                .arg("$")
+                .arg("LIMIT")
+                .arg("0")
+                .arg("100")
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
+
+            let (total, rows) = parse_ft_search(values)
+                .map_err(|e| tower_mcp::Error::tool(format!("Parse error: {e}")))?;
+
+            if rows.is_empty() {
+                return Ok(CallToolResult::text("No customers found."));
+            }
+
+            let mut output = format!("{total} customer(s):\n\n");
+
+            for (_key, json_str) in &rows {
+                let c: Customer = serde_json::from_str(json_str)
+                    .map_err(|e| tower_mcp::Error::tool(format!("JSON parse error: {e}")))?;
+
+                // Get note count for this customer
+                let note_values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
+                    .arg("idx:notes")
+                    .arg(format!(
+                        "@customerId:{{{}}}",
+                        crate::state::escape_tag(&c.id)
+                    ))
+                    .arg("LIMIT")
+                    .arg("0")
+                    .arg("0")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
+
+                let note_count = match note_values.first() {
+                    Some(redis::Value::Int(n)) => *n as usize,
+                    _ => 0,
+                };
+
+                output.push_str(&format!(
+                    "- **{}** ({}) — {} at {}, tier: {} — {} note(s)\n",
+                    c.name, c.id, c.role, c.company, c.tier, note_count
+                ));
+            }
+
+            Ok(CallToolResult::text(output))
+        })
+        .build()
+}

--- a/examples/notes-mcp/src/tools/mod.rs
+++ b/examples/notes-mcp/src/tools/mod.rs
@@ -1,4 +1,8 @@
 pub mod add_note;
+pub mod delete_note;
 pub mod get_customer;
+pub mod list_customers;
 pub mod search_customers;
 pub mod search_notes;
+pub mod update_customer;
+pub mod update_note;

--- a/examples/notes-mcp/src/tools/search_customers.rs
+++ b/examples/notes-mcp/src/tools/search_customers.rs
@@ -9,7 +9,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::{AppState, Customer, parse_ft_search};
+use crate::state::{AppState, Customer, escape_tag, or_join_query, parse_ft_search};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchCustomersInput {
@@ -38,9 +38,12 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 let text_part = if input.query == "*" {
                     None
                 } else {
-                    Some(format!("({})", input.query))
+                    Some(or_join_query(&input.query))
                 };
-                let tier_part = input.tier.as_ref().map(|t| format!("@tier:{{{t}}}"));
+                let tier_part = input
+                    .tier
+                    .as_ref()
+                    .map(|t| format!("@tier:{{{}}}", escape_tag(t)));
 
                 let query = match (text_part, tier_part) {
                     (Some(t), Some(f)) => format!("{t} {f}"),

--- a/examples/notes-mcp/src/tools/search_notes.rs
+++ b/examples/notes-mcp/src/tools/search_notes.rs
@@ -9,7 +9,7 @@ use tower_mcp::{
     extract::{Json, State},
 };
 
-use crate::state::{AppState, Note, parse_ft_search};
+use crate::state::{AppState, Note, escape_tag, or_join_query, parse_ft_search};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SearchNotesInput {
@@ -43,16 +43,16 @@ pub fn build(state: Arc<AppState>) -> Tool {
                 let mut parts: Vec<String> = Vec::new();
 
                 if input.query != "*" {
-                    parts.push(format!("({})", input.query));
+                    parts.push(or_join_query(&input.query));
                 }
                 if let Some(ref cid) = input.customer_id {
-                    parts.push(format!("@customerId:{{{cid}}}"));
+                    parts.push(format!("@customerId:{{{}}}", escape_tag(cid)));
                 }
                 if let Some(ref nt) = input.note_type {
-                    parts.push(format!("@noteType:{{{nt}}}"));
+                    parts.push(format!("@noteType:{{{}}}", escape_tag(nt)));
                 }
                 if let Some(ref tag) = input.tag {
-                    parts.push(format!("@tags:{{{tag}}}"));
+                    parts.push(format!("@tags:{{{}}}", escape_tag(tag)));
                 }
 
                 let query = if parts.is_empty() {

--- a/examples/notes-mcp/src/tools/update_customer.rs
+++ b/examples/notes-mcp/src/tools/update_customer.rs
@@ -1,0 +1,104 @@
+//! Update customer tool — JSON.SET per field
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateCustomerInput {
+    /// Customer ID (e.g. "c1")
+    id: String,
+    /// New name for the customer
+    #[serde(default)]
+    name: Option<String>,
+    /// New company name
+    #[serde(default)]
+    company: Option<String>,
+    /// New email address
+    #[serde(default)]
+    email: Option<String>,
+    /// New role/title
+    #[serde(default)]
+    role: Option<String>,
+    /// New account tier (enterprise, startup, smb)
+    #[serde(default)]
+    tier: Option<String>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_customer")
+        .description(
+            "Update a customer's profile fields. Requires the customer ID; \
+             all other fields are optional — only provided fields are changed.",
+        )
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>,
+             Json(input): Json<UpdateCustomerInput>| async move {
+                let mut conn = state.conn();
+
+                // Verify customer exists
+                let exists: Option<String> = redis::cmd("JSON.GET")
+                    .arg(format!("customer:{}", input.id))
+                    .arg("$.name")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+
+                if exists.is_none() {
+                    return Err(tower_mcp::Error::tool(format!(
+                        "Customer '{}' not found",
+                        input.id
+                    )));
+                }
+
+                let key = format!("customer:{}", input.id);
+                let mut updated = Vec::new();
+
+                let fields: Vec<(&str, Option<&String>)> = vec![
+                    ("name", input.name.as_ref()),
+                    ("company", input.company.as_ref()),
+                    ("email", input.email.as_ref()),
+                    ("role", input.role.as_ref()),
+                    ("tier", input.tier.as_ref()),
+                ];
+
+                for (field, value) in fields {
+                    if let Some(val) = value {
+                        let json_val = serde_json::to_string(val).map_err(|e| {
+                            tower_mcp::Error::tool(format!("Serialization error: {e}"))
+                        })?;
+                        redis::cmd("JSON.SET")
+                            .arg(&key)
+                            .arg(format!("$.{field}"))
+                            .arg(&json_val)
+                            .query_async::<()>(&mut conn)
+                            .await
+                            .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+                        updated.push(field);
+                    }
+                }
+
+                if updated.is_empty() {
+                    return Ok(CallToolResult::text(
+                        "No fields provided to update. Pass at least one of: \
+                         name, company, email, role, tier.",
+                    ));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Updated customer {} — changed: {}",
+                    input.id,
+                    updated.join(", ")
+                )))
+            },
+        )
+        .build()
+}

--- a/examples/notes-mcp/src/tools/update_note.rs
+++ b/examples/notes-mcp/src/tools/update_note.rs
@@ -1,0 +1,113 @@
+//! Update note tool — JSON.SET per field
+
+use std::sync::Arc;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
+
+use crate::state::AppState;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateNoteInput {
+    /// Note ID (UUID)
+    id: String,
+    /// New note content
+    #[serde(default)]
+    content: Option<String>,
+    /// New note type: "meeting", "call", "email", or "general"
+    #[serde(default)]
+    note_type: Option<String>,
+    /// New tags (replaces existing tags)
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+}
+
+pub fn build(state: Arc<AppState>) -> Tool {
+    ToolBuilder::new("update_note")
+        .description(
+            "Update a note's content or metadata. Requires the note ID; \
+             all other fields are optional — only provided fields are changed.",
+        )
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<UpdateNoteInput>| async move {
+                let mut conn = state.conn();
+
+                let key = format!("note:{}", input.id);
+
+                // Verify note exists
+                let exists: Option<String> = redis::cmd("JSON.GET")
+                    .arg(&key)
+                    .arg("$.id")
+                    .query_async(&mut conn)
+                    .await
+                    .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+
+                if exists.is_none() {
+                    return Err(tower_mcp::Error::tool(format!(
+                        "Note '{}' not found",
+                        input.id
+                    )));
+                }
+
+                let mut updated = Vec::new();
+
+                if let Some(ref content) = input.content {
+                    let json_val = serde_json::to_string(content)
+                        .map_err(|e| tower_mcp::Error::tool(format!("Serialization error: {e}")))?;
+                    redis::cmd("JSON.SET")
+                        .arg(&key)
+                        .arg("$.content")
+                        .arg(&json_val)
+                        .query_async::<()>(&mut conn)
+                        .await
+                        .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+                    updated.push("content");
+                }
+
+                if let Some(ref note_type) = input.note_type {
+                    let json_val = serde_json::to_string(note_type)
+                        .map_err(|e| tower_mcp::Error::tool(format!("Serialization error: {e}")))?;
+                    redis::cmd("JSON.SET")
+                        .arg(&key)
+                        .arg("$.noteType")
+                        .arg(&json_val)
+                        .query_async::<()>(&mut conn)
+                        .await
+                        .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+                    updated.push("note_type");
+                }
+
+                if let Some(ref tags) = input.tags {
+                    let json_val = serde_json::to_string(tags)
+                        .map_err(|e| tower_mcp::Error::tool(format!("Serialization error: {e}")))?;
+                    redis::cmd("JSON.SET")
+                        .arg(&key)
+                        .arg("$.tags")
+                        .arg(&json_val)
+                        .query_async::<()>(&mut conn)
+                        .await
+                        .map_err(|e| tower_mcp::Error::tool(format!("Redis error: {e}")))?;
+                    updated.push("tags");
+                }
+
+                if updated.is_empty() {
+                    return Ok(CallToolResult::text(
+                        "No fields provided to update. Pass at least one of: \
+                         content, note_type, tags.",
+                    ));
+                }
+
+                Ok(CallToolResult::text(format!(
+                    "Updated note {} — changed: {}",
+                    input.id,
+                    updated.join(", ")
+                )))
+            },
+        )
+        .build()
+}


### PR DESCRIPTION
## Summary

- **Fix RediSearch TAG escaping** — hyphens in tags like `case-study` and `disaster-recovery` were silently failing to match because RediSearch interprets `-` as negation. Added `escape_tag()` helper applied to all TAG filter construction.
- **Fix multi-word search** — queries like `"case study marketing"` returned nothing because RediSearch ANDs all terms. Now OR-joined automatically so any matching term produces results.
- **Add 4 new tools** — `list_customers` (with note counts), `update_customer`, `update_note`, `delete_note` for full CRUD coverage.
- **Add `notes://recent` resource** — static resource showing the 10 most recent notes across all customers.
- **Add `account_review` prompt** — tier-level portfolio analysis that guides the agent through listing customers, deep-diving each account, and producing a summary with action items.

## Test plan

- [x] `cargo fmt --check -p notes-mcp`
- [x] `cargo clippy -p notes-mcp -- -D warnings`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `search_notes` with `tag: "case-study"` — returns results (was broken)
- [x] `search_notes` with `query: "case study marketing"` — returns results (was broken)
- [x] `list_customers` — all 5 customers with note counts
- [x] `update_customer` with `id: "c3", role: "CEO"` — verified change persists
- [x] `update_note` with tag addition — verified change
- [x] `delete_note` — verified removal
- [x] Read `notes://recent` resource — 10 most recent notes rendered