### PR TITLE
perf: use named future types for CatchError services

### DIFF
--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -50,6 +50,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use pin_project_lite::pin_project;
+
 use tokio::sync::Mutex;
 use tower::util::BoxCloneService;
 use tower::{Layer, ServiceExt};
@@ -137,6 +139,42 @@ impl<S: fmt::Debug> fmt::Debug for PromptCatchError<S> {
     }
 }
 
+pin_project! {
+    /// Future for [`PromptCatchError`].
+    pub struct PromptCatchErrorFuture<F> {
+        #[pin]
+        inner: F,
+    }
+}
+
+impl<F, E> Future for PromptCatchErrorFuture<F>
+where
+    F: Future<Output = std::result::Result<GetPromptResult, E>>,
+    E: fmt::Display,
+{
+    type Output = std::result::Result<GetPromptResult, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(response)) => Poll::Ready(Ok(response)),
+            Poll::Ready(Err(err)) => Poll::Ready(Ok(GetPromptResult {
+                description: Some(format!("Prompt error: {}", err)),
+                messages: vec![PromptMessage {
+                    role: PromptRole::Assistant,
+                    content: Content::Text {
+                        text: format!("Error generating prompt: {}", err),
+                        annotations: None,
+                        meta: None,
+                    },
+                    meta: None,
+                }],
+                meta: None,
+            })),
+        }
+    }
+}
+
 impl<S> Service<PromptRequest> for PromptCatchError<S>
 where
     S: Service<PromptRequest, Response = GetPromptResult> + Clone + Send + 'static,
@@ -145,38 +183,16 @@ where
 {
     type Response = GetPromptResult;
     type Error = Infallible;
-    type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<GetPromptResult, Infallible>> + Send>>;
+    type Future = PromptCatchErrorFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         self.inner.poll_ready(cx).map_err(|_| unreachable!())
     }
 
     fn call(&mut self, req: PromptRequest) -> Self::Future {
-        let fut = self.inner.call(req);
-
-        Box::pin(async move {
-            match fut.await {
-                Ok(response) => Ok(response),
-                Err(err) => {
-                    // Convert middleware error to an error prompt result
-                    // We return a single error message as the prompt content
-                    Ok(GetPromptResult {
-                        description: Some(format!("Prompt error: {}", err)),
-                        messages: vec![PromptMessage {
-                            role: PromptRole::Assistant,
-                            content: Content::Text {
-                                text: format!("Error generating prompt: {}", err),
-                                annotations: None,
-                                meta: None,
-                            },
-                            meta: None,
-                        }],
-                        meta: None,
-                    })
-                }
-            }
-        })
+        PromptCatchErrorFuture {
+            inner: self.inner.call(req),
+        }
     }
 }
 

--- a/src/resource.rs
+++ b/src/resource.rs
@@ -74,6 +74,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use pin_project_lite::pin_project;
+
 use tower::util::BoxCloneService;
 use tower_service::Service;
 
@@ -145,6 +147,44 @@ impl<S: fmt::Debug> fmt::Debug for ResourceCatchError<S> {
     }
 }
 
+pin_project! {
+    /// Future for [`ResourceCatchError`].
+    pub struct ResourceCatchErrorFuture<F> {
+        #[pin]
+        inner: F,
+        uri: Option<String>,
+    }
+}
+
+impl<F, E> Future for ResourceCatchErrorFuture<F>
+where
+    F: Future<Output = std::result::Result<ReadResourceResult, E>>,
+    E: fmt::Display,
+{
+    type Output = std::result::Result<ReadResourceResult, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(result)) => Poll::Ready(Ok(result)),
+            Poll::Ready(Err(err)) => {
+                let uri = this.uri.take().unwrap_or_default();
+                Poll::Ready(Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some(format!("Error reading resource: {}", err)),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                }))
+            }
+        }
+    }
+}
+
 impl<S> Service<ResourceRequest> for ResourceCatchError<S>
 where
     S: Service<ResourceRequest, Response = ReadResourceResult> + Clone + Send + 'static,
@@ -153,8 +193,7 @@ where
 {
     type Response = ReadResourceResult;
     type Error = Infallible;
-    type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<ReadResourceResult, Infallible>> + Send>>;
+    type Future = ResourceCatchErrorFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         // Map any readiness error to Infallible (we catch it on call)
@@ -169,24 +208,10 @@ where
         let uri = req.uri.clone();
         let fut = self.inner.call(req);
 
-        Box::pin(async move {
-            match fut.await {
-                Ok(result) => Ok(result),
-                Err(err) => {
-                    // Return an error result with the error message
-                    Ok(ReadResourceResult {
-                        contents: vec![ResourceContent {
-                            uri,
-                            mime_type: Some("text/plain".to_string()),
-                            text: Some(format!("Error reading resource: {}", err)),
-                            blob: None,
-                            meta: None,
-                        }],
-                        meta: None,
-                    })
-                }
-            }
-        })
+        ResourceCatchErrorFuture {
+            inner: fut,
+            uri: Some(uri),
+        }
     }
 }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -38,6 +38,8 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use pin_project_lite::pin_project;
+
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -113,6 +115,30 @@ impl<S: fmt::Debug> fmt::Debug for ToolCatchError<S> {
     }
 }
 
