### PR TITLE
chore: add repo health files for SDK tier assessment

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci):"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.7.x   | Yes       |
+| < 0.7   | No        |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via [GitHub Security Advisories](https://github.com/joshrotenberg/tower-mcp/security/advisories/new).
+
+Do **not** open a public issue for security vulnerabilities.
+
+You should receive an initial response within 72 hours. If a vulnerability is confirmed, a fix will be released as soon as possible, typically within 7 days.
+
+## Scope
+
+This policy covers:
+
+- The `tower-mcp` crate
+- The `tower-mcp-types` crate
+- Example servers in this repository (as reference implementations)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,36 @@
+# Versioning Policy
+
+## Semantic Versioning
+
+tower-mcp follows [Semantic Versioning 2.0.0](https://semver.org/). While below 1.0.0, minor version bumps may include breaking changes.
+
+## Workspace Versioning
+
+The workspace maintains synchronized versions:
+
+- `tower-mcp` and `tower-mcp-types` share the same version number
+- Both crates are released together
+
+## Minimum Supported Rust Version (MSRV)
+
+- Current MSRV: **1.90** (Rust 2024 edition)
+- MSRV bumps are treated as minor version changes (not patch)
+- MSRV is tested in CI on every push
+
+## MCP Specification Tracking
+
+- tower-mcp tracks the [Model Context Protocol specification](https://spec.modelcontextprotocol.io/)
+- Current spec version: **2025-11-25**
+- Spec version changes that require breaking API changes will bump the minor version (pre-1.0) or major version (post-1.0)
+
+## Feature Flags
+
+Feature flags may be added in minor versions. Existing feature flag behavior will not change in patch versions. See `Cargo.toml` for the full list of available features.
+
+## Breaking Changes
+
+Breaking changes are:
+
+- Communicated in commit messages using `feat!:` or `fix!:` prefixes
+- Documented in the auto-generated CHANGELOG
+- Batched into minor version releases when possible


### PR DESCRIPTION
## Summary

Adds repo health/policy files required by the MCP SDK Tier 2 assessment tool (`@modelcontextprotocol/conformance tier-check`):

- **SECURITY.md** - vulnerability reporting policy
- **VERSIONING.md** - semver, MSRV, and spec tracking policies
- **.github/dependabot.yml** - weekly Cargo + daily Actions dependency updates

Also created 6 missing GitHub labels (P1-P3, needs confirmation, needs repro, ready for work) required by the tier assessment.

Closes #542, closes #544, closes #545, closes #546

## Test plan

- [ ] Verify dependabot starts creating PRs within a week
- [ ] Re-run `tier-check --skip-conformance` to confirm policy signals improve