### PR TITLE
feat: dynamic prompt registry

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -156,6 +156,11 @@ path = "../../examples/dynamic_tools.rs"
 required-features = ["dynamic-tools"]
 
 [[example]]
+name = "skill_prompts"
+path = "../../examples/skill_prompts.rs"
+required-features = ["dynamic-tools"]
+
+[[example]]
 name = "testing"
 path = "../../examples/testing.rs"
 required-features = ["testing"]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -471,7 +471,7 @@ pub use protocol::{
     ToolDefinition, ToolExecution, ToolIcon, ToolsCapability, UnsubscribeResourceParams,
 };
 #[cfg(feature = "dynamic-tools")]
-pub use registry::DynamicToolRegistry;
+pub use registry::{DynamicPromptRegistry, DynamicToolRegistry};
 pub use resource::{
     BoxResourceService, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
     ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,

--- a/crates/tower-mcp/src/registry.rs
+++ b/crates/tower-mcp/src/registry.rs
@@ -136,6 +136,130 @@ impl DynamicToolRegistry {
     }
 }
 
+// =============================================================================
+// Dynamic Prompt Registry
+// =============================================================================
+
+/// Inner state shared between the prompt registry handle and the router.
+pub(crate) struct DynamicPromptsInner {
+    prompts: RwLock<HashMap<String, Arc<crate::prompt::Prompt>>>,
+    notification_senders: RwLock<Vec<NotificationSender>>,
+}
+
+impl DynamicPromptsInner {
+    pub(crate) fn new() -> Self {
+        Self {
+            prompts: RwLock::new(HashMap::new()),
+            notification_senders: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Register a notification sender for a new session.
+    pub(crate) fn add_notification_sender(&self, sender: NotificationSender) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.push(sender);
+    }
+
+    /// Broadcast `PromptsListChanged` to all sessions, lazily cleaning up closed channels.
+    fn broadcast_prompts_changed(&self) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.retain(|tx| !tx.is_closed());
+        for tx in senders.iter() {
+            let _ = tx.try_send(ServerNotification::PromptsListChanged);
+        }
+    }
+
+    /// Get a snapshot of all dynamic prompts.
+    pub(crate) fn list(&self) -> Vec<Arc<crate::prompt::Prompt>> {
+        let prompts = self.prompts.read().unwrap();
+        prompts.values().cloned().collect()
+    }
+
+    /// Look up a dynamic prompt by name.
+    pub(crate) fn get(&self, name: &str) -> Option<Arc<crate::prompt::Prompt>> {
+        let prompts = self.prompts.read().unwrap();
+        prompts.get(name).cloned()
+    }
+
+    /// Check if a dynamic prompt exists.
+    pub(crate) fn contains(&self, name: &str) -> bool {
+        let prompts = self.prompts.read().unwrap();
+        prompts.contains_key(name)
+    }
+}
+
+/// A thread-safe, cloneable handle for runtime prompt management.
+///
+/// Obtained from [`McpRouter::with_dynamic_prompts()`](crate::McpRouter::with_dynamic_prompts).
+/// Prompts registered here are merged with the router's static prompts when
+/// handling `prompts/list` and `prompts/get` requests.
+///
+/// When a prompt is registered or unregistered, all connected sessions receive a
+/// `notifications/prompts/list_changed` notification.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::{McpRouter, PromptBuilder};
+///
+/// let (router, registry) = McpRouter::new()
+///     .server_info("my-server", "1.0.0")
+///     .with_dynamic_prompts();
+///
+/// // Register a prompt at runtime
+/// let prompt = PromptBuilder::new("greet")
+///     .description("Greet someone")
+///     .user_message("Hello!");
+///
+/// registry.register(prompt);
+/// ```
+#[derive(Clone)]
+pub struct DynamicPromptRegistry {
+    inner: Arc<DynamicPromptsInner>,
+}
+
+impl DynamicPromptRegistry {
+    pub(crate) fn new(inner: Arc<DynamicPromptsInner>) -> Self {
+        Self { inner }
+    }
+
+    /// Register a prompt, replacing any existing prompt with the same name.
+    ///
+    /// Broadcasts `PromptsListChanged` to all connected sessions.
+    pub fn register(&self, prompt: crate::prompt::Prompt) {
+        {
+            let mut prompts = self.inner.prompts.write().unwrap();
+            prompts.insert(prompt.name.clone(), Arc::new(prompt));
+        }
+        self.inner.broadcast_prompts_changed();
+    }
+
+    /// Unregister a prompt by name.
+    ///
+    /// Returns `true` if the prompt existed and was removed.
+    /// Broadcasts `PromptsListChanged` only if the prompt was actually removed.
+    pub fn unregister(&self, name: &str) -> bool {
+        let removed = {
+            let mut prompts = self.inner.prompts.write().unwrap();
+            prompts.remove(name).is_some()
+        };
+        if removed {
+            self.inner.broadcast_prompts_changed();
+        }
+        removed
+    }
+
+    /// List all currently registered dynamic prompts.
+    pub fn list(&self) -> Vec<Arc<crate::prompt::Prompt>> {
+        self.inner.list()
+    }
+
+    /// Check if a prompt with the given name is registered.
+    pub fn contains(&self, name: &str) -> bool {
+        self.inner.contains(name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -280,5 +404,89 @@ mod tests {
         registry.register(make_tool("tool_b"));
         let notification = rx2.try_recv().unwrap();
         assert!(matches!(notification, ServerNotification::ToolsListChanged));
+    }
+
+    // =========================================================================
+    // DynamicPromptRegistry tests
+    // =========================================================================
+
+    fn make_prompt(name: &str) -> crate::prompt::Prompt {
+        crate::prompt::PromptBuilder::new(name)
+            .description(format!("Test prompt: {name}"))
+            .user_message("ok")
+    }
+
+    fn make_prompt_registry() -> (DynamicPromptRegistry, Arc<DynamicPromptsInner>) {
+        let inner = Arc::new(DynamicPromptsInner::new());
+        let registry = DynamicPromptRegistry::new(inner.clone());
+        (registry, inner)
+    }
+
+    #[test]
+    fn test_prompt_register_and_list() {
+        let (registry, _) = make_prompt_registry();
+
+        assert!(registry.list().is_empty());
+
+        registry.register(make_prompt("prompt_a"));
+        assert_eq!(registry.list().len(), 1);
+        assert!(registry.contains("prompt_a"));
+
+        registry.register(make_prompt("prompt_b"));
+        assert_eq!(registry.list().len(), 2);
+        assert!(registry.contains("prompt_b"));
+    }
+
+    #[test]
+    fn test_prompt_unregister() {
+        let (registry, _) = make_prompt_registry();
+
+        registry.register(make_prompt("prompt_a"));
+        registry.register(make_prompt("prompt_b"));
+
+        assert!(registry.unregister("prompt_a"));
+        assert_eq!(registry.list().len(), 1);
+        assert!(!registry.contains("prompt_a"));
+        assert!(registry.contains("prompt_b"));
+    }
+
+    #[test]
+    fn test_prompt_unregister_nonexistent() {
+        let (registry, _) = make_prompt_registry();
+        assert!(!registry.unregister("no_such_prompt"));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_broadcast_on_register() {
+        let (registry, inner) = make_prompt_registry();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        inner.add_notification_sender(tx);
+
+        registry.register(make_prompt("prompt_a"));
+
+        let notification = rx.try_recv().unwrap();
+        assert!(matches!(
+            notification,
+            ServerNotification::PromptsListChanged
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_prompt_broadcast_on_unregister() {
+        let (registry, inner) = make_prompt_registry();
+
+        registry.register(make_prompt("prompt_a"));
+
+        let (tx, mut rx) = mpsc::channel(16);
+        inner.add_notification_sender(tx);
+
+        registry.unregister("prompt_a");
+
+        let notification = rx.try_recv().unwrap();
+        assert!(matches!(
+            notification,
+            ServerNotification::PromptsListChanged
+        ));
     }
 }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -23,7 +23,9 @@ use crate::filter::{PromptFilter, ResourceFilter, ToolFilter};
 use crate::prompt::Prompt;
 use crate::protocol::*;
 #[cfg(feature = "dynamic-tools")]
-use crate::registry::{DynamicToolRegistry, DynamicToolsInner};
+use crate::registry::{
+    DynamicPromptRegistry, DynamicPromptsInner, DynamicToolRegistry, DynamicToolsInner,
+};
 use crate::resource::{Resource, ResourceTemplate};
 use crate::session::SessionState;
 use crate::tool::Tool;
@@ -182,6 +184,9 @@ struct McpRouterInner {
     /// Dynamic tools registry for runtime tool (de)registration
     #[cfg(feature = "dynamic-tools")]
     dynamic_tools: Option<Arc<DynamicToolsInner>>,
+    /// Dynamic prompts registry for runtime prompt (de)registration
+    #[cfg(feature = "dynamic-tools")]
+    dynamic_prompts: Option<Arc<DynamicPromptsInner>>,
 }
 
 impl McpRouterInner {
@@ -298,6 +303,8 @@ impl McpRouter {
                 page_size: None,
                 #[cfg(feature = "dynamic-tools")]
                 dynamic_tools: None,
+                #[cfg(feature = "dynamic-tools")]
+                dynamic_prompts: None,
             }),
             session: SessionState::new(),
         }
@@ -388,16 +395,49 @@ impl McpRouter {
         (self, DynamicToolRegistry::new(inner_dyn))
     }
 
+    /// Enable dynamic prompt registration and return a registry handle.
+    ///
+    /// The returned [`DynamicPromptRegistry`] can be used to add and remove
+    /// prompts at runtime. Dynamic prompts are merged with static prompts
+    /// when handling `prompts/list` and `prompts/get` requests. Static
+    /// prompts take precedence over dynamic prompts when names collide.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, PromptBuilder};
+    ///
+    /// let (router, registry) = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .with_dynamic_prompts();
+    ///
+    /// let prompt = PromptBuilder::new("greet")
+    ///     .description("Greet someone")
+    ///     .user_message("Hello!");
+    ///
+    /// registry.register(prompt);
+    /// ```
+    #[cfg(feature = "dynamic-tools")]
+    pub fn with_dynamic_prompts(mut self) -> (Self, DynamicPromptRegistry) {
+        let inner_dyn = Arc::new(DynamicPromptsInner::new());
+        Arc::make_mut(&mut self.inner).dynamic_prompts = Some(inner_dyn.clone());
+        (self, DynamicPromptRegistry::new(inner_dyn))
+    }
+
     /// Set the notification sender for progress reporting
     ///
     /// This is typically called by the transport layer to receive notifications.
     pub fn with_notification_sender(mut self, tx: NotificationSender) -> Self {
         let inner = Arc::make_mut(&mut self.inner);
-        // Also register the sender with the dynamic tools registry so it can
-        // broadcast ToolsListChanged notifications to this session.
+        // Also register the sender with dynamic registries so they can
+        // broadcast list-changed notifications to this session.
         #[cfg(feature = "dynamic-tools")]
         if let Some(ref dynamic_tools) = inner.dynamic_tools {
             dynamic_tools.add_notification_sender(tx.clone());
+        }
+        #[cfg(feature = "dynamic-tools")]
+        if let Some(ref dynamic_prompts) = inner.dynamic_prompts {
+            dynamic_prompts.add_notification_sender(tx.clone());
         }
         inner.notification_tx = Some(tx);
         self
@@ -1363,6 +1403,11 @@ impl McpRouter {
         #[cfg(not(feature = "dynamic-tools"))]
         let has_dynamic_tools = false;
 
+        #[cfg(feature = "dynamic-tools")]
+        let has_dynamic_prompts = self.inner.dynamic_prompts.is_some();
+        #[cfg(not(feature = "dynamic-tools"))]
+        let has_dynamic_prompts = false;
+
         ServerCapabilities {
             tools: if self.inner.tools.is_empty() && !has_dynamic_tools {
                 None
@@ -1379,7 +1424,7 @@ impl McpRouter {
             } else {
                 None
             },
-            prompts: if self.inner.prompts.is_empty() {
+            prompts: if self.inner.prompts.is_empty() && !has_dynamic_prompts {
                 None
             } else {
                 Some(PromptsCapability {
@@ -1739,20 +1784,34 @@ impl McpRouter {
             }
 
             McpRequest::ListPrompts(params) => {
+                let is_visible = |p: &Prompt| -> bool {
+                    self.inner
+                        .prompt_filter
+                        .as_ref()
+                        .map(|f| f.is_visible(&self.session, p))
+                        .unwrap_or(true)
+                };
+
                 let mut prompts: Vec<PromptDefinition> = self
                     .inner
                     .prompts
                     .values()
-                    .filter(|p| {
-                        // Apply prompt filter if configured
-                        self.inner
-                            .prompt_filter
-                            .as_ref()
-                            .map(|f| f.is_visible(&self.session, p))
-                            .unwrap_or(true)
-                    })
+                    .filter(|p| is_visible(p))
                     .map(|p| p.definition())
                     .collect();
+
+                // Merge dynamic prompts (static prompts win on name collision)
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(ref dynamic) = self.inner.dynamic_prompts {
+                    let static_names: HashSet<String> =
+                        prompts.iter().map(|p| p.name.clone()).collect();
+                    for p in dynamic.list() {
+                        if !static_names.contains(&p.name) && is_visible(&p) {
+                            prompts.push(p.definition());
+                        }
+                    }
+                }
+
                 prompts.sort_by(|a, b| a.name.cmp(&b.name));
 
                 let (prompts, next_cursor) =
@@ -1766,7 +1825,16 @@ impl McpRouter {
             }
 
             McpRequest::GetPrompt(params) => {
-                let prompt = self.inner.prompts.get(&params.name).ok_or_else(|| {
+                // Look up static prompts first, then dynamic
+                let prompt = self.inner.prompts.get(&params.name).cloned();
+                #[cfg(feature = "dynamic-tools")]
+                let prompt = prompt.or_else(|| {
+                    self.inner
+                        .dynamic_prompts
+                        .as_ref()
+                        .and_then(|d| d.get(&params.name))
+                });
+                let prompt = prompt.ok_or_else(|| {
                     Error::JsonRpc(JsonRpcError::method_not_found(&format!(
                         "Prompt not found: {}",
                         params.name
@@ -1775,7 +1843,7 @@ impl McpRouter {
 
                 // Check prompt filter if configured
                 if let Some(filter) = &self.inner.prompt_filter
-                    && !filter.is_visible(&self.session, prompt)
+                    && !filter.is_visible(&self.session, &prompt)
                 {
                     return Err(filter.denial_error(&params.name));
                 }

--- a/examples/skill_prompts.rs
+++ b/examples/skill_prompts.rs
@@ -1,0 +1,234 @@
+//! Skill-to-prompt example -- load Agent Skills as MCP prompts.
+//!
+//! Demonstrates loading markdown skill files and registering them as dynamic
+//! MCP prompts at runtime. This pattern lets servers ship domain expertise
+//! alongside their tools without any special library support -- just
+//! `PromptBuilder` + `DynamicPromptRegistry`.
+//!
+//! The skill files follow the [Agent Skills](https://agentskills.io/specification)
+//! format: a `SKILL.md` with YAML frontmatter (`name`, `description`) and
+//! markdown body content.
+//!
+//! Run with: `cargo run --example skill_prompts --features dynamic-tools`
+//!
+//! Then try:
+//!   - `prompts/list` to see the loaded skills
+//!   - `prompts/get` with `name: "code-review"` to get the full skill content
+
+use std::path::Path;
+
+use tower_mcp::context::notification_channel;
+use tower_mcp::{
+    DynamicPromptRegistry, GetPromptResult, JsonRpcRequest, JsonRpcService, McpRouter,
+    PromptBuilder,
+};
+
+/// A parsed skill from a SKILL.md file.
+struct Skill {
+    name: String,
+    description: String,
+    body: String,
+}
+
+/// Parse a SKILL.md file with YAML frontmatter.
+///
+/// Expected format:
+/// ```text
+/// ---
+/// name: skill-name
+/// description: What this skill does
+/// ---
+///
+/// Markdown body content...
+/// ```
+fn parse_skill(content: &str) -> Option<Skill> {
+    let content = content.trim();
+    if !content.starts_with("---") {
+        return None;
+    }
+
+    // Find the closing frontmatter delimiter
+    let after_first = &content[3..];
+    let end = after_first.find("---")?;
+    let frontmatter = &after_first[..end];
+    let body = after_first[end + 3..].trim().to_string();
+
+    // Simple YAML parsing -- just extract name and description
+    let mut name = None;
+    let mut description = None;
+    for line in frontmatter.lines() {
+        let line = line.trim();
+        if let Some(val) = line.strip_prefix("name:") {
+            name = Some(val.trim().to_string());
+        } else if let Some(val) = line.strip_prefix("description:") {
+            description = Some(val.trim().to_string());
+        }
+    }
+
+    Some(Skill {
+        name: name?,
+        description: description?,
+        body,
+    })
+}
+
+/// Load all skills from a directory.
+///
+/// Each subdirectory should contain a `SKILL.md` file.
+fn load_skills(dir: &Path) -> Vec<Skill> {
+    let mut skills = Vec::new();
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) => {
+            eprintln!("Failed to read skills directory {}: {e}", dir.display());
+            return skills;
+        }
+    };
+
+    for entry in entries.flatten() {
+        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            continue;
+        }
+
+        let skill_file = entry.path().join("SKILL.md");
+        if let Ok(content) = std::fs::read_to_string(&skill_file) {
+            match parse_skill(&content) {
+                Some(skill) => {
+                    println!("  Loaded skill: {} -- {}", skill.name, skill.description);
+                    skills.push(skill);
+                }
+                None => {
+                    eprintln!("  Skipped {}: invalid frontmatter", skill_file.display());
+                }
+            }
+        }
+    }
+
+    skills
+}
+
+/// Register parsed skills as dynamic prompts.
+fn register_skills(registry: &DynamicPromptRegistry, skills: Vec<Skill>) {
+    for skill in skills {
+        let body = skill.body.clone();
+        let description = skill.description.clone();
+
+        let prompt = PromptBuilder::new(&skill.name)
+            .description(&skill.description)
+            .handler(move |_args| {
+                let body = body.clone();
+                let description = description.clone();
+                async move {
+                    Ok(GetPromptResult::user_message_with_description(
+                        body,
+                        description,
+                    ))
+                }
+            })
+            .build();
+
+        registry.register(prompt);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    // Set up router with dynamic prompts
+    let (router, prompt_registry) = McpRouter::new()
+        .server_info("skill-prompts-example", "0.1.0")
+        .with_dynamic_prompts();
+
+    // Load skills from the examples/skills directory
+    let skills_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("examples/skills");
+
+    println!("Loading skills from {}...", skills_dir.display());
+    let skills = load_skills(&skills_dir);
+    println!("Loaded {} skills.\n", skills.len());
+
+    // Register skills as prompts
+    register_skills(&prompt_registry, skills);
+
+    // Wire up notifications and create service
+    let (tx, mut rx) = notification_channel(256);
+    let router = router.with_notification_sender(tx);
+    let mut service = JsonRpcService::new(router);
+
+    println!("=== Skill Prompts Example ===\n");
+
+    // 1. Initialize
+    println!("1. Initialize:");
+    let resp = service
+        .call_single(
+            JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "example-client", "version": "1.0.0" }
+            })),
+        )
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 2. List prompts -- should show the loaded skills
+    println!("2. List prompts:");
+    let resp = service
+        .call_single(JsonRpcRequest::new(2, "prompts/list"))
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 3. Get a specific skill prompt
+    println!("3. Get 'code-review' prompt:");
+    let resp = service
+        .call_single(
+            JsonRpcRequest::new(3, "prompts/get").with_params(serde_json::json!({
+                "name": "code-review"
+            })),
+        )
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 4. Dynamically add a new skill at runtime
+    println!("4. Register a new skill at runtime:");
+    let prompt = PromptBuilder::new("quick-debug")
+        .description("Quick debugging checklist")
+        .user_message("1. Check the error message\n2. Read the stack trace\n3. Reproduce locally\n4. Add logging\n5. Check recent changes");
+    prompt_registry.register(prompt);
+    println!("   Registered 'quick-debug'\n");
+
+    // 5. List prompts again -- should include the new one
+    println!("5. List prompts (after adding 'quick-debug'):");
+    let resp = service
+        .call_single(JsonRpcRequest::new(5, "prompts/list"))
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 6. Remove a skill
+    println!("6. Unregister 'rust-error-handling':");
+    prompt_registry.unregister("rust-error-handling");
+    println!("   Done.\n");
+
+    // 7. Final prompt list
+    println!("7. List prompts (final):");
+    let resp = service
+        .call_single(JsonRpcRequest::new(7, "prompts/list"))
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 8. Drain notifications
+    println!("=== Notifications received ===");
+    let mut count = 0;
+    while let Ok(notification) = rx.try_recv() {
+        count += 1;
+        println!("   [{count}] {notification:?}");
+    }
+    if count == 0 {
+        println!("   (none)");
+    }
+
+    Ok(())
+}

--- a/examples/skills/code-review/SKILL.md
+++ b/examples/skills/code-review/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: code-review
+description: Structured code review with security, performance, and maintainability focus
+---
+
+You are a senior code reviewer. When reviewing code, follow this structured approach:
+
+## Security
+- Check for injection vulnerabilities (SQL, XSS, command injection)
+- Verify input validation at system boundaries
+- Look for hardcoded secrets or credentials
+- Check authentication and authorization logic
+
+## Performance
+- Identify N+1 query patterns
+- Look for unnecessary allocations in hot paths
+- Check for blocking operations in async contexts
+- Verify appropriate use of caching
+
+## Maintainability
+- Assess naming clarity and consistency
+- Check error handling completeness
+- Verify test coverage for new logic
+- Look for unnecessary complexity
+
+Provide specific, actionable feedback with line references. Prioritize issues by severity.

--- a/examples/skills/rust-error-handling/SKILL.md
+++ b/examples/skills/rust-error-handling/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: rust-error-handling
+description: Rust error handling best practices and patterns
+---
+
+Guide for implementing error handling in Rust projects.
+
+## Library vs Application
+
+- **Libraries**: Use `thiserror` for typed, structured errors. Each error variant should be meaningful to callers.
+- **Applications**: Use `anyhow` for ergonomic error propagation. Context via `.context()` and `.with_context()`.
+- **Never** use `unwrap()` or `expect()` in library code unless the invariant is provably guaranteed.
+
+## Error Design
+
+```rust
+// Good: specific, actionable error types
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("config file not found: {path}")]
+    NotFound { path: PathBuf },
+    #[error("invalid config at line {line}: {reason}")]
+    Parse { line: usize, reason: String },
+}
+
+// Bad: stringly-typed errors
+type Result<T> = std::result::Result<T, String>;
+```
+
+## The `?` Operator
+
+Use `?` for propagation. Add context at boundaries where the original error loses meaning:
+
+```rust
+let config = fs::read_to_string(&path)
+    .with_context(|| format!("failed to read config from {}", path.display()))?;
+```
+
+## When to Panic
+
+Only panic for programmer errors (logic bugs), never for runtime errors (I/O, network, user input).


### PR DESCRIPTION
## Summary

- Add `DynamicPromptRegistry` for runtime prompt (de)registration, mirroring `DynamicToolRegistry`
- Add `McpRouter::with_dynamic_prompts()` to enable dynamic prompt registration
- Dynamic prompts merge with static prompts in `prompts/list` and `prompts/get` (static wins on collision)
- `PromptsListChanged` notifications broadcast to all sessions on register/unregister
- Capabilities correctly advertise prompts when dynamic prompts are enabled (even with no static prompts)

Includes a `skill_prompts` example demonstrating Agent Skills markdown files loaded as MCP prompts -- no special library feature needed, just the dynamic prompt primitive plus ~50 lines of user-side file parsing.

Answers #601 by showing that the `dynamic-tools` feature flag already provides the right primitives -- a dedicated `skills` feature is unnecessary.

## Test plan

- [x] 5 new registry unit tests for `DynamicPromptRegistry`
- [x] Full test suite: 514 lib + 168 integration + 128 doc tests
- [x] `skill_prompts` example runs and demonstrates load/list/get/register/unregister
- [x] Compiles with and without `dynamic-tools` feature
- [x] clippy and fmt clean