+pin_project! {
+    /// Future for [`ToolCatchError`].
+    pub struct ToolCatchErrorFuture<F> {
+        #[pin]
+        inner: F,
+    }
+}
+
+impl<F, E> Future for ToolCatchErrorFuture<F>
+where
+    F: Future<Output = std::result::Result<CallToolResult, E>>,
+    E: fmt::Display,
+{
+    type Output = std::result::Result<CallToolResult, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project().inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(result)) => Poll::Ready(Ok(result)),
+            Poll::Ready(Err(err)) => Poll::Ready(Ok(CallToolResult::error(err.to_string()))),
+        }
+    }
+}
+
 impl<S> Service<ToolRequest> for ToolCatchError<S>
 where
     S: Service<ToolRequest, Response = CallToolResult> + Clone + Send + 'static,
@@ -121,8 +147,7 @@ where
 {
     type Response = CallToolResult;
     type Error = Infallible;
-    type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<CallToolResult, Infallible>> + Send>>;
+    type Future = ToolCatchErrorFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         // Map any readiness error to Infallible (we catch it on call)
@@ -134,14 +159,9 @@ where
     }
 
     fn call(&mut self, req: ToolRequest) -> Self::Future {
-        let fut = self.inner.call(req);
-
-        Box::pin(async move {
-            match fut.await {
-                Ok(result) => Ok(result),
-                Err(err) => Ok(CallToolResult::error(err.to_string())),
-            }
-        })
+        ToolCatchErrorFuture {
+            inner: self.inner.call(req),
+        }
     }
 }
 

--- a/src/transport/service.rs
+++ b/src/transport/service.rs
@@ -112,8 +112,7 @@ where
             Poll::Pending => Poll::Pending,
             Poll::Ready(Ok(response)) => Poll::Ready(Ok(response)),
             Poll::Ready(Err(err)) => {
-                let request_id =
-                    this.request_id.take().unwrap_or(RequestId::Number(0));
+                let request_id = this.request_id.take().unwrap_or(RequestId::Number(0));
                 Poll::Ready(Ok(RouterResponse {
                     id: request_id,
                     inner: Err(JsonRpcError::internal_error(err.to_string())),

--- a/src/transport/service.rs
+++ b/src/transport/service.rs
@@ -22,10 +22,13 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use pin_project_lite::pin_project;
+
 use tower::util::BoxCloneService;
 use tower_service::Service;
 
 use crate::error::JsonRpcError;
+use crate::protocol::RequestId;
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 
 /// A boxed, cloneable MCP service with `Error = Infallible`.
@@ -87,6 +90,39 @@ impl<S: fmt::Debug> fmt::Debug for CatchError<S> {
     }
 }
 
+pin_project! {
+    /// Future for [`CatchError`].
+    pub struct CatchErrorFuture<F> {
+        #[pin]
+        inner: F,
+        request_id: Option<RequestId>,
+    }
+}
+
+impl<F, E> Future for CatchErrorFuture<F>
+where
+    F: Future<Output = Result<RouterResponse, E>>,
+    E: fmt::Display,
+{
+    type Output = Result<RouterResponse, Infallible>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match this.inner.poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Ok(response)) => Poll::Ready(Ok(response)),
+            Poll::Ready(Err(err)) => {
+                let request_id =
+                    this.request_id.take().unwrap_or(RequestId::Number(0));
+                Poll::Ready(Ok(RouterResponse {
+                    id: request_id,
+                    inner: Err(JsonRpcError::internal_error(err.to_string())),
+                }))
+            }
+        }
+    }
+}
+
 impl<S> Service<RouterRequest> for CatchError<S>
 where
     S: Service<RouterRequest, Response = RouterResponse> + Clone + Send + 'static,
@@ -95,7 +131,7 @@ where
 {
     type Response = RouterResponse;
     type Error = Infallible;
-    type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+    type Future = CatchErrorFuture<S::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx).map_err(|_| unreachable!())
@@ -107,15 +143,10 @@ where
         let request_id = req.id.clone();
         let fut = self.inner.call(req);
 
-        Box::pin(async move {
-            match fut.await {
-                Ok(response) => Ok(response),
-                Err(err) => Ok(RouterResponse {
-                    id: request_id,
-                    inner: Err(JsonRpcError::internal_error(err.to_string())),
-                }),
-            }
-        })
+        CatchErrorFuture {
+            inner: fut,
+            request_id: Some(request_id),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace `Pin<Box<dyn Future>>` with named future types via `pin_project_lite::pin_project!` for the four CatchError service wrappers
- Eliminates one heap allocation per MCP request in the hot path
- Enables compiler inlining of future poll through the CatchError layer
- `pin-project-lite` was already a dependency but unused; now actively used

Converted services:
| Service | File | Captured Data |
|---------|------|---------------|
| `ToolCatchError<S>` | `src/tool.rs` | none |
| `PromptCatchError<S>` | `src/prompt.rs` | none |
| `CatchError<S>` | `src/transport/service.rs` | `request_id` |
| `ResourceCatchError<S>` | `src/resource.rs` | `uri` |

No API changes -- the concrete `Future` type is an implementation detail never named by consumers.

## Test plan

- [x] All 469 unit tests pass
- [x] All 153 integration tests pass
- [x] All 122 doc tests pass
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `cargo fmt --all -- --check` clean

Closes #110