### PR TITLE
docs: add .title() to examples and expand doc comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ struct GreetInput {
 
 // Build a tool with type-safe handler
 let greet = ToolBuilder::new("greet")
+    .title("Greet")
     .description("Greet someone by name")
     .handler(|input: GreetInput| async move {
         Ok(CallToolResult::text(format!("Hello, {}!", input.name)))

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -56,6 +56,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Build our tools
     let greet = ToolBuilder::new("greet")
+        .title("Greet")
         .description("Greet someone by name")
         .read_only() // This tool doesn't modify any state
         .handler(|input: GreetInput| async move {
@@ -65,6 +66,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Demonstrates returning structured JSON using from_serialize
     let add = ToolBuilder::new("add")
+        .title("Add Numbers")
         .description("Add two numbers together")
         .read_only()
         .idempotent() // Same inputs always produce same output
@@ -79,6 +81,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .build();
 
     let echo = ToolBuilder::new("echo")
+        .title("Echo Message")
         .description("Echo a message back, optionally repeated")
         .read_only()
         .handler(|input: EchoInput| async move {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //!
 //! // Looks just like an axum handler!
 //! let tool = ToolBuilder::new("search")
+//!     .title("Search Database")
 //!     .description("Search the database")
 //!     .extractor_handler(
 //!         Arc::new(AppState { db_url: "postgres://...".into() }),
@@ -73,6 +74,7 @@
 //! async fn main() -> Result<(), BoxError> {
 //!     // Define a tool
 //!     let greet = ToolBuilder::new("greet")
+//!         .title("Greet")
 //!         .description("Greet someone by name")
 //!         .handler(|input: GreetInput| async move {
 //!             Ok(CallToolResult::text(format!("Hello, {}!", input.name)))

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -771,7 +771,21 @@ impl ToolBuilder {
         })
     }
 
-    /// Set a human-readable title for the tool
+    /// Set a human-readable title for the tool.
+    ///
+    /// The title is displayed by MCP clients (e.g., Claude Code's `/mcp` tool list)
+    /// as a friendly label instead of the raw tool name. For example, a tool named
+    /// `search_crates` with title `"Search Crates"` will display the title in UIs
+    /// that support it.
+    ///
+    /// ```
+    /// # use tower_mcp::ToolBuilder;
+    /// let tool = ToolBuilder::new("search_crates")
+    ///     .title("Search Crates")
+    ///     .description("Search for Rust crates on crates.io")
+    ///     .handler(|()| async { Ok(tower_mcp::CallToolResult::text("results")) })
+    ///     .build();
+    /// ```
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self


### PR DESCRIPTION
## Summary

- Expanded the doc comment on `ToolBuilder::title()` to explain what it does, how clients use it, and added a doctest example
- Added `.title()` to all 3 tools in `examples/basic.rs`
- Added `.title()` to the README quick-start example

Downstream projects (cratesio-mcp, jpx-mcp) missed this feature because none of the examples used it and the doc comment was minimal.

Closes #521

## Test plan

- [x] New doctest passes
- [x] `basic` example builds
- [x] fmt and clippy clean