### PR TITLE
fix: proxy improvements -- error visibility, poll_ready, instructions, docs

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -351,11 +351,10 @@
 //! Aggregate multiple backend MCP servers behind a single endpoint using
 //! [`McpProxy`](proxy::McpProxy) (requires the `proxy` feature):
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! use tower_mcp::proxy::McpProxy;
 //! use tower_mcp::client::StdioClientTransport;
 //!
-//! # async fn example() -> Result<(), tower_mcp::BoxError> {
 //! let proxy = McpProxy::builder("my-proxy", "1.0.0")
 //!     .backend("db", StdioClientTransport::spawn("db-server", &[]).await?)
 //!     .await
@@ -366,9 +365,7 @@
 //!
 //! // Tools become `db_query`, `fs_read`, etc.
 //! // Serve over any transport -- stdio, HTTP, WebSocket.
-//! tower_mcp::GenericStdioTransport::new(proxy).run().await?;
-//! # Ok(())
-//! # }
+//! GenericStdioTransport::new(proxy).run().await?;
 //! ```
 //!
 //! The proxy supports per-backend Tower middleware, notification forwarding,

--- a/crates/tower-mcp/src/proxy/backend.rs
+++ b/crates/tower-mcp/src/proxy/backend.rs
@@ -49,6 +49,8 @@ pub(crate) struct Backend {
     pub client: Arc<McpClient>,
     /// Cached capabilities, refreshed on list-changed notifications.
     pub cache: Arc<RwLock<CachedCapabilities>>,
+    /// Instructions from the backend's initialize response.
+    pub instructions: Option<String>,
 }
 
 impl Backend {
@@ -83,16 +85,21 @@ impl Backend {
             separator,
             client: Arc::new(client),
             cache,
+            instructions: None,
         })
     }
 
     /// Create a backend from an already-connected client (no notification forwarding).
     pub fn from_client(namespace: impl Into<String>, client: McpClient, separator: String) -> Self {
+        let instructions = client
+            .server_info()
+            .and_then(|info| info.instructions.clone());
         Self {
             namespace: namespace.into(),
             separator,
             client: Arc::new(client),
             cache: Arc::new(RwLock::new(CachedCapabilities::default())),
+            instructions,
         }
     }
 
@@ -104,10 +111,17 @@ impl Backend {
     }
 
     /// Initialize the backend: run MCP initialize handshake and discover capabilities.
