### PR TITLE
test: add Send+Sync assertions for McpProxy

### DIFF
--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -1529,4 +1529,28 @@ mod proxy_tests {
             other => panic!("expected CallTool, got: {:?}", other),
         }
     }
+
+    // Static assertions: McpProxy must be Send + Sync so that &McpProxy is Send
+    // and methods like health_check() can be called from tokio::spawn.
+    #[allow(dead_code)]
+    const _: () = {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        fn assert_send_sync() {
+            assert_send::<McpProxy>();
+            assert_sync::<McpProxy>();
+        }
+    };
+
+    #[tokio::test]
+    async fn test_health_check_is_spawnable() {
+        // Verify that health_check future can be spawned (requires Send)
+        let proxy = std::sync::Arc::new(build_test_proxy().await);
+        let proxy_clone = proxy.clone();
+        let handle = tokio::spawn(async move {
+            proxy_clone.health_check().await
+        });
+        let results = handle.await.unwrap();
+        assert!(!results.is_empty());
+    }
 }

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -1547,9 +1547,7 @@ mod proxy_tests {
         // Verify that health_check future can be spawned (requires Send)
         let proxy = std::sync::Arc::new(build_test_proxy().await);
         let proxy_clone = proxy.clone();
-        let handle = tokio::spawn(async move {
-            proxy_clone.health_check().await
-        });
+        let handle = tokio::spawn(async move { proxy_clone.health_check().await });
         let results = handle.await.unwrap();
         assert!(!results.is_empty());
     }


### PR DESCRIPTION
## Summary
- Add compile-time static assertions that `McpProxy: Send + Sync`
- Add runtime test that `health_check()` can be called from `tokio::spawn` (requires `Send` future)
- `McpProxy` is already `Send + Sync` -- the workaround in mcp-proxy (dedicated single-threaded runtime) was unnecessary

## Context
During a deep dive into mcp-proxy usage, we found a comment claiming `McpProxy is Send+Clone but not Sync`. Investigation shows this was incorrect -- `Arc<Mutex<Vec<BackendEntry>>>` is `Sync` when `BackendEntry: Send`, which it is. These assertions prevent future regressions.

Refs #702