### PR TITLE
docs: update AGENTS.md to reference CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,15 +42,7 @@ Resources: `source://stdio_server.rs` - serves its own source code
 
 ## Development
 
-Before committing, run:
-
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --lib --all-features
-cargo test --test '*' --all-features
-cargo test --doc --all-features
-```
+See [CONTRIBUTING.md](CONTRIBUTING.md) for build commands, PR guidelines, and contribution policy.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Replace duplicated development commands in AGENTS.md with a reference to CONTRIBUTING.md.

## Test plan

- N/A (documentation only)