### PR TITLE
feat: MCP proxy for multi-server aggregation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ base64 = "0.22.1"
 # Tower ecosystem
 tower = { version = "0.5", features = ["util"] }
 tower-service = "0.3"
-tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter"] }
+tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter", "coalesce"] }
 
 # Async
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -340,7 +340,11 @@ let proxy = McpProxy::builder("proxy", "1.0.0")
     .build().await?;
 ```
 
-The proxy also supports notification forwarding (backend list-changed events propagate to clients), health checks (`proxy.health_check().await`), and request coalescing via `tower-resilience`'s `CoalesceLayer`. See the [`proxy` module docs](https://docs.rs/tower-mcp/latest/tower_mcp/proxy/) and `examples/proxy.rs`.
+The proxy also supports notification forwarding (backend list-changed events propagate to clients), health checks (`proxy.health_check().await`), and request coalescing via `tower-resilience`'s `CoalesceLayer`.
+
+Backends don't need to be built with tower-mcp -- the proxy communicates over standard MCP (JSON-RPC), so it works with servers written in any language or framework: Python (FastMCP), TypeScript, Go, or anything that speaks the MCP protocol. This makes tower-mcp a natural aggregation and middleware layer for polyglot MCP deployments.
+
+See the [`proxy` module docs](https://docs.rs/tower-mcp/latest/tower_mcp/proxy/) and `examples/proxy.rs`.
 
 ## Router-Level State
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Conformance** | 39/39 official MCP conformance tests pass in CI on every PR. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. |
+| **Multi-server proxy** | Aggregate N backend servers behind a single endpoint with per-backend middleware and namespace isolation. |
 | **axum ecosystem** | HTTP and WebSocket transports build on axum, so existing axum middleware and extractors work. |
 
 ### Trade-offs
@@ -101,6 +102,7 @@ tower-mcp = "0.7"
 | `jwks` | JWKS endpoint fetching for remote key sets (requires `oauth`) |
 | `testing` | Test utilities (`TestClient`) for in-process testing |
 | `dynamic-tools` | Runtime tool registration/deregistration via `DynamicToolRegistry` |
+| `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 
 Example with features:
 
@@ -302,6 +304,43 @@ let versioned = McpRouter::new()
     .nest("v1", v1)   // Tools become "v1_legacy_tool"
     .nest("v2", v2);  // Tools become "v2_new_tool"
 ```
+
+## Multi-Server Proxy
+
+Aggregate multiple backend MCP servers behind a single endpoint with `McpProxy` (feature: `proxy`). Each backend's tools, resources, and prompts are namespaced to avoid collisions:
+
+```rust
+use tower_mcp::proxy::McpProxy;
+use tower_mcp::client::StdioClientTransport;
+
+let proxy = McpProxy::builder("my-proxy", "1.0.0")
+    .backend("db", StdioClientTransport::spawn("db-server", &[]).await?)
+    .await
+    .backend("fs", StdioClientTransport::spawn("fs-server", &[]).await?)
+    .await
+    .build()
+    .await?;
+
+// Tools become db_query, fs_read, etc.
+// Serve over any transport.
+StdioTransport::new(proxy).run().await?;
+```
+
+Per-backend Tower middleware applies to individual backends:
+
+```rust
+use std::time::Duration;
+use tower::timeout::TimeoutLayer;
+
+let proxy = McpProxy::builder("proxy", "1.0.0")
+    .backend("fast", cache_transport).await
+    .backend_layer(TimeoutLayer::new(Duration::from_secs(2)))
+    .backend("slow", llm_transport).await
+    .backend_layer(TimeoutLayer::new(Duration::from_secs(60)))
+    .build().await?;
+```
+
+The proxy also supports notification forwarding (backend list-changed events propagate to clients), health checks (`proxy.health_check().await`), and request coalescing via `tower-resilience`'s `CoalesceLayer`. See the [`proxy` module docs](https://docs.rs/tower-mcp/latest/tower_mcp/proxy/) and `examples/proxy.rs`.
 
 ## Router-Level State
 
@@ -505,6 +544,7 @@ The repo includes several example servers you can try with any MCP-enabled agent
 | `codegen-mcp` | Helps AI agents build tower-mcp servers |
 | `weather` | Weather forecasts via NWS API |
 | `conformance` | Full MCP spec conformance server (39/39 tests) |
+| `proxy` | Multi-server proxy with per-backend middleware |
 
 ```bash
 git clone https://github.com/joshrotenberg/tower-mcp

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -33,6 +33,7 @@ async-trait.workspace = true
 tokio-test = "0.4"
 tower = { workspace = true, features = ["timeout", "limit"] }
 tower-mcp-types = { path = "../tower-mcp-types" }
+tower-resilience = { workspace = true, default-features = false, features = ["coalesce"] }
 tracing-subscriber.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "stream"] }
 jsonschema = "0.44"

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -40,7 +40,7 @@ jsonschema = "0.44"
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client"]
+full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
@@ -57,6 +57,8 @@ http-client = ["dep:reqwest"]
 oauth-client = ["http-client"]
 # Runtime tool (de)registration via DynamicToolRegistry
 dynamic-tools = []
+# MCP proxy for aggregating multiple backend servers
+proxy = []
 
 [dependencies.axum]
 workspace = true
@@ -168,3 +170,8 @@ path = "../../examples/client_handler.rs"
 name = "oauth_client"
 path = "../../examples/oauth_client.rs"
 required-features = ["oauth-client"]
+
+[[example]]
+name = "proxy"
+path = "../../examples/proxy.rs"
+required-features = ["proxy"]

--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -1,0 +1,151 @@
+//! In-process channel transport for connecting an [`McpClient`] to an [`McpRouter`].
+//!
+//! This transport bridges client and server in the same process without
+//! any network or subprocess overhead. It is primarily useful for testing
+//! (e.g., proxy tests) but can also be used for in-process composition.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::client::{McpClient, ChannelTransport};
+//! use tower_mcp::McpRouter;
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let router = McpRouter::new().server_info("backend", "1.0.0");
+//! let transport = ChannelTransport::new(router);
+//! let client = McpClient::connect(transport).await?;
+//! client.initialize("my-client", "1.0.0").await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::context::notification_channel;
+use crate::error::Result;
+use crate::jsonrpc::JsonRpcService;
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse, McpNotification};
+use crate::router::McpRouter;
+
+use super::transport::ClientTransport;
+
+/// An in-process [`ClientTransport`] that connects directly to an [`McpRouter`].
+///
+/// Messages are passed through tokio channels — the transport spawns a
+/// background task that feeds incoming JSON-RPC requests to a
+/// [`JsonRpcService<McpRouter>`] and returns responses.
+pub struct ChannelTransport {
+    /// Send raw JSON messages to the server task.
+    request_tx: mpsc::Sender<String>,
+    /// Receive raw JSON responses from the server task.
+    response_rx: mpsc::Receiver<String>,
+    connected: bool,
+}
+
+impl ChannelTransport {
+    /// Create a new channel transport backed by the given router.
+    ///
+    /// Spawns a background tokio task that processes requests.
+    pub fn new(router: McpRouter) -> Self {
+        let (request_tx, mut request_rx) = mpsc::channel::<String>(64);
+        let (response_tx, response_rx) = mpsc::channel::<String>(64);
+
+        let (notification_tx, _notification_rx) = notification_channel(64);
+        let router = router.with_notification_sender(notification_tx);
+        let mut service = JsonRpcService::new(router.clone());
+
+        tokio::spawn(async move {
+            while let Some(raw_request) = request_rx.recv().await {
+                // Parse the incoming JSON
+                let req: JsonRpcRequest = match serde_json::from_str(&raw_request) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::error!("ChannelTransport: failed to parse request: {}", e);
+                        continue;
+                    }
+                };
+
+                // Check for initialized notification embedded as a request
+                // (McpClient sends notifications as JSON-RPC messages)
+                if req.method == "notifications/initialized" {
+                    router.handle_notification(McpNotification::Initialized);
+                    // No response for notifications
+                    continue;
+                }
+
+                // Handle other notifications (no response expected)
+                if req.method.starts_with("notifications/") {
+                    continue;
+                }
+
+                // Process the request through JsonRpcService
+                let response = service.call_single(req).await;
+
+                let json = match response {
+                    Ok(resp) => match serde_json::to_string(&resp) {
+                        Ok(j) => j,
+                        Err(e) => {
+                            tracing::error!(
+                                "ChannelTransport: failed to serialize response: {}",
+                                e
+                            );
+                            continue;
+                        }
+                    },
+                    Err(e) => {
+                        // Convert error to a JSON-RPC error response
+                        let err_resp = JsonRpcResponse::error(
+                            None,
+                            tower_mcp_types::JsonRpcError::internal_error(e.to_string()),
+                        );
+                        match serde_json::to_string(&err_resp) {
+                            Ok(j) => j,
+                            Err(_) => continue,
+                        }
+                    }
+                };
+
+                if response_tx.send(json).await.is_err() {
+                    break; // Client dropped
+                }
+            }
+        });
+
+        Self {
+            request_tx,
+            response_rx,
+            connected: true,
+        }
+    }
+}
+
+#[async_trait]
+impl ClientTransport for ChannelTransport {
+    async fn send(&mut self, message: &str) -> Result<()> {
+        self.request_tx
+            .send(message.to_string())
+            .await
+            .map_err(|_| crate::error::Error::internal("ChannelTransport: server task dropped"))?;
+        Ok(())
+    }
+
+    async fn recv(&mut self) -> Result<Option<String>> {
+        match self.response_rx.recv().await {
+            Some(msg) => Ok(Some(msg)),
+            None => {
+                self.connected = false;
+                Ok(None)
+            }
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.connected = false;
+        Ok(())
+    }
+}

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -30,6 +30,7 @@
 //! }
 //! ```
 
+mod channel;
 mod handler;
 #[cfg(feature = "http-client")]
 mod http;
@@ -38,6 +39,7 @@ mod oauth;
 mod stdio;
 mod transport;
 
+pub use channel::ChannelTransport;
 pub use handler::{ClientHandler, NotificationHandler, ServerNotification};
 #[cfg(feature = "http-client")]
 pub use http::{HttpClientConfig, HttpClientTransport};

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -363,6 +363,8 @@ pub mod middleware;
 pub mod oauth;
 pub mod prompt;
 pub mod protocol;
+#[cfg(feature = "proxy")]
+pub mod proxy;
 #[cfg(feature = "dynamic-tools")]
 pub mod registry;
 pub mod resource;
@@ -377,8 +379,8 @@ pub mod transport;
 // Re-exports
 pub use async_task::{Task, TaskStore};
 pub use client::{
-    ClientHandler, ClientTransport, McpClient, McpClientBuilder, NotificationHandler,
-    StdioClientTransport,
+    ChannelTransport, ClientHandler, ClientTransport, McpClient, McpClientBuilder,
+    NotificationHandler, StdioClientTransport,
 };
 #[cfg(feature = "http-client")]
 pub use client::{HttpClientConfig, HttpClientTransport};

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -145,6 +145,7 @@
 //! - `oauth` - OAuth 2.1 resource server support (token validation, metadata endpoint)
 //! - `testing` - Test utilities (`TestClient`) for ergonomic MCP server testing
 //! - `dynamic-tools` - Runtime tool (de)registration via `DynamicToolRegistry`
+//! - `proxy` - Multi-server aggregation proxy ([`McpProxy`](proxy::McpProxy))
 //!
 //! ## Middleware Placement Guide
 //!
@@ -344,6 +345,34 @@
 //!     .merge(db_router)
 //!     .merge(api_router);
 //! ```
+//!
+//! ### Multi-Server Proxy
+//!
+//! Aggregate multiple backend MCP servers behind a single endpoint using
+//! [`McpProxy`](proxy::McpProxy) (requires the `proxy` feature):
+//!
+//! ```rust,no_run
+//! use tower_mcp::proxy::McpProxy;
+//! use tower_mcp::client::StdioClientTransport;
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let proxy = McpProxy::builder("my-proxy", "1.0.0")
+//!     .backend("db", StdioClientTransport::spawn("db-server", &[]).await?)
+//!     .await
+//!     .backend("fs", StdioClientTransport::spawn("fs-server", &[]).await?)
+//!     .await
+//!     .build()
+//!     .await?;
+//!
+//! // Tools become `db_query`, `fs_read`, etc.
+//! // Serve over any transport -- stdio, HTTP, WebSocket.
+//! tower_mcp::GenericStdioTransport::new(proxy).run().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The proxy supports per-backend Tower middleware, notification forwarding,
+//! health checks, and request coalescing. See the [`proxy`] module for details.
 //!
 //! ## MCP Specification
 //!

--- a/crates/tower-mcp/src/proxy/backend.rs
+++ b/crates/tower-mcp/src/proxy/backend.rs
@@ -1,0 +1,254 @@
+//! Backend connection management.
+//!
+//! Each backend wraps an [`McpClient`] with cached capability discovery
+//! and namespace prefixing. Backends automatically refresh their cache
+//! when the server sends list-changed notifications.
+
+use std::sync::Arc;
+
+use tokio::sync::{RwLock, mpsc};
+
+use crate::client::{ClientTransport, McpClient, NotificationHandler};
+use crate::error::Result;
+use crate::protocol::{
+    CallToolResult, GetPromptResult, PromptDefinition, ReadResourceResult, ResourceDefinition,
+    ResourceTemplateDefinition, ToolDefinition,
+};
+
+/// Cached capabilities from a backend server.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct CachedCapabilities {
+    pub tools: Vec<ToolDefinition>,
+    pub resources: Vec<ResourceDefinition>,
+    pub resource_templates: Vec<ResourceTemplateDefinition>,
+    pub prompts: Vec<PromptDefinition>,
+}
+
+/// What kind of capability list changed.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ListChanged {
+    Tools,
+    Resources,
+    Prompts,
+}
+
+/// A connected backend MCP server with namespace and cached capabilities.
+pub(crate) struct Backend {
+    /// Namespace prefix for this backend's capabilities.
+    pub namespace: String,
+    /// Separator between namespace and name (default: `_`).
+    pub separator: String,
+    /// The connected MCP client.
+    pub client: McpClient,
+    /// Cached capabilities, refreshed on list-changed notifications.
+    pub cache: Arc<RwLock<CachedCapabilities>>,
+}
+
+impl Backend {
+    /// Connect a transport and create a backend with a notification handler
+    /// that sends invalidation signals on the provided channel.
+    pub async fn connect(
+        namespace: impl Into<String>,
+        transport: impl ClientTransport,
+        separator: String,
+        invalidation_tx: mpsc::Sender<ListChanged>,
+    ) -> Result<Self> {
+        let tools_tx = invalidation_tx.clone();
+        let resources_tx = invalidation_tx.clone();
+        let prompts_tx = invalidation_tx;
+
+        let handler = NotificationHandler::new()
+            .on_tools_changed(move || {
+                let _ = tools_tx.try_send(ListChanged::Tools);
+            })
+            .on_resources_changed(move || {
+                let _ = resources_tx.try_send(ListChanged::Resources);
+            })
+            .on_prompts_changed(move || {
+                let _ = prompts_tx.try_send(ListChanged::Prompts);
+            });
+
+        let client = McpClient::connect_with_handler(transport, handler).await?;
+        let cache = Arc::new(RwLock::new(CachedCapabilities::default()));
+
+        Ok(Self {
+            namespace: namespace.into(),
+            separator,
+            client,
+            cache,
+        })
+    }
+
+    /// Create a backend from an already-connected client (no notification forwarding).
+    pub fn from_client(namespace: impl Into<String>, client: McpClient, separator: String) -> Self {
+        Self {
+            namespace: namespace.into(),
+            separator,
+            client,
+            cache: Arc::new(RwLock::new(CachedCapabilities::default())),
+        }
+    }
+
+    /// Initialize the backend: run MCP initialize handshake and discover capabilities.
+    pub async fn initialize(&self, proxy_name: &str, proxy_version: &str) -> Result<()> {
+        self.client.initialize(proxy_name, proxy_version).await?;
+        self.refresh_capabilities().await?;
+        Ok(())
+    }
+
+    /// Refresh cached capabilities from the backend.
+    pub async fn refresh_capabilities(&self) -> Result<()> {
+        // Fetch all capabilities concurrently
+        let (tools, resources, templates, prompts) = tokio::join!(
+            self.client.list_all_tools(),
+            self.client.list_all_resources(),
+            self.client.list_all_resource_templates(),
+            self.client.list_all_prompts(),
+        );
+
+        let mut cache = self.cache.write().await;
+        cache.tools = tools.unwrap_or_default();
+        cache.resources = resources.unwrap_or_default();
+        cache.resource_templates = templates.unwrap_or_default();
+        cache.prompts = prompts.unwrap_or_default();
+
+        Ok(())
+    }
+
+    /// Refresh only the tools cache.
+    pub async fn refresh_tools(&self) {
+        if let Ok(tools) = self.client.list_all_tools().await {
+            self.cache.write().await.tools = tools;
+        }
+    }
+
+    /// Refresh only the resources cache.
+    pub async fn refresh_resources(&self) {
+        let (resources, templates) = tokio::join!(
+            self.client.list_all_resources(),
+            self.client.list_all_resource_templates(),
+        );
+        let mut cache = self.cache.write().await;
+        if let Ok(r) = resources {
+            cache.resources = r;
+        }
+        if let Ok(t) = templates {
+            cache.resource_templates = t;
+        }
+    }
+
+    /// Refresh only the prompts cache.
+    pub async fn refresh_prompts(&self) {
+        if let Ok(prompts) = self.client.list_all_prompts().await {
+            self.cache.write().await.prompts = prompts;
+        }
+    }
+
+    /// Prefix a name with this backend's namespace.
+    pub fn prefixed_name(&self, name: &str) -> String {
+        format!("{}{}{}", self.namespace, self.separator, name)
+    }
+
+    /// Strip the namespace prefix from a name, if it matches.
+    pub fn strip_prefix<'a>(&self, name: &'a str) -> Option<&'a str> {
+        let prefix = format!("{}{}", self.namespace, self.separator);
+        name.strip_prefix(&prefix)
+    }
+
+    /// Prefix a resource URI with the namespace.
+    pub fn prefixed_uri(&self, uri: &str) -> String {
+        format!("{}{}{}", self.namespace, self.separator, uri)
+    }
+
+    /// Strip the namespace prefix from a URI.
+    pub fn strip_uri_prefix<'a>(&self, uri: &'a str) -> Option<&'a str> {
+        let prefix = format!("{}{}", self.namespace, self.separator);
+        uri.strip_prefix(&prefix)
+    }
+
+    /// Get namespaced tool definitions from cache.
+    pub async fn namespaced_tools(&self) -> Vec<ToolDefinition> {
+        let cache = self.cache.read().await;
+        cache
+            .tools
+            .iter()
+            .map(|t| {
+                let mut def = t.clone();
+                def.name = self.prefixed_name(&def.name);
+                def
+            })
+            .collect()
+    }
+
+    /// Get namespaced resource definitions from cache.
+    pub async fn namespaced_resources(&self) -> Vec<ResourceDefinition> {
+        let cache = self.cache.read().await;
+        cache
+            .resources
+            .iter()
+            .map(|r| {
+                let mut def = r.clone();
+                def.uri = self.prefixed_uri(&def.uri);
+                def.name = self.prefixed_name(&def.name);
+                def
+            })
+            .collect()
+    }
+
+    /// Get namespaced resource template definitions from cache.
+    pub async fn namespaced_resource_templates(&self) -> Vec<ResourceTemplateDefinition> {
+        let cache = self.cache.read().await;
+        cache
+            .resource_templates
+            .iter()
+            .map(|rt| {
+                let mut def = rt.clone();
+                def.uri_template = self.prefixed_uri(&def.uri_template);
+                def.name = self.prefixed_name(&def.name);
+                def
+            })
+            .collect()
+    }
+
+    /// Get namespaced prompt definitions from cache.
+    pub async fn namespaced_prompts(&self) -> Vec<PromptDefinition> {
+        let cache = self.cache.read().await;
+        cache
+            .prompts
+            .iter()
+            .map(|p| {
+                let mut def = p.clone();
+                def.name = self.prefixed_name(&def.name);
+                def
+            })
+            .collect()
+    }
+
+    /// Call a tool on this backend (name should already have prefix stripped).
+    pub async fn call_tool(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<CallToolResult> {
+        self.client.call_tool(name, arguments).await
+    }
+
+    /// Read a resource from this backend (uri should already have prefix stripped).
+    pub async fn read_resource(&self, uri: &str) -> Result<ReadResourceResult> {
+        self.client.read_resource(uri).await
+    }
+
+    /// Get a prompt from this backend (name should already have prefix stripped).
+    pub async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: std::collections::HashMap<String, String>,
+    ) -> Result<GetPromptResult> {
+        let args = if arguments.is_empty() {
+            None
+        } else {
+            Some(arguments)
+        };
+        self.client.get_prompt(name, args).await
+    }
+}

