### PR TITLE
refactor: sync tower-mcp-types version with workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tower-mcp"
-version = "0.7.0"
-edition = "2024"
-rust-version = "1.90"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Tower-native Model Context Protocol (MCP) implementation"
@@ -15,6 +15,11 @@ categories = ["network-programming", "asynchronous"]
 
 [workspace]
 members = ["tower-mcp-types", "examples/conformance-server", "examples/markdownlint-mcp", "examples/codegen-mcp", "examples/notes-mcp"]
+
+[workspace.package]
+version = "0.7.0"
+edition = "2024"
+rust-version = "1.90"
 
 [workspace.dependencies]
 tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }
@@ -30,7 +35,7 @@ futures = "0.3"
 pin-project-lite = "0.2"
 
 # MCP protocol types
-tower-mcp-types = { version = "0.1", path = "tower-mcp-types" }
+tower-mcp-types = { version = "0.7", path = "tower-mcp-types" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/tower-mcp-types/Cargo.toml
+++ b/tower-mcp-types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "tower-mcp-types"
-version = "0.1.0"
-edition = "2024"
-rust-version = "1.90"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 authors = ["Josh Rotenberg <joshrotenberg@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "MCP protocol and error types for tower-mcp (no runtime dependencies)"


### PR DESCRIPTION
## Summary

- Added `[workspace.package]` with shared `version`, `edition`, and `rust-version`
- Both `tower-mcp` and `tower-mcp-types` now use `version.workspace = true`
- Bumps `tower-mcp-types` from 0.1.0 to 0.7.0 to match tower-mcp

This ensures both crates stay in sync on releases, since the types are tightly coupled.

## Test plan

- [x] `cargo check --all-targets --all-features` passes
- [x] `cargo build --examples --all-features` passes
- [x] All lib tests pass
- [x] Clippy clean