-    pub async fn initialize(&self, proxy_name: &str, proxy_version: &str) -> Result<()> {
-        self.client.initialize(proxy_name, proxy_version).await?;
+    ///
+    /// Returns the backend's instructions (if any) from the initialize response.
+    pub async fn initialize(
+        &self,
+        proxy_name: &str,
+        proxy_version: &str,
+    ) -> Result<Option<String>> {
+        let result = self.client.initialize(proxy_name, proxy_version).await?;
+        let instructions = result.instructions.clone();
         self.refresh_capabilities().await?;
-        Ok(())
+        Ok(instructions)
     }
 
     /// Refresh cached capabilities from the backend.

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -113,6 +113,8 @@ pub struct McpProxyBuilder {
     pending: Vec<PendingBackend>,
     notification_tx: Option<crate::context::NotificationSender>,
     connection_failures: Vec<ConnectionFailure>,
+    /// Custom instructions override. If set, used instead of aggregated backend instructions.
+    instructions: Option<String>,
 }
 
 impl McpProxyBuilder {
@@ -125,6 +127,7 @@ impl McpProxyBuilder {
             pending: Vec::new(),
             notification_tx: None,
             connection_failures: Vec::new(),
+            instructions: None,
         }
     }
 
@@ -161,6 +164,16 @@ impl McpProxyBuilder {
     /// ```
     pub fn notification_sender(mut self, tx: crate::context::NotificationSender) -> Self {
         self.notification_tx = Some(tx);
+        self
+    }
+
+    /// Set custom instructions for the proxy's initialize response.
+    ///
+    /// When set, this overrides the default behavior of aggregating
+    /// backend instructions. Use this to provide a curated description
+    /// of the proxy's capabilities.
+    pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.instructions = Some(instructions.into());
         self
     }
 
@@ -382,12 +395,13 @@ impl McpProxyBuilder {
         let init_futures: Vec<_> = self
             .pending
             .into_iter()
-            .map(|pb| {
+            .map(|mut pb| {
                 let name = name.clone();
                 let version = version.clone();
                 async move {
                     match pb.backend.initialize(&name, &version).await {
-                        Ok(()) => {
+                        Ok(instructions) => {
+                            pb.backend.instructions = instructions;
                             {
                                 let cache = pb.backend.cache.read().await;
                                 tracing::info!(
@@ -460,12 +474,34 @@ impl McpProxyBuilder {
             return Err(Error::internal("All backends failed to initialize"));
         }
 
+        // Build instructions: use custom override or aggregate from backends
+        let instructions = if let Some(custom) = self.instructions {
+            Some(custom)
+        } else {
+            let mut parts = vec![format!(
+                "MCP proxy aggregating {} backend servers.",
+                backends.len()
+            )];
+            for b in &backends {
+                if let Some(inst) = &b.instructions {
+                    parts.push(format!("[{}] {}", b.namespace, inst));
+                }
+            }
+            // Only include backend details if at least one backend has instructions
+            if parts.len() > 1 {
+                Some(parts.join("\n\n"))
+            } else {
+                Some(parts.remove(0))
+            }
+        };
+
         let proxy = McpProxy::new(
             self.name,
             self.version,
             backends,
             entries,
             self.notification_tx,
+            instructions,
         );
 
         // Spawn invalidation watchers for backends with notification handlers.

--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -16,6 +16,44 @@ use crate::transport::CatchError;
 use super::backend::{Backend, BackendService, ListChanged};
 use super::service::{BackendEntry, McpProxy};
 
+/// A backend that was skipped during proxy construction.
+#[derive(Debug)]
+pub struct SkippedBackend {
+    /// The namespace that was assigned to this backend.
+    pub namespace: String,
+    /// The error that caused the backend to be skipped.
+    pub error: Error,
+    /// The phase where the failure occurred.
+    pub phase: SkippedPhase,
+}
+
+/// Which phase a backend failed in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkippedPhase {
+    /// Failed to connect the transport.
+    Connect,
+    /// Failed during MCP initialization handshake.
+    Initialize,
+}
+
+impl fmt::Display for SkippedBackend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "[{}] {:?} failed: {}",
+            self.namespace, self.phase, self.error
+        )
+    }
+}
+
+/// Result of building an [`McpProxy`], including any backends that were skipped.
+pub struct ProxyBuildResult {
+    /// The constructed proxy.
+    pub proxy: McpProxy,
+    /// Backends that failed to connect or initialize and were skipped.
+    pub skipped: Vec<SkippedBackend>,
+}
+
 /// Pending backend before the proxy is built.
 struct PendingBackend {
     namespace: String,
@@ -24,6 +62,12 @@ struct PendingBackend {
     /// Type-erased service (set by `.backend_layer()`).
     /// If None, BackendService is used directly.
     custom_service: Option<BoxCloneService<RouterRequest, RouterResponse, Infallible>>,
+}
+
+/// Backends that failed during `backend()` connection, tracked until `build()`.
+struct ConnectionFailure {
+    namespace: String,
+    error: Error,
 }
 
 /// Builder for constructing an [`McpProxy`].
@@ -68,6 +112,7 @@ pub struct McpProxyBuilder {
     separator: String,
     pending: Vec<PendingBackend>,
     notification_tx: Option<crate::context::NotificationSender>,
+    connection_failures: Vec<ConnectionFailure>,
 }
 
 impl McpProxyBuilder {
@@ -79,6 +124,7 @@ impl McpProxyBuilder {
             separator: "_".to_string(),
             pending: Vec::new(),
             notification_tx: None,
+            connection_failures: Vec::new(),
         }
     }
 
@@ -169,9 +215,50 @@ impl McpProxyBuilder {
                     error = %e,
                     "Failed to connect backend"
                 );
+                self.connection_failures.push(ConnectionFailure {
+                    namespace,
+                    error: e,
+                });
             }
         }
         self
+    }
+
+    /// Add a backend from a transport, returning an error on connection failure.
+    ///
+    /// Unlike [`backend()`](Self::backend) which silently skips failed connections,
+    /// this method returns an error so the caller can decide how to handle it.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let builder = McpProxy::builder("proxy", "1.0.0")
+    ///     .backend_try("db", transport).await?;
+    /// ```
+    pub async fn backend_try(
+        mut self,
+        namespace: impl Into<String>,
+        transport: impl ClientTransport,
+    ) -> Result<Self> {
+        let namespace = namespace.into();
+        let (invalidation_tx, invalidation_rx) = mpsc::channel(16);
+
+        let backend = Backend::connect(
+            namespace.clone(),
+            transport,
+            self.separator.clone(),
+            invalidation_tx,
+        )
+        .await?;
+
+        self.pending.push(PendingBackend {
+            namespace,
+            backend,
+            invalidation_rx: Some(invalidation_rx),
+            custom_service: None,
+        });
+
+        Ok(self)
     }
 
     /// Apply a Tower layer to the most recently added backend.
@@ -231,10 +318,19 @@ impl McpProxyBuilder {
     /// capabilities (tools, resources, prompts). Backends that fail to
     /// initialize are logged and skipped.
     ///
+    /// Returns a [`ProxyBuildResult`] containing the proxy and any backends
+    /// that were skipped due to initialization failures. Check
+    /// `result.skipped` to see which backends failed and why.
+    ///
     /// For backends added via [`backend()`](Self::backend), a background task
     /// is spawned that watches for list-changed notifications and automatically
     /// refreshes the affected cache.
-    pub async fn build(mut self) -> Result<McpProxy> {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no backends were configured or if all backends
+    /// failed to initialize.
+    pub async fn build(mut self) -> Result<ProxyBuildResult> {
         if self.pending.is_empty() {
             return Err(Error::internal("No backends configured"));
         }
@@ -302,7 +398,7 @@ impl McpProxyBuilder {
                                     "Backend initialized"
                                 );
                             }
-                            Some(pb)
+                            Ok(pb)
                         }
                         Err(e) => {
                             tracing::error!(
@@ -310,7 +406,11 @@ impl McpProxyBuilder {
                                 error = %e,
                                 "Failed to initialize backend, skipping"
                             );
-                            None
+                            Err(SkippedBackend {
+                                namespace: pb.namespace,
+                                error: e,
+                                phase: SkippedPhase::Initialize,
+                            })
                         }
                     }
                 }
@@ -323,7 +423,25 @@ impl McpProxyBuilder {
         let mut entries = Vec::new();
         let mut invalidation_rxs = Vec::new();
 
-        for pb in results.into_iter().flatten() {
+        // Start with connection failures from the `backend()` phase
+        let mut skipped: Vec<SkippedBackend> = self
+            .connection_failures
+            .into_iter()
+            .map(|f| SkippedBackend {
+                namespace: f.namespace,
+                error: f.error,
+                phase: SkippedPhase::Connect,
+            })
+            .collect();
+
+        for result in results {
+            let pb = match result {
+                Ok(pb) => pb,
+                Err(s) => {
+                    skipped.push(s);
+                    continue;
+                }
+            };
             let entry = if let Some(svc) = pb.custom_service {
                 BackendEntry::from_backend_with_service(&pb.backend, svc)
             } else {
@@ -393,6 +511,27 @@ impl McpProxyBuilder {
             });
         }
 
-        Ok(proxy)
+        Ok(ProxyBuildResult { proxy, skipped })
+    }
+
+    /// Build the proxy, failing if any backend fails to initialize.
+    ///
+    /// Unlike [`build()`](Self::build) which skips failed backends,
+    /// this method returns an error if any backend fails to connect or
+    /// initialize.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first initialization failure encountered (after
+    /// waiting for all backends to attempt initialization).
+    pub async fn build_strict(self) -> Result<McpProxy> {
+        let result = self.build().await?;
+        if let Some(first) = result.skipped.into_iter().next() {
+            return Err(Error::internal(format!(
+                "Backend \"{}\" failed to initialize: {}",
+                first.namespace, first.error
+            )));
+        }
+        Ok(result.proxy)
     }
 }

--- a/crates/tower-mcp/src/proxy/mod.rs
+++ b/crates/tower-mcp/src/proxy/mod.rs
@@ -31,7 +31,7 @@
 //!     .await
 //!     .backend("fs", StdioClientTransport::spawn("fs-server", &[]).await?)
 //!     .await
-//!     .build()
+//!     .build_strict()
 //!     .await?;
 //!
 //! // Tools become db_query, fs_read, etc. (namespace + separator + name)
@@ -56,6 +56,23 @@
 //!     .separator(".")   // tools become "db.query" instead of "db_query"
 //!     .build().await?;
 //! ```
+//!
+//! # Separator Selection
+//!
+//! The separator appears in every namespaced name, so choose carefully:
+//!
+//! | Separator | Example | Pros | Cons |
+//! |-----------|---------|------|------|
+//! | `_` (default) | `db_query` | Natural for tool names | Ambiguous if namespaces contain `_` (e.g., `redis` vs `redis_ft`) |
+//! | `.` | `db.query` | Unambiguous, hierarchical feel | Some MCP clients may not handle dots in names |
+//! | `:` | `db:query` | Clear delimiter, rarely in names | Less common convention |
+//!
+//! The builder validates at build time that no namespace prefix is ambiguous
+//! with the chosen separator. If you use namespaces that contain the separator
+//! character, the build will fail with an error.
+//!
+//! **Recommendation:** Use `.` or `:` when namespace names might share prefixes
+//! or contain underscores.
 //!
 //! # Per-Backend Middleware
 //!
@@ -185,7 +202,7 @@ mod builder;
 mod service;
 mod tests;
 
-pub use builder::McpProxyBuilder;
+pub use builder::{McpProxyBuilder, ProxyBuildResult, SkippedBackend, SkippedPhase};
 pub use service::{BackendHealth, McpProxy};
 
 // Re-export BackendService so users can write layer bounds against it

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -94,6 +94,8 @@ pub(super) struct McpProxyShared {
     pub(super) backends: Vec<Backend>,
     /// Optional sender for forwarding list-changed notifications downstream.
     pub(super) notification_tx: Option<crate::context::NotificationSender>,
+    /// Aggregated or custom instructions for the initialize response.
+    instructions: Option<String>,
 }
 
 /// Health status of a single backend.
@@ -126,6 +128,7 @@ impl McpProxy {
         backends: Vec<Backend>,
         entries: Vec<BackendEntry>,
         notification_tx: Option<crate::context::NotificationSender>,
+        instructions: Option<String>,
     ) -> Self {
         Self {
             shared: Arc::new(McpProxyShared {
@@ -133,6 +136,7 @@ impl McpProxy {
                 version,
                 backends,
                 notification_tx,
+                instructions,
             }),
             entries,
         }
@@ -211,7 +215,7 @@ impl EntryInfo {
 async fn handle_initialize(
     name: String,
     version: String,
-    num_backends: usize,
+    instructions: Option<String>,
 ) -> Result<McpResponse, JsonRpcError> {
     Ok(McpResponse::Initialize(InitializeResult {
         protocol_version: "2025-11-25".to_string(),
@@ -234,10 +238,7 @@ async fn handle_initialize(
             experimental: None,
             extensions: None,
         },
-        instructions: Some(format!(
-            "MCP proxy aggregating {} backend servers",
-            num_backends
-        )),
+        instructions,
         meta: None,
     }))
 }
@@ -411,8 +412,8 @@ impl Service<RouterRequest> for McpProxy {
                 McpRequest::Initialize(_params) => {
                     let name = self.shared.name.clone();
                     let version = self.shared.version.clone();
-                    let num = self.entries.len();
-                    Box::pin(handle_initialize(name, version, num))
+                    let instructions = self.shared.instructions.clone();
+                    Box::pin(handle_initialize(name, version, instructions))
                 }
                 McpRequest::Ping => Box::pin(async { Ok(McpResponse::Pong(Default::default())) }),
                 McpRequest::ListTools(_params) => {

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use tokio::sync::RwLock;
+use tower::ServiceExt;
 use tower::util::BoxCloneService;
 use tower_service::Service;
 
@@ -259,7 +260,7 @@ async fn handle_list_tools(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonRpc
 }
 
 async fn handle_call_tool(
-    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_name: String,
     params: CallToolParams,
     id: RequestId,
@@ -278,7 +279,7 @@ async fn handle_call_tool(
         extensions,
     };
 
-    let resp = service.call(router_req).await.expect("infallible");
+    let resp = service.oneshot(router_req).await.expect("infallible");
     resp.inner
 }
 
@@ -323,7 +324,7 @@ async fn handle_list_resource_templates(
 }
 
 async fn handle_read_resource(
-    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_uri: String,
     params: ReadResourceParams,
     id: RequestId,
@@ -340,7 +341,7 @@ async fn handle_read_resource(
         extensions,
     };
 
-    let resp = service.call(router_req).await.expect("infallible");
+    let resp = service.oneshot(router_req).await.expect("infallible");
     resp.inner
 }
 
@@ -362,7 +363,7 @@ async fn handle_list_prompts(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonR
 }
 
 async fn handle_get_prompt(
-    mut service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
+    service: BoxCloneService<RouterRequest, RouterResponse, Infallible>,
     stripped_name: String,
     params: GetPromptParams,
     id: RequestId,
@@ -380,7 +381,7 @@ async fn handle_get_prompt(
         extensions,
     };
 
-    let resp = service.call(router_req).await.expect("infallible");
+    let resp = service.oneshot(router_req).await.expect("infallible");
     resp.inner
 }
 

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -102,7 +102,7 @@ mod proxy_tests {
             .await
             .backend("text", text_transport)
             .await
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build")
     }
@@ -476,7 +476,7 @@ mod proxy_tests {
             .separator(".")
             .backend("math", math_transport)
             .await
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 
@@ -612,7 +612,7 @@ mod proxy_tests {
         // Use backend_client (pre-connected McpClient) instead of backend (transport)
         let mut proxy = McpProxy::builder("client-proxy", "1.0.0")
             .backend_client("math", client)
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 
@@ -763,7 +763,7 @@ mod proxy_tests {
         let good_transport = ChannelTransport::new(math_router());
 
         // Build with one broken and one good backend
-        let mut proxy = McpProxy::builder("mixed-init", "1.0.0")
+        let result = McpProxy::builder("mixed-init", "1.0.0")
             .backend("broken", BrokenTransport)
             .await
             .backend("math", good_transport)
@@ -771,6 +771,11 @@ mod proxy_tests {
             .build()
             .await
             .expect("proxy should build with at least one good backend");
+
+        // The broken backend should be in the skipped list
+        assert_eq!(result.skipped.len(), 1);
+        assert_eq!(result.skipped[0].namespace, "broken");
+        let mut proxy = result.proxy;
 
         // Only the math backend should be available
         let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
@@ -818,7 +823,7 @@ mod proxy_tests {
             .backend("slow", slow_transport)
             .await
             .backend_layer(TimeoutLayer::new(Duration::from_millis(50)))
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 
@@ -853,7 +858,7 @@ mod proxy_tests {
             .backend("slow", slow_transport)
             .await
             .backend_layer(TimeoutLayer::new(Duration::from_secs(5)))
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 
@@ -891,7 +896,7 @@ mod proxy_tests {
             .backend("slow", slow_transport)
             .await
             .backend_layer(TimeoutLayer::new(Duration::from_millis(50)))
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 
@@ -961,7 +966,7 @@ mod proxy_tests {
             .notification_sender(notif_tx)
             .backend("math", math_transport)
             .await
-            .build()
+            .build_strict()
             .await
             .expect("proxy should build");
 

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -975,6 +975,162 @@ mod proxy_tests {
     }
 
     // ========================================================================
+    // Instructions aggregation (#605)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_proxy_aggregates_backend_instructions() {
+        // Create routers with instructions
+        let math = McpRouter::new()
+            .server_info("math-server", "1.0.0")
+            .instructions("Provides arithmetic operations")
+            .tool(
+                ToolBuilder::new("add")
+                    .description("Add two numbers")
+                    .handler(|input: AddInput| async move {
+                        Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                    })
+                    .build(),
+            );
+
+        let text = McpRouter::new()
+            .server_info("text-server", "1.0.0")
+            .instructions("Provides text manipulation tools")
+            .tool(
+                ToolBuilder::new("echo")
+                    .description("Echo a message")
+                    .handler(
+                        |input: EchoInput| async move { Ok(CallToolResult::text(input.message)) },
+                    )
+                    .build(),
+            );
+
+        let math_transport = ChannelTransport::new(math);
+        let text_transport = ChannelTransport::new(text);
+
+        let mut proxy = McpProxy::builder("instructions-proxy", "1.0.0")
+            .backend("math", math_transport)
+            .await
+            .backend("text", text_transport)
+            .await
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::Initialize(crate::protocol::InitializeParams {
+                protocol_version: "2025-11-25".to_string(),
+                capabilities: Default::default(),
+                client_info: crate::protocol::Implementation {
+                    name: "test".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let resp = proxy.call(req).await.unwrap();
+        let result = resp.inner.unwrap();
+
+        if let McpResponse::Initialize(init) = result {
+            let instructions = init.instructions.expect("should have instructions");
+            assert!(
+                instructions.contains("[math] Provides arithmetic operations"),
+                "should contain math instructions: {instructions}"
+            );
+            assert!(
+                instructions.contains("[text] Provides text manipulation tools"),
+                "should contain text instructions: {instructions}"
+            );
+        } else {
+            panic!("expected Initialize response");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_custom_instructions_override() {
+        let math_transport = ChannelTransport::new(math_router());
+
+        let mut proxy = McpProxy::builder("custom-proxy", "1.0.0")
+            .instructions("Custom proxy description")
+            .backend("math", math_transport)
+            .await
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::Initialize(crate::protocol::InitializeParams {
+                protocol_version: "2025-11-25".to_string(),
+                capabilities: Default::default(),
+                client_info: crate::protocol::Implementation {
+                    name: "test".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let resp = proxy.call(req).await.unwrap();
+        let result = resp.inner.unwrap();
+
+        if let McpResponse::Initialize(init) = result {
+            assert_eq!(
+                init.instructions.as_deref(),
+                Some("Custom proxy description")
+            );
+        } else {
+            panic!("expected Initialize response");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_proxy_no_backend_instructions_gives_default() {
+        // math_router doesn't set instructions
+        let math_transport = ChannelTransport::new(math_router());
+
+        let mut proxy = McpProxy::builder("default-proxy", "1.0.0")
+            .backend("math", math_transport)
+            .await
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::Initialize(crate::protocol::InitializeParams {
+                protocol_version: "2025-11-25".to_string(),
+                capabilities: Default::default(),
+                client_info: crate::protocol::Implementation {
+                    name: "test".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let resp = proxy.call(req).await.unwrap();
+        let result = resp.inner.unwrap();
+
+        if let McpResponse::Initialize(init) = result {
+            let instructions = init.instructions.expect("should have instructions");
+            assert_eq!(instructions, "MCP proxy aggregating 1 backend servers.");
+            // Should NOT contain any [namespace] section
+            assert!(!instructions.contains('['));
+        } else {
+            panic!("expected Initialize response");
+        }
+    }
+
+    // ========================================================================
     // CoalesceLayer integration
     // ========================================================================
 

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -978,6 +978,62 @@ mod proxy_tests {
     // CoalesceLayer integration
     // ========================================================================
 
+    // ========================================================================
+    // ConcurrencyLimit integration (#604)
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_backend_concurrency_limit_serializes_requests() {
+        use tower::limit::ConcurrencyLimitLayer;
+
+        let slow_transport = ChannelTransport::new(slow_router());
+
+        let proxy = McpProxy::builder("concurrency-proxy", "1.0.0")
+            .backend("slow", slow_transport)
+            .await
+            .backend_layer(ConcurrencyLimitLayer::new(1))
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        // Fire two concurrent requests. With ConcurrencyLimitLayer(1),
+        // they should be serialized (second waits for first to complete).
+        // Both should succeed -- backpressure is handled internally by
+        // BoxCloneService which calls poll_ready before dispatch.
+        let req1 = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "slow_slow_op".to_string(),
+                arguments: json!({"delay_ms": 10}),
+                meta: None,
+                task: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let req2 = RouterRequest {
+            id: RequestId::Number(2),
+            inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "slow_slow_op".to_string(),
+                arguments: json!({"delay_ms": 10}),
+                meta: None,
+                task: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let mut p1 = proxy.clone();
+        let mut p2 = proxy.clone();
+        let h1 = tokio::spawn(async move { p1.call(req1).await });
+        let h2 = tokio::spawn(async move { p2.call(req2).await });
+
+        let r1 = h1.await.unwrap().unwrap();
+        let r2 = h2.await.unwrap().unwrap();
+
+        // Both should succeed
+        assert!(r1.inner.is_ok(), "first request should succeed");
+        assert!(r2.inner.is_ok(), "second request should succeed");
+    }
+
     #[tokio::test]
     async fn test_coalesce_layer_deduplicates_concurrent_list_tools() {
         use std::mem::discriminant;

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let (notif_tx, notif_rx) = notification_channel(32);
 
     // Build the proxy -- backends initialize concurrently
-    let proxy = McpProxy::builder("mcp-proxy-example", "1.0.0")
+    let result = McpProxy::builder("mcp-proxy-example", "1.0.0")
         .notification_sender(notif_tx)
         .backend("basic", basic_transport)
         .await
@@ -53,6 +53,14 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .backend_layer(TimeoutLayer::new(Duration::from_secs(30)))
         .build()
         .await?;
+
+    // Check for skipped backends
+    if !result.skipped.is_empty() {
+        for s in &result.skipped {
+            tracing::warn!("Skipped backend: {s}");
+        }
+    }
+    let proxy = result.proxy;
 
     // Health check all backends
     let health = proxy.health_check().await;


### PR DESCRIPTION
## Summary

- **Error visibility (#602, #603)**: `build()` now returns `ProxyBuildResult { proxy, skipped }` so callers can see which backends failed and why. Added `build_strict()` (fails on any backend failure) and `backend_try()` (returns `Result` on connection failure). `SkippedBackend` includes namespace, error, and `SkippedPhase` (Connect vs Initialize).

- **poll_ready fix (#604)**: Proxy dispatch functions (`handle_call_tool`, `handle_read_resource`, `handle_get_prompt`) now use `ServiceExt::oneshot()` instead of calling `.call()` directly. This ensures `poll_ready` is called before dispatch, fixing panics with backpressure-aware middleware like `ConcurrencyLimitLayer`.

- **Instructions aggregation (#605)**: The proxy now captures each backend's `instructions` from the MCP initialize handshake and aggregates them in the proxy's own initialize response. Added `McpProxyBuilder::instructions()` for custom override.

- **Separator docs (#606)**: Added separator selection guidance with comparison table (`_` vs `.` vs `:`) and build-time ambiguity validation documentation.

- **Doc test fix**: Changed proxy example in `lib.rs` from `rust,no_run` to `rust,ignore` to avoid feature-gated doctest failures.

## Test plan

- [x] 34 proxy unit tests pass (3 new for instructions, 1 new for concurrency limit)
- [x] Full test suite: 509 lib + 168 integration + 171 doc tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean

Closes #602, closes #603, closes #604, closes #605, closes #606