### PR TITLE
feat: dynamic resource and resource template registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ tower-mcp = "0.7"
 | `oauth` | OAuth 2.1 resource server support (JWT validation) |
 | `jwks` | JWKS endpoint fetching for remote key sets (requires `oauth`) |
 | `testing` | Test utilities (`TestClient`) for in-process testing |
-| `dynamic-tools` | Runtime tool registration/deregistration via `DynamicToolRegistry` |
+| `dynamic-tools` | Runtime registration/deregistration of tools, prompts, and resources |
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
 

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -471,7 +471,10 @@ pub use protocol::{
     ToolDefinition, ToolExecution, ToolIcon, ToolsCapability, UnsubscribeResourceParams,
 };
 #[cfg(feature = "dynamic-tools")]
-pub use registry::{DynamicPromptRegistry, DynamicToolRegistry};
+pub use registry::{
+    DynamicPromptRegistry, DynamicResourceRegistry, DynamicResourceTemplateRegistry,
+    DynamicToolRegistry,
+};
 pub use resource::{
     BoxResourceService, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
     ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,

--- a/crates/tower-mcp/src/registry.rs
+++ b/crates/tower-mcp/src/registry.rs
@@ -260,6 +260,251 @@ impl DynamicPromptRegistry {
     }
 }
 
