### PR TITLE
chore: update reqwest to 0.13 in markdownlint-mcp

### DIFF
--- a/examples/markdownlint-mcp/Cargo.toml
+++ b/examples/markdownlint-mcp/Cargo.toml
@@ -15,7 +15,7 @@ tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 schemars.workspace = true
-reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.13", features = ["rustls"], default-features = false }
 tracing.workspace = true
 tracing-subscriber.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

- Update reqwest from 0.12 to 0.13 in markdownlint-mcp
- Rename `rustls-tls` feature to `rustls` (renamed in reqwest 0.13)

## Test plan

- [x] `cargo check --manifest-path examples/markdownlint-mcp/Cargo.toml` passes