### PR TITLE
feat!: add #[non_exhaustive] to all public enums

### DIFF
--- a/examples/client_cli.rs
+++ b/examples/client_cli.rs
@@ -158,6 +158,9 @@ fn print_result(result: &tower_mcp::CallToolResult) {
             tower_mcp::Content::ResourceLink { .. } => {
                 println!("    Result: (resource link)");
             }
+            _ => {
+                println!("    Result: (unknown content type)");
+            }
         }
     }
     println!();

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -42,6 +42,7 @@ use tower::Layer;
 
 /// Result of an authentication attempt
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum AuthResult {
     /// Authentication succeeded with optional user/client info
     Authenticated(Option<AuthInfo>),

--- a/src/client.rs
+++ b/src/client.rs
@@ -516,6 +516,7 @@ impl ClientTransport for StdioClientTransport {
         match response {
             JsonRpcResponse::Result(r) => Ok(r.result),
             JsonRpcResponse::Error(e) => Err(Error::JsonRpc(e.error)),
+            _ => Err(Error::Transport("unexpected response variant".to_string())),
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,6 +83,7 @@ use crate::protocol::{
 
 /// A notification to be sent to the client
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ServerNotification {
     /// Progress update for a request
     Progress(ProgressParams),

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -69,6 +69,7 @@ impl Filterable for Prompt {
 
 /// Behavior when a filtered capability is accessed directly.
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub enum DenialBehavior {
     /// Return "method not found" error -- hides the capability entirely.
     ///

--- a/src/jsonrpc.rs
+++ b/src/jsonrpc.rs
@@ -177,6 +177,10 @@ impl<S> JsonRpcService<S> {
                 let responses = self.call_batch(requests).await?;
                 Ok(JsonRpcResponseMessage::Batch(responses))
             }
+            _ => Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
+                None,
+                JsonRpcError::invalid_request("Unsupported message type"),
+            ))),
         }
     }
 }
@@ -303,6 +307,10 @@ where
 
                     Ok(JsonRpcResponseMessage::Batch(results))
                 }
+                _ => Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
+                    None,
+                    JsonRpcError::invalid_request("Unsupported message type"),
+                ))),
             }
         })
     }
@@ -407,6 +415,7 @@ mod tests {
                 assert_eq!(tools.len(), 1);
             }
             JsonRpcResponse::Error(e) => panic!("Expected result, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -483,6 +492,7 @@ mod tests {
                 assert_eq!(tools.len(), 1);
             }
             JsonRpcResponse::Error(e) => panic!("Expected result, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
     }
 

--- a/src/oauth/error.rs
+++ b/src/oauth/error.rs
@@ -11,6 +11,7 @@ use std::fmt;
 /// Each variant maps to a specific HTTP status code and `WWW-Authenticate`
 /// header value per RFC 6750 Section 3.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum OAuthError {
     /// No bearer token was provided in the request.
     /// Returns HTTP 401 with `WWW-Authenticate: Bearer`.

--- a/src/oauth/token.rs
+++ b/src/oauth/token.rs
@@ -17,6 +17,7 @@ use super::error::OAuthError;
 /// Audience claim value, which can be a single string or array of strings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum TokenAudience {
     /// A single audience string.
     Single(String),
@@ -329,6 +330,7 @@ impl<V: crate::auth::Validate> TokenValidator for ValidateAdapter<V> {
 /// Errors from JWKS endpoint fetching and key parsing.
 #[cfg(feature = "jwks")]
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum JwksError {
     /// HTTP request to the JWKS endpoint failed.
     Fetch(reqwest::Error),

--- a/src/router.rs
+++ b/src/router.rs
@@ -942,6 +942,7 @@ impl McpRouter {
     ///                 // Return resource URI completions
     ///                 Ok(CompleteResult::new(vec![]))
     ///             }
+    ///             _ => Ok(CompleteResult::new(vec![])),
     ///         }
     ///     });
     /// ```
@@ -1774,6 +1775,9 @@ impl McpRouter {
             McpRequest::Unknown { method, .. } => {
                 Err(Error::JsonRpc(JsonRpcError::method_not_found(&method)))
             }
+            _ => Err(Error::JsonRpc(JsonRpcError::method_not_found(
+                "unknown method",
+            ))),
         }
     }
 
@@ -1835,6 +1839,9 @@ impl McpRouter {
             }
             McpNotification::Unknown { method, .. } => {
                 tracing::debug!(method = %method, "Unknown notification received");
+            }
+            _ => {
+                tracing::debug!("Unrecognized notification variant received");
             }
         }
     }
