### PR TITLE
ci: skip checks on markdown-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE-*"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "LICENSE-*"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

Skip CI for changes that only touch markdown files or license files. No need to run the full build/test matrix for docs-only PRs.

## Test plan

- [x] This PR itself is a good test - it only touches the workflow file, so CI should still run for it