### PR TITLE
refactor: hide internal builder state types from docs

### DIFF
--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -996,6 +996,7 @@ where
 }
 
 /// Builder state for extractor-based handlers
+#[doc(hidden)]
 pub struct ToolBuilderWithExtractor<S, F, T> {
     pub(crate) name: String,
     pub(crate) title: Option<String>,
@@ -1108,6 +1109,7 @@ where
 /// Builder state after a layer has been applied to an extractor handler.
 ///
 /// This builder allows chaining additional layers and building the final tool.
+#[doc(hidden)]
 pub struct ToolBuilderWithExtractorLayer<S, F, T, L> {
     name: String,
     title: Option<String>,
@@ -1204,6 +1206,7 @@ where
 }
 
 /// Builder state for extractor-based handlers with typed JSON input
+#[doc(hidden)]
 #[deprecated(
     since = "0.8.0",
     note = "Use `ToolBuilderWithExtractor` via `extractor_handler` instead"

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -112,6 +112,7 @@ pub type BoxPromptService = BoxCloneService<PromptRequest, GetPromptResult, Infa
 /// wrapper converts it into a prompt error. This allows error information to
 /// flow through the normal response path rather than requiring special
 /// error handling.
+#[doc(hidden)]
 pub struct PromptCatchError<S> {
     inner: S,
 }
@@ -141,6 +142,7 @@ impl<S: fmt::Debug> fmt::Debug for PromptCatchError<S> {
 
 pin_project! {
     /// Future for [`PromptCatchError`].
+    #[doc(hidden)]
     pub struct PromptCatchErrorFuture<F> {
         #[pin]
         inner: F,
@@ -200,6 +202,7 @@ where
 ///
 /// This allows the handler to be wrapped with tower middleware layers.
 /// Used by `.layer()` on `PromptBuilderWithHandler`.
+#[doc(hidden)]
 pub struct PromptHandlerService<F> {
     handler: F,
 }
@@ -237,6 +240,7 @@ where
 /// Adapts a context-aware prompt handler function into a `Service<PromptRequest>`.
 ///
 /// Used by `.layer()` on `PromptBuilderWithContextHandler`.
+#[doc(hidden)]
 pub struct PromptContextHandlerService<F> {
     handler: F,
 }
@@ -620,6 +624,7 @@ impl PromptBuilder {
 ///
 /// This allows either calling `.build()` to create the prompt directly,
 /// or `.layer()` to apply middleware before building.
+#[doc(hidden)]
 pub struct PromptBuilderWithHandler<F> {
     name: String,
     title: Option<String>,
@@ -708,6 +713,7 @@ where
 }
 
 /// Builder state after context-aware handler is specified
+#[doc(hidden)]
 pub struct PromptBuilderWithContextHandler<F> {
     name: String,
     title: Option<String>,

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -120,6 +120,7 @@ pub type BoxResourceService = BoxCloneService<ResourceRequest, ReadResourceResul
 /// This wrapper ensures that middleware errors (e.g., timeouts, rate limits)
 /// and handler errors are converted to `Err(Error)` responses wrapped in
 /// `Ok`, rather than propagating as Tower service errors.
+#[doc(hidden)]
 pub struct ResourceCatchError<S> {
     inner: S,
 }
@@ -149,6 +150,7 @@ impl<S: fmt::Debug> fmt::Debug for ResourceCatchError<S> {
 
 pin_project! {
     /// Future for [`ResourceCatchError`].
+    #[doc(hidden)]
     pub struct ResourceCatchErrorFuture<F> {
         #[pin]
         inner: F,
@@ -695,6 +697,7 @@ impl ResourceBuilder {
 ///
 /// This builder allows applying middleware layers via `.layer()` or building
 /// the resource directly via `.build()`.
+#[doc(hidden)]
 pub struct ResourceBuilderWithHandler<F> {
     uri: String,
     name: Option<String>,
@@ -780,6 +783,7 @@ where
 /// Builder state after a layer has been applied to the handler.
 ///
 /// This builder allows chaining additional layers and building the final resource.
+#[doc(hidden)]
 pub struct ResourceBuilderWithLayer<F, L> {
     uri: String,
     name: Option<String>,
@@ -853,6 +857,7 @@ where
 }
 
 /// Builder state after context-aware handler is specified.
+#[doc(hidden)]
 pub struct ResourceBuilderWithContextHandler<F> {
     uri: String,
     name: Option<String>,
@@ -909,6 +914,7 @@ where
 }
 
 /// Builder state after a layer has been applied to a context-aware handler.
+#[doc(hidden)]
 pub struct ResourceBuilderWithContextLayer<F, L> {
     uri: String,
     name: Option<String>,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -29,7 +29,7 @@ use crate::session::SessionState;
 use crate::tool::Tool;
 
 /// Type alias for completion handler function
-pub type CompletionHandler = Arc<
+pub(crate) type CompletionHandler = Arc<
     dyn Fn(CompleteParams) -> Pin<Box<dyn Future<Output = Result<CompleteResult>> + Send>>
         + Send
         + Sync,

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -88,6 +88,7 @@ pub type BoxToolService = BoxCloneService<ToolRequest, CallToolResult, Infallibl
 /// This wrapper ensures that middleware errors (e.g., timeouts, rate limits)
 /// and handler errors are converted to tool-level error responses with
 /// `is_error: true`, rather than propagating as Tower service errors.
+#[doc(hidden)]
 pub struct ToolCatchError<S> {
     inner: S,
 }
@@ -117,6 +118,7 @@ impl<S: fmt::Debug> fmt::Debug for ToolCatchError<S> {
 
 pin_project! {
     /// Future for [`ToolCatchError`].
+    #[doc(hidden)]
     pub struct ToolCatchErrorFuture<F> {
         #[pin]
         inner: F,
@@ -227,6 +229,7 @@ where
 /// Service wrapper that runs a guard check before calling the inner service.
 ///
 /// Created by [`GuardLayer`]. See its documentation for usage.
+#[doc(hidden)]
 #[derive(Clone)]
 pub struct GuardService<G, S> {
     guard: G,
@@ -356,7 +359,7 @@ impl JsonSchema for NoParams {
 ///   and forward slashes
 ///
 /// Returns `Ok(())` if valid, `Err` with description if invalid.
-pub fn validate_tool_name(name: &str) -> Result<()> {
+pub(crate) fn validate_tool_name(name: &str) -> Result<()> {
     if name.is_empty() {
         return Err(Error::tool("Tool name cannot be empty"));
     }
@@ -1188,6 +1191,7 @@ where
 }
 
 /// Builder state after handler is specified
+#[doc(hidden)]
 pub struct ToolBuilderWithHandler<I, F> {
     name: String,
     title: Option<String>,
@@ -1203,6 +1207,7 @@ pub struct ToolBuilderWithHandler<I, F> {
 /// Builder state for tools with no parameters.
 ///
 /// Created by [`ToolBuilder::no_params_handler`].
+#[doc(hidden)]
 pub struct ToolBuilderWithNoParamsHandler<F> {
     name: String,
     title: Option<String>,
@@ -1264,6 +1269,7 @@ where
 }
 
 /// Builder state after a layer has been applied to a no-params handler.
+#[doc(hidden)]
 pub struct ToolBuilderWithNoParamsHandlerLayer<F, L> {
     name: String,
     title: Option<String>,
@@ -1422,6 +1428,7 @@ where
 /// Builder state after a layer has been applied to the handler.
 ///
 /// This builder allows chaining additional layers and building the final tool.
+#[doc(hidden)]
 pub struct ToolBuilderWithLayer<I, F, L> {
     name: String,
     title: Option<String>,

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -524,9 +524,9 @@ struct AppState {
 /// discovery per RFC 9728.
 #[cfg(feature = "oauth")]
 #[derive(Clone)]
-pub struct OAuthConfig {
+pub(crate) struct OAuthConfig {
     /// Protected Resource Metadata to serve at the well-known endpoint.
-    pub metadata: crate::oauth::ProtectedResourceMetadata,
+    pub(crate) metadata: crate::oauth::ProtectedResourceMetadata,
 }
 
 /// HTTP transport for MCP servers

--- a/crates/tower-mcp/src/transport/service.rs
+++ b/crates/tower-mcp/src/transport/service.rs
@@ -3,7 +3,7 @@
 //! This module provides the types needed to apply tower middleware layers
 //! to MCP request processing within HTTP and WebSocket transports.
 //!
-//! The key type is [`ServiceFactory`], a function that takes an [`McpRouter`]
+//! The key type is `ServiceFactory`, a function that takes an [`McpRouter`]
 //! and produces a boxed, middleware-wrapped service. Transports store this
 //! factory and use it when creating sessions.
 //!
@@ -19,6 +19,7 @@ use std::convert::Infallible;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
+#[cfg(any(feature = "http", feature = "websocket"))]
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -29,7 +30,9 @@ use tower_service::Service;
 
 use crate::error::JsonRpcError;
 use crate::protocol::RequestId;
-use crate::router::{McpRouter, RouterRequest, RouterResponse};
+#[cfg(any(feature = "http", feature = "websocket"))]
+use crate::router::McpRouter;
+use crate::router::{RouterRequest, RouterResponse};
 
 /// A boxed, cloneable MCP service with `Error = Infallible`.
 ///
@@ -42,15 +45,17 @@ pub type McpBoxService = BoxCloneService<RouterRequest, RouterResponse, Infallib
 /// A factory function that produces a [`McpBoxService`] from an [`McpRouter`].
 ///
 /// Transports store this factory and call it when creating new sessions.
-/// The default factory (from [`identity_factory`]) returns the router as-is.
+/// The default factory (from `identity_factory`) returns the router as-is.
 /// When `.layer()` is called on a transport, the factory wraps the router
 /// with the given middleware and a [`CatchError`] adapter.
-pub type ServiceFactory = Arc<dyn Fn(McpRouter) -> McpBoxService + Send + Sync>;
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub(crate) type ServiceFactory = Arc<dyn Fn(McpRouter) -> McpBoxService + Send + Sync>;
 
-/// Create a [`ServiceFactory`] that returns the router unchanged.
+/// Create a `ServiceFactory` that returns the router unchanged.
 ///
 /// This is the default factory used by transports when no `.layer()` is applied.
-pub fn identity_factory() -> ServiceFactory {
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub(crate) fn identity_factory() -> ServiceFactory {
     Arc::new(|router: McpRouter| BoxCloneService::new(router))
 }
 
@@ -155,6 +160,7 @@ mod tests {
     use crate::protocol::RequestId;
 
     #[test]
+    #[cfg(any(feature = "http", feature = "websocket"))]
     fn test_identity_factory_produces_service() {
         let router = McpRouter::new().server_info("test", "1.0.0");
         let factory = identity_factory();


### PR DESCRIPTION
## Summary

- Add `#[doc(hidden)]` to 22 internal types across tool, resource, prompt, and extract modules
- These are builder state types (`ToolBuilderWith*`, `ResourceBuilderWith*`, `PromptBuilderWith*`) and internal service wrappers (`*CatchError`, `*CatchErrorFuture`, `*HandlerService`, `GuardService`) that are implementation details not meant for direct use
- Part of #539 (API audit for 1.0 evaluation)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (85 passed)
- [x] `cargo test --test '*' --all-features` (44 passed)
- [x] `cargo test --doc --all-features` (45 passed)
- [x] `cargo doc --no-deps --all-features` builds cleanly