@@ -2074,6 +2081,7 @@ mod tests {
                 assert_eq!(tools.len(), 1);
             }
             JsonRpcResponse::Error(_) => panic!("Expected success response"),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -2114,6 +2122,7 @@ mod tests {
                 assert_eq!(tools.len(), 1);
             }
             JsonRpcResponse::Error(_) => panic!("Expected success for tools/list"),
+            _ => panic!("unexpected response variant"),
         }
 
         // Check second response (tools/call)
@@ -2125,6 +2134,7 @@ mod tests {
                 assert_eq!(text, "30");
             }
             JsonRpcResponse::Error(_) => panic!("Expected success for tools/call"),
+            _ => panic!("unexpected response variant"),
         }
 
         // Check third response (ping)
@@ -2133,6 +2143,7 @@ mod tests {
                 assert_eq!(r.id, RequestId::Number(3));
             }
             JsonRpcResponse::Error(_) => panic!("Expected success for ping"),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -2198,6 +2209,7 @@ mod tests {
         match resp {
             JsonRpcResponse::Result(_) => {}
             JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
 
         // Verify progress was reported by handler
@@ -2304,6 +2316,7 @@ mod tests {
                 assert_eq!(r.id, RequestId::Number(1));
             }
             JsonRpcResponse::Error(_) => panic!("Expected success for first request"),
+            _ => panic!("unexpected response variant"),
         }
 
         // Second should be an error (tool not found)
@@ -2314,6 +2327,7 @@ mod tests {
                 assert!(e.error.message.contains("not found") || e.error.code == -32601);
             }
             JsonRpcResponse::Result(_) => panic!("Expected error for second request"),
+            _ => panic!("unexpected response variant"),
         }
 
         // Third should be success
@@ -2322,6 +2336,7 @@ mod tests {
                 assert_eq!(r.id, RequestId::Number(3));
             }
             JsonRpcResponse::Error(_) => panic!("Expected success for third request"),
+            _ => panic!("unexpected response variant"),
         }
     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,6 +15,7 @@ use crate::router::Extensions;
 /// Session lifecycle phase
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum SessionPhase {
     /// Initial state - only `initialize` and `ping` requests are valid
     Uninitialized = 0,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -357,6 +357,7 @@ impl TestClient {
                     );
                 }
             }
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -464,6 +465,7 @@ impl TestClient {
                     method, r.result
                 );
             }
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -501,6 +503,7 @@ impl TestClient {
                     method, e.error.message, e.error.code,
                 );
             }
+            _ => panic!("unexpected response variant"),
         }
     }
 }

--- a/src/tracing_layer.rs
+++ b/src/tracing_layer.rs
@@ -213,6 +213,7 @@ fn extract_operation_details(req: &McpRequest) -> (Option<&'static str>, Option<
                 crate::protocol::CompletionReference::Prompt { name } => {
                     format!("prompt:{}", name)
                 }
+                _ => "unknown".to_string(),
             };
             (Some("complete"), Some(ref_type))
         }
@@ -222,6 +223,7 @@ fn extract_operation_details(req: &McpRequest) -> (Option<&'static str>, Option<
         McpRequest::Initialize(_) => (Some("init"), None),
         McpRequest::Ping => (Some("ping"), None),
         McpRequest::Unknown { method, .. } => (Some("unknown"), Some(method.clone())),
+        _ => (Some("unknown"), None),
     }
 }
 

