### PR TITLE
feat(notes-mcp): add JSON output format to read-only tools

### DIFF
--- a/examples/notes-mcp/src/state.rs
+++ b/examples/notes-mcp/src/state.rs
@@ -26,6 +26,29 @@ pub struct Note {
     pub created_at: String,
 }
 
+/// A customer with their note count, used by list_customers JSON output
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomerSummary {
+    #[serde(flatten)]
+    pub customer: Customer,
+    pub note_count: usize,
+}
+
+/// A customer profile bundled with their notes, used by get_customer JSON output
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomerWithNotes {
+    #[serde(flatten)]
+    pub customer: Customer,
+    pub notes: Vec<Note>,
+}
+
+/// Returns true if the caller requested JSON output format.
+pub fn is_json_output(format: &Option<String>) -> bool {
+    matches!(format.as_deref(), Some("json"))
+}
+
 /// Shared state for the MCP server
 pub struct AppState {
     conn: MultiplexedConnection,

--- a/examples/notes-mcp/src/tools/list_customers.rs
+++ b/examples/notes-mcp/src/tools/list_customers.rs
@@ -2,9 +2,21 @@
 
 use std::sync::Arc;
 
-use tower_mcp::{CallToolResult, Tool, ToolBuilder, extract::State};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, Tool, ToolBuilder,
+    extract::{Json, State},
+};
 
-use crate::state::{AppState, Customer, parse_ft_search};
+use crate::state::{AppState, Customer, CustomerSummary, is_json_output, parse_ft_search};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ListCustomersInput {
+    /// Output format: "markdown" (default) or "json"
+    #[serde(default)]
+    output_format: Option<String>,
+}
 
 pub fn build(state: Arc<AppState>) -> Tool {
     ToolBuilder::new("list_customers")
@@ -14,62 +26,84 @@ pub fn build(state: Arc<AppState>) -> Tool {
         )
         .read_only()
         .idempotent()
-        .extractor_handler(state, |State(state): State<Arc<AppState>>| async move {
-            let mut conn = state.conn();
+        .extractor_handler(
+            state,
+            |State(state): State<Arc<AppState>>, Json(input): Json<ListCustomersInput>| async move {
+                let mut conn = state.conn();
 
-            // Get all customers
-            let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
-                .arg("idx:customers")
-                .arg("*")
-                .arg("RETURN")
-                .arg("1")
-                .arg("$")
-                .arg("LIMIT")
-                .arg("0")
-                .arg("100")
-                .query_async(&mut conn)
-                .await
-                .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
-
-            let (total, rows) = parse_ft_search(values)
-                .map_err(|e| tower_mcp::Error::tool(format!("Parse error: {e}")))?;
-
-            if rows.is_empty() {
-                return Ok(CallToolResult::text("No customers found."));
-            }
-
-            let mut output = format!("{total} customer(s):\n\n");
-
-            for (_key, json_str) in &rows {
-                let c: Customer = serde_json::from_str(json_str)
-                    .map_err(|e| tower_mcp::Error::tool(format!("JSON parse error: {e}")))?;
-
-                // Get note count for this customer
-                let note_values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
-                    .arg("idx:notes")
-                    .arg(format!(
-                        "@customerId:{{{}}}",
-                        crate::state::escape_tag(&c.id)
-                    ))
+                // Get all customers
+                let values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
+                    .arg("idx:customers")
+                    .arg("*")
+                    .arg("RETURN")
+                    .arg("1")
+                    .arg("$")
                     .arg("LIMIT")
                     .arg("0")
-                    .arg("0")
+                    .arg("100")
                     .query_async(&mut conn)
                     .await
                     .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
 
-                let note_count = match note_values.first() {
-                    Some(redis::Value::Int(n)) => *n as usize,
-                    _ => 0,
-                };
+                let (total, rows) = parse_ft_search(values)
+                    .map_err(|e| tower_mcp::Error::tool(format!("Parse error: {e}")))?;
 
-                output.push_str(&format!(
-                    "- **{}** ({}) — {} at {}, tier: {} — {} note(s)\n",
-                    c.name, c.id, c.role, c.company, c.tier, note_count
-                ));
-            }
+                if rows.is_empty() {
+                    if is_json_output(&input.output_format) {
+                        return Ok(CallToolResult::text("[]"));
+                    }
+                    return Ok(CallToolResult::text("No customers found."));
+                }
 
-            Ok(CallToolResult::text(output))
-        })
+                let mut summaries = Vec::with_capacity(rows.len());
+
+                for (_key, json_str) in &rows {
+                    let customer: Customer = serde_json::from_str(json_str)
+                        .map_err(|e| tower_mcp::Error::tool(format!("JSON parse error: {e}")))?;
+
+                    // Get note count for this customer
+                    let note_values: Vec<redis::Value> = redis::cmd("FT.SEARCH")
+                        .arg("idx:notes")
+                        .arg(format!(
+                            "@customerId:{{{}}}",
+                            crate::state::escape_tag(&customer.id)
+                        ))
+                        .arg("LIMIT")
+                        .arg("0")
+                        .arg("0")
+                        .query_async(&mut conn)
+                        .await
+                        .map_err(|e| tower_mcp::Error::tool(format!("Redis search error: {e}")))?;
+
+                    let note_count = match note_values.first() {
+                        Some(redis::Value::Int(n)) => *n as usize,
+                        _ => 0,
+                    };
+
+                    summaries.push(CustomerSummary {
+                        customer,
+                        note_count,
+                    });
+                }
+
+                if is_json_output(&input.output_format) {
+                    let json = serde_json::to_string_pretty(&summaries)
+                        .map_err(|e| tower_mcp::Error::tool(format!("JSON error: {e}")))?;
+                    return Ok(CallToolResult::text(json));
+                }
+
+                let mut output = format!("{total} customer(s):\n\n");
+
+                for s in &summaries {
+                    let c = &s.customer;
+                    output.push_str(&format!(
+                        "- **{}** ({}) — {} at {}, tier: {} — {} note(s)\n",
+                        c.name, c.id, c.role, c.company, c.tier, s.note_count
+                    ));
+                }
+
+                Ok(CallToolResult::text(output))
+            },
+        )
         .build()
 }


### PR DESCRIPTION
## Summary

- Add optional `output_format` parameter to all read-only data tools (`search_notes`, `search_customers`, `list_customers`, `get_customer`)
- Default is `"markdown"` (unchanged behavior), `"json"` returns raw JSON arrays/objects
- Enables MCP sidecar patterns — e.g. notes-mcp JSON output piped directly into jpx for JMESPath transformations like `count_by(&noteType, @)` or `sort(unique([].tags[]))`
- New types: `CustomerSummary` (flattened customer + `noteCount`), `CustomerWithNotes` (customer + notes array)

## Test plan

- [x] `cargo clippy -p notes-mcp -- -D warnings`
- [x] `cargo check --workspace --all-targets --all-features`
- [x] `search_notes` with `output_format: "json"` — returns JSON array of 18 notes
- [x] `search_customers` with `output_format: "json"` — returns JSON array
- [x] `list_customers` with `output_format: "json"` — returns array with `noteCount` field
- [x] `get_customer` with `output_format: "json"` — returns customer object with nested notes array
- [x] Default (no `output_format`) — all tools still return markdown as before
- [x] End-to-end: notes-mcp JSON → jpx `batch_evaluate` with 4 expressions