### PR TITLE
docs: documentation accuracy and completeness roundup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,11 @@ This repo has MCP servers configured in `.mcp.json` that you can use directly.
 
 ## Available MCP Servers
 
+### tower-mcp-example
+Simple demo server with `echo`, `add`, `reverse` tools.
+
+Resources: `source://stdio_server.rs` - serves its own source code
+
 ### markdownlint-mcp
 Lint markdown files with 66 rules.
 
@@ -23,16 +28,14 @@ Tools: `init_project`, `add_tool`, `remove_tool`, `get_project`,
 
 Resources: `project://Cargo.toml`, `project://src/main.rs`, `project://state.json`
 
-### conformance
-Full MCP protocol conformance server (39/39 tests passing).
+### notes-mcp
+Full-featured MCP server with tools, resources, and prompts.
 
-Tools: `test_simple_text`, `test_tool_with_progress`, `test_sampling`,
-`test_elicitation`, and more
+Tools: note management (create, list, search, delete)
 
-### tower-mcp-example
-Simple demo server with `echo`, `add`, `reverse` tools.
+Resources: `notes://` URI scheme for individual notes
 
-Resources: `source://stdio_server.rs` - serves its own source code
+Prompts: note summarization and analysis
 
 ## Getting Started
 
@@ -46,10 +49,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build commands, PR guidelines, and co
 
 ## Project Structure
 
-- `src/` - Main library code
+- `crates/tower-mcp/src/` - Main library code
+- `crates/tower-mcp-types/src/` - Protocol types (no runtime deps)
 - `examples/` - Example MCP servers
   - `markdownlint-mcp/` - Markdown linting server
   - `codegen-mcp/` - MCP server builder (generates tower-mcp code)
-  - `conformance-server/` - MCP spec conformance tests
+  - `notes-mcp/` - Full-featured note-taking server
+  - `conformance-server/` - MCP spec conformance tests (39/39)
+  - `conformance-client/` - MCP spec conformance client (265/265 checks)
   - `stdio_server.rs` - Minimal example
+  - `http_server.rs` - HTTP transport example
   - `weather_server.rs` - External API example

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/crates/l/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp#license)
 [![MSRV](https://img.shields.io/crates/msrv/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp)
 [![MCP](https://img.shields.io/badge/MCP-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
-[![Conformance](https://img.shields.io/badge/conformance-39%2F39-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
+[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_265%2F265_client-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
 
 Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
 
@@ -38,9 +38,10 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 official MCP conformance tests pass in CI on every PR. |
+| **Conformance** | 39/39 server and 265/265 client conformance checks pass in CI on every PR. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
+| **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
 | **Multi-server proxy** | Aggregate N backend servers behind a single endpoint with per-backend middleware and namespace isolation. |
 | **axum ecosystem** | HTTP and WebSocket transports build on axum, so existing axum middleware and extractors work. |
 
@@ -98,8 +99,10 @@ tower-mcp = "0.8"
 | `http` | HTTP transport with SSE support (adds axum, hyper) |
 | `websocket` | WebSocket transport for full-duplex communication |
 | `childproc` | Child process transport for spawning subprocess MCP servers |
-| `oauth` | OAuth 2.1 resource server support (JWT validation) |
+| `oauth` | OAuth 2.1 resource server support -- JWT validation, protected resource metadata (requires `http`) |
 | `jwks` | JWKS endpoint fetching for remote key sets (requires `oauth`) |
+| `http-client` | HTTP client transport for connecting to remote MCP servers |
+| `oauth-client` | OAuth 2.0 client-side token acquisition -- client credentials grant, auto-discovery, token caching (requires `http-client`) |
 | `testing` | Test utilities (`TestClient`) for in-process testing |
 | `dynamic-tools` | Runtime registration/deregistration of tools, prompts, and resources |
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
@@ -569,7 +572,7 @@ let router = McpRouter::new()
 
 ## Protocol Compliance
 
-tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml) runs in CI on every PR, currently passing 39/39 tests.
+tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml) runs in CI on every PR, currently passing 39/39 server tests and 265/265 client checks (24/24 scenarios).
 
 - [x] [JSON-RPC 2.0 message format](https://modelcontextprotocol.io/specification/2025-11-25/basic#messages)
 - [x] [Protocol version negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation) (supports `2025-11-25` and `2025-03-26`)
@@ -606,12 +609,11 @@ The repo includes several example servers you can try with any MCP-enabled agent
 
 | Server | Description |
 |--------|-------------|
+| `tower-mcp-example` | Simple demo with `echo`, `add`, `reverse` tools |
 | `markdownlint-mcp` | Lint markdown with 66 rules |
 | `codegen-mcp` | Helps AI agents build tower-mcp servers |
 | `weather` | Weather forecasts via NWS API |
-| `conformance` | Full MCP spec conformance server (39/39 tests) |
-| `proxy` | Multi-server proxy with per-backend middleware |
-| `skill_prompts` | Load Agent Skills markdown files as MCP prompts |
+| `notes-mcp` | Full-featured server with tools, resources, and prompts |
 
 ```bash
 git clone https://github.com/joshrotenberg/tower-mcp

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -139,15 +139,19 @@
 //! ## Feature Flags
 //!
 //! - `full` - Enable all optional features
-//! - `http` - HTTP/SSE transport for web servers
+//! - `http` - HTTP/SSE transport for web servers (adds axum, hyper)
 //! - `websocket` - WebSocket transport for bidirectional communication
 //! - `childproc` - Child process transport for subprocess management
-//! - `oauth` - OAuth 2.1 resource server support (token validation, metadata endpoint)
+//! - `oauth` - OAuth 2.1 resource server support (JWT validation, metadata endpoint; requires `http`)
+//! - `jwks` - JWKS endpoint fetching for remote key sets (requires `oauth`)
 //! - `testing` - Test utilities (`TestClient`) for ergonomic MCP server testing
 //! - `dynamic-tools` - Runtime registration/deregistration of tools, prompts, and resources via
 //!   [`DynamicToolRegistry`], [`DynamicPromptRegistry`], [`DynamicResourceRegistry`],
 //!   [`DynamicResourceTemplateRegistry`]
 //! - `proxy` - Multi-server aggregation proxy ([`McpProxy`](proxy::McpProxy))
+//! - `http-client` - HTTP client transport for connecting to remote MCP servers
+//! - `oauth-client` - OAuth 2.0 client-side token acquisition via client credentials grant (requires `http-client`)
+//! - `macros` - Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`)
 //!
 //! ## Middleware Placement Guide
 //!


### PR DESCRIPTION
## Summary

- Add missing feature flags to lib.rs docs (jwks, http-client, oauth-client, macros)
- Distinguish `oauth` (server-side JWT validation) from `oauth-client` (client credentials grant) in README feature table
- Fix README .mcp.json server table to match actual configuration (remove stale entries, add notes-mcp and tower-mcp-example)
- Add conformance client results (265/265 checks, 24/24 scenarios) alongside server (39/39 tests) in badge, strengths table, and compliance section
- Highlight async tasks support in README strengths table
- Sync AGENTS.md with .mcp.json and update project structure

## Closes

Closes #718, closes #719, closes #720, closes #721, closes #722, closes #723

## Test plan

- [x] `cargo doc --no-deps -p tower-mcp --all-features` builds clean
- [ ] Verify badge renders correctly on GitHub
- [ ] Spot-check docs.rs feature flags section after publish