### PR TITLE
docs: pre-release documentation fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tower-mcp = "0.7"
+tower-mcp = "0.8"
 ```
 
 ### Feature Flags
@@ -109,7 +109,7 @@ Example with features:
 
 ```toml
 [dependencies]
-tower-mcp = { version = "0.7", features = ["full"] }
+tower-mcp = { version = "0.8", features = ["full"] }
 ```
 
 ### Types Only
@@ -121,7 +121,7 @@ any context where you want to serialize/deserialize MCP messages without a runti
 
 ```toml
 [dependencies]
-tower-mcp-types = "0.1"
+tower-mcp-types = "0.8"
 ```
 
 `tower-mcp-types` provides all types from `tower_mcp::protocol` and `tower_mcp::error`
@@ -458,6 +458,31 @@ let app = transport.into_router()
     .layer(middleware::from_fn(auth_middleware));
 ```
 
+## MCP Middleware
+
+tower-mcp ships three MCP-specific middleware layers alongside standard tower middleware:
+
+| Layer | Target | Purpose |
+|-------|--------|---------|
+| `McpTracingLayer` | All requests | Structured tracing with spans for request lifecycle |
+| `ToolCallLoggingLayer` | `tools/call` only | Focused tool call audit logging with annotation hints |
+| `AuditLayer` | All requests | Comprehensive audit events (`mcp::audit` tracing target) |
+
+```rust
+use tower::ServiceBuilder;
+use tower_mcp::middleware::{AuditLayer, McpTracingLayer};
+
+let transport = StdioTransport::new(router)
+    .layer(
+        ServiceBuilder::new()
+            .layer(McpTracingLayer::new())
+            .layer(AuditLayer::new())
+            .into_inner(),
+    );
+```
+
+Standard tower middleware (timeout, rate limiting, concurrency) also composes naturally via `.layer()` on transports and individual tools.
+
 ## Testing
 
 tower-mcp includes `TestClient` (feature: `testing`) for in-process server testing -- no subprocess, no network, no port management:
@@ -586,6 +611,7 @@ The repo includes several example servers you can try with any MCP-enabled agent
 | `weather` | Weather forecasts via NWS API |
 | `conformance` | Full MCP spec conformance server (39/39 tests) |
 | `proxy` | Multi-server proxy with per-backend middleware |
+| `skill_prompts` | Load Agent Skills markdown files as MCP prompts |
 
 ```bash
 git clone https://github.com/joshrotenberg/tower-mcp

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -144,7 +144,9 @@
 //! - `childproc` - Child process transport for subprocess management
 //! - `oauth` - OAuth 2.1 resource server support (token validation, metadata endpoint)
 //! - `testing` - Test utilities (`TestClient`) for ergonomic MCP server testing
-//! - `dynamic-tools` - Runtime tool (de)registration via `DynamicToolRegistry`
+//! - `dynamic-tools` - Runtime registration/deregistration of tools, prompts, and resources via
+//!   [`DynamicToolRegistry`], [`DynamicPromptRegistry`], [`DynamicResourceRegistry`],
+//!   [`DynamicResourceTemplateRegistry`]
 //! - `proxy` - Multi-server aggregation proxy ([`McpProxy`](proxy::McpProxy))
 //!
 //! ## Middleware Placement Guide
@@ -434,7 +436,8 @@ pub use filter::{
 };
 pub use jsonrpc::{JsonRpcLayer, JsonRpcService};
 pub use middleware::{
-    McpTracingLayer, McpTracingService, ToolCallLoggingLayer, ToolCallLoggingService,
+    AuditLayer, AuditService, McpTracingLayer, McpTracingService, ToolCallLoggingLayer,
+    ToolCallLoggingService,
 };
 pub use prompt::{BoxPromptService, Prompt, PromptBuilder, PromptHandler, PromptRequest};
 #[allow(deprecated)]


### PR DESCRIPTION
## Summary

Release readiness fixes found during pre-release audit:

- **Export `AuditLayer`/`AuditService`** from crate root (was only accessible via `tower_mcp::middleware::AuditLayer`)
- **Update `dynamic-tools` feature flag doc** in lib.rs to list all four registries, not just `DynamicToolRegistry`
- **Add MCP Middleware section** to README with table of the three MCP-specific layers
- **Add `skill_prompts` example** to README examples table

## Test plan

- [x] `cargo fmt`, `cargo clippy` pass
- [x] Doc tests pass (130 + 45)
- [x] No doc build warnings