### PR TITLE
fix(session): accept initialized notification in uninitialized state

### DIFF
--- a/src/router.rs
+++ b/src/router.rs
@@ -1781,12 +1781,19 @@ impl McpRouter {
     pub fn handle_notification(&self, notification: McpNotification) {
         match notification {
             McpNotification::Initialized => {
+                let phase_before = self.session.phase();
                 if self.session.mark_initialized() {
-                    tracing::info!("Session initialized, entering operation phase");
+                    if phase_before == crate::session::SessionPhase::Uninitialized {
+                        tracing::info!(
+                            "Session initialized from uninitialized state (race resolved)"
+                        );
+                    } else {
+                        tracing::info!("Session initialized, entering operation phase");
+                    }
                 } else {
                     tracing::warn!(
-                        "Received initialized notification in unexpected state: {:?}",
-                        self.session.phase()
+                        phase = ?self.session.phase(),
+                        "Received initialized notification in unexpected state"
                     );
                 }
             }


### PR DESCRIPTION
## Summary

- Fixes a race condition in HTTP transports where the `initialized` notification arrives before the `initialize` request finishes processing
- `mark_initialized()` now accepts both `Initializing -> Initialized` (normal path) and `Uninitialized -> Initialized` (race path)
- Adds differentiated logging to distinguish normal vs race-resolved initialization

## Context

Observed in Fly.io logs: Claude Code sends the `initialized` notification immediately after receiving the `initialize` response, but due to async processing the session may still be in `Uninitialized` state. This caused `mark_initialized()` to fail (it only accepted `Initializing` as source state), which left sessions stuck and subsequent requests like `prompts/list` and `resources/list` rejected with `-32600`.

## Test plan

- [x] New test: `test_mark_initialized_from_uninitialized` covers the race path
- [x] New test: `test_mark_initialized_idempotent_when_already_initialized` verifies double-call safety
- [x] Existing `test_session_lifecycle` still passes (normal path unchanged)
- [x] All 478 lib + 62 integration + 44 schema + 128 doc tests pass

Closes #458