### PR TITLE
feat: add request rewrite helpers and response error checking

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -309,6 +309,16 @@ impl Extensions {
             self.map.insert(*k, v.clone());
         }
     }
+
+    /// Returns the number of entries in the extensions map.
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    /// Returns `true` if the extensions map contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
 }
 
 impl std::fmt::Debug for Extensions {

--- a/crates/tower-mcp/src/middleware/mod.rs
+++ b/crates/tower-mcp/src/middleware/mod.rs
@@ -29,6 +29,46 @@
 //!             .into_inner(),
 //!     );
 //! ```
+//!
+//! # Writing Custom Middleware
+//!
+//! ## Preserving extensions when rewriting requests
+//!
+//! When middleware rewrites a [`RouterRequest`](crate::router::RouterRequest),
+//! use [`with_inner`](crate::router::RouterRequest::with_inner) or
+//! [`clone_with_inner`](crate::router::RouterRequest::clone_with_inner) to
+//! preserve extensions set by earlier layers (token claims, RBAC context, etc.):
+//!
+//! ```rust,ignore
+//! fn call(&mut self, req: RouterRequest) -> Self::Future {
+//!     let rewritten = req.with_inner(new_mcp_request);
+//!     self.inner.call(rewritten)
+//! }
+//! ```
+//!
+//! For traffic mirroring or fan-out (where the original request is still
+//! needed), use `clone_with_inner`:
+//!
+//! ```rust,ignore
+//! let mirror_req = req.clone_with_inner(req.inner.clone());
+//! ```
+//!
+//! ## Error handling and retry
+//!
+//! tower-mcp services use `Error = Infallible` -- errors are carried inside
+//! [`RouterResponse::inner`](crate::router::RouterResponse) as
+//! `Result<McpResponse, JsonRpcError>`, not in the outer `Result`. This means
+//! standard tower retry middleware (which checks `Result::Err`) will never
+//! trigger retries.
+//!
+//! Use [`RouterResponse::is_error()`](crate::router::RouterResponse::is_error)
+//! with a response-based retry predicate:
+//!
+//! ```rust,ignore
+//! fn should_retry(response: &RouterResponse) -> bool {
+//!     response.is_error()
+//! }
+//! ```
 
 mod audit;
 mod tool_call_logging;

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2326,7 +2326,27 @@ impl ToolAnnotationsMap {
     }
 }
 