+// =============================================================================
+// Dynamic Resource Registry
+// =============================================================================
+
+/// Inner state shared between the resource registry handle and the router.
+pub(crate) struct DynamicResourcesInner {
+    resources: RwLock<HashMap<String, Arc<crate::resource::Resource>>>,
+    notification_senders: RwLock<Vec<NotificationSender>>,
+}
+
+impl DynamicResourcesInner {
+    pub(crate) fn new() -> Self {
+        Self {
+            resources: RwLock::new(HashMap::new()),
+            notification_senders: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn add_notification_sender(&self, sender: NotificationSender) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.push(sender);
+    }
+
+    fn broadcast_resources_changed(&self) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.retain(|tx| !tx.is_closed());
+        for tx in senders.iter() {
+            let _ = tx.try_send(ServerNotification::ResourcesListChanged);
+        }
+    }
+
+    pub(crate) fn list(&self) -> Vec<Arc<crate::resource::Resource>> {
+        let resources = self.resources.read().unwrap();
+        resources.values().cloned().collect()
+    }
+
+    pub(crate) fn get(&self, uri: &str) -> Option<Arc<crate::resource::Resource>> {
+        let resources = self.resources.read().unwrap();
+        resources.get(uri).cloned()
+    }
+}
+
+/// A thread-safe, cloneable handle for runtime resource management.
+///
+/// Obtained from [`McpRouter::with_dynamic_resources()`](crate::McpRouter::with_dynamic_resources).
+/// Resources registered here are merged with the router's static resources
+/// when handling `resources/list` and `resources/read` requests. Static
+/// resources take precedence over dynamic resources when URIs collide.
+///
+/// When a resource is registered or unregistered, all connected sessions
+/// receive a `notifications/resources/list_changed` notification.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::{McpRouter, ResourceBuilder};
+///
+/// let (router, registry) = McpRouter::new()
+///     .server_info("my-server", "1.0.0")
+///     .with_dynamic_resources();
+///
+/// let resource = ResourceBuilder::new("file:///data.json")
+///     .name("Data")
+///     .text(r#"{"key": "value"}"#);
+///
+/// registry.register(resource);
+/// ```
+#[derive(Clone)]
+pub struct DynamicResourceRegistry {
+    inner: Arc<DynamicResourcesInner>,
+}
+
+impl DynamicResourceRegistry {
+    pub(crate) fn new(inner: Arc<DynamicResourcesInner>) -> Self {
+        Self { inner }
+    }
+
+    /// Register a resource, replacing any existing resource with the same URI.
+    ///
+    /// Broadcasts `ResourcesListChanged` to all connected sessions.
+    pub fn register(&self, resource: crate::resource::Resource) {
+        {
+            let mut resources = self.inner.resources.write().unwrap();
+            resources.insert(resource.uri.clone(), Arc::new(resource));
+        }
+        self.inner.broadcast_resources_changed();
+    }
+
+    /// Unregister a resource by URI.
+    ///
+    /// Returns `true` if the resource existed and was removed.
+    /// Broadcasts `ResourcesListChanged` only if the resource was actually removed.
+    pub fn unregister(&self, uri: &str) -> bool {
+        let removed = {
+            let mut resources = self.inner.resources.write().unwrap();
+            resources.remove(uri).is_some()
+        };
+        if removed {
+            self.inner.broadcast_resources_changed();
+        }
+        removed
+    }
+
+    /// List all currently registered dynamic resources.
+    pub fn list(&self) -> Vec<Arc<crate::resource::Resource>> {
+        self.inner.list()
+    }
+
+    /// Check if a resource with the given URI is registered.
+    pub fn contains(&self, uri: &str) -> bool {
+        let resources = self.inner.resources.read().unwrap();
+        resources.contains_key(uri)
+    }
+}
+
+// =============================================================================
+// Dynamic Resource Template Registry
+// =============================================================================
+
+/// Inner state shared between the resource template registry handle and the router.
+pub(crate) struct DynamicResourceTemplatesInner {
+    templates: RwLock<Vec<Arc<crate::resource::ResourceTemplate>>>,
+    notification_senders: RwLock<Vec<NotificationSender>>,
+}
+
+impl DynamicResourceTemplatesInner {
+    pub(crate) fn new() -> Self {
+        Self {
+            templates: RwLock::new(Vec::new()),
+            notification_senders: RwLock::new(Vec::new()),
+        }
+    }
+
+    pub(crate) fn add_notification_sender(&self, sender: NotificationSender) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.push(sender);
+    }
+
+    fn broadcast_resources_changed(&self) {
+        let mut senders = self.notification_senders.write().unwrap();
+        senders.retain(|tx| !tx.is_closed());
+        for tx in senders.iter() {
+            let _ = tx.try_send(ServerNotification::ResourcesListChanged);
+        }
+    }
+
+    pub(crate) fn list(&self) -> Vec<Arc<crate::resource::ResourceTemplate>> {
+        let templates = self.templates.read().unwrap();
+        templates.clone()
+    }
+
+    pub(crate) fn match_uri(
+        &self,
+        uri: &str,
+    ) -> Option<(
+        Arc<crate::resource::ResourceTemplate>,
+        std::collections::HashMap<String, String>,
+    )> {
+        let templates = self.templates.read().unwrap();
+        for template in templates.iter() {
+            if let Some(variables) = template.match_uri(uri) {
+                return Some((Arc::clone(template), variables));
+            }
+        }
+        None
+    }
+}
+
+/// A thread-safe, cloneable handle for runtime resource template management.
+///
+/// Obtained from [`McpRouter::with_dynamic_resource_templates()`](crate::McpRouter::with_dynamic_resource_templates).
+/// Templates registered here are merged with the router's static templates
+/// when handling `resources/templates/list` and `resources/read` requests.
+/// Static templates are checked before dynamic ones.
+///
+/// When a template is registered or unregistered, all connected sessions
+/// receive a `notifications/resources/list_changed` notification.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tower_mcp::{McpRouter, ResourceTemplateBuilder};
+///
+/// let (router, registry) = McpRouter::new()
+///     .server_info("my-server", "1.0.0")
+///     .with_dynamic_resource_templates();
+///
+/// let template = ResourceTemplateBuilder::new("db://tables/{table}")
+///     .name("Database Table")
+///     .handler(|uri, vars| async move { /* ... */ });
+///
+/// registry.register(template);
+/// ```
+#[derive(Clone)]
+pub struct DynamicResourceTemplateRegistry {
+    inner: Arc<DynamicResourceTemplatesInner>,
+}
+
+impl DynamicResourceTemplateRegistry {
+    pub(crate) fn new(inner: Arc<DynamicResourceTemplatesInner>) -> Self {
+        Self { inner }
+    }
+
+    /// Register a resource template.
+    ///
+    /// Broadcasts `ResourcesListChanged` to all connected sessions.
+    pub fn register(&self, template: crate::resource::ResourceTemplate) {
+        {
+            let mut templates = self.inner.templates.write().unwrap();
+            // Remove any existing template with the same URI pattern
+            templates.retain(|t| t.uri_template != template.uri_template);
+            templates.push(Arc::new(template));
+        }
+        self.inner.broadcast_resources_changed();
+    }
+
+    /// Unregister a resource template by URI pattern.
+    ///
+    /// Returns `true` if the template existed and was removed.
+    /// Broadcasts `ResourcesListChanged` only if the template was actually removed.
+    pub fn unregister(&self, uri_template: &str) -> bool {
+        let removed = {
+            let mut templates = self.inner.templates.write().unwrap();
+            let before = templates.len();
+            templates.retain(|t| t.uri_template != uri_template);
+            templates.len() < before
+        };
+        if removed {
+            self.inner.broadcast_resources_changed();
+        }
+        removed
+    }
+
+    /// List all currently registered dynamic resource templates.
+    pub fn list(&self) -> Vec<Arc<crate::resource::ResourceTemplate>> {
+        self.inner.list()
+    }
+
+    /// Check if a template with the given URI pattern is registered.
+    pub fn contains(&self, uri_template: &str) -> bool {
+        let templates = self.inner.templates.read().unwrap();
+        templates.iter().any(|t| t.uri_template == uri_template)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -488,5 +733,212 @@ mod tests {
             notification,
             ServerNotification::PromptsListChanged
         ));
+    }
+
+    // =========================================================================
+    // DynamicResourceRegistry tests
+    // =========================================================================
+
+    fn make_resource(uri: &str) -> crate::resource::Resource {
+        crate::resource::ResourceBuilder::new(uri)
+            .name(uri)
+            .text("content")
+    }
+
+    fn make_resource_registry() -> (DynamicResourceRegistry, Arc<DynamicResourcesInner>) {
+        let inner = Arc::new(DynamicResourcesInner::new());
+        let registry = DynamicResourceRegistry::new(inner.clone());
+        (registry, inner)
+    }
+
+    #[test]
+    fn test_resource_register_and_list() {
+        let (registry, _) = make_resource_registry();
+
+        assert!(registry.list().is_empty());
+
+        registry.register(make_resource("file:///a.txt"));
+        assert_eq!(registry.list().len(), 1);
+        assert!(registry.contains("file:///a.txt"));
+
+        registry.register(make_resource("file:///b.txt"));
+        assert_eq!(registry.list().len(), 2);
+    }
+
+    #[test]
+    fn test_resource_unregister() {
+        let (registry, _) = make_resource_registry();
+
+        registry.register(make_resource("file:///a.txt"));
+        registry.register(make_resource("file:///b.txt"));
+
+        assert!(registry.unregister("file:///a.txt"));
+        assert_eq!(registry.list().len(), 1);
+        assert!(!registry.contains("file:///a.txt"));
+        assert!(registry.contains("file:///b.txt"));
+    }
+
+    #[test]
+    fn test_resource_unregister_nonexistent() {
+        let (registry, _) = make_resource_registry();
+        assert!(!registry.unregister("file:///nope"));
+    }
+
+    #[tokio::test]
+    async fn test_resource_broadcast_on_register() {
+        let (registry, inner) = make_resource_registry();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        inner.add_notification_sender(tx);
+
+        registry.register(make_resource("file:///a.txt"));
+
+        let notification = rx.try_recv().unwrap();
+        assert!(matches!(
+            notification,
+            ServerNotification::ResourcesListChanged
+        ));
+    }
+
+    // =========================================================================
+    // DynamicResourceTemplateRegistry tests
+    // =========================================================================
+
+    fn make_template_registry() -> (
+        DynamicResourceTemplateRegistry,
+        Arc<DynamicResourceTemplatesInner>,
+    ) {
+        let inner = Arc::new(DynamicResourceTemplatesInner::new());
+        let registry = DynamicResourceTemplateRegistry::new(inner.clone());
+        (registry, inner)
+    }
+
+    #[test]
+    fn test_template_register_and_list() {
+        use crate::resource::ResourceTemplateBuilder;
+
+        let (registry, _) = make_template_registry();
+        assert!(registry.list().is_empty());
+
+        let template = ResourceTemplateBuilder::new("db://tables/{table}")
+            .name("Tables")
+            .handler(
+                |uri: String, _vars: std::collections::HashMap<String, String>| async move {
+                    Ok(crate::protocol::ReadResourceResult {
+                        contents: vec![crate::protocol::ResourceContent {
+                            uri,
+                            mime_type: None,
+                            text: Some("data".to_string()),
+                            blob: None,
+                            meta: None,
+                        }],
+                        meta: None,
+                    })
+                },
+            );
+
+        registry.register(template);
+        assert_eq!(registry.list().len(), 1);
+        assert!(registry.contains("db://tables/{table}"));
+    }
+
+    #[test]
+    fn test_template_unregister() {
+        use crate::resource::ResourceTemplateBuilder;
+
+        let (registry, _) = make_template_registry();
+
+        let template = ResourceTemplateBuilder::new("db://tables/{table}")
+            .name("Tables")
+            .handler(
+                |uri: String, _vars: std::collections::HashMap<String, String>| async move {
+                    Ok(crate::protocol::ReadResourceResult {
+                        contents: vec![crate::protocol::ResourceContent {
+                            uri,
+                            mime_type: None,
+                            text: Some("data".to_string()),
+                            blob: None,
+                            meta: None,
+                        }],
+                        meta: None,
+                    })
+                },
+            );
+
+        registry.register(template);
+        assert!(registry.unregister("db://tables/{table}"));
+        assert!(registry.list().is_empty());
+        assert!(!registry.unregister("db://tables/{table}"));
+    }
+
+    #[tokio::test]
+    async fn test_template_broadcast_on_register() {
+        use crate::resource::ResourceTemplateBuilder;
+
+        let (registry, inner) = make_template_registry();
+
+        let (tx, mut rx) = mpsc::channel(16);
+        inner.add_notification_sender(tx);
+
+        let template = ResourceTemplateBuilder::new("db://tables/{table}")
+            .name("Tables")
+            .handler(
+                |uri: String, _vars: std::collections::HashMap<String, String>| async move {
+                    Ok(crate::protocol::ReadResourceResult {
+                        contents: vec![crate::protocol::ResourceContent {
+                            uri,
+                            mime_type: None,
+                            text: Some("data".to_string()),
+                            blob: None,
+                            meta: None,
+                        }],
+                        meta: None,
+                    })
+                },
+            );
+
+        registry.register(template);
+
+        let notification = rx.try_recv().unwrap();
+        assert!(matches!(
+            notification,
+            ServerNotification::ResourcesListChanged
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_template_match_uri() {
+        use crate::resource::ResourceTemplateBuilder;
+
+        let (_, inner) = make_template_registry();
+
+        let template = ResourceTemplateBuilder::new("db://tables/{table}")
+            .name("Tables")
+            .handler(
+                |uri: String, _vars: std::collections::HashMap<String, String>| async move {
+                    Ok(crate::protocol::ReadResourceResult {
+                        contents: vec![crate::protocol::ResourceContent {
+                            uri,
+                            mime_type: None,
+                            text: Some("data".to_string()),
+                            blob: None,
+                            meta: None,
+                        }],
+                        meta: None,
+                    })
+                },
+            );
+
+        {
+            let mut templates = inner.templates.write().unwrap();
+            templates.push(Arc::new(template));
+        }
+
+        let result = inner.match_uri("db://tables/users");
+        assert!(result.is_some());
+        let (_, vars) = result.unwrap();
+        assert_eq!(vars.get("table").unwrap(), "users");
+
+        assert!(inner.match_uri("db://other/path").is_none());
     }
 }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -24,7 +24,9 @@ use crate::prompt::Prompt;
 use crate::protocol::*;
 #[cfg(feature = "dynamic-tools")]
 use crate::registry::{
-    DynamicPromptRegistry, DynamicPromptsInner, DynamicToolRegistry, DynamicToolsInner,
+    DynamicPromptRegistry, DynamicPromptsInner, DynamicResourceRegistry,
+    DynamicResourceTemplateRegistry, DynamicResourceTemplatesInner, DynamicResourcesInner,
+    DynamicToolRegistry, DynamicToolsInner,
 };
 use crate::resource::{Resource, ResourceTemplate};
 use crate::session::SessionState;
@@ -187,6 +189,12 @@ struct McpRouterInner {
     /// Dynamic prompts registry for runtime prompt (de)registration
     #[cfg(feature = "dynamic-tools")]
     dynamic_prompts: Option<Arc<DynamicPromptsInner>>,
+    /// Dynamic resources registry for runtime resource (de)registration
+    #[cfg(feature = "dynamic-tools")]
+    dynamic_resources: Option<Arc<DynamicResourcesInner>>,
+    /// Dynamic resource templates registry for runtime template (de)registration
+    #[cfg(feature = "dynamic-tools")]
+    dynamic_resource_templates: Option<Arc<DynamicResourceTemplatesInner>>,
 }
 
 impl McpRouterInner {
@@ -305,6 +313,10 @@ impl McpRouter {
                 dynamic_tools: None,
                 #[cfg(feature = "dynamic-tools")]
                 dynamic_prompts: None,
+                #[cfg(feature = "dynamic-tools")]
+                dynamic_resources: None,
+                #[cfg(feature = "dynamic-tools")]
+                dynamic_resource_templates: None,
             }),
             session: SessionState::new(),
         }
@@ -424,6 +436,63 @@ impl McpRouter {
         (self, DynamicPromptRegistry::new(inner_dyn))
     }
 
+    /// Enable dynamic resource registration and return a registry handle.
+    ///
+    /// The returned [`DynamicResourceRegistry`] can be used to add and remove
+    /// resources at runtime. Dynamic resources are merged with static resources
+    /// when handling `resources/list` and `resources/read` requests. Static
+    /// resources take precedence over dynamic resources when URIs collide.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ResourceBuilder};
+    ///
+    /// let (router, registry) = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .with_dynamic_resources();
+    ///
+    /// let resource = ResourceBuilder::new("file:///data.json")
+    ///     .name("Data")
+    ///     .text(r#"{"key": "value"}"#);
+    ///
+    /// registry.register(resource);
+    /// ```
+    #[cfg(feature = "dynamic-tools")]
+    pub fn with_dynamic_resources(mut self) -> (Self, DynamicResourceRegistry) {
+        let inner_dyn = Arc::new(DynamicResourcesInner::new());
+        Arc::make_mut(&mut self.inner).dynamic_resources = Some(inner_dyn.clone());
+        (self, DynamicResourceRegistry::new(inner_dyn))
+    }
+
+    /// Enable dynamic resource template registration and return a registry handle.
+    ///
+    /// The returned [`DynamicResourceTemplateRegistry`] can be used to add and
+    /// remove resource templates at runtime. Dynamic templates are checked
+    /// after static templates when handling `resources/read` requests.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tower_mcp::{McpRouter, ResourceTemplateBuilder};
+    ///
+    /// let (router, registry) = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .with_dynamic_resource_templates();
+    ///
+    /// let template = ResourceTemplateBuilder::new("db://tables/{table}")
+    ///     .name("Database Table")
+    ///     .handler(|uri, vars| async move { /* ... */ });
+    ///
+    /// registry.register(template);
+    /// ```
+    #[cfg(feature = "dynamic-tools")]
+    pub fn with_dynamic_resource_templates(mut self) -> (Self, DynamicResourceTemplateRegistry) {
+        let inner_dyn = Arc::new(DynamicResourceTemplatesInner::new());
+        Arc::make_mut(&mut self.inner).dynamic_resource_templates = Some(inner_dyn.clone());
+        (self, DynamicResourceTemplateRegistry::new(inner_dyn))
+    }
+
     /// Set the notification sender for progress reporting
     ///
     /// This is typically called by the transport layer to receive notifications.
@@ -438,6 +507,14 @@ impl McpRouter {
         #[cfg(feature = "dynamic-tools")]
         if let Some(ref dynamic_prompts) = inner.dynamic_prompts {
             dynamic_prompts.add_notification_sender(tx.clone());
+        }
+        #[cfg(feature = "dynamic-tools")]
+        if let Some(ref dynamic_resources) = inner.dynamic_resources {
+            dynamic_resources.add_notification_sender(tx.clone());
+        }
+        #[cfg(feature = "dynamic-tools")]
+        if let Some(ref dynamic_resource_templates) = inner.dynamic_resource_templates {
+            dynamic_resource_templates.add_notification_sender(tx.clone());
         }
         inner.notification_tx = Some(tx);
         self
@@ -1408,6 +1485,12 @@ impl McpRouter {
         #[cfg(not(feature = "dynamic-tools"))]
         let has_dynamic_prompts = false;
 
+        #[cfg(feature = "dynamic-tools")]
+        let has_dynamic_resources = self.inner.dynamic_resources.is_some()
+            || self.inner.dynamic_resource_templates.is_some();
+        #[cfg(not(feature = "dynamic-tools"))]
+        let has_dynamic_resources = false;
+
         ServerCapabilities {
             tools: if self.inner.tools.is_empty() && !has_dynamic_tools {
                 None
@@ -1416,7 +1499,7 @@ impl McpRouter {
                     list_changed: has_notifications,
                 })
             },
-            resources: if has_resources {
+            resources: if has_resources || has_dynamic_resources {
                 Some(ResourcesCapability {
                     subscribe: true,
                     list_changed: has_notifications,
@@ -1671,20 +1754,34 @@ impl McpRouter {
             }
 
             McpRequest::ListResources(params) => {
+                let is_visible = |r: &Resource| -> bool {
+                    self.inner
+                        .resource_filter
+                        .as_ref()
+                        .map(|f| f.is_visible(&self.session, r))
+                        .unwrap_or(true)
+                };
+
                 let mut resources: Vec<ResourceDefinition> = self
                     .inner
                     .resources
                     .values()
-                    .filter(|r| {
-                        // Apply resource filter if configured
-                        self.inner
-                            .resource_filter
-                            .as_ref()
-                            .map(|f| f.is_visible(&self.session, r))
-                            .unwrap_or(true)
-                    })
+                    .filter(|r| is_visible(r))
                     .map(|r| r.definition())
                     .collect();
+
+                // Merge dynamic resources (static resources win on URI collision)
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(ref dynamic) = self.inner.dynamic_resources {
+                    let static_uris: HashSet<String> =
+                        resources.iter().map(|r| r.uri.clone()).collect();
+                    for r in dynamic.list() {
+                        if !static_uris.contains(&r.uri) && is_visible(&r) {
+                            resources.push(r.definition());
+                        }
+                    }
+                }
+
                 resources.sort_by(|a, b| a.uri.cmp(&b.uri));
 
                 let (resources, next_cursor) =
@@ -1704,6 +1801,21 @@ impl McpRouter {
                     .iter()
                     .map(|t| t.definition())
                     .collect();
+
+                // Merge dynamic resource templates (static win on collision)
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(ref dynamic) = self.inner.dynamic_resource_templates {
+                    let static_patterns: HashSet<String> = resource_templates
+                        .iter()
+                        .map(|t| t.uri_template.clone())
+                        .collect();
+                    for t in dynamic.list() {
+                        if !static_patterns.contains(&t.uri_template) {
+                            resource_templates.push(t.definition());
+                        }
+                    }
+                }
+
                 resource_templates.sort_by(|a, b| a.uri_template.cmp(&b.uri_template));
 
                 let (resource_templates, next_cursor) = paginate(
@@ -1736,13 +1848,44 @@ impl McpRouter {
                     return Ok(McpResponse::ReadResource(result));
                 }
 
-                // If no static resource found, try to match against templates
+                // Try dynamic resources
+                #[cfg(feature = "dynamic-tools")]
+                #[allow(clippy::collapsible_if)]
+                if let Some(ref dynamic) = self.inner.dynamic_resources {
+                    if let Some(resource) = dynamic.get(&params.uri) {
+                        if let Some(filter) = &self.inner.resource_filter
+                            && !filter.is_visible(&self.session, &resource)
+                        {
+                            return Err(filter.denial_error(&params.uri));
+                        }
+                        tracing::debug!(uri = %params.uri, "Reading dynamic resource");
+                        let result = resource.read().await;
+                        return Ok(McpResponse::ReadResource(result));
+                    }
+                }
+
+                // Try static templates
                 for template in &self.inner.resource_templates {
                     if let Some(variables) = template.match_uri(&params.uri) {
                         tracing::debug!(
                             uri = %params.uri,
                             template = %template.uri_template,
                             "Reading resource via template"
+                        );
+                        let result = template.read(&params.uri, variables).await?;
+                        return Ok(McpResponse::ReadResource(result));
+                    }
+                }
+
+                // Try dynamic templates
+                #[cfg(feature = "dynamic-tools")]
+                #[allow(clippy::collapsible_if)]
+                if let Some(ref dynamic) = self.inner.dynamic_resource_templates {
+                    if let Some((template, variables)) = dynamic.match_uri(&params.uri) {
+                        tracing::debug!(
+                            uri = %params.uri,
+                            template = %template.uri_template,
+                            "Reading resource via dynamic template"
                         );
                         let result = template.read(&params.uri, variables).await?;
                         return Ok(McpResponse::ReadResource(result));

--- a/examples/dynamic_tools.rs
+++ b/examples/dynamic_tools.rs
@@ -1,9 +1,11 @@
-//! Dynamic tools example showing meta-tools that create/remove tools at runtime.
+//! Dynamic registration example -- tools, prompts, and resources at runtime.
 //!
 //! This example demonstrates:
-//! - Using `DynamicToolRegistry` for runtime tool registration
-//! - Building meta-tools (`create_tool`, `remove_tool`) that manage other tools
-//! - `ToolsListChanged` notifications when the tool set changes
+//! - `DynamicToolRegistry` for runtime tool registration
+//! - `DynamicPromptRegistry` for runtime prompt registration
+//! - `DynamicResourceRegistry` for runtime resource registration
+//! - Meta-tools (`create_tool`, `remove_tool`) that manage other tools
+//! - List-changed notifications when capabilities change
 //!
 //! Run with: `cargo run --example dynamic_tools --features dynamic-tools`
 
@@ -12,7 +14,8 @@ use serde::Deserialize;
 use tower_mcp::context::notification_channel;
 use tower_mcp::extract::{Json, State};
 use tower_mcp::{
-    CallToolResult, DynamicToolRegistry, JsonRpcRequest, JsonRpcService, McpRouter, ToolBuilder,
+    CallToolResult, DynamicToolRegistry, JsonRpcRequest, JsonRpcService, McpRouter, PromptBuilder,
+    ResourceBuilder, ToolBuilder,
 };
 
 /// Input for the `create_tool` meta-tool.
@@ -46,16 +49,18 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .with_env_filter("tower_mcp=debug")
         .init();
 
-    // Set up router with dynamic tool support
-    let (router, registry) = McpRouter::new()
-        .server_info("dynamic-tools-example", "0.1.0")
+    // Set up router with dynamic tools, prompts, and resources
+    let (router, tool_registry) = McpRouter::new()
+        .server_info("dynamic-example", "0.1.0")
         .with_dynamic_tools();
+    let (router, prompt_registry) = router.with_dynamic_prompts();
+    let (router, resource_registry) = router.with_dynamic_resources();
 
-    // Meta-tool: create_tool — registers a new dynamic tool
+    // Meta-tool: create_tool -- registers a new dynamic tool
     let create_tool = ToolBuilder::new("create_tool")
         .description("Create a new tool that prefixes messages")
         .extractor_handler(
-            registry.clone(),
+            tool_registry.clone(),
             |State(reg): State<DynamicToolRegistry>, Json(input): Json<CreateToolInput>| async move {
                 let prefix = input.prefix.clone();
                 let tool = ToolBuilder::new(&input.name)
@@ -72,11 +77,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         )
         .build();
 
-    // Meta-tool: remove_tool — unregisters a dynamic tool
+    // Meta-tool: remove_tool -- unregisters a dynamic tool
     let remove_tool = ToolBuilder::new("remove_tool")
         .description("Remove a previously created tool")
         .extractor_handler(
-            registry.clone(),
+            tool_registry.clone(),
             |State(reg): State<DynamicToolRegistry>, Json(input): Json<RemoveToolInput>| async move {
                 if reg.unregister(&input.name) {
                     Ok(CallToolResult::text(format!("Removed tool '{}'", input.name)))
@@ -96,7 +101,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     let mut service = JsonRpcService::new(router);
 
-    println!("=== Dynamic Tools Example ===\n");
+    println!("=== Dynamic Registration Example ===\n");
 
     // 1. Initialize
     println!("1. Initialize:");
@@ -111,18 +116,53 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .await?;
     println!("   {}\n", serde_json::to_string_pretty(&resp)?);
 
-    // 2. List tools — only meta-tools exist
-    println!("2. List tools (before creating any):");
+    // 2. Register a dynamic prompt
+    println!("2. Register dynamic prompt 'code-review':");
+    let prompt = PromptBuilder::new("code-review")
+        .description("Structured code review guidance")
+        .user_message("Review the code for security, performance, and maintainability.");
+    prompt_registry.register(prompt);
+    println!("   Done.\n");
+
+    // 3. List prompts
+    println!("3. List prompts:");
     let resp = service
-        .call_single(JsonRpcRequest::new(2, "tools/list"))
+        .call_single(JsonRpcRequest::new(3, "prompts/list"))
         .await?;
     println!("   {}\n", serde_json::to_string_pretty(&resp)?);
 
-    // 3. Create a dynamic "greet" tool
-    println!("3. Call create_tool to make 'greet':");
+    // 4. Register a dynamic resource
+    println!("4. Register dynamic resource 'config://app':");
+    let resource = ResourceBuilder::new("config://app")
+        .name("App Config")
+        .description("Current application configuration")
+        .text(r#"{"debug": true, "log_level": "info"}"#);
+    resource_registry.register(resource);
+    println!("   Done.\n");
+
+    // 5. List resources
+    println!("5. List resources:");
+    let resp = service
+        .call_single(JsonRpcRequest::new(5, "resources/list"))
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 6. Read the dynamic resource
+    println!("6. Read 'config://app':");
     let resp = service
         .call_single(
-            JsonRpcRequest::new(3, "tools/call").with_params(serde_json::json!({
+            JsonRpcRequest::new(6, "resources/read").with_params(serde_json::json!({
+                "uri": "config://app"
+            })),
+        )
+        .await?;
+    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+
+    // 7. Create a dynamic tool via meta-tool
+    println!("7. Create dynamic tool 'greet':");
+    let resp = service
+        .call_single(
+            JsonRpcRequest::new(7, "tools/call").with_params(serde_json::json!({
                 "name": "create_tool",
                 "arguments": {
                     "name": "greet",
@@ -134,18 +174,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .await?;
     println!("   {}\n", serde_json::to_string_pretty(&resp)?);
 
-    // 4. List tools — now includes "greet"
-    println!("4. List tools (after creating 'greet'):");
-    let resp = service
-        .call_single(JsonRpcRequest::new(4, "tools/list"))
-        .await?;
-    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
-
-    // 5. Call the dynamic "greet" tool
-    println!("5. Call dynamic 'greet' tool:");
+    // 8. Call the dynamic tool
+    println!("8. Call dynamic 'greet' tool:");
     let resp = service
         .call_single(
-            JsonRpcRequest::new(5, "tools/call").with_params(serde_json::json!({
+            JsonRpcRequest::new(8, "tools/call").with_params(serde_json::json!({
                 "name": "greet",
                 "arguments": { "message": "World" }
             })),
@@ -153,26 +186,16 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .await?;
     println!("   {}\n", serde_json::to_string_pretty(&resp)?);
 
-    // 6. Remove the "greet" tool
-    println!("6. Call remove_tool to remove 'greet':");
-    let resp = service
-        .call_single(
-            JsonRpcRequest::new(6, "tools/call").with_params(serde_json::json!({
-                "name": "remove_tool",
-                "arguments": { "name": "greet" }
-            })),
-        )
-        .await?;
-    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
+    // 9. Unregister everything
+    println!("9. Unregister dynamic capabilities:");
+    tool_registry.unregister("greet");
+    println!("   Removed tool 'greet'");
+    prompt_registry.unregister("code-review");
+    println!("   Removed prompt 'code-review'");
+    resource_registry.unregister("config://app");
+    println!("   Removed resource 'config://app'\n");
 
-    // 7. List tools — back to meta-tools only
-    println!("7. List tools (after removing 'greet'):");
-    let resp = service
-        .call_single(JsonRpcRequest::new(7, "tools/list"))
-        .await?;
-    println!("   {}\n", serde_json::to_string_pretty(&resp)?);
-
-    // 8. Drain and display notifications
+    // 10. Drain and display notifications
     println!("=== Notifications received ===");
     let mut count = 0;
     while let Ok(notification) = rx.try_recv() {


### PR DESCRIPTION
## Summary

Completes the dynamic registration trifecta -- tools, prompts, and now resources + resource templates all support runtime (de)registration under the `dynamic-tools` feature flag.

- `DynamicResourceRegistry` for runtime resource management (keyed by URI)
- `DynamicResourceTemplateRegistry` for runtime template management (keyed by URI pattern)
- `McpRouter::with_dynamic_resources()` and `McpRouter::with_dynamic_resource_templates()`
- Merge into `resources/list`, `resources/templates/list`, and `resources/read`
- Static resources/templates always take precedence over dynamic ones
- `ResourcesListChanged` notifications on register/unregister
- Capabilities correctly advertise resources when only dynamic resources are configured

## Test plan

- [x] 8 new registry unit tests (resource + template register/unregister/broadcast/match)
- [x] Full test suite: 522 lib + 168 integration + 130 doc tests
- [x] Compiles with and without `dynamic-tools` feature
- [x] clippy and fmt clean