--- a/src/transport/childproc.rs
+++ b/src/transport/childproc.rs
@@ -180,6 +180,7 @@ impl ChildProcessConnection {
         match response {
             JsonRpcResponse::Result(r) => Ok(r.result),
             JsonRpcResponse::Error(e) => Err(Error::JsonRpc(e.error)),
+            _ => Err(Error::Transport("unexpected response variant".to_string())),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -191,6 +191,7 @@ async fn test_session_lifecycle_happy_path() {
             assert!(r.result.get("capabilities").is_some());
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 
     // 2. Send initialized notification (handled by router directly)
@@ -205,6 +206,7 @@ async fn test_session_lifecycle_happy_path() {
             assert_eq!(tools.len(), 3);
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 
     // 4. Call a tool
@@ -222,6 +224,7 @@ async fn test_session_lifecycle_happy_path() {
             assert_eq!(text, "Hello, MCP!");
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -239,6 +242,7 @@ async fn test_session_rejects_requests_before_init() {
             assert!(e.error.message.contains("not initialized"));
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for pre-init request"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -254,6 +258,7 @@ async fn test_ping_always_allowed() {
     match resp {
         JsonRpcResponse::Result(_) => {} // Success
         JsonRpcResponse::Error(e) => panic!("Ping should always work: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -289,6 +294,7 @@ async fn test_tool_call_add() {
             assert_eq!(text, "42");
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -318,6 +324,7 @@ async fn test_tool_not_found() {
             assert_eq!(e.error.code, -32601); // Method not found
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for nonexistent tool"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -358,6 +365,7 @@ async fn test_tool_invalid_arguments() {
             "Expected CallToolResult with is_error, got JSON-RPC error: {:?}",
             e
         ),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -398,6 +406,7 @@ async fn test_tool_execution_error() {
             "Expected CallToolResult with is_error, got JSON-RPC error: {:?}",
             e
         ),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -438,6 +447,7 @@ async fn test_batch_requests() {
         match resp {
             JsonRpcResponse::Result(_) => {}
             JsonRpcResponse::Error(e) => panic!("Unexpected error in batch: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
     }
 }
@@ -465,6 +475,7 @@ async fn test_protocol_version_negotiation_supported() {
             assert_eq!(version, "2025-03-26");
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -489,6 +500,7 @@ async fn test_protocol_version_negotiation_unsupported() {
             assert_eq!(version, "2025-11-25");
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -516,6 +528,7 @@ async fn test_invalid_jsonrpc_version() {
             assert_eq!(e.error.code, -32600); // Invalid request
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for invalid JSON-RPC version"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -547,6 +560,7 @@ async fn test_error_unknown_method() {
             assert!(e.error.message.contains("unknown/method"));
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for unknown method"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -587,6 +601,7 @@ async fn test_error_malformed_tool_arguments() {
             "Expected CallToolResult with is_error, got JSON-RPC error: {:?}",
             e
         ),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -650,6 +665,7 @@ async fn test_error_missing_required_params() {
             "Expected CallToolResult with is_error, got JSON-RPC error: {:?}",
             e
         ),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -678,6 +694,7 @@ async fn test_error_resources_not_found() {
             assert_eq!(e.error.code, -32002); // MCP ResourceNotFound
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for resource not found"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -706,6 +723,7 @@ async fn test_error_prompts_not_found() {
             assert_eq!(e.error.code, -32601); // Method not found (prompt not found)
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for prompt not found"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -736,6 +754,7 @@ async fn test_resources_list() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 
     router.handle_notification(tower_mcp::protocol::McpNotification::Initialized);
@@ -756,6 +775,7 @@ async fn test_resources_list() {
             }
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -800,6 +820,7 @@ async fn test_resources_read_json() {
             assert!(parsed.get("debug").unwrap().as_bool().unwrap());
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -831,6 +852,7 @@ async fn test_resources_read_text() {
             assert!(text.contains("# Test Project"));
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -862,6 +884,7 @@ async fn test_resources_read_dynamic() {
             assert_eq!(text, "42");
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -891,6 +914,7 @@ async fn test_resources_read_not_found() {
             assert!(e.error.message.contains("not found"));
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for non-existent resource"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -921,6 +945,7 @@ async fn test_prompts_list() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 
     router.handle_notification(tower_mcp::protocol::McpNotification::Initialized);
@@ -940,6 +965,7 @@ async fn test_prompts_list() {
             }
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -979,6 +1005,7 @@ async fn test_prompts_get_with_args() {
             assert!(text.contains("Alice"));
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1015,6 +1042,7 @@ async fn test_prompts_get_code_review() {
             assert!(text.contains("println"));
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1046,6 +1074,7 @@ async fn test_prompts_get_static() {
             assert_eq!(text, "How can I help you today?");
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1075,6 +1104,7 @@ async fn test_prompts_get_not_found() {
             assert!(e.error.message.contains("not found"));
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for non-existent prompt"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1111,6 +1141,7 @@ async fn test_capabilities_tools_only() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1143,6 +1174,7 @@ async fn test_capabilities_all() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Unexpected error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1410,6 +1442,7 @@ mod scope_enforcement_tests {
                 );
             }
             JsonRpcResponse::Result(_) => panic!("Expected forbidden error"),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -1435,6 +1468,7 @@ mod scope_enforcement_tests {
                 assert_eq!(text, "hello");
             }
             JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -1460,6 +1494,7 @@ mod scope_enforcement_tests {
                 assert_eq!(text, "no auth");
             }
             JsonRpcResponse::Error(e) => panic!("Expected pass-through, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -1482,6 +1517,7 @@ mod scope_enforcement_tests {
                 assert_eq!(e.error.code, -32007);
             }
             JsonRpcResponse::Result(_) => panic!("Expected forbidden error for resource"),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -1505,6 +1541,7 @@ mod scope_enforcement_tests {
                 assert_eq!(e.error.code, -32007);
             }
             JsonRpcResponse::Result(_) => panic!("Expected forbidden error for prompt"),
+            _ => panic!("unexpected response variant"),
         }
     }
 
@@ -1530,6 +1567,7 @@ mod scope_enforcement_tests {
                 assert_eq!(e.error.code, -32007);
             }
             JsonRpcResponse::Result(_) => panic!("Expected forbidden error for default scope"),
+            _ => panic!("unexpected response variant"),
         }
     }
 }
@@ -1620,6 +1658,7 @@ async fn test_task_create_via_tools_call() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1640,6 +1679,7 @@ async fn test_task_list_after_creation() {
     let task_id = match &resp {
         JsonRpcResponse::Result(r) => r.result["task"]["taskId"].as_str().unwrap().to_string(),
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     };
 
     // List tasks
@@ -1656,6 +1696,7 @@ async fn test_task_list_after_creation() {
             assert!(found, "created task should be in the list");
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1676,6 +1717,7 @@ async fn test_task_get_info() {
     let task_id = match &resp {
         JsonRpcResponse::Result(r) => r.result["task"]["taskId"].as_str().unwrap().to_string(),
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     };
 
     // Get task info
@@ -1703,6 +1745,7 @@ async fn test_task_get_info() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1723,6 +1766,7 @@ async fn test_task_lifecycle_get_result() {
     let task_id = match &resp {
         JsonRpcResponse::Result(r) => r.result["task"]["taskId"].as_str().unwrap().to_string(),
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     };
 
     // Wait briefly for the spawned task to complete
@@ -1748,6 +1792,7 @@ async fn test_task_lifecycle_get_result() {
             assert_eq!(related_task["taskId"].as_str().unwrap(), task_id);
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1768,6 +1813,7 @@ async fn test_task_cancel() {
     let task_id = match &resp {
         JsonRpcResponse::Result(r) => r.result["task"]["taskId"].as_str().unwrap().to_string(),
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     };
 
     // Cancel the task
@@ -1782,6 +1828,7 @@ async fn test_task_cancel() {
             assert_eq!(r.result["status"].as_str().unwrap(), "cancelled");
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1802,6 +1849,7 @@ async fn test_task_cancel_already_terminal() {
     let task_id = match &resp {
         JsonRpcResponse::Result(r) => r.result["task"]["taskId"].as_str().unwrap().to_string(),
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     };
 
     // Wait for completion
@@ -1822,6 +1870,7 @@ async fn test_task_cancel_already_terminal() {
             );
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for cancel of terminal task"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1848,6 +1897,7 @@ async fn test_task_forbidden_tool_rejects_task_params() {
             );
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for forbidden tool with task params"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1875,6 +1925,7 @@ async fn test_task_required_tool_rejects_sync_call() {
         JsonRpcResponse::Result(_) => {
             panic!("Expected error for required tool without task params")
         }
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1905,6 +1956,7 @@ async fn test_task_capabilities_advertised() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1930,6 +1982,7 @@ async fn test_task_capabilities_not_advertised_without_task_tools() {
             );
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1973,6 +2026,7 @@ async fn test_task_tool_definition_includes_execution() {
             }
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -1996,6 +2050,7 @@ async fn test_task_get_nonexistent() {
             );
         }
         JsonRpcResponse::Result(_) => panic!("Expected error for nonexistent task"),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -2026,6 +2081,7 @@ async fn test_client_tasks_capability_round_trip() {
     match resp {
         JsonRpcResponse::Result(_) => {}
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -2052,6 +2108,7 @@ async fn test_sampling_capability_round_trip() {
     match resp {
         JsonRpcResponse::Result(_) => {}
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }
 
@@ -2079,5 +2136,6 @@ async fn test_experimental_capabilities_round_trip() {
     match resp {
         JsonRpcResponse::Result(_) => {}
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
     }
 }

--- a/tower-mcp-types/src/error.rs
+++ b/tower-mcp-types/src/error.rs
@@ -41,6 +41,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 /// Standard JSON-RPC error codes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum ErrorCode {
     /// Invalid JSON was received
     ParseError = -32700,
@@ -57,6 +58,7 @@ pub enum ErrorCode {
 /// MCP-specific error codes (in the -32000 to -32099 range)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
+#[non_exhaustive]
 pub enum McpErrorCode {
     /// Transport connection was closed
     ConnectionClosed = -32000,
@@ -277,6 +279,7 @@ impl ToolError {
 
 /// tower-mcp error type
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("JSON-RPC error: {0:?}")]
     JsonRpc(JsonRpcError),

--- a/tower-mcp-types/src/protocol.rs
+++ b/tower-mcp-types/src/protocol.rs
@@ -90,6 +90,7 @@ pub struct JsonRpcErrorResponse {
 /// JSON-RPC 2.0 response (either success or error).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum JsonRpcResponse {
     /// Successful response with result.
     Result(JsonRpcResultResponse),
@@ -120,6 +121,7 @@ impl JsonRpcResponse {
 /// JSON-RPC 2.0 message - can be a single request or a batch
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum JsonRpcMessage {
     /// A single request
     Single(JsonRpcRequest),
@@ -150,6 +152,7 @@ impl JsonRpcMessage {
 /// JSON-RPC 2.0 response message - can be a single response or a batch
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum JsonRpcResponseMessage {
     /// A single response
     Single(JsonRpcResponse),
@@ -219,6 +222,7 @@ pub mod notifications {
 /// Levels are ordered from most severe (emergency) to least severe (debug).
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum LogLevel {
     /// System is unusable
     Emergency,
@@ -307,6 +311,7 @@ pub struct SetLogLevelParams {
 /// Request ID - can be string or number per JSON-RPC spec
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum RequestId {
     String(String),
     Number(i64),
@@ -342,6 +347,7 @@ impl From<i32> for RequestId {
 
 /// High-level MCP request (parsed from JSON-RPC)
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum McpRequest {
     /// Initialize session
     Initialize(InitializeParams),
@@ -412,6 +418,7 @@ impl McpRequest {
 
 /// High-level MCP notification (parsed from JSON-RPC)
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum McpNotification {
     /// Client has completed initialization
     Initialized,
@@ -465,6 +472,7 @@ pub struct ProgressParams {
 /// Progress token - can be string or number
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ProgressToken {
     String(String),
     Number(i64),
@@ -482,6 +490,7 @@ pub struct RequestMeta {
 /// High-level MCP response
 #[derive(Debug, Clone, Serialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum McpResponse {
     Initialize(InitializeResult),
     ListTools(ListToolsResult),
@@ -751,6 +760,7 @@ impl ResourceReference {
 /// Reference for completion - either a prompt or resource reference
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
+#[non_exhaustive]
 pub enum CompletionReference {
     /// Reference to a prompt
     #[serde(rename = "ref/prompt")]
@@ -958,6 +968,7 @@ impl ModelPreferences {
 /// Context inclusion mode for sampling
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum IncludeContext {
     /// Include context from all connected MCP servers
     AllServers,
@@ -1088,6 +1099,7 @@ impl ToolChoice {
 /// Content types for sampling messages
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum SamplingContent {
     /// Text content
     Text {
@@ -1200,6 +1212,7 @@ impl SamplingContent {
 /// SamplingContent or an array of SamplingContent items.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum SamplingContentOrArray {
     /// Single content item
     Single(SamplingContent),
@@ -1572,6 +1585,7 @@ pub struct ToolDefinition {
 /// Icon theme context
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum IconTheme {
     /// Icon designed for light backgrounds
     Light,
@@ -2046,6 +2060,7 @@ impl CallToolResult {
 /// supports optional annotations for audience targeting and priority hints.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum Content {
     /// Plain text content.
     Text {
@@ -2199,6 +2214,7 @@ impl Content {
 /// Used in content annotations to specify the target audience.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ContentRole {
     /// Content intended for the human user.
     User,
@@ -2885,6 +2901,7 @@ pub struct PromptMessage {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum PromptRole {
     User,
     Assistant,
@@ -2897,6 +2914,7 @@ pub enum PromptRole {
 /// Task support mode for tool execution
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub enum TaskSupportMode {
     /// Task execution is required (tool MUST be called with task params)
     Required,
@@ -2928,6 +2946,7 @@ pub struct TaskRequestParams {
 /// Status of an async task
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[non_exhaustive]
 pub enum TaskStatus {
     /// Task is actively being processed
     Working,
@@ -3137,6 +3156,7 @@ pub struct ElicitUrlParams {
 /// Elicitation request parameters (union of form and URL modes)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ElicitRequestParams {
     Form(ElicitFormParams),
     Url(ElicitUrlParams),
@@ -3145,6 +3165,7 @@ pub enum ElicitRequestParams {
 /// Elicitation mode
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ElicitMode {
     /// Form-based elicitation with structured input
     Form,
@@ -3424,6 +3445,7 @@ impl Default for ElicitFormSchema {
 /// Primitive schema definition for form fields
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum PrimitiveSchemaDefinition {
     /// String field
     String(StringSchema),
@@ -3571,6 +3593,7 @@ pub struct MultiSelectEnumItems {
 /// User action in response to elicitation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum ElicitAction {
     /// User submitted the form/confirmed the action
     Accept,
@@ -3625,6 +3648,7 @@ impl ElicitResult {
 /// Value from an elicitation form field
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
+#[non_exhaustive]
 pub enum ElicitFieldValue {
     String(String),
     Number(f64),


### PR DESCRIPTION
## Summary

- Add `#[non_exhaustive]` to all 34 public enums across `tower-mcp-types` (27) and `tower-mcp` (7)
- Fix all cross-crate exhaustive match statements with wildcard arms (16 files, ~60 match sites)
- Protects downstream consumers from breakage when new variants are added as the MCP spec evolves

Closes #478

## Breaking Change

All public enums are now `#[non_exhaustive]`. Downstream code matching on these enums must add a wildcard arm (`_ =>`).

## Test plan

- [x] `cargo check -p tower-mcp-types`
- [x] `cargo test -p tower-mcp-types` (35 passed)
- [x] `cargo check -p tower-mcp --all-features`
- [x] `cargo test --lib --all-features` (397 passed)
- [x] `cargo test --test '*' --all-features` (44 passed)
- [x] `cargo test --doc --all-features` (94 passed)
- [x] `cargo build --examples --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Workspace examples: conformance-server, codegen-mcp, markdownlint-mcp, notes-mcp
- [x] `cargo doc --no-deps --all-features`