-/// Request type for the tower Service implementation
+/// Request type for the tower Service implementation.
+///
+/// # Preserving extensions in middleware
+///
+/// When rewriting a request in middleware, use [`with_inner`](Self::with_inner)
+/// or [`clone_with_inner`](Self::clone_with_inner) instead of constructing a
+/// new `RouterRequest` directly. Constructing with `Extensions::new()` will
+/// silently drop extensions set by earlier middleware layers (token claims,
+/// RBAC context, etc.).
+///
+/// ```rust,ignore
+/// // WRONG: drops extensions from earlier middleware
+/// let rewritten = RouterRequest {
+///     id: req.id.clone(),
+///     inner: new_inner,
+///     extensions: Extensions::new(),
+/// };
+///
+/// // RIGHT: preserves extensions
+/// let rewritten = req.with_inner(new_inner);
+/// ```
 #[derive(Debug, Clone)]
 pub struct RouterRequest {
     /// The JSON-RPC request ID.
@@ -2335,6 +2355,58 @@ pub struct RouterRequest {
     pub inner: McpRequest,
     /// Type-map for passing data (e.g., `TokenClaims`) through middleware.
     pub extensions: Extensions,
+}
+
+impl RouterRequest {
+    /// Create a new `RouterRequest` with empty extensions.
+    pub fn new(id: RequestId, inner: McpRequest) -> Self {
+        Self {
+            id,
+            inner,
+            extensions: Extensions::new(),
+        }
+    }
+
+    /// Replace the inner MCP request, preserving the id and extensions.
+    ///
+    /// This is the recommended way to rewrite requests in middleware,
+    /// as it ensures extensions set by earlier middleware layers
+    /// (e.g., token claims, RBAC context) are not lost.
+    pub fn with_inner(self, inner: McpRequest) -> Self {
+        Self {
+            id: self.id,
+            inner,
+            extensions: self.extensions,
+        }
+    }
+
+    /// Replace both the id and inner MCP request, preserving extensions.
+    ///
+    /// Useful when middleware needs to assign a new request id
+    /// (e.g., for fan-out or request duplication) while keeping
+    /// the extensions from the original request.
+    pub fn with_id_and_inner(self, id: RequestId, inner: McpRequest) -> Self {
+        Self {
+            id,
+            inner,
+            extensions: self.extensions,
+        }
+    }
+
+    /// Create a copy of this request with a different inner request,
+    /// cloning the id and extensions from the original.
+    ///
+    /// Unlike [`with_inner`](Self::with_inner), this borrows `self`,
+    /// which is useful when the original request is still needed
+    /// (e.g., for traffic mirroring where you send the request to
+    /// two backends).
+    pub fn clone_with_inner(&self, inner: McpRequest) -> Self {
+        Self {
+            id: self.id.clone(),
+            inner,
+            extensions: self.extensions.clone(),
+        }
+    }
 }
 
 /// Response type for the tower Service implementation
@@ -2347,6 +2419,25 @@ pub struct RouterResponse {
 }
 
 impl RouterResponse {
+    /// Returns `true` if the response contains a JSON-RPC error.
+    ///
+    /// Since tower-mcp services use `Error = Infallible` (errors are carried
+    /// inside the response, not in the `Result`), this method is useful for
+    /// middleware that needs to inspect whether a request failed -- for example,
+    /// retry or circuit breaker middleware.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// // Response-based retry predicate for tower-resilience or similar
+    /// fn is_retriable(response: &RouterResponse) -> bool {
+    ///     response.is_error()
+    /// }
+    /// ```
+    pub fn is_error(&self) -> bool {
+        self.inner.is_err()
+    }
+
     /// Convert to JSON-RPC response
     pub fn into_jsonrpc(self) -> JsonRpcResponse {
         match self.inner {
@@ -6028,5 +6119,85 @@ mod tests {
 
         let router = McpRouter::new().prompt_if(false, prompt);
         assert_eq!(router.inner.prompts.len(), 0);
+    }
+
+    #[test]
+    fn test_router_request_new() {
+        let req = RouterRequest::new(RequestId::Number(1), McpRequest::Ping);
+        assert_eq!(req.id, RequestId::Number(1));
+        assert!(req.extensions.is_empty());
+    }
+
+    #[test]
+    fn test_with_inner_preserves_extensions() {
+        let mut req = RouterRequest::new(RequestId::Number(1), McpRequest::Ping);
+        req.extensions.insert(42u32);
+
+        let rewritten = req.with_inner(McpRequest::ListTools(Default::default()));
+        assert!(matches!(rewritten.inner, McpRequest::ListTools(_)));
+        assert_eq!(rewritten.id, RequestId::Number(1));
+        assert_eq!(rewritten.extensions.get::<u32>(), Some(&42));
+    }
+
+    #[test]
+    fn test_with_id_and_inner_preserves_extensions() {
+        let mut req = RouterRequest::new(RequestId::Number(1), McpRequest::Ping);
+        req.extensions.insert(String::from("token-abc"));
+
+        let rewritten = req.with_id_and_inner(
+            RequestId::Number(99),
+            McpRequest::ListResources(Default::default()),
+        );
+        assert_eq!(rewritten.id, RequestId::Number(99));
+        assert!(matches!(rewritten.inner, McpRequest::ListResources(_)));
+        assert_eq!(
+            rewritten.extensions.get::<String>(),
+            Some(&String::from("token-abc"))
+        );
+    }
+
+    #[test]
+    fn test_clone_with_inner_preserves_extensions() {
+        let mut req = RouterRequest::new(RequestId::Number(1), McpRequest::Ping);
+        req.extensions.insert(true);
+
+        let cloned = req.clone_with_inner(McpRequest::ListTools(Default::default()));
+
+        // Original still intact
+        assert!(matches!(req.inner, McpRequest::Ping));
+        assert_eq!(req.extensions.get::<bool>(), Some(&true));
+
+        // Clone has new inner but same extensions
+        assert!(matches!(cloned.inner, McpRequest::ListTools(_)));
+        assert_eq!(cloned.extensions.get::<bool>(), Some(&true));
+    }
+
+    #[test]
+    fn test_router_response_is_error() {
+        let ok_resp = RouterResponse {
+            id: RequestId::Number(1),
+            inner: Ok(McpResponse::Pong(Default::default())),
+        };
+        assert!(!ok_resp.is_error());
+
+        let err_resp = RouterResponse {
+            id: RequestId::Number(2),
+            inner: Err(JsonRpcError::internal_error("boom")),
+        };
+        assert!(err_resp.is_error());
+    }
+
+    #[test]
+    fn test_extensions_len_and_is_empty() {
+        let mut ext = Extensions::new();
+        assert!(ext.is_empty());
+        assert_eq!(ext.len(), 0);
+
+        ext.insert(42u32);
+        assert!(!ext.is_empty());
+        assert_eq!(ext.len(), 1);
+
+        ext.insert(String::from("hello"));
+        assert_eq!(ext.len(), 2);
     }
 }


### PR DESCRIPTION
## Summary
- Add `RouterRequest::with_inner()`, `with_id_and_inner()`, `clone_with_inner()` for middleware that rewrites requests while preserving extensions
- Add `RouterResponse::is_error()` for response-based retry/circuit breaker predicates
- Add `Extensions::len()` and `is_empty()`
- Document middleware authoring patterns (extension preservation, retry with `Error=Infallible`)

## Context
Discovered while analyzing mcp-proxy usage: middleware that rewrites requests (canary routing, traffic mirroring) was constructing `RouterRequest { extensions: Extensions::new() }`, silently dropping context from earlier layers. These helpers make the correct pattern easy and the wrong pattern obvious.

The `is_error()` method addresses the `Error=Infallible` pattern where standard tower retry never triggers because errors live inside the response.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features`
- [x] 548 lib tests pass
- [x] 44 integration tests pass
- [x] 45 doc tests pass
- New tests: `test_with_inner_preserves_extensions`, `test_with_id_and_inner_preserves_extensions`, `test_clone_with_inner_preserves_extensions`, `test_router_response_is_error`, `test_extensions_len_and_is_empty`, `test_router_request_new`

Closes #703
Closes #704