### PR TITLE
chore: update tower-resilience to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ base64 = "0.22.1"
 # Tower ecosystem
 tower = { version = "0.5", features = ["util"] }
 tower-service = "0.3"
-tower-resilience = { version = "0.7", default-features = false, features = ["bulkhead", "ratelimiter", "coalesce"] }
+tower-resilience = { version = "0.8", default-features = false, features = ["bulkhead", "ratelimiter", "coalesce"] }
 
 # Async
 futures = "0.3"


### PR DESCRIPTION
## Summary

- Update tower-resilience from 0.7 to 0.8

No breaking changes -- compiles and all tests pass.