--- a/crates/tower-mcp/src/proxy/backend.rs
+++ b/crates/tower-mcp/src/proxy/backend.rs
@@ -1,19 +1,26 @@
 //! Backend connection management.
 //!
-//! Each backend wraps an [`McpClient`] with cached capability discovery
-//! and namespace prefixing. Backends automatically refresh their cache
-//! when the server sends list-changed notifications.
+//! Each backend wraps an [`McpClient`] with cached capability discovery,
+//! namespace prefixing, and a Tower service for dispatching routed requests.
 
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use tokio::sync::{RwLock, mpsc};
+use tower_service::Service;
 
 use crate::client::{ClientTransport, McpClient, NotificationHandler};
-use crate::error::Result;
 use crate::protocol::{
-    CallToolResult, GetPromptResult, PromptDefinition, ReadResourceResult, ResourceDefinition,
-    ResourceTemplateDefinition, ToolDefinition,
+    McpRequest, McpResponse, PromptDefinition, ResourceDefinition, ResourceTemplateDefinition,
+    ToolDefinition,
 };
+use crate::router::{RouterRequest, RouterResponse};
+use tower_mcp_types::JsonRpcError;
+
+type Result<T> = std::result::Result<T, crate::error::Error>;
 
 /// Cached capabilities from a backend server.
 #[derive(Debug, Default, Clone)]
@@ -38,8 +45,8 @@ pub(crate) struct Backend {
     pub namespace: String,
     /// Separator between namespace and name (default: `_`).
     pub separator: String,
-    /// The connected MCP client.
-    pub client: McpClient,
+    /// The connected MCP client (shared with BackendService).
+    pub client: Arc<McpClient>,
     /// Cached capabilities, refreshed on list-changed notifications.
     pub cache: Arc<RwLock<CachedCapabilities>>,
 }
@@ -74,7 +81,7 @@ impl Backend {
         Ok(Self {
             namespace: namespace.into(),
             separator,
-            client,
+            client: Arc::new(client),
             cache,
         })
     }
@@ -84,8 +91,15 @@ impl Backend {
         Self {
             namespace: namespace.into(),
             separator,
-            client,
+            client: Arc::new(client),
             cache: Arc::new(RwLock::new(CachedCapabilities::default())),
+        }
+    }
+
+    /// Create a [`BackendService`] for dispatching routed requests to this backend.
+    pub fn service(&self) -> BackendService {
+        BackendService {
+            client: Arc::clone(&self.client),
         }
     }
 
