### PR TITLE
docs: add missing doc comments for all public API items

### DIFF
--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -797,6 +797,7 @@ where
 
 /// Helper trait to get schema from `Json<T>` extractor
 pub trait HasSchema {
+    /// Returns the JSON Schema for this type, if available.
     fn schema() -> Option<Value>;
 }
 

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -300,10 +300,15 @@ pub trait PromptHandler: Send + Sync {
 
 /// A complete prompt definition with handler
 pub struct Prompt {
+    /// The prompt name (must be unique within the router).
     pub name: String,
+    /// Optional human-readable title.
     pub title: Option<String>,
+    /// Optional description of the prompt.
     pub description: Option<String>,
+    /// Optional icons for the prompt.
     pub icons: Option<Vec<ToolIcon>>,
+    /// The arguments this prompt accepts.
     pub arguments: Vec<PromptArgument>,
     handler: Arc<dyn PromptHandler>,
 }
@@ -420,6 +425,7 @@ pub struct PromptBuilder {
 }
 
 impl PromptBuilder {
+    /// Create a new prompt builder with the given name.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -947,7 +953,9 @@ impl PromptHandler for ServiceContextHandler {
 /// assert_eq!(prompt.name, "code_review");
 /// ```
 pub trait McpPrompt: Send + Sync + 'static {
+    /// The prompt name (must be unique within the router).
     const NAME: &'static str;
+    /// A human-readable description of the prompt.
     const DESCRIPTION: &'static str;
 
     /// Define the arguments for this prompt
@@ -955,6 +963,7 @@ pub trait McpPrompt: Send + Sync + 'static {
         Vec::new()
     }
 
+    /// Generate the prompt messages for the given arguments.
     fn get(
         &self,
         arguments: HashMap<String, String>,

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -481,6 +481,7 @@ pub struct ResourceBuilder {
 }
 
 impl ResourceBuilder {
+    /// Create a new resource builder with the given URI.
     pub fn new(uri: impl Into<String>) -> Self {
         Self {
             uri: uri.into(),
@@ -1070,11 +1071,16 @@ where
 /// assert_eq!(resource.uri, "file:///config.json");
 /// ```
 pub trait McpResource: Send + Sync + 'static {
+    /// The resource URI.
     const URI: &'static str;
+    /// The resource name.
     const NAME: &'static str;
+    /// Optional human-readable description.
     const DESCRIPTION: Option<&'static str> = None;
+    /// Optional MIME type for the resource content.
     const MIME_TYPE: Option<&'static str> = None;
 
+    /// Read the resource content.
     fn read(&self) -> impl Future<Output = Result<ReadResourceResult>> + Send;
 
     /// Convert to a Resource instance

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1973,7 +1973,9 @@ pub use crate::context::Extensions;
 /// Request type for the tower Service implementation
 #[derive(Debug, Clone)]
 pub struct RouterRequest {
+    /// The JSON-RPC request ID.
     pub id: RequestId,
+    /// The parsed MCP request.
     pub inner: McpRequest,
     /// Type-map for passing data (e.g., `TokenClaims`) through middleware.
     pub extensions: Extensions,
@@ -1982,7 +1984,9 @@ pub struct RouterRequest {
 /// Response type for the tower Service implementation
 #[derive(Debug, Clone)]
 pub struct RouterResponse {
+    /// The JSON-RPC request ID this response corresponds to.
     pub id: RequestId,
+    /// The MCP response or JSON-RPC error.
     pub inner: std::result::Result<McpResponse, JsonRpcError>,
 }
 

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -1595,12 +1595,17 @@ where
 /// assert_eq!(tool.name, "add");
 /// ```
 pub trait McpTool: Send + Sync + 'static {
+    /// The tool name (must be unique within the router).
     const NAME: &'static str;
+    /// A human-readable description of the tool.
     const DESCRIPTION: &'static str;
 
+    /// The input type, deserialized from tool call arguments.
     type Input: JsonSchema + DeserializeOwned + Send;
+    /// The output type, serialized into the tool call result.
     type Output: Serialize + Send;
 
+    /// Execute the tool with the given input.
     fn call(&self, input: Self::Input) -> impl Future<Output = Result<Self::Output>> + Send;
 
     /// Optional annotations for the tool


### PR DESCRIPTION
## Summary

- Add doc comments to 25 public items missing documentation across 5 files
- Trait constants/types/methods on `McpTool`, `McpResource`, `McpPrompt`
- Struct fields on `Prompt`, `RouterRequest`, `RouterResponse`
- Constructor methods on `PromptBuilder::new()`, `ResourceBuilder::new()`
- `HasSchema::schema()` trait method
- All public types now pass `RUSTDOCFLAGS="-D missing_docs"`

Part of #539 (API audit for 1.0 evaluation).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (85 passed)
- [x] `cargo test --test '*' --all-features` (44 passed)
- [x] `cargo test --doc --all-features` (45 passed)
- [x] `RUSTDOCFLAGS="-D missing_docs" cargo doc` passes with zero warnings