### PR TITLE
docs: deprecate extractor_handler_typed in favor of extractor_handler

### DIFF
--- a/src/extract.rs
+++ b/src/extract.rs
@@ -840,6 +840,10 @@ impl<T> HasSchema for Extension<T> {
 ///
 /// This trait is similar to [`ExtractorHandler`] but provides proper JSON
 /// schema generation for the input type when `Json<T>` is used.
+#[deprecated(
+    since = "0.8.0",
+    note = "Use `ExtractorHandler` instead -- `extractor_handler` auto-detects JSON schema from `Json<T>` extractors"
+)]
 pub trait TypedExtractorHandler<S, T, I>: Clone + Send + Sync + 'static
 where
     I: JsonSchema,
@@ -852,6 +856,7 @@ where
 }
 
 // Single extractor with Json<T>
+#[allow(deprecated)]
 impl<S, F, Fut, T> TypedExtractorHandler<S, (Json<T>,), T> for F
 where
     S: Clone + Send + Sync + 'static,
@@ -871,6 +876,7 @@ where
 }
 
 // Two extractors ending with Json<T>
+#[allow(deprecated)]
 impl<S, F, Fut, T1, T> TypedExtractorHandler<S, (T1, Json<T>), T> for F
 where
     S: Clone + Send + Sync + 'static,
@@ -892,6 +898,7 @@ where
 }
 
 // Three extractors ending with Json<T>
+#[allow(deprecated)]
 impl<S, F, Fut, T1, T2, T> TypedExtractorHandler<S, (T1, T2, Json<T>), T> for F
 where
     S: Clone + Send + Sync + 'static,
@@ -915,6 +922,7 @@ where
 }
 
 // Four extractors ending with Json<T>
+#[allow(deprecated)]
 impl<S, F, Fut, T1, T2, T3, T> TypedExtractorHandler<S, (T1, T2, T3, Json<T>), T> for F
 where
     S: Clone + Send + Sync + 'static,
@@ -1196,6 +1204,10 @@ where
 }
 
 /// Builder state for extractor-based handlers with typed JSON input
+#[deprecated(
+    since = "0.8.0",
+    note = "Use `ToolBuilderWithExtractor` via `extractor_handler` instead"
+)]
 pub struct ToolBuilderWithTypedExtractor<S, F, T, I> {
     pub(crate) name: String,
     pub(crate) title: Option<String>,
@@ -1209,6 +1221,7 @@ pub struct ToolBuilderWithTypedExtractor<S, F, T, I> {
     pub(crate) _phantom: PhantomData<(T, I)>,
 }
 
+#[allow(deprecated)]
 impl<S, F, T, I> ToolBuilderWithTypedExtractor<S, F, T, I>
 where
     S: Clone + Send + Sync + 'static,
@@ -1260,6 +1273,7 @@ struct TypedExtractorToolHandler<S, F, T, I> {
     _phantom: PhantomData<(T, I)>,
 }
 
+#[allow(deprecated)]
 impl<S, F, T, I> ToolHandler for TypedExtractorToolHandler<S, F, T, I>
 where
     S: Clone + Send + Sync + 'static,
@@ -1571,6 +1585,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)]
     async fn test_tool_builder_extractor_handler_typed() {
         use crate::ToolBuilder;
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -981,8 +981,8 @@ impl ToolBuilder {
     ///
     /// When a [`Json<T>`](crate::extract::Json) extractor is used, the proper JSON
     /// schema is automatically generated from `T`'s `JsonSchema` implementation.
-    /// This means `extractor_handler` produces the same schema as
-    /// `extractor_handler_typed` for the common case, without requiring a turbofish.
+    /// No turbofish is needed -- the schema type is inferred from the closure
+    /// parameters.
     ///
     /// # Extractors
     ///
@@ -1090,33 +1090,30 @@ impl ToolBuilder {
 
     /// Create a tool using the extractor pattern with typed JSON input.
     ///
-    /// This is similar to [`extractor_handler`](Self::extractor_handler) but requires
-    /// an explicit type parameter for the JSON input type via turbofish syntax.
+    /// # Deprecated
     ///
-    /// Since `extractor_handler` now auto-detects the JSON schema from `Json<T>`
-    /// extractors, this method is typically unnecessary. It remains available for
-    /// cases where you need explicit control over the schema type parameter.
-    ///
-    /// # Example
+    /// Use [`extractor_handler`](Self::extractor_handler) instead. It auto-detects
+    /// the JSON schema from `Json<T>` extractors, producing identical results
+    /// without requiring a turbofish.
     ///
     /// ```rust
-    /// use std::sync::Arc;
-    /// use tower_mcp::{ToolBuilder, CallToolResult};
-    /// use tower_mcp::extract::{Json, State};
-    /// use schemars::JsonSchema;
-    /// use serde::Deserialize;
+    /// # use std::sync::Arc;
+    /// # use tower_mcp::{ToolBuilder, CallToolResult};
+    /// # use tower_mcp::extract::{Json, State};
+    /// # use schemars::JsonSchema;
+    /// # use serde::Deserialize;
+    /// # #[derive(Clone)]
+    /// # struct AppState { prefix: String }
+    /// # #[derive(Debug, Deserialize, JsonSchema)]
+    /// # struct GreetInput { name: String }
+    /// # let state = Arc::new(AppState { prefix: "Hello".to_string() });
+    /// // Before (deprecated):
+    /// // .extractor_handler_typed::<_, _, _, GreetInput>(state, handler)
     ///
-    /// #[derive(Clone)]
-    /// struct AppState { prefix: String }
-    ///
-    /// #[derive(Debug, Deserialize, JsonSchema)]
-    /// struct GreetInput { name: String }
-    ///
-    /// let state = Arc::new(AppState { prefix: "Hello".to_string() });
-    ///
+    /// // After:
     /// let tool = ToolBuilder::new("greet")
     ///     .description("Greet someone")
-    ///     .extractor_handler_typed::<_, _, _, GreetInput>(state, |
+    ///     .extractor_handler(state, |
     ///         State(app): State<Arc<AppState>>,
     ///         Json(input): Json<GreetInput>,
     ///     | async move {
@@ -1124,6 +1121,11 @@ impl ToolBuilder {
     ///     })
     ///     .build();
     /// ```
+    #[deprecated(
+        since = "0.8.0",
+        note = "Use `extractor_handler` instead -- it auto-detects JSON schema from `Json<T>` extractors without requiring a turbofish"
+    )]
+    #[allow(deprecated)]
     pub fn extractor_handler_typed<S, F, T, I>(
         self,
         state: S,


### PR DESCRIPTION
## Summary

- Deprecate `extractor_handler_typed`, `TypedExtractorHandler`, and `ToolBuilderWithTypedExtractor`
- `extractor_handler` auto-detects JSON schema from `Json<T>` extractors, producing identical results without a turbofish
- Verified by converting all 302 usages in redisctl-mcp -- all compile clean with `extractor_handler`

Before (deprecated):
```rust
.extractor_handler_typed::<_, _, _, MyInput>(state, |
    State(s): State<Arc<AppState>>,
    Json(input): Json<MyInput>,
| async move { ... })
```

After:
```rust
.extractor_handler(state, |
    State(s): State<Arc<AppState>>,
    Json(input): Json<MyInput>,
| async move { ... })
```

## Test plan

- [x] All 469 unit tests pass
- [x] All 122 doc tests pass (including deprecated method's doc example)
- [x] `cargo clippy --all-targets --all-features` clean
- [x] Verified against redisctl-mcp: 302 `extractor_handler_typed` -> `extractor_handler`, all compile

Closes #470