### PR TITLE
fix: align ToolAnnotations::Default with MCP spec defaults

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1598,7 +1598,7 @@ pub struct ToolIcon {
 
 /// Annotations describing tool behavior for trust and safety.
 /// Clients MUST consider these untrusted unless the server is trusted.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolAnnotations {
     /// Human-readable title for the tool
@@ -1618,6 +1618,18 @@ pub struct ToolAnnotations {
     /// If true, tool interacts with external entities. Default: true
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub open_world_hint: bool,
+}
+
+impl Default for ToolAnnotations {
+    fn default() -> Self {
+        Self {
+            title: None,
+            read_only_hint: false,
+            destructive_hint: true,
+            idempotent_hint: false,
+            open_world_hint: true,
+        }
+    }
 }
 
 impl ToolAnnotations {
@@ -4610,15 +4622,13 @@ mod tests {
 
     #[test]
     fn test_tool_annotations_defaults() {
-        // Default::default() uses Rust defaults (false for bool).
-        // The serde defaults (destructive_hint=true, open_world_hint=true)
-        // only apply during deserialization.
+        // Default matches MCP spec defaults: destructive=true, open_world=true
         let annotations = ToolAnnotations::default();
 
         assert!(!annotations.is_read_only());
-        assert!(!annotations.is_destructive());
+        assert!(annotations.is_destructive());
         assert!(!annotations.is_idempotent());
-        assert!(!annotations.is_open_world());
+        assert!(annotations.is_open_world());
     }
 
     #[test]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -810,11 +810,34 @@ impl ToolBuilder {
         self
     }
 
+    /// Mark the tool as destructive (may perform irreversible operations)
+    pub fn destructive(mut self) -> Self {
+        self.annotations
+            .get_or_insert_with(ToolAnnotations::default)
+            .destructive_hint = true;
+        self
+    }
+
     /// Mark the tool as idempotent (same args = same effect)
     pub fn idempotent(mut self) -> Self {
         self.annotations
             .get_or_insert_with(ToolAnnotations::default)
             .idempotent_hint = true;
+        self
+    }
+
+    /// Mark the tool as read-only, idempotent, and non-destructive.
+    ///
+    /// This is a convenience method for safe, side-effect-free tools.
+    /// For finer control, use `.read_only()`, `.idempotent()`, and
+    /// `.non_destructive()` individually.
+    pub fn read_only_safe(mut self) -> Self {
+        let ann = self
+            .annotations
+            .get_or_insert_with(ToolAnnotations::default);
+        ann.read_only_hint = true;
+        ann.idempotent_hint = true;
+        ann.destructive_hint = false;
         self
     }
 


### PR DESCRIPTION
## Summary

- Fix `ToolAnnotations::Default` to match MCP spec: `destructive_hint` and `open_world_hint` now default to `true` instead of `false`
- Add `ToolBuilder::destructive()` method for explicitly marking tools as destructive
- Add `ToolBuilder::read_only_safe()` convenience method that sets `read_only + idempotent + non_destructive` in one call

## Context

The derived `Default` impl set all bools to `false`, but the MCP spec defines `destructive_hint` and `open_world_hint` as `true` by default. This meant that calling any `ToolBuilder` annotation method (e.g., `.read_only()`) would silently mark the tool as non-destructive via the `..Default::default()` fill, which is incorrect.

The existing `.read_only()`, `.non_destructive()`, and `.idempotent()` methods are left unchanged for fine-grained control.

Closes #467, closes #468

## Test plan

- [ ] `test_tool_annotations_defaults` updated to assert spec-correct defaults
- [ ] All existing tests pass (478 lib, 111 integration, 128 doc)
- [ ] `test_auto_instructions_multiple_annotation_tags` unaffected (annotation_tags only checks read_only/idempotent)