### PR TITLE
feat: conditional registration and allow/deny filters

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -33,6 +33,7 @@
 //!     }));
 //! ```
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::error::{Error, JsonRpcError};
@@ -218,6 +219,48 @@ impl<T: Filterable> CapabilityFilter<T> {
     pub fn denial_error(&self, name: &str) -> Error {
         self.denial.to_error(name)
     }
+
+    /// Create a filter that only shows capabilities whose names are in the list.
+    ///
+    /// Capabilities not in the list are hidden. This is useful for exposing
+    /// a curated subset of capabilities (e.g., from a config file or CLI flag).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{CapabilityFilter, Tool};
+    ///
+    /// // Only expose these two tools
+    /// let filter = CapabilityFilter::<Tool>::allow_list(&["query", "list_tables"]);
+    /// ```
+    pub fn allow_list(names: &[&str]) -> Self
+    where
+        T: 'static,
+    {
+        let allowed: HashSet<String> = names.iter().map(|s| (*s).to_string()).collect();
+        Self::new(move |_session, cap: &T| allowed.contains(cap.name()))
+    }
+
+    /// Create a filter that hides capabilities whose names are in the list.
+    ///
+    /// All capabilities are visible except those explicitly listed. This is
+    /// useful for blocking specific dangerous or irrelevant capabilities.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{CapabilityFilter, Tool};
+    ///
+    /// // Hide these destructive tools
+    /// let filter = CapabilityFilter::<Tool>::deny_list(&["delete", "drop_table"]);
+    /// ```
+    pub fn deny_list(names: &[&str]) -> Self
+    where
+        T: 'static,
+    {
+        let denied: HashSet<String> = names.iter().map(|s| (*s).to_string()).collect();
+        Self::new(move |_session, cap: &T| !denied.contains(cap.name()))
+    }
 }
 
 impl CapabilityFilter<Tool> {
@@ -384,6 +427,58 @@ mod tests {
 
         assert!(!filter.is_visible(&session, &tool));
         let error = filter.denial_error("writer");
+        match error {
+            Error::JsonRpc(e) => assert_eq!(e.code, -32007),
+            _ => panic!("Expected JsonRpc error"),
+        }
+    }
+
+    #[test]
+    fn test_allow_list_shows_listed_tools() {
+        let filter = CapabilityFilter::<Tool>::allow_list(&["query", "list_tables"]);
+        let session = SessionState::new();
+
+        assert!(filter.is_visible(&session, &make_test_tool("query")));
+        assert!(filter.is_visible(&session, &make_test_tool("list_tables")));
+        assert!(!filter.is_visible(&session, &make_test_tool("delete")));
+        assert!(!filter.is_visible(&session, &make_test_tool("drop_table")));
+    }
+
+    #[test]
+    fn test_allow_list_empty_blocks_all() {
+        let filter = CapabilityFilter::<Tool>::allow_list(&[]);
+        let session = SessionState::new();
+
+        assert!(!filter.is_visible(&session, &make_test_tool("anything")));
+    }
+
+    #[test]
+    fn test_deny_list_hides_listed_tools() {
+        let filter = CapabilityFilter::<Tool>::deny_list(&["delete", "drop_table"]);
+        let session = SessionState::new();
+
+        assert!(filter.is_visible(&session, &make_test_tool("query")));
+        assert!(filter.is_visible(&session, &make_test_tool("list_tables")));
+        assert!(!filter.is_visible(&session, &make_test_tool("delete")));
+        assert!(!filter.is_visible(&session, &make_test_tool("drop_table")));
+    }
+
+    #[test]
+    fn test_deny_list_empty_allows_all() {
+        let filter = CapabilityFilter::<Tool>::deny_list(&[]);
+        let session = SessionState::new();
+
+        assert!(filter.is_visible(&session, &make_test_tool("anything")));
+    }
+
+    #[test]
+    fn test_allow_list_with_denial_behavior() {
+        let filter = CapabilityFilter::<Tool>::allow_list(&["query"])
+            .denial_behavior(DenialBehavior::Unauthorized);
+        let session = SessionState::new();
+
+        assert!(!filter.is_visible(&session, &make_test_tool("delete")));
+        let error = filter.denial_error("delete");
         match error {
             Error::JsonRpc(e) => assert_eq!(e.code, -32007),
             _ => panic!("Expected JsonRpc error"),

--- a/src/router.rs
+++ b/src/router.rs
@@ -643,12 +643,67 @@ impl McpRouter {
         self
     }
 
+    /// Conditionally register a tool.
+    ///
+    /// Registers the tool only if `condition` is `true`. This keeps fluent
+    /// builder chains intact when tools are conditionally enabled.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+    /// use schemars::JsonSchema;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize, JsonSchema)]
+    /// struct Input { value: String }
+    ///
+    /// let enable_admin = false;
+    ///
+    /// let admin_tool = ToolBuilder::new("admin")
+    ///     .description("Admin tool")
+    ///     .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
+    ///     .build();
+    ///
+    /// let router = McpRouter::new()
+    ///     .tool_if(enable_admin, admin_tool);
+    /// ```
+    pub fn tool_if(self, condition: bool, tool: Tool) -> Self {
+        if condition { self.tool(tool) } else { self }
+    }
+
     /// Register a resource
     pub fn resource(mut self, resource: Resource) -> Self {
         Arc::make_mut(&mut self.inner)
             .resources
             .insert(resource.uri.clone(), Arc::new(resource));
         self
+    }
+
+    /// Conditionally register a resource.
+    ///
+    /// Registers the resource only if `condition` is `true`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ResourceBuilder};
+    ///
+    /// let enable_config = false;
+    ///
+    /// let config = ResourceBuilder::new("config://system")
+    ///     .name("config")
+    ///     .text("secret=xxx");
+    ///
+    /// let router = McpRouter::new()
+    ///     .resource_if(enable_config, config);
+    /// ```
+    pub fn resource_if(self, condition: bool, resource: Resource) -> Self {
+        if condition {
+            self.resource(resource)
+        } else {
+            self
+        }
     }
 
     /// Register a resource template
@@ -698,6 +753,28 @@ impl McpRouter {
         self
     }
 
+    /// Conditionally register a prompt.
+    ///
+    /// Registers the prompt only if `condition` is `true`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, PromptBuilder};
+    ///
+    /// let enable_debug = false;
+    ///
+    /// let debug_prompt = PromptBuilder::new("debug")
+    ///     .description("Debug prompt")
+    ///     .user_message("Debug mode enabled");
+    ///
+    /// let router = McpRouter::new()
+    ///     .prompt_if(enable_debug, debug_prompt);
+    /// ```
+    pub fn prompt_if(self, condition: bool, prompt: Prompt) -> Self {
+        if condition { self.prompt(prompt) } else { self }
+    }
+
     /// Register multiple tools at once.
     ///
     /// # Example
@@ -729,6 +806,13 @@ impl McpRouter {
             .fold(self, |router, tool| router.tool(tool))
     }
 
+    /// Conditionally register multiple tools at once.
+    ///
+    /// Registers all tools only if `condition` is `true`.
+    pub fn tools_if(self, condition: bool, tools: impl IntoIterator<Item = Tool>) -> Self {
+        if condition { self.tools(tools) } else { self }
+    }
+
     /// Register multiple resources at once.
     ///
     /// # Example
@@ -753,6 +837,21 @@ impl McpRouter {
             .fold(self, |router, resource| router.resource(resource))
     }
 
+    /// Conditionally register multiple resources at once.
+    ///
+    /// Registers all resources only if `condition` is `true`.
+    pub fn resources_if(
+        self,
+        condition: bool,
+        resources: impl IntoIterator<Item = Resource>,
+    ) -> Self {
+        if condition {
+            self.resources(resources)
+        } else {
+            self
+        }
+    }
+
     /// Register multiple prompts at once.
     ///
     /// # Example
@@ -775,6 +874,17 @@ impl McpRouter {
         prompts
             .into_iter()
             .fold(self, |router, prompt| router.prompt(prompt))
+    }
+
+    /// Conditionally register multiple prompts at once.
+    ///
+    /// Registers all prompts only if `condition` is `true`.
+    pub fn prompts_if(self, condition: bool, prompts: impl IntoIterator<Item = Prompt>) -> Self {
+        if condition {
+            self.prompts(prompts)
+        } else {
+            self
+        }
     }
 
     /// Merge another router's capabilities into this one.
@@ -5440,4 +5550,123 @@ mod tests {
             assert!(names.contains(&"tool_b"));
         }
     } // mod dynamic_tools_tests
+
+    #[tokio::test]
+    async fn test_tool_if_true_registers() {
+        let tool = ToolBuilder::new("conditional")
+            .description("Conditional tool")
+            .handler(|_: AddInput| async { Ok(CallToolResult::text("ok")) })
+            .build();
+
+        let mut router = McpRouter::new().tool_if(true, tool);
+        init_router(&mut router).await;
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ListTools(ListToolsParams::default()),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        match resp.inner {
+            Ok(McpResponse::ListTools(result)) => {
+                assert_eq!(result.tools.len(), 1);
+                assert_eq!(result.tools[0].name, "conditional");
+            }
+            _ => panic!("Expected ListTools response"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tool_if_false_skips() {
+        let tool = ToolBuilder::new("conditional")
+            .description("Conditional tool")
+            .handler(|_: AddInput| async { Ok(CallToolResult::text("ok")) })
+            .build();
+
+        let mut router = McpRouter::new().tool_if(false, tool);
+        init_router(&mut router).await;
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ListTools(ListToolsParams::default()),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        match resp.inner {
+            Ok(McpResponse::ListTools(result)) => {
+                assert_eq!(result.tools.len(), 0);
+            }
+            _ => panic!("Expected ListTools response"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tools_if_batch_conditional() {
+        let tools = vec![
+            ToolBuilder::new("a")
+                .description("Tool A")
+                .handler(|_: AddInput| async { Ok(CallToolResult::text("ok")) })
+                .build(),
+            ToolBuilder::new("b")
+                .description("Tool B")
+                .handler(|_: AddInput| async { Ok(CallToolResult::text("ok")) })
+                .build(),
+        ];
+
+        let mut router = McpRouter::new().tools_if(false, tools);
+        init_router(&mut router).await;
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ListTools(ListToolsParams::default()),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        match resp.inner {
+            Ok(McpResponse::ListTools(result)) => {
+                assert_eq!(result.tools.len(), 0);
+            }
+            _ => panic!("Expected ListTools response"),
+        }
+    }
+
+    #[test]
+    fn test_resource_if_true_registers() {
+        let resource = crate::resource::ResourceBuilder::new("file:///test.txt")
+            .name("test")
+            .text("hello");
+
+        let router = McpRouter::new().resource_if(true, resource);
+        assert_eq!(router.inner.resources.len(), 1);
+    }
+
+    #[test]
+    fn test_resource_if_false_skips() {
+        let resource = crate::resource::ResourceBuilder::new("file:///test.txt")
+            .name("test")
+            .text("hello");
+
+        let router = McpRouter::new().resource_if(false, resource);
+        assert_eq!(router.inner.resources.len(), 0);
+    }
+
+    #[test]
+    fn test_prompt_if_true_registers() {
+        let prompt = crate::prompt::PromptBuilder::new("greet")
+            .description("Greeting")
+            .user_message("Hello!");
+
+        let router = McpRouter::new().prompt_if(true, prompt);
+        assert_eq!(router.inner.prompts.len(), 1);
+    }
+
+    #[test]
+    fn test_prompt_if_false_skips() {
+        let prompt = crate::prompt::PromptBuilder::new("greet")
+            .description("Greeting")
+            .user_message("Hello!");
+
+        let router = McpRouter::new().prompt_if(false, prompt);
+        assert_eq!(router.inner.prompts.len(), 0);
+    }
 }


### PR DESCRIPTION
## Summary

- Add `tool_if()`, `resource_if()`, `prompt_if()` to `McpRouter` for fluent conditional registration (keeps builder chains intact instead of breaking into `if` blocks)
- Add batch variants: `tools_if()`, `resources_if()`, `prompts_if()`
- Add `CapabilityFilter::allow_list()` and `CapabilityFilter::deny_list()` convenience constructors for common name-based filtering

### Before
```rust
let mut router = McpRouter::new();
if config.enable_admin {
    router = router.tool(admin_tool);
}
```

### After
```rust
let router = McpRouter::new()
    .tool_if(config.enable_admin, admin_tool)
    .tool_filter(CapabilityFilter::deny_list(&["delete", "drop_table"]));
```

## Test plan

- [x] Unit tests for `tool_if`/`resource_if`/`prompt_if` (true and false cases)
- [x] Unit test for `tools_if` batch conditional
- [x] Unit tests for `allow_list` (allows listed, blocks unlisted, empty blocks all)
- [x] Unit tests for `deny_list` (blocks listed, allows unlisted, empty allows all)
- [x] Test `allow_list` composes with `denial_behavior`
- [x] All existing tests pass (469 unit + 153 integration + 122 doc tests)
- [x] `cargo fmt`, `cargo clippy`, `cargo build --examples` all pass

Closes #512
Closes #513