### PR TITLE
fix: use oneshot() to ensure poll_ready before call in JsonRpcService

### DIFF
--- a/crates/tower-mcp/src/auth.rs
+++ b/crates/tower-mcp/src/auth.rs
@@ -38,7 +38,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 
-use tower::Layer;
+use tower::{Layer, ServiceExt};
 
 /// Result of an authentication attempt
 #[derive(Debug, Clone)]
@@ -343,7 +343,7 @@ where
             .and_then(extract_api_key)
             .map(|s| s.to_owned());
 
-        let mut inner = self.inner.clone();
+        let inner = self.inner.clone();
         let validator = self.validator.clone();
 
         Box::pin(async move {
@@ -359,7 +359,7 @@ where
                     if let Some(info) = info {
                         req.extensions_mut().insert(info);
                     }
-                    inner.call(req).await
+                    inner.oneshot(req).await
                 }
                 AuthResult::Failed(err) => Ok(unauthorized_response(&err.message)),
             }

--- a/crates/tower-mcp/src/auth.rs
+++ b/crates/tower-mcp/src/auth.rs
@@ -38,7 +38,9 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::sync::Arc;
 
-use tower::{Layer, ServiceExt};
+use tower::Layer;
+#[cfg(feature = "http")]
+use tower::ServiceExt;
 
 /// Result of an authentication attempt
 #[derive(Debug, Clone)]

--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -15,7 +15,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use tower::Layer;
+use tower::{Layer, ServiceExt};
 use tower_service::Service;
 
 use crate::error::{Error, JsonRpcError, Result};
@@ -215,7 +215,7 @@ where
     }
 
     fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
-        let mut inner = self.inner.clone();
+        let inner = self.inner.clone();
         let extensions = self.extensions.clone();
         Box::pin(async move {
             // Parse the MCP request from JSON-RPC
@@ -228,8 +228,8 @@ where
                 extensions,
             };
 
-            // Call the inner service
-            let response = inner.call(router_req).await.unwrap(); // Infallible
+            // Call the inner service (oneshot handles poll_ready)
+            let response = inner.oneshot(router_req).await.unwrap(); // Infallible
 
             // Convert to JSON-RPC response
             Ok(response.into_jsonrpc())
@@ -318,7 +318,7 @@ where
 
 /// Helper function to process a single JSON-RPC request
 async fn process_single_request<S>(
-    mut inner: S,
+    inner: S,
     req: JsonRpcRequest,
     extensions: Extensions,
 ) -> std::result::Result<JsonRpcResponse, Error>
@@ -351,8 +351,8 @@ where
         extensions,
     };
 
-    // Call the inner service
-    let response = inner.call(router_req).await.unwrap(); // Infallible
+    // Call the inner service (oneshot handles poll_ready)
+    let response = inner.oneshot(router_req).await.unwrap(); // Infallible
 
     // Convert to JSON-RPC response
     Ok(response.into_jsonrpc())

--- a/crates/tower-mcp/src/oauth/middleware.rs
+++ b/crates/tower-mcp/src/oauth/middleware.rs
@@ -10,7 +10,7 @@ use std::task::{Context, Poll};
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
 use axum::response::{IntoResponse, Response};
-use tower::Layer;
+use tower::{Layer, ServiceExt};
 
 use super::error::OAuthError;
 use super::metadata::ProtectedResourceMetadata;
@@ -122,17 +122,17 @@ where
         let validator = self.validator.clone();
         let metadata = self.metadata.clone();
         let scope_policy = self.scope_policy.clone();
-        let mut inner = self.inner.clone();
+        let inner = self.inner.clone();
 
         Box::pin(async move {
             // Skip validation for public paths
             if public_paths.iter().any(|p| path.starts_with(p.as_str())) {
-                return inner.call(req).await;
+                return inner.oneshot(req).await;
             }
 
             // Also skip well-known paths that may be nested under a mount point
             if path.contains("/.well-known/") {
-                return inner.call(req).await;
+                return inner.oneshot(req).await;
             }
 
             // Extract bearer token
@@ -167,7 +167,7 @@ where
             // Inject claims into request extensions
             let mut req = req;
             req.extensions_mut().insert(claims);
-            inner.call(req).await
+            inner.oneshot(req).await
         })
     }
 }


### PR DESCRIPTION
## Summary

- `Service::call()` was invoked on cloned services without first calling `poll_ready()`, violating the Tower Service contract
- Replaced `inner.call(req)` with `inner.oneshot(router_req)` which handles readiness automatically
- Fixed in three locations:
  - **`jsonrpc.rs`** — `Service<JsonRpcRequest>::call` impl and `process_single_request` helper (high impact: `McpRouter::poll_ready` gates on init state)
  - **`auth.rs`** — `AuthService::call` clone-then-call pattern
  - **`oauth/middleware.rs`** — `OAuthService::call` clone-then-call pattern (3 call sites)

Fixes #597

## Test plan

- [x] All library tests pass (`cargo test --lib --all-features`)
- [x] All integration tests pass (`cargo test --test '*' --all-features`)
- [x] clippy clean with all features
- [x] fmt check passes