@@ -98,7 +112,6 @@ impl Backend {
 
     /// Refresh cached capabilities from the backend.
     pub async fn refresh_capabilities(&self) -> Result<()> {
-        // Fetch all capabilities concurrently
         let (tools, resources, templates, prompts) = tokio::join!(
             self.client.list_all_tools(),
             self.client.list_all_resources(),
@@ -143,112 +156,84 @@ impl Backend {
             self.cache.write().await.prompts = prompts;
         }
     }
+}
 
-    /// Prefix a name with this backend's namespace.
-    pub fn prefixed_name(&self, name: &str) -> String {
-        format!("{}{}{}", self.namespace, self.separator, name)
+// =============================================================================
+// BackendService
+// =============================================================================
+
+/// A Tower [`Service`] that dispatches routed requests to a backend [`McpClient`].
+///
+/// This service handles individual requests after the proxy has already
+/// determined which backend they belong to and stripped the namespace prefix.
+/// It converts `McpClient` method calls into the `Service<RouterRequest>`
+/// interface, allowing standard Tower middleware to wrap per-backend dispatch.
+///
+/// Created via `Backend::service()` and typically wrapped with middleware
+/// before being type-erased into the proxy's backend entry.
+#[derive(Clone)]
+pub struct BackendService {
+    client: Arc<McpClient>,
+}
+
+impl Service<RouterRequest> for BackendService {
+    type Response = RouterResponse;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<RouterResponse, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
-    /// Strip the namespace prefix from a name, if it matches.
-    pub fn strip_prefix<'a>(&self, name: &'a str) -> Option<&'a str> {
-        let prefix = format!("{}{}", self.namespace, self.separator);
-        name.strip_prefix(&prefix)
-    }
+    fn call(&mut self, req: RouterRequest) -> Self::Future {
+        let client = Arc::clone(&self.client);
+        let request_id = req.id.clone();
 
-    /// Prefix a resource URI with the namespace.
-    pub fn prefixed_uri(&self, uri: &str) -> String {
-        format!("{}{}{}", self.namespace, self.separator, uri)
-    }
-
-    /// Strip the namespace prefix from a URI.
-    pub fn strip_uri_prefix<'a>(&self, uri: &'a str) -> Option<&'a str> {
-        let prefix = format!("{}{}", self.namespace, self.separator);
-        uri.strip_prefix(&prefix)
-    }
-
-    /// Get namespaced tool definitions from cache.
-    pub async fn namespaced_tools(&self) -> Vec<ToolDefinition> {
-        let cache = self.cache.read().await;
-        cache
-            .tools
-            .iter()
-            .map(|t| {
-                let mut def = t.clone();
-                def.name = self.prefixed_name(&def.name);
-                def
+        Box::pin(async move {
+            let result = dispatch_to_client(&client, req.inner).await;
+            Ok(RouterResponse {
+                id: request_id,
+                inner: result,
             })
-            .collect()
+        })
     }
+}
 
-    /// Get namespaced resource definitions from cache.
-    pub async fn namespaced_resources(&self) -> Vec<ResourceDefinition> {
-        let cache = self.cache.read().await;
-        cache
-            .resources
-            .iter()
-            .map(|r| {
-                let mut def = r.clone();
-                def.uri = self.prefixed_uri(&def.uri);
-                def.name = self.prefixed_name(&def.name);
-                def
-            })
-            .collect()
-    }
-
-    /// Get namespaced resource template definitions from cache.
-    pub async fn namespaced_resource_templates(&self) -> Vec<ResourceTemplateDefinition> {
-        let cache = self.cache.read().await;
-        cache
-            .resource_templates
-            .iter()
-            .map(|rt| {
-                let mut def = rt.clone();
-                def.uri_template = self.prefixed_uri(&def.uri_template);
-                def.name = self.prefixed_name(&def.name);
-                def
-            })
-            .collect()
-    }
-
-    /// Get namespaced prompt definitions from cache.
-    pub async fn namespaced_prompts(&self) -> Vec<PromptDefinition> {
-        let cache = self.cache.read().await;
-        cache
-            .prompts
-            .iter()
-            .map(|p| {
-                let mut def = p.clone();
-                def.name = self.prefixed_name(&def.name);
-                def
-            })
-            .collect()
-    }
-
-    /// Call a tool on this backend (name should already have prefix stripped).
-    pub async fn call_tool(
-        &self,
-        name: &str,
-        arguments: serde_json::Value,
-    ) -> Result<CallToolResult> {
-        self.client.call_tool(name, arguments).await
-    }
-
-    /// Read a resource from this backend (uri should already have prefix stripped).
-    pub async fn read_resource(&self, uri: &str) -> Result<ReadResourceResult> {
-        self.client.read_resource(uri).await
-    }
-
-    /// Get a prompt from this backend (name should already have prefix stripped).
-    pub async fn get_prompt(
-        &self,
-        name: &str,
-        arguments: std::collections::HashMap<String, String>,
-    ) -> Result<GetPromptResult> {
-        let args = if arguments.is_empty() {
-            None
-        } else {
-            Some(arguments)
-        };
-        self.client.get_prompt(name, args).await
+/// Dispatch a single (namespace-stripped) MCP request to the backend client.
+async fn dispatch_to_client(
+    client: &McpClient,
+    request: McpRequest,
+) -> std::result::Result<McpResponse, JsonRpcError> {
+    match request {
+        McpRequest::CallTool(params) => {
+            let result = client
+                .call_tool(&params.name, params.arguments)
+                .await
+                .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+            Ok(McpResponse::CallTool(result))
+        }
+        McpRequest::ReadResource(params) => {
+            let result = client
+                .read_resource(&params.uri)
+                .await
+                .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+            Ok(McpResponse::ReadResource(result))
+        }
+        McpRequest::GetPrompt(params) => {
+            let args = if params.arguments.is_empty() {
+                None
+            } else {
+                Some(params.arguments)
+            };
+            let result = client
+                .get_prompt(&params.name, args)
+                .await
+                .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+            Ok(McpResponse::GetPrompt(result))
+        }
+        _ => Err(JsonRpcError::method_not_found(
+            "Method not routable to backend",
+        )),
     }
 }

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -67,6 +67,7 @@ pub struct McpProxyBuilder {
     version: String,
     separator: String,
     pending: Vec<PendingBackend>,
+    notification_tx: Option<crate::context::NotificationSender>,
 }
 
 impl McpProxyBuilder {
@@ -77,6 +78,7 @@ impl McpProxyBuilder {
             version: version.into(),
             separator: "_".to_string(),
             pending: Vec::new(),
+            notification_tx: None,
         }
     }
 
@@ -87,6 +89,32 @@ impl McpProxyBuilder {
     /// namespace `"db"`, a tool named `"query"` becomes `"db_query"`.
     pub fn separator(mut self, sep: impl Into<String>) -> Self {
         self.separator = sep.into();
+        self
+    }
+
+    /// Set a notification sender for forwarding backend list-changed
+    /// notifications to downstream clients.
+    ///
+    /// When a backend emits `tools/list_changed`, `resources/list_changed`,
+    /// or `prompts/list_changed`, the proxy refreshes its cache and then
+    /// forwards the notification through this sender so transports can
+    /// relay it to connected clients.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tower_mcp::context::notification_channel;
+    ///
+    /// let (notif_tx, notif_rx) = notification_channel(32);
+    /// let proxy = McpProxy::builder("proxy", "1.0.0")
+    ///     .notification_sender(notif_tx)
+    ///     .backend("db", transport).await
+    ///     .build().await?;
+    ///
+    /// let mut transport = GenericStdioTransport::with_notifications(proxy, notif_rx);
+    /// ```
+    pub fn notification_sender(mut self, tx: crate::context::NotificationSender) -> Self {
+        self.notification_tx = Some(tx);
         self
     }
 
@@ -288,9 +316,17 @@ impl McpProxyBuilder {
             return Err(Error::internal("All backends failed to initialize"));
         }
 
-        let proxy = McpProxy::new(self.name, self.version, backends, entries);
+        let proxy = McpProxy::new(
+            self.name,
+            self.version,
+            backends,
+            entries,
+            self.notification_tx,
+        );
 
-        // Spawn invalidation watchers for backends with notification handlers
+        // Spawn invalidation watchers for backends with notification handlers.
+        // After refreshing the cache, forward list-changed notifications
+        // downstream so transports can relay them to connected clients.
         for (backend_idx, mut rx) in invalidation_rxs {
             let shared = Arc::clone(&proxy.shared);
             tokio::spawn(async move {
@@ -302,9 +338,30 @@ impl McpProxyBuilder {
                         "Backend list changed, refreshing cache"
                     );
                     match changed {
-                        ListChanged::Tools => backend.refresh_tools().await,
-                        ListChanged::Resources => backend.refresh_resources().await,
-                        ListChanged::Prompts => backend.refresh_prompts().await,
+                        ListChanged::Tools => {
+                            backend.refresh_tools().await;
+                            if let Some(tx) = &shared.notification_tx {
+                                let _ = tx
+                                    .send(crate::context::ServerNotification::ToolsListChanged)
+                                    .await;
+                            }
+                        }
+                        ListChanged::Resources => {
+                            backend.refresh_resources().await;
+                            if let Some(tx) = &shared.notification_tx {
+                                let _ = tx
+                                    .send(crate::context::ServerNotification::ResourcesListChanged)
+                                    .await;
+                            }
+                        }
+                        ListChanged::Prompts => {
+                            backend.refresh_prompts().await;
+                            if let Some(tx) = &shared.notification_tx {
+                                let _ = tx
+                                    .send(crate::context::ServerNotification::PromptsListChanged)
+                                    .await;
+                            }
+                        }
                     }
                 }
             });

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -1,28 +1,29 @@
 //! Builder for [`McpProxy`].
 
+use std::convert::Infallible;
+use std::fmt;
 use std::sync::Arc;
 
 use tokio::sync::mpsc;
+use tower::Layer;
+use tower::util::BoxCloneService;
 
 use crate::client::{ClientTransport, McpClient};
 use crate::error::{Error, Result};
+use crate::router::{RouterRequest, RouterResponse};
+use crate::transport::CatchError;
 
-use super::backend::{Backend, ListChanged};
-use super::service::McpProxy;
+use super::backend::{Backend, BackendService, ListChanged};
+use super::service::{BackendEntry, McpProxy};
 
 /// Pending backend before the proxy is built.
-enum PendingBackend {
-    /// Connected with notification handler (from `.backend()` with transport).
-    Connected {
-        namespace: String,
-        backend: Backend,
-        invalidation_rx: mpsc::Receiver<ListChanged>,
-    },
-    /// Pre-connected client (from `.backend_client()`), no notification forwarding.
-    Client {
-        namespace: String,
-        client: McpClient,
-    },
+struct PendingBackend {
+    namespace: String,
+    backend: Backend,
+    invalidation_rx: Option<mpsc::Receiver<ListChanged>>,
+    /// Type-erased service (set by `.backend_layer()`).
+    /// If None, BackendService is used directly.
+    custom_service: Option<BoxCloneService<RouterRequest, RouterResponse, Infallible>>,
 }
 
 /// Builder for constructing an [`McpProxy`].
@@ -42,6 +43,24 @@ enum PendingBackend {
 ///     .await?;
 /// # Ok(())
 /// # }
+/// ```
+///
+/// # Per-Backend Middleware
+///
+/// Apply Tower middleware to individual backends using
+/// [`backend_layer()`](Self::backend_layer):
+///
+/// ```rust,ignore
+/// use std::time::Duration;
+/// use tower::timeout::TimeoutLayer;
+///
+/// let proxy = McpProxy::builder("proxy", "1.0.0")
+///     .backend("slow-api", slow_transport).await
+///     .backend_layer(TimeoutLayer::new(Duration::from_secs(60)))
+///     .backend("fast-db", fast_transport).await
+///     .backend_layer(TimeoutLayer::new(Duration::from_secs(5)))
+///     .build()
+///     .await?;
 /// ```
 pub struct McpProxyBuilder {
     name: String,
@@ -77,9 +96,12 @@ impl McpProxyBuilder {
     /// on list-changed notifications. Use [`backend()`](Self::backend) with
     /// a transport for full notification support.
     pub fn backend_client(mut self, namespace: impl Into<String>, client: McpClient) -> Self {
-        self.pending.push(PendingBackend::Client {
-            namespace: namespace.into(),
-            client,
+        let backend = Backend::from_client(namespace, client, self.separator.clone());
+        self.pending.push(PendingBackend {
+            namespace: backend.namespace.clone(),
+            backend,
+            invalidation_rx: None,
+            custom_service: None,
         });
         self
     }
@@ -106,10 +128,11 @@ impl McpProxyBuilder {
         .await
         {
             Ok(backend) => {
-                self.pending.push(PendingBackend::Connected {
+                self.pending.push(PendingBackend {
                     namespace,
                     backend,
-                    invalidation_rx,
+                    invalidation_rx: Some(invalidation_rx),
+                    custom_service: None,
                 });
             }
             Err(e) => {
@@ -120,6 +143,57 @@ impl McpProxyBuilder {
                 );
             }
         }
+        self
+    }
+
+    /// Apply a Tower layer to the most recently added backend.
+    ///
+    /// The layer wraps the backend's dispatch service, allowing standard
+    /// Tower middleware (timeout, rate limit, concurrency limit, etc.) to
+    /// be applied per-backend.
+    ///
+    /// Layers that produce errors (e.g., `TimeoutLayer`) are automatically
+    /// wrapped with [`CatchError`] to convert errors into JSON-RPC error
+    /// responses, maintaining the `Error = Infallible` contract.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use std::time::Duration;
+    /// use tower::timeout::TimeoutLayer;
+    ///
+    /// let proxy = McpProxy::builder("proxy", "1.0.0")
+    ///     .backend("slow", transport).await
+    ///     .backend_layer(TimeoutLayer::new(Duration::from_secs(30)))
+    ///     .build()
+    ///     .await?;
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if no backend has been added yet.
+    pub fn backend_layer<L>(mut self, layer: L) -> Self
+    where
+        L: Layer<BackendService> + Send + 'static,
+        L::Service: tower_service::Service<RouterRequest, Response = RouterResponse>
+            + Clone
+            + Send
+            + 'static,
+        <L::Service as tower_service::Service<RouterRequest>>::Error: fmt::Display + Send,
+        <L::Service as tower_service::Service<RouterRequest>>::Future: Send,
+    {
+        let pending = self
+            .pending
+            .last_mut()
+            .expect("backend_layer called before adding a backend");
+
+        // Get the base BackendService and apply the layer
+        let base = pending.backend.service();
+        let layered = layer.layer(base);
+        // Wrap with CatchError to convert middleware errors to JSON-RPC errors
+        let caught = CatchError::new(layered);
+        pending.custom_service = Some(BoxCloneService::new(caught));
+
         self
     }
 
@@ -141,10 +215,7 @@ impl McpProxyBuilder {
         let namespaces: Vec<&str> = self
             .pending
             .iter()
-            .map(|pb| match pb {
-                PendingBackend::Connected { namespace, .. } => namespace.as_str(),
-                PendingBackend::Client { namespace, .. } => namespace.as_str(),
-            })
+            .map(|pb| pb.namespace.as_str())
             .collect();
         {
             let mut sorted = namespaces.clone();
@@ -155,50 +226,33 @@ impl McpProxyBuilder {
             }
         }
 
-        // Split pending into backends + invalidation receivers
-        let mut init_items = Vec::new();
-        for pb in self.pending {
-            match pb {
-                PendingBackend::Connected {
-                    backend,
-                    invalidation_rx,
-                    ..
-                } => {
-                    init_items.push((backend, Some(invalidation_rx)));
-                }
-                PendingBackend::Client { namespace, client } => {
-                    let backend = Backend::from_client(namespace, client, self.separator.clone());
-                    init_items.push((backend, None));
-                }
-            }
-        }
-
         // Initialize all backends concurrently
         let name = self.name.clone();
         let version = self.version.clone();
-        let init_futures: Vec<_> = init_items
+        let init_futures: Vec<_> = self
+            .pending
             .into_iter()
-            .map(|(backend, invalidation_rx)| {
+            .map(|pb| {
                 let name = name.clone();
                 let version = version.clone();
                 async move {
-                    match backend.initialize(&name, &version).await {
+                    match pb.backend.initialize(&name, &version).await {
                         Ok(()) => {
                             {
-                                let cache = backend.cache.read().await;
+                                let cache = pb.backend.cache.read().await;
                                 tracing::info!(
-                                    namespace = %backend.namespace,
+                                    namespace = %pb.namespace,
                                     tools = cache.tools.len(),
                                     resources = cache.resources.len(),
                                     prompts = cache.prompts.len(),
                                     "Backend initialized"
                                 );
                             }
-                            Some((backend, invalidation_rx))
+                            Some(pb)
                         }
                         Err(e) => {
                             tracing::error!(
-                                namespace = %backend.namespace,
+                                namespace = %pb.namespace,
                                 error = %e,
                                 "Failed to initialize backend, skipping"
                             );
@@ -212,28 +266,36 @@ impl McpProxyBuilder {
         let results = futures::future::join_all(init_futures).await;
 
         let mut backends = Vec::new();
+        let mut entries = Vec::new();
         let mut invalidation_rxs = Vec::new();
 
-        for item in results.into_iter().flatten() {
-            let (backend, rx) = item;
-            if let Some(rx) = rx {
+        for pb in results.into_iter().flatten() {
+            let entry = if let Some(svc) = pb.custom_service {
+                BackendEntry::from_backend_with_service(&pb.backend, svc)
+            } else {
+                BackendEntry::from_backend(&pb.backend)
+            };
+
+            if let Some(rx) = pb.invalidation_rx {
                 invalidation_rxs.push((backends.len(), rx));
             }
-            backends.push(backend);
+
+            entries.push(entry);
+            backends.push(pb.backend);
         }
 
         if backends.is_empty() {
             return Err(Error::internal("All backends failed to initialize"));
         }
 
-        let proxy = McpProxy::new(self.name, self.version, backends);
+        let proxy = McpProxy::new(self.name, self.version, backends, entries);
 
         // Spawn invalidation watchers for backends with notification handlers
         for (backend_idx, mut rx) in invalidation_rxs {
-            let inner = Arc::clone(&proxy.inner);
+            let shared = Arc::clone(&proxy.shared);
             tokio::spawn(async move {
                 while let Some(changed) = rx.recv().await {
-                    let backend = &inner.backends[backend_idx];
+                    let backend = &shared.backends[backend_idx];
                     tracing::debug!(
                         namespace = %backend.namespace,
                         kind = ?changed,

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -234,9 +234,15 @@ impl McpProxyBuilder {
     /// For backends added via [`backend()`](Self::backend), a background task
     /// is spawned that watches for list-changed notifications and automatically
     /// refreshes the affected cache.
-    pub async fn build(self) -> Result<McpProxy> {
+    pub async fn build(mut self) -> Result<McpProxy> {
         if self.pending.is_empty() {
             return Err(Error::internal("No backends configured"));
+        }
+
+        // Ensure all backends use the builder's final separator.
+        // This handles the case where `.separator()` is called after `.backend()`.
+        for pb in &mut self.pending {
+            pb.backend.separator = self.separator.clone();
         }
 
         // Check for duplicate namespaces
@@ -251,6 +257,26 @@ impl McpProxyBuilder {
             sorted.dedup();
             if sorted.len() != namespaces.len() {
                 return Err(Error::internal("Duplicate backend namespaces"));
+            }
+        }
+
+        // Check for ambiguous namespace prefixes.
+        // With separator "_", namespaces "redis" and "redis_ft" both produce
+        // the prefix "redis_", making "redis_ft_search" ambiguous.
+        let prefixes: Vec<String> = namespaces
+            .iter()
+            .map(|ns| format!("{}{}", ns, self.separator))
+            .collect();
+        for (i, prefix_i) in prefixes.iter().enumerate() {
+            for (j, prefix_j) in prefixes.iter().enumerate() {
+                if i != j && prefix_j.starts_with(prefix_i.as_str()) {
+                    return Err(Error::internal(format!(
+                        "Ambiguous namespace prefixes: \"{}\" and \"{}\" with separator \"{}\". \
+                         The prefix \"{}\" is a prefix of \"{}\", which makes routing ambiguous. \
+                         Use a different separator (e.g., \".\") or rename the namespaces.",
+                        namespaces[i], namespaces[j], self.separator, prefix_i, prefix_j,
+                    )));
+                }
             }
         }
 

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -1,0 +1,253 @@
+//! Builder for [`McpProxy`].
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::client::{ClientTransport, McpClient};
+use crate::error::{Error, Result};
+
+use super::backend::{Backend, ListChanged};
+use super::service::McpProxy;
+
+/// Pending backend before the proxy is built.
+enum PendingBackend {
+    /// Connected with notification handler (from `.backend()` with transport).
+    Connected {
+        namespace: String,
+        backend: Backend,
+        invalidation_rx: mpsc::Receiver<ListChanged>,
+    },
+    /// Pre-connected client (from `.backend_client()`), no notification forwarding.
+    Client {
+        namespace: String,
+        client: McpClient,
+    },
+}
+
+/// Builder for constructing an [`McpProxy`].
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use tower_mcp::proxy::McpProxy;
+/// use tower_mcp::client::StdioClientTransport;
+///
+/// # async fn example() -> Result<(), tower_mcp::BoxError> {
+/// let proxy = McpProxy::builder("my-proxy", "1.0.0")
+///     .backend("db", StdioClientTransport::spawn("db-server", &[]).await?)
+///     .await
+///     .separator(".")
+///     .build()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct McpProxyBuilder {
+    name: String,
+    version: String,
+    separator: String,
+    pending: Vec<PendingBackend>,
+}
+
+impl McpProxyBuilder {
+    /// Create a new proxy builder.
+    pub(crate) fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            version: version.into(),
+            separator: "_".to_string(),
+            pending: Vec::new(),
+        }
+    }
+
+    /// Set the namespace separator (default: `_`).
+    ///
+    /// The separator is inserted between the backend namespace and the
+    /// tool/resource/prompt name. For example, with separator `"_"` and
+    /// namespace `"db"`, a tool named `"query"` becomes `"db_query"`.
+    pub fn separator(mut self, sep: impl Into<String>) -> Self {
+        self.separator = sep.into();
+        self
+    }
+
+    /// Add a backend from a connected [`McpClient`].
+    ///
+    /// Note: backends added this way will not have automatic cache refresh
+    /// on list-changed notifications. Use [`backend()`](Self::backend) with
+    /// a transport for full notification support.
+    pub fn backend_client(mut self, namespace: impl Into<String>, client: McpClient) -> Self {
+        self.pending.push(PendingBackend::Client {
+            namespace: namespace.into(),
+            client,
+        });
+        self
+    }
+
+    /// Add a backend from a [`ClientTransport`].
+    ///
+    /// The transport will be connected immediately with a notification handler
+    /// that watches for list-changed events. Initialization happens during
+    /// [`build()`](Self::build).
+    pub async fn backend(
+        mut self,
+        namespace: impl Into<String>,
+        transport: impl ClientTransport,
+    ) -> Self {
+        let namespace = namespace.into();
+        let (invalidation_tx, invalidation_rx) = mpsc::channel(16);
+
+        match Backend::connect(
+            namespace.clone(),
+            transport,
+            self.separator.clone(),
+            invalidation_tx,
+        )
+        .await
+        {
+            Ok(backend) => {
+                self.pending.push(PendingBackend::Connected {
+                    namespace,
+                    backend,
+                    invalidation_rx,
+                });
+            }
+            Err(e) => {
+                tracing::error!(
+                    namespace = %namespace,
+                    error = %e,
+                    "Failed to connect backend"
+                );
+            }
+        }
+        self
+    }
+
+    /// Build the proxy, initializing all backends concurrently.
+    ///
+    /// Each backend runs the MCP initialize handshake and discovers its
+    /// capabilities (tools, resources, prompts). Backends that fail to
+    /// initialize are logged and skipped.
+    ///
+    /// For backends added via [`backend()`](Self::backend), a background task
+    /// is spawned that watches for list-changed notifications and automatically
+    /// refreshes the affected cache.
+    pub async fn build(self) -> Result<McpProxy> {
+        if self.pending.is_empty() {
+            return Err(Error::internal("No backends configured"));
+        }
+
+        // Check for duplicate namespaces
+        let namespaces: Vec<&str> = self
+            .pending
+            .iter()
+            .map(|pb| match pb {
+                PendingBackend::Connected { namespace, .. } => namespace.as_str(),
+                PendingBackend::Client { namespace, .. } => namespace.as_str(),
+            })
+            .collect();
+        {
+            let mut sorted = namespaces.clone();
+            sorted.sort();
+            sorted.dedup();
+            if sorted.len() != namespaces.len() {
+                return Err(Error::internal("Duplicate backend namespaces"));
+            }
+        }
+
+        // Split pending into backends + invalidation receivers
+        let mut init_items = Vec::new();
+        for pb in self.pending {
+            match pb {
+                PendingBackend::Connected {
+                    backend,
+                    invalidation_rx,
+                    ..
+                } => {
+                    init_items.push((backend, Some(invalidation_rx)));
+                }
+                PendingBackend::Client { namespace, client } => {
+                    let backend = Backend::from_client(namespace, client, self.separator.clone());
+                    init_items.push((backend, None));
+                }
+            }
+        }
+
+        // Initialize all backends concurrently
+        let name = self.name.clone();
+        let version = self.version.clone();
+        let init_futures: Vec<_> = init_items
+            .into_iter()
+            .map(|(backend, invalidation_rx)| {
+                let name = name.clone();
+                let version = version.clone();
+                async move {
+                    match backend.initialize(&name, &version).await {
+                        Ok(()) => {
+                            {
+                                let cache = backend.cache.read().await;
+                                tracing::info!(
+                                    namespace = %backend.namespace,
+                                    tools = cache.tools.len(),
+                                    resources = cache.resources.len(),
+                                    prompts = cache.prompts.len(),
+                                    "Backend initialized"
+                                );
+                            }
+                            Some((backend, invalidation_rx))
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                namespace = %backend.namespace,
+                                error = %e,
+                                "Failed to initialize backend, skipping"
+                            );
+                            None
+                        }
+                    }
+                }
+            })
+            .collect();
+
+        let results = futures::future::join_all(init_futures).await;
+
+        let mut backends = Vec::new();
+        let mut invalidation_rxs = Vec::new();
+
+        for item in results.into_iter().flatten() {
+            let (backend, rx) = item;
+            if let Some(rx) = rx {
+                invalidation_rxs.push((backends.len(), rx));
+            }
+            backends.push(backend);
+        }
+
+        if backends.is_empty() {
+            return Err(Error::internal("All backends failed to initialize"));
+        }
+
+        let proxy = McpProxy::new(self.name, self.version, backends);
+
+        // Spawn invalidation watchers for backends with notification handlers
+        for (backend_idx, mut rx) in invalidation_rxs {
+            let inner = Arc::clone(&proxy.inner);
+            tokio::spawn(async move {
+                while let Some(changed) = rx.recv().await {
+                    let backend = &inner.backends[backend_idx];
+                    tracing::debug!(
+                        namespace = %backend.namespace,
+                        kind = ?changed,
+                        "Backend list changed, refreshing cache"
+                    );
+                    match changed {
+                        ListChanged::Tools => backend.refresh_tools().await,
+                        ListChanged::Resources => backend.refresh_resources().await,
+                        ListChanged::Prompts => backend.refresh_prompts().await,
+                    }
+                }
+            });
+        }
+
+        Ok(proxy)
+    }
+}

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -1,0 +1,62 @@
+//! MCP Proxy -- aggregate multiple backend MCP servers behind a single endpoint.
+//!
+//! The proxy connects to N backend MCP servers and exposes their combined
+//! tools, resources, and prompts through a unified [`Service<RouterRequest>`]
+//! interface. Each backend's capabilities are namespaced to avoid collisions.
+//!
+//! # Architecture
+//!
+//! ```text
+//!                     McpProxy
+//!                    /    |    \
+//!           Backend A  Backend B  Backend C
+//!           (stdio)    (HTTP)     (stdio)
+//! ```
+//!
+//! Each backend is an [`McpClient`] that the proxy initializes and manages.
+//! Tool/resource/prompt discovery runs concurrently across all backends with
+//! per-backend timeouts. Results are cached and refreshed on `toolListChanged`
+//! notifications.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::proxy::McpProxy;
+//! use tower_mcp::client::StdioClientTransport;
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let proxy = McpProxy::builder("my-proxy", "1.0.0")
+//!     .backend("db", StdioClientTransport::spawn("db-server", &[]).await?)
+//!     .await
+//!     .backend("fs", StdioClientTransport::spawn("fs-server", &[]).await?)
+//!     .await
+//!     .build()
+//!     .await?;
+//!
+//! // Use with any transport -- stdio, HTTP, WebSocket
+//! let mut transport = tower_mcp::GenericStdioTransport::new(proxy);
+//! transport.run().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Middleware
+//!
+//! Because `McpProxy` implements `Service<RouterRequest>`, standard tower
+//! middleware composes naturally:
+//!
+//! ```rust,ignore
+//! // Auth -> RateLimit -> Proxy
+//! let service = ServiceBuilder::new()
+//!     .layer(AuthLayer::new(validator))
+//!     .layer(RateLimitLayer::new(100, Duration::from_secs(1)))
+//!     .service(proxy);
+//! ```
+
+mod backend;
+mod builder;
+mod service;
+mod tests;
+
+pub use builder::McpProxyBuilder;
+pub use service::McpProxy;

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -157,6 +157,28 @@
 //! Note that `CoalesceLayer` changes the error type from `Infallible` to
 //! `CoalesceError<Infallible>`. Use [`CatchError`](crate::transport::CatchError)
 //! to convert back to `Infallible` for transport compatibility.
+//!
+//! # Language-Agnostic Backends
+//!
+//! The proxy communicates with backends over standard MCP (JSON-RPC), so
+//! backends can be written in any language or framework -- Python (FastMCP),
+//! TypeScript, Go, or anything that speaks the protocol. This makes
+//! tower-mcp a natural aggregation and middleware layer for polyglot MCP
+//! deployments:
+//!
+//! ```rust,ignore
+//! let proxy = McpProxy::builder("polyglot-proxy", "1.0.0")
+//!     // Python FastMCP server
+//!     .backend("ml", StdioClientTransport::spawn("python", &["-m", "ml_server"]).await?)
+//!     .await
+//!     // TypeScript MCP server
+//!     .backend("docs", StdioClientTransport::spawn("npx", &["docs-server"]).await?)
+//!     .await
+//!     // Rust tower-mcp server
+//!     .backend("data", StdioClientTransport::spawn("data-server", &[]).await?)
+//!     .await
+//!     .build().await?;
+//! ```
 
 mod backend;
 mod builder;

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -59,7 +59,7 @@ mod service;
 mod tests;
 
 pub use builder::McpProxyBuilder;
-pub use service::McpProxy;
+pub use service::{BackendHealth, McpProxy};
 
 // Re-export BackendService so users can write layer bounds against it
 pub use backend::BackendService;

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -13,12 +13,13 @@
 //!           (stdio)    (HTTP)     (stdio)
 //! ```
 //!
-//! Each backend is an [`McpClient`](crate::client::McpClient) that the proxy initializes and manages.
-//! Tool/resource/prompt discovery runs concurrently across all backends with
-//! per-backend timeouts. Results are cached and refreshed on `toolListChanged`
-//! notifications.
+//! Each backend is an [`McpClient`](crate::client::McpClient) that the proxy
+//! initializes and manages. Tool/resource/prompt discovery runs concurrently
+//! across all backends. Results are cached and automatically refreshed when
+//! backends emit `tools/list_changed`, `resources/list_changed`, or
+//! `prompts/list_changed` notifications.
 //!
-//! # Example
+//! # Quick Start
 //!
 //! ```rust,no_run
 //! use tower_mcp::proxy::McpProxy;
@@ -33,25 +34,129 @@
 //!     .build()
 //!     .await?;
 //!
-//! // Use with any transport -- stdio, HTTP, WebSocket
+//! // Tools become db_query, fs_read, etc. (namespace + separator + name)
+//! // Serve over any transport -- stdio, HTTP, WebSocket.
 //! let mut transport = tower_mcp::GenericStdioTransport::new(proxy);
 //! transport.run().await?;
 //! # Ok(())
 //! # }
 //! ```
 //!
-//! # Middleware
+//! # Namespacing
 //!
-//! Because `McpProxy` implements `Service<RouterRequest>`, standard tower
-//! middleware composes naturally:
+//! All tools, resources, and prompts from each backend are prefixed with
+//! `{namespace}{separator}` to avoid naming collisions. The default separator
+//! is `_`, so a tool named `query` on the `db` backend becomes `db_query`.
+//!
+//! Use [`McpProxyBuilder::separator()`] to change the separator:
 //!
 //! ```rust,ignore
-//! // Auth -> RateLimit -> Proxy
+//! McpProxy::builder("proxy", "1.0.0")
+//!     .backend("db", transport).await
+//!     .separator(".")   // tools become "db.query" instead of "db_query"
+//!     .build().await?;
+//! ```
+//!
+//! # Per-Backend Middleware
+//!
+//! Apply Tower middleware to individual backends using
+//! [`McpProxyBuilder::backend_layer()`]. This is useful for backend-specific
+//! timeouts, rate limits, or retry policies:
+//!
+//! ```rust,ignore
+//! use std::time::Duration;
+//! use tower::timeout::TimeoutLayer;
+//!
+//! let proxy = McpProxy::builder("proxy", "1.0.0")
+//!     // Fast backend: tight timeout
+//!     .backend("cache", cache_transport).await
+//!     .backend_layer(TimeoutLayer::new(Duration::from_secs(2)))
+//!     // Slow backend: generous timeout
+//!     .backend("llm", llm_transport).await
+//!     .backend_layer(TimeoutLayer::new(Duration::from_secs(60)))
+//!     // No middleware on this one
+//!     .backend("db", db_transport).await
+//!     .build().await?;
+//! ```
+//!
+//! Middleware errors (e.g., `tower::timeout::error::Elapsed`) are automatically
+//! converted to JSON-RPC error responses via
+//! [`CatchError`](crate::transport::CatchError), preserving the
+//! `Error = Infallible` contract required by transports.
+//!
+//! # Proxy-Level Middleware
+//!
+//! Because [`McpProxy`] implements `Service<RouterRequest>`, standard Tower
+//! middleware composes naturally at the proxy level:
+//!
+//! ```rust,ignore
+//! use tower::ServiceBuilder;
+//!
 //! let service = ServiceBuilder::new()
 //!     .layer(AuthLayer::new(validator))
 //!     .layer(RateLimitLayer::new(100, Duration::from_secs(1)))
 //!     .service(proxy);
 //! ```
+//!
+//! # Notification Forwarding
+//!
+//! When a backend emits a list-changed notification (e.g., after adding or
+//! removing tools at runtime), the proxy:
+//!
+//! 1. Refreshes its cached capabilities for that backend
+//! 2. Forwards the notification to connected downstream clients
+//!
+//! To enable forwarding, provide a [`NotificationSender`](crate::context::NotificationSender)
+//! via [`McpProxyBuilder::notification_sender()`] and wire it to a transport
+//! that supports notifications:
+//!
+//! ```rust,ignore
+//! use tower_mcp::context::notification_channel;
+//!
+//! let (notif_tx, notif_rx) = notification_channel(32);
+//!
+//! let proxy = McpProxy::builder("proxy", "1.0.0")
+//!     .notification_sender(notif_tx)
+//!     .backend("tools", transport).await
+//!     .build().await?;
+//!
+//! // GenericStdioTransport forwards notifications to connected clients
+//! let mut transport = tower_mcp::GenericStdioTransport::with_notifications(proxy, notif_rx);
+//! transport.run().await?;
+//! ```
+//!
+//! # Health Checks
+//!
+//! Ping all backends concurrently to verify connectivity:
+//!
+//! ```rust,ignore
+//! let health = proxy.health_check().await;
+//! for h in &health {
+//!     println!("{}: {}", h.namespace, if h.healthy { "ok" } else { "down" });
+//! }
+//! ```
+//!
+//! # Request Coalescing
+//!
+//! Use [`tower-resilience`](https://docs.rs/tower-resilience)'s `CoalesceLayer`
+//! to deduplicate concurrent identical requests. This is especially useful for
+//! list operations when multiple clients connect simultaneously:
+//!
+//! ```rust,ignore
+//! use std::mem::discriminant;
+//! use tower::Layer;
+//! use tower_resilience::coalesce::CoalesceLayer;
+//!
+//! // Coalesce by MCP method type -- concurrent list_tools calls share
+//! // a single execution, while call_tool runs independently.
+//! let coalesced = CoalesceLayer::new(|req: &RouterRequest| {
+//!     discriminant(&req.inner)
+//! }).layer(proxy);
+//! ```
+//!
+//! Note that `CoalesceLayer` changes the error type from `Infallible` to
+//! `CoalesceError<Infallible>`. Use [`CatchError`](crate::transport::CatchError)
+//! to convert back to `Infallible` for transport compatibility.
 
 mod backend;
 mod builder;

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -1,7 +1,7 @@
 //! MCP Proxy -- aggregate multiple backend MCP servers behind a single endpoint.
 //!
 //! The proxy connects to N backend MCP servers and exposes their combined
-//! tools, resources, and prompts through a unified [`Service<RouterRequest>`]
+//! tools, resources, and prompts through a unified `Service<RouterRequest>`
 //! interface. Each backend's capabilities are namespaced to avoid collisions.
 //!
 //! # Architecture
@@ -13,7 +13,7 @@
 //!           (stdio)    (HTTP)     (stdio)
 //! ```
 //!
-//! Each backend is an [`McpClient`] that the proxy initializes and manages.
+//! Each backend is an [`McpClient`](crate::client::McpClient) that the proxy initializes and manages.
 //! Tool/resource/prompt discovery runs concurrently across all backends with
 //! per-backend timeouts. Results are cached and refreshed on `toolListChanged`
 //! notifications.
@@ -60,3 +60,6 @@ mod tests;
 
 pub use builder::McpProxyBuilder;
 pub use service::McpProxy;
+
+// Re-export BackendService so users can write layer bounds against it
+pub use backend::BackendService;

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -1,0 +1,270 @@
+//! Core proxy service implementing `Service<RouterRequest>`.
+
+use std::convert::Infallible;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use tower_service::Service;
+
+use crate::protocol::{
+    CallToolParams, GetPromptParams, Implementation, InitializeResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, McpRequest, McpResponse,
+    ReadResourceParams, ServerCapabilities, ToolsCapability,
+};
+use crate::router::{RouterRequest, RouterResponse};
+use tower_mcp_types::JsonRpcError;
+
+use super::backend::Backend;
+use super::builder::McpProxyBuilder;
+
+/// An MCP proxy that aggregates multiple backend servers.
+///
+/// Implements `Service<RouterRequest>` so it can be used with any tower-mcp
+/// transport (HTTP, WebSocket, stdio) and composed with tower middleware.
+#[derive(Clone)]
+pub struct McpProxy {
+    pub(super) inner: Arc<McpProxyInner>,
+}
+
+pub(super) struct McpProxyInner {
+    name: String,
+    version: String,
+    pub(super) backends: Vec<Backend>,
+}
+
+impl McpProxy {
+    /// Create a builder for configuring the proxy.
+    pub fn builder(name: impl Into<String>, version: impl Into<String>) -> McpProxyBuilder {
+        McpProxyBuilder::new(name, version)
+    }
+
+    /// Create a new proxy with the given backends (called by builder).
+    pub(crate) fn new(name: String, version: String, backends: Vec<Backend>) -> Self {
+        Self {
+            inner: Arc::new(McpProxyInner {
+                name,
+                version,
+                backends,
+            }),
+        }
+    }
+
+    /// Handle an MCP request by dispatching to the appropriate backend.
+    async fn handle_request(
+        inner: Arc<McpProxyInner>,
+        request: McpRequest,
+    ) -> Result<McpResponse, JsonRpcError> {
+        match request {
+            McpRequest::Initialize(_params) => inner.handle_initialize().await,
+            McpRequest::Ping => Ok(McpResponse::Pong(Default::default())),
+            McpRequest::ListTools(_params) => inner.handle_list_tools().await,
+            McpRequest::CallTool(params) => inner.handle_call_tool(params).await,
+            McpRequest::ListResources(_params) => inner.handle_list_resources().await,
+            McpRequest::ListResourceTemplates(_params) => {
+                inner.handle_list_resource_templates().await
+            }
+            McpRequest::ReadResource(params) => inner.handle_read_resource(params).await,
+            McpRequest::ListPrompts(_params) => inner.handle_list_prompts().await,
+            McpRequest::GetPrompt(params) => inner.handle_get_prompt(params).await,
+            _ => Err(JsonRpcError::method_not_found(
+                "Method not supported by proxy",
+            )),
+        }
+    }
+}
+
+impl McpProxyInner {
+    /// Find the backend that owns a namespaced tool name.
+    /// Returns the backend and the stripped (original) name.
+    fn route_tool(&self, name: &str) -> Option<(&Backend, String)> {
+        for backend in &self.backends {
+            if let Some(stripped) = backend.strip_prefix(name) {
+                return Some((backend, stripped.to_string()));
+            }
+        }
+        None
+    }
+
+    /// Find the backend that owns a namespaced resource URI.
+    fn route_resource(&self, uri: &str) -> Option<(&Backend, String)> {
+        for backend in &self.backends {
+            if let Some(stripped) = backend.strip_uri_prefix(uri) {
+                return Some((backend, stripped.to_string()));
+            }
+        }
+        None
+    }
+
+    /// Find the backend that owns a namespaced prompt name.
+    fn route_prompt(&self, name: &str) -> Option<(&Backend, String)> {
+        for backend in &self.backends {
+            if let Some(stripped) = backend.strip_prefix(name) {
+                return Some((backend, stripped.to_string()));
+            }
+        }
+        None
+    }
+
+    async fn handle_initialize(&self) -> Result<McpResponse, JsonRpcError> {
+        Ok(McpResponse::Initialize(InitializeResult {
+            protocol_version: "2025-11-25".to_string(),
+            server_info: Implementation {
+                name: self.name.clone(),
+                version: self.version.clone(),
+                title: None,
+                description: None,
+                icons: None,
+                website_url: None,
+                meta: None,
+            },
+            capabilities: ServerCapabilities {
+                tools: Some(ToolsCapability { list_changed: true }),
+                resources: None,
+                prompts: None,
+                logging: None,
+                tasks: None,
+                completions: None,
+                experimental: None,
+                extensions: None,
+            },
+            instructions: Some(format!(
+                "MCP proxy aggregating {} backend servers",
+                self.backends.len()
+            )),
+            meta: None,
+        }))
+    }
+
+    async fn handle_list_tools(&self) -> Result<McpResponse, JsonRpcError> {
+        // Fan out to all backends concurrently
+        let futures: Vec<_> = self.backends.iter().map(|b| b.namespaced_tools()).collect();
+        let results = futures::future::join_all(futures).await;
+
+        let tools: Vec<_> = results.into_iter().flatten().collect();
+        Ok(McpResponse::ListTools(ListToolsResult {
+            tools,
+            next_cursor: None,
+            meta: None,
+        }))
+    }
+
+    async fn handle_call_tool(&self, params: CallToolParams) -> Result<McpResponse, JsonRpcError> {
+        let (backend, stripped_name) = self.route_tool(&params.name).ok_or_else(|| {
+            JsonRpcError::invalid_params(format!("Unknown tool: {}", params.name))
+        })?;
+
+        let result = backend
+            .call_tool(&stripped_name, params.arguments)
+            .await
+            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+
+        Ok(McpResponse::CallTool(result))
+    }
+
+    async fn handle_list_resources(&self) -> Result<McpResponse, JsonRpcError> {
+        let futures: Vec<_> = self
+            .backends
+            .iter()
+            .map(|b| b.namespaced_resources())
+            .collect();
+        let results = futures::future::join_all(futures).await;
+
+        let resources: Vec<_> = results.into_iter().flatten().collect();
+        Ok(McpResponse::ListResources(ListResourcesResult {
+            resources,
+            next_cursor: None,
+            meta: None,
+        }))
+    }
+
+    async fn handle_list_resource_templates(&self) -> Result<McpResponse, JsonRpcError> {
+        let futures: Vec<_> = self
+            .backends
+            .iter()
+            .map(|b| b.namespaced_resource_templates())
+            .collect();
+        let results = futures::future::join_all(futures).await;
+
+        let resource_templates: Vec<_> = results.into_iter().flatten().collect();
+        Ok(McpResponse::ListResourceTemplates(
+            ListResourceTemplatesResult {
+                resource_templates,
+                next_cursor: None,
+                meta: None,
+            },
+        ))
+    }
+
+    async fn handle_read_resource(
+        &self,
+        params: ReadResourceParams,
+    ) -> Result<McpResponse, JsonRpcError> {
+        let (backend, stripped_uri) = self.route_resource(&params.uri).ok_or_else(|| {
+            JsonRpcError::invalid_params(format!("Unknown resource: {}", params.uri))
+        })?;
+
+        let result = backend
+            .read_resource(&stripped_uri)
+            .await
+            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+
+        Ok(McpResponse::ReadResource(result))
+    }
+
+    async fn handle_list_prompts(&self) -> Result<McpResponse, JsonRpcError> {
+        let futures: Vec<_> = self
+            .backends
+            .iter()
+            .map(|b| b.namespaced_prompts())
+            .collect();
+        let results = futures::future::join_all(futures).await;
+
+        let prompts: Vec<_> = results.into_iter().flatten().collect();
+        Ok(McpResponse::ListPrompts(ListPromptsResult {
+            prompts,
+            next_cursor: None,
+            meta: None,
+        }))
+    }
+
+    async fn handle_get_prompt(
+        &self,
+        params: GetPromptParams,
+    ) -> Result<McpResponse, JsonRpcError> {
+        let (backend, stripped_name) = self.route_prompt(&params.name).ok_or_else(|| {
+            JsonRpcError::invalid_params(format!("Unknown prompt: {}", params.name))
+        })?;
+
+        let result = backend
+            .get_prompt(&stripped_name, params.arguments)
+            .await
+            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
+
+        Ok(McpResponse::GetPrompt(result))
+    }
+}
+
+impl Service<RouterRequest> for McpProxy {
+    type Response = RouterResponse;
+    type Error = Infallible;
+    type Future = Pin<Box<dyn Future<Output = Result<RouterResponse, Infallible>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RouterRequest) -> Self::Future {
+        let inner = Arc::clone(&self.inner);
+        let request_id = req.id.clone();
+
+        Box::pin(async move {
+            let result = McpProxy::handle_request(inner, req.inner).await;
+            Ok(RouterResponse {
+                id: request_id,
+                inner: result,
+            })
+        })
+    }
+}

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -262,6 +262,8 @@ async fn handle_call_tool(
     mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_name: String,
     params: CallToolParams,
+    id: RequestId,
+    extensions: Extensions,
 ) -> Result<McpResponse, JsonRpcError> {
     let inner_request = McpRequest::CallTool(CallToolParams {
         name: stripped_name,
@@ -271,9 +273,9 @@ async fn handle_call_tool(
     });
 
     let router_req = RouterRequest {
-        id: RequestId::Number(0),
+        id,
         inner: inner_request,
-        extensions: Extensions::new(),
+        extensions,
     };
 
     let resp = service.call(router_req).await.expect("infallible");
@@ -324,6 +326,8 @@ async fn handle_read_resource(
     mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_uri: String,
     params: ReadResourceParams,
+    id: RequestId,
+    extensions: Extensions,
 ) -> Result<McpResponse, JsonRpcError> {
     let inner_request = McpRequest::ReadResource(ReadResourceParams {
         uri: stripped_uri,
@@ -331,9 +335,9 @@ async fn handle_read_resource(
     });
 
     let router_req = RouterRequest {
-        id: RequestId::Number(0),
+        id,
         inner: inner_request,
-        extensions: Extensions::new(),
+        extensions,
     };
 
     let resp = service.call(router_req).await.expect("infallible");
@@ -361,6 +365,8 @@ async fn handle_get_prompt(
     mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_name: String,
     params: GetPromptParams,
+    id: RequestId,
+    extensions: Extensions,
 ) -> Result<McpResponse, JsonRpcError> {
     let inner_request = McpRequest::GetPrompt(GetPromptParams {
         name: stripped_name,
@@ -369,9 +375,9 @@ async fn handle_get_prompt(
     });
 
     let router_req = RouterRequest {
-        id: RequestId::Number(0),
+        id,
         inner: inner_request,
-        extensions: Extensions::new(),
+        extensions,
     };
 
     let resp = service.call(router_req).await.expect("infallible");
@@ -393,6 +399,7 @@ impl Service<RouterRequest> for McpProxy {
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
         let request_id = req.id.clone();
+        let extensions = req.extensions.clone();
 
         // All routing and data extraction happens synchronously here (no await),
         // so we never hold a &[BackendEntry] reference across an await point.
@@ -415,7 +422,13 @@ impl Service<RouterRequest> for McpProxy {
                     match Self::route_by_prefix(&self.entries, &params.name) {
                         Some((idx, stripped)) => {
                             let service = self.entries[idx].service.clone();
-                            Box::pin(handle_call_tool(service, stripped, params))
+                            Box::pin(handle_call_tool(
+                                service,
+                                stripped,
+                                params,
+                                request_id.clone(),
+                                extensions.clone(),
+                            ))
                         }
                         None => Box::pin(async move {
                             Err(JsonRpcError::invalid_params(format!(
@@ -437,7 +450,13 @@ impl Service<RouterRequest> for McpProxy {
                     match Self::route_by_uri_prefix(&self.entries, &params.uri) {
                         Some((idx, stripped)) => {
                             let service = self.entries[idx].service.clone();
-                            Box::pin(handle_read_resource(service, stripped, params))
+                            Box::pin(handle_read_resource(
+                                service,
+                                stripped,
+                                params,
+                                request_id.clone(),
+                                extensions.clone(),
+                            ))
                         }
                         None => Box::pin(async move {
                             Err(JsonRpcError::invalid_params(format!(
@@ -455,7 +474,13 @@ impl Service<RouterRequest> for McpProxy {
                     match Self::route_by_prefix(&self.entries, &params.name) {
                         Some((idx, stripped)) => {
                             let service = self.entries[idx].service.clone();
-                            Box::pin(handle_get_prompt(service, stripped, params))
+                            Box::pin(handle_get_prompt(
+                                service,
+                                stripped,
+                                params,
+                                request_id.clone(),
+                                extensions.clone(),
+                            ))
                         }
                         None => Box::pin(async move {
                             Err(JsonRpcError::invalid_params(format!(

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -91,6 +91,17 @@ pub(super) struct McpProxyShared {
     name: String,
     version: String,
     pub(super) backends: Vec<Backend>,
+    /// Optional sender for forwarding list-changed notifications downstream.
+    pub(super) notification_tx: Option<crate::context::NotificationSender>,
+}
+
+/// Health status of a single backend.
+#[derive(Debug, Clone)]
+pub struct BackendHealth {
+    /// The backend's namespace.
+    pub namespace: String,
+    /// Whether the backend responded to a ping.
+    pub healthy: bool,
 }
 
 /// Namespace + cache extracted from a `BackendEntry` for `Send`-safe async use.
@@ -113,15 +124,39 @@ impl McpProxy {
         version: String,
         backends: Vec<Backend>,
         entries: Vec<BackendEntry>,
+        notification_tx: Option<crate::context::NotificationSender>,
     ) -> Self {
         Self {
             shared: Arc::new(McpProxyShared {
                 name,
                 version,
                 backends,
+                notification_tx,
             }),
             entries,
         }
+    }
+
+    /// Check the health of all backends by pinging them concurrently.
+    ///
+    /// Returns a map of namespace to health status. Backends that respond
+    /// to ping within a reasonable time are considered healthy.
+    pub async fn health_check(&self) -> Vec<BackendHealth> {
+        let futures: Vec<_> = self
+            .shared
+            .backends
+            .iter()
+            .map(|backend| {
+                let client = Arc::clone(&backend.client);
+                let namespace = backend.namespace.clone();
+                async move {
+                    let healthy = client.ping().await.is_ok();
+                    BackendHealth { namespace, healthy }
+                }
+            })
+            .collect();
+
+        futures::future::join_all(futures).await
     }
 
     /// Extract Send-safe info from entries (synchronous, no borrow across await).

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -6,245 +6,346 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use tokio::sync::RwLock;
+use tower::util::BoxCloneService;
 use tower_service::Service;
 
 use crate::protocol::{
     CallToolParams, GetPromptParams, Implementation, InitializeResult, ListPromptsResult,
     ListResourceTemplatesResult, ListResourcesResult, ListToolsResult, McpRequest, McpResponse,
-    ReadResourceParams, ServerCapabilities, ToolsCapability,
+    PromptDefinition, ReadResourceParams, RequestId, ResourceDefinition,
+    ResourceTemplateDefinition, ServerCapabilities, ToolDefinition, ToolsCapability,
 };
-use crate::router::{RouterRequest, RouterResponse};
+use crate::router::{Extensions, RouterRequest, RouterResponse};
 use tower_mcp_types::JsonRpcError;
 
-use super::backend::Backend;
-use super::builder::McpProxyBuilder;
+use super::backend::{Backend, CachedCapabilities};
+
+/// A backend entry in the proxy, combining cached capabilities with a
+/// type-erased service for dispatching routed requests.
+#[derive(Clone)]
+pub(crate) struct BackendEntry {
+    pub namespace: String,
+    pub separator: String,
+    pub cache: Arc<RwLock<CachedCapabilities>>,
+    /// Type-erased service for dispatching call_tool, read_resource, get_prompt.
+    /// Middleware layers are applied before type-erasure.
+    pub service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+}
+
+impl BackendEntry {
+    /// Create from a Backend using its default BackendService (no middleware).
+    pub fn from_backend(backend: &Backend) -> Self {
+        Self {
+            namespace: backend.namespace.clone(),
+            separator: backend.separator.clone(),
+            cache: Arc::clone(&backend.cache),
+            service: BoxCloneService::new(backend.service()),
+        }
+    }
+
+    /// Create from a Backend with a custom (already-layered) service.
+    pub fn from_backend_with_service(
+        backend: &Backend,
+        service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    ) -> Self {
+        Self {
+            namespace: backend.namespace.clone(),
+            separator: backend.separator.clone(),
+            cache: Arc::clone(&backend.cache),
+            service,
+        }
+    }
+
+    /// Strip the namespace prefix from a name, if it matches.
+    fn strip_prefix<'a>(&self, name: &'a str) -> Option<&'a str> {
+        let prefix = format!("{}{}", self.namespace, self.separator);
+        name.strip_prefix(&prefix)
+    }
+
+    /// Strip the namespace prefix from a URI.
+    fn strip_uri_prefix<'a>(&self, uri: &'a str) -> Option<&'a str> {
+        let prefix = format!("{}{}", self.namespace, self.separator);
+        uri.strip_prefix(&prefix)
+    }
+}
 
 /// An MCP proxy that aggregates multiple backend servers.
 ///
 /// Implements `Service<RouterRequest>` so it can be used with any tower-mcp
 /// transport (HTTP, WebSocket, stdio) and composed with tower middleware.
+///
+/// Each backend's capabilities are namespaced to avoid collisions, and
+/// individual backends can have their own Tower middleware stack applied
+/// via [`McpProxyBuilder::backend_layer()`](super::McpProxyBuilder::backend_layer).
 #[derive(Clone)]
 pub struct McpProxy {
-    pub(super) inner: Arc<McpProxyInner>,
+    pub(super) shared: Arc<McpProxyShared>,
+    /// Per-backend entries with type-erased services. Kept outside `Arc`
+    /// because `BoxCloneService` is `Send + Clone` but not `Sync`.
+    pub(super) entries: Vec<BackendEntry>,
 }
 
-pub(super) struct McpProxyInner {
+/// Shared, `Send + Sync` state for the proxy (no `BoxCloneService`).
+pub(super) struct McpProxyShared {
     name: String,
     version: String,
     pub(super) backends: Vec<Backend>,
 }
 
+/// Namespace + cache extracted from a `BackendEntry` for `Send`-safe async use.
+/// Both fields are `Send + Sync`, so futures holding these can cross thread boundaries.
+struct EntryInfo {
+    namespace: String,
+    separator: String,
+    cache: Arc<RwLock<CachedCapabilities>>,
+}
+
 impl McpProxy {
     /// Create a builder for configuring the proxy.
-    pub fn builder(name: impl Into<String>, version: impl Into<String>) -> McpProxyBuilder {
-        McpProxyBuilder::new(name, version)
+    pub fn builder(name: impl Into<String>, version: impl Into<String>) -> super::McpProxyBuilder {
+        super::McpProxyBuilder::new(name, version)
     }
 
-    /// Create a new proxy with the given backends (called by builder).
-    pub(crate) fn new(name: String, version: String, backends: Vec<Backend>) -> Self {
+    /// Create a new proxy with the given backends and entries (called by builder).
+    pub(crate) fn new(
+        name: String,
+        version: String,
+        backends: Vec<Backend>,
+        entries: Vec<BackendEntry>,
+    ) -> Self {
         Self {
-            inner: Arc::new(McpProxyInner {
+            shared: Arc::new(McpProxyShared {
                 name,
                 version,
                 backends,
             }),
+            entries,
         }
     }
 
-    /// Handle an MCP request by dispatching to the appropriate backend.
-    async fn handle_request(
-        inner: Arc<McpProxyInner>,
-        request: McpRequest,
-    ) -> Result<McpResponse, JsonRpcError> {
-        match request {
-            McpRequest::Initialize(_params) => inner.handle_initialize().await,
-            McpRequest::Ping => Ok(McpResponse::Pong(Default::default())),
-            McpRequest::ListTools(_params) => inner.handle_list_tools().await,
-            McpRequest::CallTool(params) => inner.handle_call_tool(params).await,
-            McpRequest::ListResources(_params) => inner.handle_list_resources().await,
-            McpRequest::ListResourceTemplates(_params) => {
-                inner.handle_list_resource_templates().await
+    /// Extract Send-safe info from entries (synchronous, no borrow across await).
+    fn entry_infos(entries: &[BackendEntry]) -> Vec<EntryInfo> {
+        entries
+            .iter()
+            .map(|e| EntryInfo {
+                namespace: e.namespace.clone(),
+                separator: e.separator.clone(),
+                cache: Arc::clone(&e.cache),
+            })
+            .collect()
+    }
+
+    /// Route a namespaced name to the correct backend index + stripped name.
+    fn route_by_prefix(entries: &[BackendEntry], name: &str) -> Option<(usize, String)> {
+        for (i, entry) in entries.iter().enumerate() {
+            if let Some(stripped) = entry.strip_prefix(name) {
+                return Some((i, stripped.to_string()));
             }
-            McpRequest::ReadResource(params) => inner.handle_read_resource(params).await,
-            McpRequest::ListPrompts(_params) => inner.handle_list_prompts().await,
-            McpRequest::GetPrompt(params) => inner.handle_get_prompt(params).await,
-            _ => Err(JsonRpcError::method_not_found(
-                "Method not supported by proxy",
-            )),
         }
+        None
+    }
+
+    /// Route a namespaced URI to the correct backend index + stripped URI.
+    fn route_by_uri_prefix(entries: &[BackendEntry], uri: &str) -> Option<(usize, String)> {
+        for (i, entry) in entries.iter().enumerate() {
+            if let Some(stripped) = entry.strip_uri_prefix(uri) {
+                return Some((i, stripped.to_string()));
+            }
+        }
+        None
     }
 }
 
-impl McpProxyInner {
-    /// Find the backend that owns a namespaced tool name.
-    /// Returns the backend and the stripped (original) name.
-    fn route_tool(&self, name: &str) -> Option<(&Backend, String)> {
-        for backend in &self.backends {
-            if let Some(stripped) = backend.strip_prefix(name) {
-                return Some((backend, stripped.to_string()));
-            }
-        }
-        None
+impl EntryInfo {
+    fn prefixed_name(&self, name: &str) -> String {
+        format!("{}{}{}", self.namespace, self.separator, name)
     }
 
-    /// Find the backend that owns a namespaced resource URI.
-    fn route_resource(&self, uri: &str) -> Option<(&Backend, String)> {
-        for backend in &self.backends {
-            if let Some(stripped) = backend.strip_uri_prefix(uri) {
-                return Some((backend, stripped.to_string()));
-            }
-        }
-        None
-    }
-
-    /// Find the backend that owns a namespaced prompt name.
-    fn route_prompt(&self, name: &str) -> Option<(&Backend, String)> {
-        for backend in &self.backends {
-            if let Some(stripped) = backend.strip_prefix(name) {
-                return Some((backend, stripped.to_string()));
-            }
-        }
-        None
-    }
-
-    async fn handle_initialize(&self) -> Result<McpResponse, JsonRpcError> {
-        Ok(McpResponse::Initialize(InitializeResult {
-            protocol_version: "2025-11-25".to_string(),
-            server_info: Implementation {
-                name: self.name.clone(),
-                version: self.version.clone(),
-                title: None,
-                description: None,
-                icons: None,
-                website_url: None,
-                meta: None,
-            },
-            capabilities: ServerCapabilities {
-                tools: Some(ToolsCapability { list_changed: true }),
-                resources: None,
-                prompts: None,
-                logging: None,
-                tasks: None,
-                completions: None,
-                experimental: None,
-                extensions: None,
-            },
-            instructions: Some(format!(
-                "MCP proxy aggregating {} backend servers",
-                self.backends.len()
-            )),
-            meta: None,
-        }))
-    }
-
-    async fn handle_list_tools(&self) -> Result<McpResponse, JsonRpcError> {
-        // Fan out to all backends concurrently
-        let futures: Vec<_> = self.backends.iter().map(|b| b.namespaced_tools()).collect();
-        let results = futures::future::join_all(futures).await;
-
-        let tools: Vec<_> = results.into_iter().flatten().collect();
-        Ok(McpResponse::ListTools(ListToolsResult {
-            tools,
-            next_cursor: None,
-            meta: None,
-        }))
-    }
-
-    async fn handle_call_tool(&self, params: CallToolParams) -> Result<McpResponse, JsonRpcError> {
-        let (backend, stripped_name) = self.route_tool(&params.name).ok_or_else(|| {
-            JsonRpcError::invalid_params(format!("Unknown tool: {}", params.name))
-        })?;
-
-        let result = backend
-            .call_tool(&stripped_name, params.arguments)
-            .await
-            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
-
-        Ok(McpResponse::CallTool(result))
-    }
-
-    async fn handle_list_resources(&self) -> Result<McpResponse, JsonRpcError> {
-        let futures: Vec<_> = self
-            .backends
-            .iter()
-            .map(|b| b.namespaced_resources())
-            .collect();
-        let results = futures::future::join_all(futures).await;
-
-        let resources: Vec<_> = results.into_iter().flatten().collect();
-        Ok(McpResponse::ListResources(ListResourcesResult {
-            resources,
-            next_cursor: None,
-            meta: None,
-        }))
-    }
-
-    async fn handle_list_resource_templates(&self) -> Result<McpResponse, JsonRpcError> {
-        let futures: Vec<_> = self
-            .backends
-            .iter()
-            .map(|b| b.namespaced_resource_templates())
-            .collect();
-        let results = futures::future::join_all(futures).await;
-
-        let resource_templates: Vec<_> = results.into_iter().flatten().collect();
-        Ok(McpResponse::ListResourceTemplates(
-            ListResourceTemplatesResult {
-                resource_templates,
-                next_cursor: None,
-                meta: None,
-            },
-        ))
-    }
-
-    async fn handle_read_resource(
-        &self,
-        params: ReadResourceParams,
-    ) -> Result<McpResponse, JsonRpcError> {
-        let (backend, stripped_uri) = self.route_resource(&params.uri).ok_or_else(|| {
-            JsonRpcError::invalid_params(format!("Unknown resource: {}", params.uri))
-        })?;
-
-        let result = backend
-            .read_resource(&stripped_uri)
-            .await
-            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
-
-        Ok(McpResponse::ReadResource(result))
-    }
-
-    async fn handle_list_prompts(&self) -> Result<McpResponse, JsonRpcError> {
-        let futures: Vec<_> = self
-            .backends
-            .iter()
-            .map(|b| b.namespaced_prompts())
-            .collect();
-        let results = futures::future::join_all(futures).await;
-
-        let prompts: Vec<_> = results.into_iter().flatten().collect();
-        Ok(McpResponse::ListPrompts(ListPromptsResult {
-            prompts,
-            next_cursor: None,
-            meta: None,
-        }))
-    }
-
-    async fn handle_get_prompt(
-        &self,
-        params: GetPromptParams,
-    ) -> Result<McpResponse, JsonRpcError> {
-        let (backend, stripped_name) = self.route_prompt(&params.name).ok_or_else(|| {
-            JsonRpcError::invalid_params(format!("Unknown prompt: {}", params.name))
-        })?;
-
-        let result = backend
-            .get_prompt(&stripped_name, params.arguments)
-            .await
-            .map_err(|e| JsonRpcError::internal_error(format!("Backend error: {}", e)))?;
-
-        Ok(McpResponse::GetPrompt(result))
+    fn prefixed_uri(&self, uri: &str) -> String {
+        format!("{}{}{}", self.namespace, self.separator, uri)
     }
 }
+
+// =========================================================================
+// Async handlers that only touch Send+Sync data (no BackendEntry references
+// held across .await points).
+// =========================================================================
+
+async fn handle_initialize(
+    name: String,
+    version: String,
+    num_backends: usize,
+) -> Result<McpResponse, JsonRpcError> {
+    Ok(McpResponse::Initialize(InitializeResult {
+        protocol_version: "2025-11-25".to_string(),
+        server_info: Implementation {
+            name,
+            version,
+            title: None,
+            description: None,
+            icons: None,
+            website_url: None,
+            meta: None,
+        },
+        capabilities: ServerCapabilities {
+            tools: Some(ToolsCapability { list_changed: true }),
+            resources: None,
+            prompts: None,
+            logging: None,
+            tasks: None,
+            completions: None,
+            experimental: None,
+            extensions: None,
+        },
+        instructions: Some(format!(
+            "MCP proxy aggregating {} backend servers",
+            num_backends
+        )),
+        meta: None,
+    }))
+}
+
+async fn handle_list_tools(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonRpcError> {
+    let mut tools = Vec::new();
+    for info in &infos {
+        let cache = info.cache.read().await;
+        for t in &cache.tools {
+            let mut def: ToolDefinition = t.clone();
+            def.name = info.prefixed_name(&def.name);
+            tools.push(def);
+        }
+    }
+    Ok(McpResponse::ListTools(ListToolsResult {
+        tools,
+        next_cursor: None,
+        meta: None,
+    }))
+}
+
+async fn handle_call_tool(
+    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    stripped_name: String,
+    params: CallToolParams,
+) -> Result<McpResponse, JsonRpcError> {
+    let inner_request = McpRequest::CallTool(CallToolParams {
+        name: stripped_name,
+        arguments: params.arguments,
+        meta: params.meta,
+        task: params.task,
+    });
+
+    let router_req = RouterRequest {
+        id: RequestId::Number(0),
+        inner: inner_request,
+        extensions: Extensions::new(),
+    };
+
+    let resp = service.call(router_req).await.expect("infallible");
+    resp.inner
+}
+
+async fn handle_list_resources(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonRpcError> {
+    let mut resources = Vec::new();
+    for info in &infos {
+        let cache = info.cache.read().await;
+        for r in &cache.resources {
+            let mut def: ResourceDefinition = r.clone();
+            def.uri = info.prefixed_uri(&def.uri);
+            def.name = info.prefixed_name(&def.name);
+            resources.push(def);
+        }
+    }
+    Ok(McpResponse::ListResources(ListResourcesResult {
+        resources,
+        next_cursor: None,
+        meta: None,
+    }))
+}
+
+async fn handle_list_resource_templates(
+    infos: Vec<EntryInfo>,
+) -> Result<McpResponse, JsonRpcError> {
+    let mut resource_templates = Vec::new();
+    for info in &infos {
+        let cache = info.cache.read().await;
+        for rt in &cache.resource_templates {
+            let mut def: ResourceTemplateDefinition = rt.clone();
+            def.uri_template = info.prefixed_uri(&def.uri_template);
+            def.name = info.prefixed_name(&def.name);
+            resource_templates.push(def);
+        }
+    }
+    Ok(McpResponse::ListResourceTemplates(
+        ListResourceTemplatesResult {
+            resource_templates,
+            next_cursor: None,
+            meta: None,
+        },
+    ))
+}
+
+async fn handle_read_resource(
+    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    stripped_uri: String,
+    params: ReadResourceParams,
+) -> Result<McpResponse, JsonRpcError> {
+    let inner_request = McpRequest::ReadResource(ReadResourceParams {
+        uri: stripped_uri,
+        meta: params.meta,
+    });
+
+    let router_req = RouterRequest {
+        id: RequestId::Number(0),
+        inner: inner_request,
+        extensions: Extensions::new(),
+    };
+
+    let resp = service.call(router_req).await.expect("infallible");
+    resp.inner
+}
+
+async fn handle_list_prompts(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonRpcError> {
+    let mut prompts = Vec::new();
+    for info in &infos {
+        let cache = info.cache.read().await;
+        for p in &cache.prompts {
+            let mut def: PromptDefinition = p.clone();
+            def.name = info.prefixed_name(&def.name);
+            prompts.push(def);
+        }
+    }
+    Ok(McpResponse::ListPrompts(ListPromptsResult {
+        prompts,
+        next_cursor: None,
+        meta: None,
+    }))
+}
+
+async fn handle_get_prompt(
+    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    stripped_name: String,
+    params: GetPromptParams,
+) -> Result<McpResponse, JsonRpcError> {
+    let inner_request = McpRequest::GetPrompt(GetPromptParams {
+        name: stripped_name,
+        arguments: params.arguments,
+        meta: params.meta,
+    });
+
+    let router_req = RouterRequest {
+        id: RequestId::Number(0),
+        inner: inner_request,
+        extensions: Extensions::new(),
+    };
+
+    let resp = service.call(router_req).await.expect("infallible");
+    resp.inner
+}
+
+// =========================================================================
+// Service implementation
+// =========================================================================
 
 impl Service<RouterRequest> for McpProxy {
     type Response = RouterResponse;
@@ -256,11 +357,88 @@ impl Service<RouterRequest> for McpProxy {
     }
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
-        let inner = Arc::clone(&self.inner);
         let request_id = req.id.clone();
 
+        // All routing and data extraction happens synchronously here (no await),
+        // so we never hold a &[BackendEntry] reference across an await point.
+        // Only Send+Sync data (EntryInfo, cloned BoxCloneService, Arc<McpProxyShared>)
+        // is moved into the returned future.
+        let result_future: Pin<Box<dyn Future<Output = Result<McpResponse, JsonRpcError>> + Send>> =
+            match req.inner {
+                McpRequest::Initialize(_params) => {
+                    let name = self.shared.name.clone();
+                    let version = self.shared.version.clone();
+                    let num = self.entries.len();
+                    Box::pin(handle_initialize(name, version, num))
+                }
+                McpRequest::Ping => Box::pin(async { Ok(McpResponse::Pong(Default::default())) }),
+                McpRequest::ListTools(_params) => {
+                    let infos = Self::entry_infos(&self.entries);
+                    Box::pin(handle_list_tools(infos))
+                }
+                McpRequest::CallTool(params) => {
+                    match Self::route_by_prefix(&self.entries, &params.name) {
+                        Some((idx, stripped)) => {
+                            let service = self.entries[idx].service.clone();
+                            Box::pin(handle_call_tool(service, stripped, params))
+                        }
+                        None => Box::pin(async move {
+                            Err(JsonRpcError::invalid_params(format!(
+                                "Unknown tool: {}",
+                                params.name
+                            )))
+                        }),
+                    }
+                }
+                McpRequest::ListResources(_params) => {
+                    let infos = Self::entry_infos(&self.entries);
+                    Box::pin(handle_list_resources(infos))
+                }
+                McpRequest::ListResourceTemplates(_params) => {
+                    let infos = Self::entry_infos(&self.entries);
+                    Box::pin(handle_list_resource_templates(infos))
+                }
+                McpRequest::ReadResource(params) => {
+                    match Self::route_by_uri_prefix(&self.entries, &params.uri) {
+                        Some((idx, stripped)) => {
+                            let service = self.entries[idx].service.clone();
+                            Box::pin(handle_read_resource(service, stripped, params))
+                        }
+                        None => Box::pin(async move {
+                            Err(JsonRpcError::invalid_params(format!(
+                                "Unknown resource: {}",
+                                params.uri
+                            )))
+                        }),
+                    }
+                }
+                McpRequest::ListPrompts(_params) => {
+                    let infos = Self::entry_infos(&self.entries);
+                    Box::pin(handle_list_prompts(infos))
+                }
+                McpRequest::GetPrompt(params) => {
+                    match Self::route_by_prefix(&self.entries, &params.name) {
+                        Some((idx, stripped)) => {
+                            let service = self.entries[idx].service.clone();
+                            Box::pin(handle_get_prompt(service, stripped, params))
+                        }
+                        None => Box::pin(async move {
+                            Err(JsonRpcError::invalid_params(format!(
+                                "Unknown prompt: {}",
+                                params.name
+                            )))
+                        }),
+                    }
+                }
+                _ => Box::pin(async {
+                    Err(JsonRpcError::method_not_found(
+                        "Method not supported by proxy",
+                    ))
+                }),
+            };
+
         Box::pin(async move {
-            let result = McpProxy::handle_request(inner, req.inner).await;
+            let result = result_future.await;
             Ok(RouterResponse {
                 id: request_id,
                 inner: result,

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -14,7 +14,8 @@ mod proxy_tests {
     use crate::proxy::McpProxy;
     use crate::router::{Extensions, RouterRequest};
     use crate::{
-        CallToolResult, GetPromptResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder,
+        CallToolResult, GetPromptResult, McpRouter, PromptBuilder, ReadResourceResult,
+        ResourceBuilder, ResourceContent, ResourceTemplateBuilder, ToolBuilder,
     };
 
     use schemars::JsonSchema;
@@ -57,6 +58,23 @@ mod proxy_tests {
             .description("Project readme")
             .text("# Hello");
 
+        let file_template = ResourceTemplateBuilder::new("file:///{path}")
+            .name("File Template")
+            .description("Read a file by path")
+            .handler(|uri: String, vars: HashMap<String, String>| async move {
+                let path = vars.get("path").cloned().unwrap_or_default();
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some(format!("contents of {}", path)),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                })
+            });
+
         let greet = PromptBuilder::new("greet")
             .description("Greet someone")
             .required_arg("name", "Name to greet")
@@ -70,6 +88,7 @@ mod proxy_tests {
             .server_info("text-server", "1.0.0")
             .tool(echo)
             .resource(readme)
+            .resource_template(file_template)
             .prompt(greet)
     }
 
@@ -249,6 +268,51 @@ mod proxy_tests {
     // ========================================================================
 
     #[tokio::test]
+    async fn test_proxy_call_unknown_resource_returns_error() {
+        let mut proxy = build_test_proxy().await;
+
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::ReadResource(crate::protocol::ReadResourceParams {
+                uri: "unknown://resource".to_string(),
+                meta: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err(), "should return error for unknown resource");
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("Unknown resource"),
+            "error should mention unknown resource, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_call_unknown_prompt_returns_error() {
+        let mut proxy = build_test_proxy().await;
+
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::GetPrompt(crate::protocol::GetPromptParams {
+                name: "nonexistent_prompt".to_string(),
+                arguments: Default::default(),
+                meta: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err(), "should return error for unknown prompt");
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("Unknown prompt"),
+            "error should mention unknown prompt, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
     async fn test_proxy_list_resources() {
         let mut proxy = build_test_proxy().await;
 
@@ -293,6 +357,42 @@ mod proxy_tests {
                 assert_eq!(result.first_text(), Some("# Hello"));
             }
             other => panic!("expected ReadResource response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // List resource templates
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_list_resource_templates() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::ListResourceTemplates(Default::default()),
+        )
+        .await
+        .expect("list resource templates should succeed");
+
+        match resp {
+            McpResponse::ListResourceTemplates(result) => {
+                // text backend has one resource template
+                assert_eq!(result.resource_templates.len(), 1);
+                let template = &result.resource_templates[0];
+                // Should be namespaced
+                assert!(
+                    template.name.starts_with("text_"),
+                    "template name should be namespaced, got: {}",
+                    template.name
+                );
+                assert!(
+                    template.uri_template.starts_with("text_"),
+                    "template URI should be namespaced, got: {}",
+                    template.uri_template
+                );
+            }
+            other => panic!("expected ListResourceTemplates, got: {:?}", other),
         }
     }
 
@@ -439,6 +539,71 @@ mod proxy_tests {
         assert!(result.is_err());
     }
 
+    #[tokio::test]
+    async fn test_proxy_unsupported_method_returns_error() {
+        let mut proxy = build_test_proxy().await;
+
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::SetLoggingLevel(crate::protocol::SetLogLevelParams {
+                level: crate::protocol::LogLevel::Info,
+                meta: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err(), "unsupported method should return error");
+        let err = result.unwrap_err();
+        assert!(
+            err.message.contains("not supported"),
+            "error should mention not supported, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_backend_client_path() {
+        let transport = ChannelTransport::new(math_router());
+        let client = McpClient::connect(transport).await.expect("should connect");
+
+        // Use backend_client (pre-connected McpClient) instead of backend (transport)
+        let mut proxy = McpProxy::builder("client-proxy", "1.0.0")
+            .backend_client("math", client)
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // Should still be able to list and call tools
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .expect("list tools should succeed");
+
+        match resp {
+            McpResponse::ListTools(result) => {
+                assert_eq!(result.tools.len(), 1);
+                assert_eq!(result.tools[0].name, "math_add");
+            }
+            other => panic!("expected ListTools, got: {:?}", other),
+        }
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math_add".to_string(),
+                arguments: json!({"a": 5, "b": 7}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("call tool should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => assert_eq!(result.all_text(), "12"),
+            other => panic!("expected CallTool, got: {:?}", other),
+        }
+    }
+
     // ========================================================================
     // Clone
     // ========================================================================
@@ -526,6 +691,56 @@ mod proxy_tests {
             .await
             .expect("should get prompt");
         assert!(prompt.first_message_text().unwrap().contains("Bob"));
+    }
+
+    /// A transport that immediately returns EOF, causing initialization to fail.
+    struct BrokenTransport;
+
+    #[async_trait::async_trait]
+    impl crate::client::ClientTransport for BrokenTransport {
+        async fn send(&mut self, _message: &str) -> crate::error::Result<()> {
+            Err(crate::error::Error::internal("broken transport"))
+        }
+
+        async fn recv(&mut self) -> crate::error::Result<Option<String>> {
+            Ok(None) // EOF
+        }
+
+        fn is_connected(&self) -> bool {
+            false
+        }
+
+        async fn close(&mut self) -> crate::error::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_skips_failed_backend_initialization() {
+        let good_transport = ChannelTransport::new(math_router());
+
+        // Build with one broken and one good backend
+        let mut proxy = McpProxy::builder("mixed-init", "1.0.0")
+            .backend("broken", BrokenTransport)
+            .await
+            .backend("math", good_transport)
+            .await
+            .build()
+            .await
+            .expect("proxy should build with at least one good backend");
+
+        // Only the math backend should be available
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .expect("list tools should succeed");
+
+        match resp {
+            McpResponse::ListTools(result) => {
+                assert_eq!(result.tools.len(), 1);
+                assert_eq!(result.tools[0].name, "math_add");
+            }
+            other => panic!("expected ListTools, got: {:?}", other),
+        }
     }
 
     // ========================================================================

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -1,11 +1,14 @@
 #[cfg(test)]
 mod proxy_tests {
     use std::collections::HashMap;
+    use std::time::Duration;
 
     use serde_json::json;
+    use tower::timeout::TimeoutLayer;
     use tower_service::Service;
 
     use crate::client::{ChannelTransport, McpClient};
+    use crate::context::notification_channel;
     use crate::protocol::{McpRequest, McpResponse, RequestId};
     use crate::proxy::McpProxy;
     use crate::router::{Extensions, RouterRequest};
@@ -522,5 +525,188 @@ mod proxy_tests {
             .await
             .expect("should get prompt");
         assert!(prompt.first_message_text().unwrap().contains("Bob"));
+    }
+
+    // ========================================================================
+    // Per-backend middleware
+    // ========================================================================
+
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct SlowInput {
+        delay_ms: u64,
+    }
+
+    /// Create a "slow" backend router with a tool that sleeps.
+    fn slow_router() -> McpRouter {
+        let slow = ToolBuilder::new("slow_op")
+            .description("A slow operation")
+            .handler(|input: SlowInput| async move {
+                tokio::time::sleep(Duration::from_millis(input.delay_ms)).await;
+                Ok(CallToolResult::text("done"))
+            })
+            .build();
+
+        McpRouter::new()
+            .server_info("slow-server", "1.0.0")
+            .tool(slow)
+    }
+
+    #[tokio::test]
+    async fn test_backend_layer_timeout_triggers() {
+        let slow_transport = ChannelTransport::new(slow_router());
+
+        let mut proxy = McpProxy::builder("timeout-proxy", "1.0.0")
+            .backend("slow", slow_transport)
+            .await
+            .backend_layer(TimeoutLayer::new(Duration::from_millis(50)))
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // Call with a delay that exceeds the timeout
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "slow_slow_op".to_string(),
+                arguments: json!({"delay_ms": 500}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        // Should get a JSON-RPC error from the CatchError wrapper
+        assert!(result.is_err(), "should timeout");
+        let err = result.unwrap_err();
+        assert!(
+            err.message.to_lowercase().contains("timed out")
+                || err.message.to_lowercase().contains("timeout"),
+            "error should mention timeout, got: {}",
+            err.message
+        );
+    }
+
+    #[tokio::test]
+    async fn test_backend_layer_timeout_allows_fast_requests() {
+        let slow_transport = ChannelTransport::new(slow_router());
+
+        let mut proxy = McpProxy::builder("timeout-proxy", "1.0.0")
+            .backend("slow", slow_transport)
+            .await
+            .backend_layer(TimeoutLayer::new(Duration::from_secs(5)))
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // Call with no delay -- should succeed
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "slow_slow_op".to_string(),
+                arguments: json!({"delay_ms": 0}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("fast call should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "done");
+            }
+            other => panic!("expected CallTool response, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backend_layer_only_affects_target_backend() {
+        let math_transport = ChannelTransport::new(math_router());
+        let slow_transport = ChannelTransport::new(slow_router());
+
+        let mut proxy = McpProxy::builder("mixed-proxy", "1.0.0")
+            // math backend: no middleware
+            .backend("math", math_transport)
+            .await
+            // slow backend: tight timeout
+            .backend("slow", slow_transport)
+            .await
+            .backend_layer(TimeoutLayer::new(Duration::from_millis(50)))
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // math backend should work fine (no timeout layer)
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math_add".to_string(),
+                arguments: json!({"a": 1, "b": 2}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("math should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => assert_eq!(result.all_text(), "3"),
+            other => panic!("expected CallTool, got: {:?}", other),
+        }
+
+        // slow backend should timeout
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "slow_slow_op".to_string(),
+                arguments: json!({"delay_ms": 500}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err(), "slow backend should timeout");
+    }
+
+    // ========================================================================
+    // Health check
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_health_check_all_healthy() {
+        let proxy = build_test_proxy().await;
+
+        let health = proxy.health_check().await;
+        assert_eq!(health.len(), 2);
+        assert!(
+            health.iter().all(|h| h.healthy),
+            "all backends should be healthy"
+        );
+
+        let namespaces: Vec<&str> = health.iter().map(|h| h.namespace.as_str()).collect();
+        assert!(namespaces.contains(&"math"));
+        assert!(namespaces.contains(&"text"));
+    }
+
+    // ========================================================================
+    // Notification forwarding
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_notification_sender_configured() {
+        let (notif_tx, _notif_rx) = notification_channel(32);
+        let math_transport = ChannelTransport::new(math_router());
+
+        let proxy = McpProxy::builder("notif-proxy", "1.0.0")
+            .notification_sender(notif_tx)
+            .backend("math", math_transport)
+            .await
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // Verify proxy built successfully with notification sender
+        assert!(proxy.shared.notification_tx.is_some());
     }
 }

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -1,0 +1,526 @@
+#[cfg(test)]
+mod proxy_tests {
+    use std::collections::HashMap;
+
+    use serde_json::json;
+    use tower_service::Service;
+
+    use crate::client::{ChannelTransport, McpClient};
+    use crate::protocol::{McpRequest, McpResponse, RequestId};
+    use crate::proxy::McpProxy;
+    use crate::router::{Extensions, RouterRequest};
+    use crate::{
+        CallToolResult, GetPromptResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder,
+    };
+
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct AddInput {
+        a: i64,
+        b: i64,
+    }
+
+    #[derive(Debug, Deserialize, JsonSchema)]
+    struct EchoInput {
+        message: String,
+    }
+
+    /// Create a "math" backend router with an `add` tool.
+    fn math_router() -> McpRouter {
+        let add = ToolBuilder::new("add")
+            .description("Add two numbers")
+            .handler(|input: AddInput| async move {
+                Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+            })
+            .build();
+
+        McpRouter::new()
+            .server_info("math-server", "1.0.0")
+            .tool(add)
+    }
+
+    /// Create a "text" backend router with an `echo` tool and a `greet` prompt.
+    fn text_router() -> McpRouter {
+        let echo = ToolBuilder::new("echo")
+            .description("Echo a message")
+            .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+            .build();
+
+        let readme = ResourceBuilder::new("file:///README.md")
+            .name("README")
+            .description("Project readme")
+            .text("# Hello");
+
+        let greet = PromptBuilder::new("greet")
+            .description("Greet someone")
+            .required_arg("name", "Name to greet")
+            .handler(|args: HashMap<String, String>| async move {
+                let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+                Ok(GetPromptResult::user_message(format!("Hello, {}!", name)))
+            })
+            .build();
+
+        McpRouter::new()
+            .server_info("text-server", "1.0.0")
+            .tool(echo)
+            .resource(readme)
+            .prompt(greet)
+    }
+
+    /// Build a proxy with two in-process backends.
+    async fn build_test_proxy() -> McpProxy {
+        let math_transport = ChannelTransport::new(math_router());
+        let text_transport = ChannelTransport::new(text_router());
+
+        McpProxy::builder("test-proxy", "1.0.0")
+            .backend("math", math_transport)
+            .await
+            .backend("text", text_transport)
+            .await
+            .build()
+            .await
+            .expect("proxy should build")
+    }
+
+    /// Helper: send an McpRequest through the proxy and get the McpResponse.
+    async fn call_proxy(
+        proxy: &mut McpProxy,
+        request: McpRequest,
+    ) -> Result<McpResponse, tower_mcp_types::JsonRpcError> {
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: request,
+            extensions: Extensions::new(),
+        };
+        let resp = proxy.call(req).await.expect("infallible");
+        resp.inner
+    }
+
+    // ========================================================================
+    // Initialize
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_initialize() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::Initialize(crate::protocol::InitializeParams {
+                protocol_version: "2025-11-25".to_string(),
+                capabilities: Default::default(),
+                client_info: crate::protocol::Implementation {
+                    name: "test".to_string(),
+                    version: "1.0".to_string(),
+                    title: None,
+                    description: None,
+                    icons: None,
+                    website_url: None,
+                    meta: None,
+                },
+                meta: None,
+            }),
+        )
+        .await
+        .expect("initialize should succeed");
+
+        match resp {
+            McpResponse::Initialize(init) => {
+                assert_eq!(init.server_info.name, "test-proxy");
+                assert_eq!(init.server_info.version, "1.0.0");
+                assert!(init.capabilities.tools.is_some());
+            }
+            other => panic!("expected Initialize response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // List tools
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_list_tools() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .expect("list tools should succeed");
+
+        match resp {
+            McpResponse::ListTools(result) => {
+                let names: Vec<&str> = result.tools.iter().map(|t| t.name.as_str()).collect();
+                assert!(
+                    names.contains(&"math_add"),
+                    "expected math_add, got: {:?}",
+                    names
+                );
+                assert!(
+                    names.contains(&"text_echo"),
+                    "expected text_echo, got: {:?}",
+                    names
+                );
+                assert_eq!(result.tools.len(), 2);
+            }
+            other => panic!("expected ListTools response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Call tool - routing
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_call_tool_routes_to_correct_backend() {
+        let mut proxy = build_test_proxy().await;
+
+        // Call math_add
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math_add".to_string(),
+                arguments: json!({"a": 10, "b": 32}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("call tool should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "42");
+            }
+            other => panic!("expected CallTool response, got: {:?}", other),
+        }
+
+        // Call text_echo
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "text_echo".to_string(),
+                arguments: json!({"message": "hello"}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("call tool should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "hello");
+            }
+            other => panic!("expected CallTool response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Call tool - unknown tool
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_call_unknown_tool_returns_error() {
+        let mut proxy = build_test_proxy().await;
+
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "nonexistent_tool".to_string(),
+                arguments: json!({}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(result.is_err(), "should return error for unknown tool");
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Unknown tool"));
+    }
+
+    // ========================================================================
+    // List resources
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_list_resources() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(&mut proxy, McpRequest::ListResources(Default::default()))
+            .await
+            .expect("list resources should succeed");
+
+        match resp {
+            McpResponse::ListResources(result) => {
+                assert_eq!(result.resources.len(), 1);
+                // URI should be namespaced
+                assert!(
+                    result.resources[0].uri.starts_with("text_"),
+                    "expected text_ prefix on URI, got: {}",
+                    result.resources[0].uri
+                );
+            }
+            other => panic!("expected ListResources response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Read resource - routing
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_read_resource_routes_correctly() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::ReadResource(crate::protocol::ReadResourceParams {
+                uri: "text_file:///README.md".to_string(),
+                meta: None,
+            }),
+        )
+        .await
+        .expect("read resource should succeed");
+
+        match resp {
+            McpResponse::ReadResource(result) => {
+                assert_eq!(result.first_text(), Some("# Hello"));
+            }
+            other => panic!("expected ReadResource response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // List prompts
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_list_prompts() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(&mut proxy, McpRequest::ListPrompts(Default::default()))
+            .await
+            .expect("list prompts should succeed");
+
+        match resp {
+            McpResponse::ListPrompts(result) => {
+                assert_eq!(result.prompts.len(), 1);
+                assert_eq!(result.prompts[0].name, "text_greet");
+            }
+            other => panic!("expected ListPrompts response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Get prompt - routing
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_get_prompt_routes_correctly() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::GetPrompt(crate::protocol::GetPromptParams {
+                name: "text_greet".to_string(),
+                arguments: HashMap::from([("name".to_string(), "Alice".to_string())]),
+                meta: None,
+            }),
+        )
+        .await
+        .expect("get prompt should succeed");
+
+        match resp {
+            McpResponse::GetPrompt(result) => {
+                let text = result.first_message_text().unwrap();
+                assert!(
+                    text.contains("Alice"),
+                    "expected Alice in prompt, got: {}",
+                    text
+                );
+            }
+            other => panic!("expected GetPrompt response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Ping
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_ping() {
+        let mut proxy = build_test_proxy().await;
+
+        let resp = call_proxy(&mut proxy, McpRequest::Ping)
+            .await
+            .expect("ping should succeed");
+
+        assert!(matches!(resp, McpResponse::Pong(_)));
+    }
+
+    // ========================================================================
+    // Custom separator
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_custom_separator() {
+        let math_transport = ChannelTransport::new(math_router());
+
+        let mut proxy = McpProxy::builder("sep-proxy", "1.0.0")
+            .separator(".")
+            .backend("math", math_transport)
+            .await
+            .build()
+            .await
+            .expect("proxy should build");
+
+        // List tools with dot separator
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .expect("list tools should succeed");
+
+        match resp {
+            McpResponse::ListTools(result) => {
+                assert_eq!(result.tools[0].name, "math.add");
+            }
+            other => panic!("expected ListTools response, got: {:?}", other),
+        }
+
+        // Call tool with dot separator
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math.add".to_string(),
+                arguments: json!({"a": 1, "b": 2}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("call tool should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "3");
+            }
+            other => panic!("expected CallTool response, got: {:?}", other),
+        }
+    }
+
+    // ========================================================================
+    // Builder validation
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_builder_rejects_empty_backends() {
+        let result = McpProxy::builder("empty", "1.0.0").build().await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_proxy_builder_rejects_duplicate_namespaces() {
+        let t1 = ChannelTransport::new(math_router());
+        let t2 = ChannelTransport::new(text_router());
+
+        let result = McpProxy::builder("dup", "1.0.0")
+            .backend("same", t1)
+            .await
+            .backend("same", t2)
+            .await
+            .build()
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    // ========================================================================
+    // Clone
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_is_clone() {
+        let proxy = build_test_proxy().await;
+        let mut proxy2 = proxy.clone();
+
+        // Both should work independently
+        let resp = call_proxy(&mut proxy2, McpRequest::Ping)
+            .await
+            .expect("ping should succeed");
+        assert!(matches!(resp, McpResponse::Pong(_)));
+    }
+
+    // ========================================================================
+    // ChannelTransport basics
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_channel_transport_basic_roundtrip() {
+        let router = math_router();
+        let transport = ChannelTransport::new(router);
+
+        let client = McpClient::connect(transport).await.expect("should connect");
+        client
+            .initialize("test-client", "1.0.0")
+            .await
+            .expect("should initialize");
+
+        let tools = client.list_all_tools().await.expect("should list tools");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "add");
+
+        let result = client
+            .call_tool("add", json!({"a": 100, "b": 200}))
+            .await
+            .expect("should call tool");
+        assert_eq!(result.all_text(), "300");
+    }
+
+    #[tokio::test]
+    async fn test_channel_transport_with_resources_and_prompts() {
+        let router = text_router();
+        let transport = ChannelTransport::new(router);
+
+        let client = McpClient::connect(transport).await.expect("should connect");
+        client
+            .initialize("test-client", "1.0.0")
+            .await
+            .expect("should initialize");
+
+        // Tools
+        let tools = client.list_all_tools().await.expect("should list tools");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "echo");
+
+        // Resources
+        let resources = client
+            .list_all_resources()
+            .await
+            .expect("should list resources");
+        assert_eq!(resources.len(), 1);
+
+        let content = client
+            .read_resource("file:///README.md")
+            .await
+            .expect("should read resource");
+        assert_eq!(content.first_text(), Some("# Hello"));
+
+        // Prompts
+        let prompts = client
+            .list_all_prompts()
+            .await
+            .expect("should list prompts");
+        assert_eq!(prompts.len(), 1);
+        assert_eq!(prompts[0].name, "greet");
+
+        let prompt = client
+            .get_prompt(
+                "greet",
+                Some(HashMap::from([("name".to_string(), "Bob".to_string())])),
+            )
+            .await
+            .expect("should get prompt");
+        assert!(prompt.first_message_text().unwrap().contains("Bob"));
+    }
+}

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -540,6 +540,49 @@ mod proxy_tests {
     }
 
     #[tokio::test]
+    async fn test_proxy_builder_rejects_ambiguous_namespace_prefixes() {
+        // With separator "_", "redis" produces prefix "redis_" and "redis_ft"
+        // produces prefix "redis_ft_". Since "redis_ft_" starts with "redis_",
+        // routing "redis_ft_search" is ambiguous.
+        let t1 = ChannelTransport::new(math_router());
+        let t2 = ChannelTransport::new(text_router());
+
+        let result = McpProxy::builder("ambiguous", "1.0.0")
+            .backend("redis", t1)
+            .await
+            .backend("redis_ft", t2)
+            .await
+            .build()
+            .await;
+
+        let err = result.err().expect("should fail with ambiguous prefixes");
+        assert!(
+            err.to_string().contains("Ambiguous namespace prefixes"),
+            "Expected ambiguous prefix error, got: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_builder_allows_non_ambiguous_prefixes_with_dot_separator() {
+        // With separator ".", "redis" -> "redis." and "redis_ft" -> "redis_ft."
+        // Neither is a prefix of the other, so this is fine.
+        let t1 = ChannelTransport::new(math_router());
+        let t2 = ChannelTransport::new(text_router());
+
+        let result = McpProxy::builder("dot-sep", "1.0.0")
+            .separator(".")
+            .backend("redis", t1)
+            .await
+            .backend("redis_ft", t2)
+            .await
+            .build()
+            .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn test_proxy_unsupported_method_returns_error() {
         let mut proxy = build_test_proxy().await;
 

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -4,6 +4,7 @@ mod proxy_tests {
     use std::time::Duration;
 
     use serde_json::json;
+    use tower::Layer;
     use tower::timeout::TimeoutLayer;
     use tower_service::Service;
 
@@ -708,5 +709,126 @@ mod proxy_tests {
 
         // Verify proxy built successfully with notification sender
         assert!(proxy.shared.notification_tx.is_some());
+    }
+
+    // ========================================================================
+    // CoalesceLayer integration
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_coalesce_layer_deduplicates_concurrent_list_tools() {
+        use std::mem::discriminant;
+        use tower::ServiceExt;
+        use tower_resilience::coalesce::{CoalesceError, CoalesceLayer};
+
+        type CoalesceResult =
+            Result<crate::router::RouterResponse, CoalesceError<std::convert::Infallible>>;
+
+        let proxy = build_test_proxy().await;
+
+        // Wrap the proxy in CoalesceLayer keyed by McpRequest discriminant.
+        // This means concurrent list_tools calls share a single execution.
+        let coalesced =
+            CoalesceLayer::new(|req: &RouterRequest| discriminant(&req.inner)).layer(proxy);
+
+        // Fire 5 concurrent list_tools requests
+        let mut handles = vec![];
+        for _ in 0..5 {
+            let mut svc = coalesced.clone();
+            handles.push(tokio::spawn(async move {
+                let req = RouterRequest {
+                    id: RequestId::Number(1),
+                    inner: McpRequest::ListTools(Default::default()),
+                    extensions: Extensions::new(),
+                };
+                let result: CoalesceResult = svc.ready().await.unwrap().call(req).await;
+                result
+            }));
+        }
+
+        // All should succeed with identical tool lists
+        let mut tool_lists: Vec<Vec<String>> = Vec::new();
+        for handle in handles {
+            let resp = handle.await.unwrap().unwrap();
+            let mcp_resp = resp.inner.expect("should be Ok");
+            match mcp_resp {
+                McpResponse::ListTools(list) => {
+                    let names: Vec<String> = list.tools.iter().map(|t| t.name.clone()).collect();
+                    tool_lists.push(names);
+                }
+                other => panic!("expected ListTools, got: {:?}", other),
+            }
+        }
+
+        // All responses should be identical (coalesced from the same execution)
+        assert_eq!(tool_lists.len(), 5);
+        for list in &tool_lists {
+            assert_eq!(list, &tool_lists[0], "all responses should match");
+        }
+        // Should contain tools from both backends
+        assert!(tool_lists[0].contains(&"math_add".to_string()));
+        assert!(tool_lists[0].contains(&"text_echo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_coalesce_layer_does_not_affect_different_methods() {
+        use std::mem::discriminant;
+        use tower::ServiceExt;
+        use tower_resilience::coalesce::{CoalesceError, CoalesceLayer};
+
+        type CoalesceResult =
+            Result<crate::router::RouterResponse, CoalesceError<std::convert::Infallible>>;
+
+        let proxy = build_test_proxy().await;
+
+        let coalesced =
+            CoalesceLayer::new(|req: &RouterRequest| discriminant(&req.inner)).layer(proxy);
+
+        // Fire list_tools and call_tool concurrently -- they have different
+        // discriminants so they should NOT be coalesced.
+        let mut list_svc = coalesced.clone();
+        let mut call_svc = coalesced.clone();
+
+        let list_handle: tokio::task::JoinHandle<CoalesceResult> = tokio::spawn(async move {
+            let req = RouterRequest {
+                id: RequestId::Number(1),
+                inner: McpRequest::ListTools(Default::default()),
+                extensions: Extensions::new(),
+            };
+            list_svc.ready().await.unwrap().call(req).await
+        });
+
+        let call_handle: tokio::task::JoinHandle<CoalesceResult> = tokio::spawn(async move {
+            let req = RouterRequest {
+                id: RequestId::Number(2),
+                inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                    name: "math_add".to_string(),
+                    arguments: json!({"a": 10, "b": 20}),
+                    meta: None,
+                    task: None,
+                }),
+                extensions: Extensions::new(),
+            };
+            call_svc.ready().await.unwrap().call(req).await
+        });
+
+        let list_resp = list_handle.await.unwrap().unwrap();
+        let call_resp = call_handle.await.unwrap().unwrap();
+
+        // list_tools should return tool definitions
+        match list_resp.inner.unwrap() {
+            McpResponse::ListTools(list) => {
+                assert!(!list.tools.is_empty());
+            }
+            other => panic!("expected ListTools, got: {:?}", other),
+        }
+
+        // call_tool should return the computation result
+        match call_resp.inner.unwrap() {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.all_text(), "30");
+            }
+            other => panic!("expected CallTool, got: {:?}", other),
+        }
     }
 }

--- a/crates/tower-mcp/src/transport/service.rs
+++ b/crates/tower-mcp/src/transport/service.rs
@@ -207,6 +207,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::protocol::{CallToolParams, CallToolResult, RequestId, ToolAnnotations};
     use crate::router::McpRouter;

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,21 +1,26 @@
 //! MCP Proxy example -- aggregate multiple backend servers
 //!
 //! Demonstrates using McpProxy to combine tools from multiple backend
-//! MCP servers behind a single endpoint.
+//! MCP servers behind a single endpoint, with:
+//! - Namespace prefixing (tools become `basic_*` and `sampling_*`)
+//! - Per-backend middleware (timeout on the sampling backend)
+//! - Notification forwarding (backend list changes propagate to clients)
+//! - Health checks (ping all backends)
 //!
 //! This example spawns two backend servers as subprocesses:
 //! - `basic` server (provides echo and add tools)
 //! - `sampling_server` (provides summarize, confirm_delete, slow_task tools)
 //!
-//! The proxy namespaces them as `basic_*` and `sampling_*` and exposes
-//! all tools through a single stdio interface.
-//!
-//! Run with: cargo run --example proxy
+//! Run with: cargo run --example proxy --features proxy
 //!
 //! Then interact via JSON-RPC on stdin/stdout, or connect with any MCP client.
 
+use std::time::Duration;
+
+use tower::timeout::TimeoutLayer;
 use tower_mcp::GenericStdioTransport;
 use tower_mcp::client::StdioClientTransport;
+use tower_mcp::context::notification_channel;
 use tower_mcp::proxy::McpProxy;
 
 #[tokio::main]
@@ -33,20 +38,39 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let sampling_transport =
         StdioClientTransport::spawn("cargo", &["run", "--example", "sampling_server"]).await?;
 
+    // Create notification channel for forwarding backend list-changed
+    // events to downstream clients (e.g., when a backend adds/removes tools)
+    let (notif_tx, notif_rx) = notification_channel(32);
+
     // Build the proxy -- backends initialize concurrently
     let proxy = McpProxy::builder("mcp-proxy-example", "1.0.0")
+        .notification_sender(notif_tx)
         .backend("basic", basic_transport)
         .await
+        // Per-backend middleware: 30s timeout on sampling backend
         .backend("sampling", sampling_transport)
         .await
+        .backend_layer(TimeoutLayer::new(Duration::from_secs(30)))
         .build()
         .await?;
 
+    // Health check all backends
+    let health = proxy.health_check().await;
+    for h in &health {
+        tracing::info!(
+            namespace = %h.namespace,
+            healthy = h.healthy,
+            "Backend health"
+        );
+    }
+
     tracing::info!("Proxy ready, serving on stdio");
 
-    // Serve the proxy over stdio
-    // McpProxy implements Service<RouterRequest>, so it works with any transport
-    let mut transport = GenericStdioTransport::new(proxy);
+    // Serve the proxy over stdio with notification forwarding.
+    // When a backend emits tools/list_changed, resources/list_changed,
+    // or prompts/list_changed, the proxy refreshes its cache and forwards
+    // the notification to connected clients via this transport.
+    let mut transport = GenericStdioTransport::with_notifications(proxy, notif_rx);
     transport.run().await?;
 
     Ok(())

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,0 +1,53 @@
+//! MCP Proxy example -- aggregate multiple backend servers
+//!
+//! Demonstrates using McpProxy to combine tools from multiple backend
+//! MCP servers behind a single endpoint.
+//!
+//! This example spawns two backend servers as subprocesses:
+//! - `basic` server (provides echo and add tools)
+//! - `sampling_server` (provides summarize, confirm_delete, slow_task tools)
+//!
+//! The proxy namespaces them as `basic_*` and `sampling_*` and exposes
+//! all tools through a single stdio interface.
+//!
+//! Run with: cargo run --example proxy
+//!
+//! Then interact via JSON-RPC on stdin/stdout, or connect with any MCP client.
+
+use tower_mcp::GenericStdioTransport;
+use tower_mcp::client::StdioClientTransport;
+use tower_mcp::proxy::McpProxy;
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter("tower_mcp=info,proxy=debug")
+        .with_writer(std::io::stderr)
+        .init();
+
+    tracing::info!("Starting MCP proxy...");
+
+    // Spawn backend servers as subprocesses
+    let basic_transport =
+        StdioClientTransport::spawn("cargo", &["run", "--example", "basic"]).await?;
+    let sampling_transport =
+        StdioClientTransport::spawn("cargo", &["run", "--example", "sampling_server"]).await?;
+
+    // Build the proxy -- backends initialize concurrently
+    let proxy = McpProxy::builder("mcp-proxy-example", "1.0.0")
+        .backend("basic", basic_transport)
+        .await
+        .backend("sampling", sampling_transport)
+        .await
+        .build()
+        .await?;
+
+    tracing::info!("Proxy ready, serving on stdio");
+
+    // Serve the proxy over stdio
+    // McpProxy implements Service<RouterRequest>, so it works with any transport
+    let mut transport = GenericStdioTransport::new(proxy);
+    transport.run().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `McpProxy` -- a Tower service that aggregates multiple backend MCP servers behind a single endpoint with namespace prefixing. This is the implementation for #339.

### New types

- **`McpProxy`** -- implements `Service<RouterRequest>`, routes requests to backends by namespace prefix
- **`McpProxyBuilder`** -- concurrent backend initialization, configurable separator, duplicate namespace detection
- **`ChannelTransport`** -- in-process `ClientTransport` connecting `McpClient` to `McpRouter` via tokio channels (zero-overhead composition)

### Capabilities

- Namespace prefixing: `backend_toolname` (separator configurable via `.separator(".")`)
- Concurrent fan-out for `list_tools`, `list_resources`, `list_prompts`
- Automatic cache invalidation when backends send `toolListChanged` / `resourceListChanged` / `promptListChanged` notifications
- Background refresh tasks per backend (selective: only refreshes the changed capability type)
- Works with any transport (stdio, HTTP, WebSocket) since it implements `Service<RouterRequest>`

### New feature flag

- `proxy` -- gated behind feature flag, included in `full`
- `ChannelTransport` is always available (not feature-gated)

### Example

```rust
let proxy = McpProxy::builder("my-proxy", "1.0.0")
    .backend("math", StdioClientTransport::spawn("math-server", &[]).await?)
    .await
    .backend("text", ChannelTransport::new(local_router))
    .await
    .build()
    .await?;

// Serve over any transport
GenericStdioTransport::new(proxy).run().await?;
```

### Test coverage (15 tests)

- Initialize, ping
- List tools/resources/prompts (fan-out + namespace verification)
- Call tool routing to correct backend
- Read resource routing
- Get prompt routing
- Unknown tool error handling
- Custom separator (`.` instead of `_`)
- Builder validation (empty backends, duplicate namespaces)
- Clone behavior
- ChannelTransport end-to-end roundtrip
- ChannelTransport with tools, resources, and prompts

### Future work

- Per-backend Tower middleware (timeout, rate limit per backend)
- Forward list-changed notifications to downstream proxy clients
- Health checks / circuit breaker for unreachable backends

Closes #339

## Test plan

- [x] `cargo test --lib --all-features` (85 passed)
- [x] `cargo test --test '*' --all-features` (44 passed)
- [x] `cargo test --doc --all-features` (45 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p tower-mcp` (default features, no proxy)