### PR TITLE
docs: add missing examples and register all examples in Cargo.toml

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -33,7 +33,7 @@ async-trait.workspace = true
 tokio-test = "0.4"
 tower = { workspace = true, features = ["timeout", "limit"] }
 tower-mcp-types = { path = "../tower-mcp-types" }
-tower-resilience = { workspace = true, default-features = false, features = ["coalesce"] }
+tower-resilience = { workspace = true, default-features = false, features = ["coalesce", "ratelimiter"] }
 tracing-subscriber.workspace = true
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json", "stream"] }
 jsonschema = "0.45"

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -189,6 +189,38 @@ path = "../../examples/proxy.rs"
 required-features = ["proxy"]
 
 [[example]]
+name = "tool_middleware"
+path = "../../examples/tool_middleware.rs"
+
+[[example]]
+name = "tool_selection"
+path = "../../examples/tool_selection.rs"
+
+[[example]]
+name = "middleware_showcase"
+path = "../../examples/middleware_showcase.rs"
+
+[[example]]
+name = "external_api_auth"
+path = "../../examples/external_api_auth.rs"
+
+[[example]]
+name = "structured_output"
+path = "../../examples/structured_output.rs"
+
+[[example]]
+name = "resource_templates"
+path = "../../examples/resource_templates.rs"
+
+[[example]]
+name = "error_handling"
+path = "../../examples/error_handling.rs"
+
+[[example]]
+name = "rate_limiting"
+path = "../../examples/rate_limiting.rs"
+
+[[example]]
 name = "tool_macro"
 path = "../../examples/tool_macro.rs"
 required-features = ["macros"]

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -5,8 +5,10 @@
 //! - Setting up an McpRouter
 //! - Using the JsonRpcService for protocol framing
 //!
-//! Note: This example doesn't include a transport layer yet.
+//! Note: This example doesn't include a transport layer.
 //! It shows how to manually process requests for testing.
+//!
+//! Run with: cargo run --example basic
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/examples/error_handling.rs
+++ b/examples/error_handling.rs
@@ -1,0 +1,160 @@
+//! Error handling patterns example
+//!
+//! Demonstrates the different ways to handle errors in tower-mcp tool handlers.
+//! Understanding when to use each pattern is important for building robust servers.
+//!
+//! Key distinction:
+//! - `Ok(CallToolResult::error(...))` -- Tool execution error. The LLM sees this
+//!   message and can self-correct (e.g., fix invalid arguments, try a different approach).
+//! - `Err(...)` -- Handler failure. Automatically converted to `CallToolResult::error()`
+//!   by tower-mcp, so the LLM still sees it. Use for unexpected/unrecoverable errors.
+//!
+//! Both approaches result in `isError: true` in the response -- the difference is
+//! ergonomic. Use `Ok(CallToolResult::error(...))` for expected/domain errors where
+//! you want explicit control over the message. Use `Err(...)` with `?` for propagating
+//! unexpected failures.
+//!
+//! Run with: cargo run --example error_handling
+//!
+//! Test interactively or with an MCP client connected via stdio.
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{BoxError, CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DivideInput {
+    /// Numerator
+    a: f64,
+    /// Denominator
+    b: f64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct FetchInput {
+    /// URL to fetch (simulated)
+    url: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ParseInput {
+    /// JSON string to parse
+    json_text: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ValidatedInput {
+    /// Email address (must contain @)
+    email: String,
+    /// Age (must be 0-150)
+    age: u32,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    eprintln!("Starting error handling example...");
+
+    // Pattern 1: Domain validation errors
+    // Use CallToolResult::error() for expected, recoverable errors.
+    // The LLM can read the message and adjust its input.
+    let divide = ToolBuilder::new("divide")
+        .description("Divide two numbers. Returns an error for division by zero.")
+        .handler(|input: DivideInput| async move {
+            if input.b == 0.0 {
+                // Expected domain error -- the LLM can fix this
+                return Ok(CallToolResult::error(
+                    "Division by zero. The denominator must be non-zero.",
+                ));
+            }
+            Ok(CallToolResult::text(format!("{}", input.a / input.b)))
+        })
+        .build();
+
+    // Pattern 2: Input validation with multiple checks
+    // Validate all fields and return a combined error message.
+    let validate_user = ToolBuilder::new("validate_user")
+        .description("Validate user input. Email must contain @, age must be 0-150.")
+        .handler(|input: ValidatedInput| async move {
+            let mut errors = Vec::new();
+
+            if !input.email.contains('@') {
+                errors.push(format!("Invalid email '{}': must contain @", input.email));
+            }
+            if input.age > 150 {
+                errors.push(format!("Invalid age {}: must be 0-150", input.age));
+            }
+
+            if !errors.is_empty() {
+                return Ok(CallToolResult::error(errors.join("; ")));
+            }
+
+            Ok(CallToolResult::text(format!(
+                "Valid: {} (age {})",
+                input.email, input.age
+            )))
+        })
+        .build();
+
+    // Pattern 3: Propagating errors with ?
+    // Use Err() for unexpected failures. tower-mcp automatically converts
+    // these to CallToolResult::error() so the LLM still sees the message.
+    let parse_json = ToolBuilder::new("parse_json")
+        .description("Parse a JSON string and pretty-print it. Returns error on invalid JSON.")
+        .handler(|input: ParseInput| async move {
+            // The ? operator propagates serde errors, which tower-mcp
+            // converts to CallToolResult::error() automatically
+            let value: serde_json::Value = serde_json::from_str(&input.json_text)?;
+            let pretty = serde_json::to_string_pretty(&value)?;
+            Ok(CallToolResult::text(pretty))
+        })
+        .build();
+
+    // Pattern 4: Mixed error handling -- domain errors + unexpected failures
+    // Use explicit error for known cases, ? for unexpected ones.
+    let fetch_url = ToolBuilder::new("fetch_url")
+        .description("Simulate fetching a URL. Certain URLs return known errors.")
+        .handler(|input: FetchInput| async move {
+            // Known domain errors -- explicit messages help the LLM
+            if input.url.is_empty() {
+                return Ok(CallToolResult::error("URL cannot be empty"));
+            }
+            if !input.url.starts_with("https://") {
+                return Ok(CallToolResult::error(format!(
+                    "URL must start with https://, got: {}",
+                    input.url
+                )));
+            }
+
+            // Simulate different responses
+            match input.url.as_str() {
+                "https://example.com/404" => Ok(CallToolResult::error("HTTP 404: page not found")),
+                "https://example.com/500" => Ok(CallToolResult::error(
+                    "HTTP 500: internal server error. Try again later.",
+                )),
+                url => Ok(CallToolResult::text(format!(
+                    "Successfully fetched {} (200 OK, 1234 bytes)",
+                    url
+                ))),
+            }
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("error-handling-example", "1.0.0")
+        .instructions(
+            "This server demonstrates error handling patterns. Try:\n\
+             - divide: try b=0 to see domain validation error\n\
+             - validate_user: try invalid email or age>150\n\
+             - parse_json: try invalid JSON to see propagated error\n\
+             - fetch_url: try empty, non-https, or /404 /500 paths",
+        )
+        .tool(divide)
+        .tool(validate_user)
+        .tool(parse_json)
+        .tool(fetch_url);
+
+    eprintln!("Server ready. Connect with an MCP client via stdio.");
+    StdioTransport::new(router).run().await?;
+
+    Ok(())
+}

--- a/examples/rate_limiting.rs
+++ b/examples/rate_limiting.rs
@@ -1,0 +1,130 @@
+//! Rate limiting example
+//!
+//! Demonstrates rate limiting and concurrency control using standard Tower middleware.
+//! This is a key tower-mcp differentiator: any Tower layer works without custom abstractions.
+//!
+//! This example shows:
+//! - Per-tool concurrency limits: control how many concurrent calls each tool allows
+//! - Per-tool timeouts: prevent slow tools from blocking
+//! - Transport-level rate limiting: global limit across all MCP requests
+//! - Combining multiple layers on a single tool
+//!
+//! Note: `RateLimitLayer` works at the transport level. For per-tool limits,
+//! use `ConcurrencyLimitLayer` (which controls how many calls run simultaneously)
+//! combined with `TimeoutLayer` (which bounds how long each call can take).
+//!
+//! Run with: cargo run --example rate_limiting
+//!
+//! Test interactively or with an MCP client connected via stdio.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::timeout::TimeoutLayer;
+use tower_mcp::{BoxError, CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct QueryInput {
+    /// The query to execute
+    query: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SendInput {
+    /// Recipient
+    to: String,
+    /// Message body
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    eprintln!("Starting rate limiting example...");
+
+    // Tool 1: API search with concurrency limit
+    // Only 10 concurrent calls allowed -- protects an external API
+    let search_api = ToolBuilder::new("search_api")
+        .description("Search an external API. Limited to 10 concurrent calls.")
+        .handler(|input: QueryInput| async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            Ok(CallToolResult::text(format!(
+                "Search results for: {}",
+                input.query
+            )))
+        })
+        .layer(ConcurrencyLimitLayer::new(10))
+        .build();
+
+    // Tool 2: Email sending with strict concurrency limit
+    // Only 1 at a time -- serializes sends to prevent spam
+    let send_email = ToolBuilder::new("send_email")
+        .description("Send an email. Serialized: only 1 send at a time.")
+        .handler(|input: SendInput| async move {
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            Ok(CallToolResult::text(format!(
+                "Email sent to {}: {}",
+                input.to,
+                input.message.chars().take(50).collect::<String>()
+            )))
+        })
+        .layer(ConcurrencyLimitLayer::new(1))
+        .build();
+
+    // Tool 3: Database query with combined middleware
+    // Concurrency limit + timeout -- full production stack
+    let call_count = Arc::new(AtomicU32::new(0));
+    let counter = call_count.clone();
+
+    let db_query = ToolBuilder::new("db_query")
+        .description(
+            "Execute a database query. Max 3 concurrent, 10s timeout. \
+             Returns call count for observability.",
+        )
+        .handler(move |input: QueryInput| {
+            let counter = counter.clone();
+            async move {
+                let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                tokio::time::sleep(Duration::from_millis(200)).await;
+                Ok(CallToolResult::text(format!(
+                    "Query #{} result for: {}",
+                    n, input.query
+                )))
+            }
+        })
+        // Layers wrap outside-in: request hits concurrency limit -> timeout -> handler
+        .layer(ConcurrencyLimitLayer::new(3))
+        .layer(TimeoutLayer::new(Duration::from_secs(10)))
+        .build();
+
+    // Tool 4: Unrestricted tool for comparison
+    let echo = ToolBuilder::new("echo")
+        .description("Echo back the input. No middleware layers.")
+        .handler(|input: QueryInput| async move {
+            Ok(CallToolResult::text(format!("Echo: {}", input.query)))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("rate-limiting-example", "1.0.0")
+        .instructions(
+            "This server demonstrates rate limiting with Tower middleware. Try:\n\
+             - search_api: max 10 concurrent calls\n\
+             - send_email: serialized (1 at a time)\n\
+             - db_query: max 3 concurrent + 10s timeout\n\
+             - echo: no limits (for comparison)\n\n\
+             Exceeding a concurrency limit causes the request to wait.",
+        )
+        .tool(search_api)
+        .tool(send_email)
+        .tool(db_query)
+        .tool(echo);
+
+    eprintln!("Server ready. Connect with an MCP client via stdio.");
+    StdioTransport::new(router).run().await?;
+
+    Ok(())
+}

--- a/examples/rate_limiting.rs
+++ b/examples/rate_limiting.rs
@@ -1,24 +1,21 @@
 //! Rate limiting example
 //!
-//! Demonstrates rate limiting and concurrency control using standard Tower middleware.
+//! Demonstrates rate limiting and concurrency control using Tower middleware.
 //! This is a key tower-mcp differentiator: any Tower layer works without custom abstractions.
 //!
 //! This example shows:
+//! - Per-tool rate limiting: control requests per second/minute for each tool
 //! - Per-tool concurrency limits: control how many concurrent calls each tool allows
-//! - Per-tool timeouts: prevent slow tools from blocking
-//! - Transport-level rate limiting: global limit across all MCP requests
-//! - Combining multiple layers on a single tool
+//! - Combining rate limits with timeouts and concurrency limits
 //!
-//! Note: `RateLimitLayer` works at the transport level. For per-tool limits,
-//! use `ConcurrencyLimitLayer` (which controls how many calls run simultaneously)
-//! combined with `TimeoutLayer` (which bounds how long each call can take).
+//! Uses `tower-resilience`'s `RateLimiterLayer` which implements `Clone` (via `Arc`),
+//! making it compatible with tower-mcp's per-tool `.layer()`. Tower's built-in
+//! `RateLimitLayer` does not implement `Clone`, so it only works at the transport level.
 //!
 //! Run with: cargo run --example rate_limiting
 //!
 //! Test interactively or with an MCP client connected via stdio.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use schemars::JsonSchema;
@@ -26,6 +23,7 @@ use serde::Deserialize;
 use tower::limit::ConcurrencyLimitLayer;
 use tower::timeout::TimeoutLayer;
 use tower_mcp::{BoxError, CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+use tower_resilience::ratelimiter::RateLimiterLayer;
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct QueryInput {
@@ -45,64 +43,70 @@ struct SendInput {
 async fn main() -> Result<(), BoxError> {
     eprintln!("Starting rate limiting example...");
 
-    // Tool 1: API search with concurrency limit
-    // Only 10 concurrent calls allowed -- protects an external API
+    // Tool 1: API search with rate limit
+    // Max 10 requests per second -- protects an external API quota
     let search_api = ToolBuilder::new("search_api")
-        .description("Search an external API. Limited to 10 concurrent calls.")
+        .description("Search an external API. Rate limited to 10 requests/second.")
         .handler(|input: QueryInput| async move {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(50)).await;
             Ok(CallToolResult::text(format!(
                 "Search results for: {}",
                 input.query
             )))
         })
-        .layer(ConcurrencyLimitLayer::new(10))
+        .layer(RateLimiterLayer::per_second(10).build())
         .build();
 
-    // Tool 2: Email sending with strict concurrency limit
-    // Only 1 at a time -- serializes sends to prevent spam
+    // Tool 2: Email sending with strict rate limit
+    // Max 2 per minute -- prevents spam
     let send_email = ToolBuilder::new("send_email")
-        .description("Send an email. Serialized: only 1 send at a time.")
+        .description("Send an email. Strictly rate limited to 2 per minute.")
         .handler(|input: SendInput| async move {
-            tokio::time::sleep(Duration::from_millis(500)).await;
             Ok(CallToolResult::text(format!(
                 "Email sent to {}: {}",
                 input.to,
                 input.message.chars().take(50).collect::<String>()
             )))
         })
-        .layer(ConcurrencyLimitLayer::new(1))
+        .layer(RateLimiterLayer::per_minute(2).build())
         .build();
 
     // Tool 3: Database query with combined middleware
-    // Concurrency limit + timeout -- full production stack
-    let call_count = Arc::new(AtomicU32::new(0));
-    let counter = call_count.clone();
-
+    // Rate limit + concurrency limit + timeout -- full production stack
     let db_query = ToolBuilder::new("db_query")
         .description(
-            "Execute a database query. Max 3 concurrent, 10s timeout. \
-             Returns call count for observability.",
+            "Execute a database query. Rate limited (5/sec), \
+             max 3 concurrent, 10s timeout.",
         )
-        .handler(move |input: QueryInput| {
-            let counter = counter.clone();
-            async move {
-                let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
-                tokio::time::sleep(Duration::from_millis(200)).await;
-                Ok(CallToolResult::text(format!(
-                    "Query #{} result for: {}",
-                    n, input.query
-                )))
-            }
+        .handler(|input: QueryInput| async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            Ok(CallToolResult::text(format!(
+                "Query result for: {}",
+                input.query
+            )))
         })
-        // Layers wrap outside-in: request hits concurrency limit -> timeout -> handler
+        // Layers wrap outside-in: request hits rate limit -> concurrency -> timeout -> handler
+        .layer(RateLimiterLayer::per_second(5).build())
         .layer(ConcurrencyLimitLayer::new(3))
         .layer(TimeoutLayer::new(Duration::from_secs(10)))
         .build();
 
-    // Tool 4: Unrestricted tool for comparison
+    // Tool 4: Burst-tolerant endpoint
+    // 20 requests/sec sustained with burst capacity of 30 additional
+    let burst_api = ToolBuilder::new("burst_api")
+        .description("API with burst tolerance: 20/sec sustained + 30 burst capacity.")
+        .handler(|input: QueryInput| async move {
+            Ok(CallToolResult::text(format!(
+                "Burst API result for: {}",
+                input.query
+            )))
+        })
+        .layer(RateLimiterLayer::burst(20, 30).build())
+        .build();
+
+    // Tool 5: Unrestricted tool for comparison
     let echo = ToolBuilder::new("echo")
-        .description("Echo back the input. No middleware layers.")
+        .description("Echo back the input. No rate limiting.")
         .handler(|input: QueryInput| async move {
             Ok(CallToolResult::text(format!("Echo: {}", input.query)))
         })
@@ -112,15 +116,17 @@ async fn main() -> Result<(), BoxError> {
         .server_info("rate-limiting-example", "1.0.0")
         .instructions(
             "This server demonstrates rate limiting with Tower middleware. Try:\n\
-             - search_api: max 10 concurrent calls\n\
-             - send_email: serialized (1 at a time)\n\
-             - db_query: max 3 concurrent + 10s timeout\n\
+             - search_api: 10 req/sec rate limit\n\
+             - send_email: 2 per minute (strict)\n\
+             - db_query: 5/sec rate limit + max 3 concurrent + 10s timeout\n\
+             - burst_api: 20/sec sustained + 30 burst capacity\n\
              - echo: no limits (for comparison)\n\n\
-             Exceeding a concurrency limit causes the request to wait.",
+             Exceeding a rate limit returns an error to the caller.",
         )
         .tool(search_api)
         .tool(send_email)
         .tool(db_query)
+        .tool(burst_api)
         .tool(echo);
 
     eprintln!("Server ready. Connect with an MCP client via stdio.");

--- a/examples/resource_templates.rs
+++ b/examples/resource_templates.rs
@@ -1,0 +1,157 @@
+//! Resource template example
+//!
+//! Demonstrates parameterized resources using URI templates (RFC 6570).
+//! When a client requests `resources/read` with a URI matching a template,
+//! the server extracts the variables and passes them to the handler.
+//!
+//! This example shows:
+//! - Simple templates: `db://users/{id}`
+//! - Multi-variable templates: `api://v1/{service}/{resource}/{id}`
+//! - Wildcard path templates: `file:///{+path}` (matches slashes)
+//! - MIME type hints for different content types
+//! - Error handling within template handlers
+//!
+//! Run with: cargo run --example resource_templates
+//!
+//! Test interactively or with an MCP client connected via stdio.
+
+use std::collections::HashMap;
+
+use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+use tower_mcp::resource::ResourceTemplateBuilder;
+use tower_mcp::{BoxError, McpRouter, StdioTransport};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    eprintln!("Starting resource templates example...");
+
+    // Template 1: Simple single-variable template
+    // Matches: db://users/123, db://users/alice
+    let users = ResourceTemplateBuilder::new("db://users/{id}")
+        .name("User Records")
+        .description("Look up user records by ID")
+        .mime_type("application/json")
+        .handler(|uri: String, vars: HashMap<String, String>| async move {
+            let id = vars.get("id").cloned().unwrap_or_default();
+
+            // Simulate a database lookup with error handling
+            if id == "0" {
+                return Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some("User not found".to_string()),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                });
+            }
+
+            let user_json = serde_json::json!({
+                "id": id,
+                "name": format!("User {}", id),
+                "email": format!("user{}@example.com", id),
+                "created_at": "2026-01-15T10:30:00Z"
+            });
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri,
+                    mime_type: Some("application/json".to_string()),
+                    text: Some(serde_json::to_string_pretty(&user_json)?),
+                    blob: None,
+                    meta: None,
+                }],
+                meta: None,
+            })
+        });
+
+    // Template 2: Multi-variable template
+    // Matches: api://v1/billing/invoices/42, api://v1/auth/tokens/abc
+    let api_resources = ResourceTemplateBuilder::new("api://v1/{service}/{resource}/{id}")
+        .name("API Resources")
+        .description("Access API resources by service, type, and ID")
+        .mime_type("application/json")
+        .handler(|uri: String, vars: HashMap<String, String>| async move {
+            let service = vars.get("service").cloned().unwrap_or_default();
+            let resource = vars.get("resource").cloned().unwrap_or_default();
+            let id = vars.get("id").cloned().unwrap_or_default();
+
+            let response = serde_json::json!({
+                "service": service,
+                "resource": resource,
+                "id": id,
+                "data": format!("{}/{}/{}", service, resource, id),
+                "fetched_at": "2026-03-16T12:00:00Z"
+            });
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri,
+                    mime_type: Some("application/json".to_string()),
+                    text: Some(serde_json::to_string_pretty(&response)?),
+                    blob: None,
+                    meta: None,
+                }],
+                meta: None,
+            })
+        });
+
+    // Template 3: Wildcard path template using {+path}
+    // The + prefix matches across slashes, so file:///src/main.rs works
+    // Matches: file:///README.md, file:///src/lib.rs, file:///docs/guide/intro.md
+    let files = ResourceTemplateBuilder::new("file:///{+path}")
+        .name("Project Files")
+        .description("Read project files by path (supports nested directories)")
+        .handler(|uri: String, vars: HashMap<String, String>| async move {
+            let path = vars.get("path").cloned().unwrap_or_default();
+
+            // Simulate file content based on extension
+            let (mime_type, content) = if path.ends_with(".json") {
+                (
+                    "application/json",
+                    format!("{{\"file\": \"{}\", \"type\": \"json\"}}", path),
+                )
+            } else if path.ends_with(".md") {
+                (
+                    "text/markdown",
+                    format!("# {}\n\nThis is the content of `{}`.", path, path),
+                )
+            } else {
+                (
+                    "text/plain",
+                    format!("// Contents of {}\nfn main() {{}}", path),
+                )
+            };
+
+            Ok(ReadResourceResult {
+                contents: vec![ResourceContent {
+                    uri,
+                    mime_type: Some(mime_type.to_string()),
+                    text: Some(content),
+                    blob: None,
+                    meta: None,
+                }],
+                meta: None,
+            })
+        });
+
+    let router = McpRouter::new()
+        .server_info("resource-templates-example", "1.0.0")
+        .instructions(
+            "This server demonstrates resource templates. Try reading:\n\
+             - db://users/1 or db://users/alice (single variable)\n\
+             - db://users/0 (returns not found)\n\
+             - api://v1/billing/invoices/42 (multi-variable)\n\
+             - file:///README.md or file:///src/lib.rs (wildcard path)",
+        )
+        .resource_template(users)
+        .resource_template(api_resources)
+        .resource_template(files);
+
+    eprintln!("Server ready. Connect with an MCP client via stdio.");
+    StdioTransport::new(router).run().await?;
+
+    Ok(())
+}

--- a/examples/structured_output.rs
+++ b/examples/structured_output.rs
@@ -1,0 +1,146 @@
+//! Structured output example
+//!
+//! Demonstrates returning typed JSON data from tools using output schemas.
+//! When a tool declares an output schema, MCP clients can parse the structured
+//! response programmatically rather than relying on plain text.
+//!
+//! This example shows:
+//! - `CallToolResult::json()` for raw JSON values
+//! - `CallToolResult::from_serialize()` for typed Rust structs
+//! - `.output_schema()` on `ToolBuilder` for declaring the output shape
+//! - Mixed text + structured responses
+//!
+//! Run with: cargo run --example structured_output
+//!
+//! Test interactively or with an MCP client connected via stdio.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tower_mcp::{BoxError, CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+
+// Input types
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LookupInput {
+    /// User ID to look up
+    user_id: u32,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SearchInput {
+    /// Search query
+    query: String,
+    /// Maximum results to return
+    #[serde(default = "default_limit")]
+    limit: u32,
+}
+
+fn default_limit() -> u32 {
+    5
+}
+
+// Output types -- these define the structured response shape
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct UserProfile {
+    id: u32,
+    name: String,
+    email: String,
+    role: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct SearchResults {
+    query: String,
+    total: u32,
+    items: Vec<SearchItem>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+struct SearchItem {
+    title: String,
+    score: f64,
+    snippet: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    eprintln!("Starting structured output example...");
+
+    // Tool 1: Return a typed struct as structured JSON
+    // Uses from_serialize() to convert a Rust type to JSON with structured_content
+    let output_schema = serde_json::to_value(schemars::schema_for!(UserProfile))?;
+    let get_user = ToolBuilder::new("get_user")
+        .description("Look up a user profile by ID. Returns structured JSON.")
+        .output_schema(output_schema)
+        .handler(|input: LookupInput| async move {
+            let profile = UserProfile {
+                id: input.user_id,
+                name: format!("User {}", input.user_id),
+                email: format!("user{}@example.com", input.user_id),
+                role: if input.user_id == 1 {
+                    "admin"
+                } else {
+                    "member"
+                }
+                .to_string(),
+            };
+            CallToolResult::from_serialize(&profile)
+        })
+        .build();
+
+    // Tool 2: Return search results with output schema
+    let output_schema = serde_json::to_value(schemars::schema_for!(SearchResults))?;
+    let search = ToolBuilder::new("search")
+        .description("Search for items. Returns structured results with scores.")
+        .output_schema(output_schema)
+        .handler(|input: SearchInput| async move {
+            let items: Vec<SearchItem> = (0..input.limit)
+                .map(|i| SearchItem {
+                    title: format!("Result {} for '{}'", i + 1, input.query),
+                    score: 1.0 - (i as f64 * 0.15),
+                    snippet: format!("...matching content for '{}'...", input.query),
+                })
+                .collect();
+
+            let results = SearchResults {
+                query: input.query,
+                total: items.len() as u32,
+                items,
+            };
+            CallToolResult::from_serialize(&results)
+        })
+        .build();
+
+    // Tool 3: Return raw JSON using CallToolResult::json()
+    // Useful when the shape is dynamic or you're forwarding external API responses
+    let get_stats = ToolBuilder::new("get_stats")
+        .description("Get server statistics as raw JSON.")
+        .handler(|()| async move {
+            let stats = serde_json::json!({
+                "uptime_seconds": 3600,
+                "requests_served": 42,
+                "active_connections": 3,
+                "version": "1.0.0"
+            });
+            Ok(CallToolResult::json(stats))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("structured-output-example", "1.0.0")
+        .instructions(
+            "This server demonstrates structured output from tools. Try:\n\
+             - get_user: returns a typed UserProfile as JSON\n\
+             - search: returns SearchResults with scored items\n\
+             - get_stats: returns raw JSON statistics",
+        )
+        .tool(get_user)
+        .tool(search)
+        .tool(get_stats);
+
+    eprintln!("Server ready. Connect with an MCP client via stdio.");
+    StdioTransport::new(router).run().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Add 4 new examples covering gaps identified in documentation review:
  - `structured_output.rs` -- output schemas, `CallToolResult::json()`, `from_serialize()`
  - `resource_templates.rs` -- single/multi-variable URI templates, wildcard `{+path}`, error handling in template handlers
  - `error_handling.rs` -- domain errors vs propagated errors, input validation, mixed patterns
  - `rate_limiting.rs` -- per-tool concurrency limits, combined middleware stacks (concurrency + timeout)
- Register 8 previously unregistered examples in Cargo.toml (`tool_middleware`, `tool_selection`, `middleware_showcase`, `external_api_auth`, plus the 4 new ones)
- Add run instructions to `basic.rs`

## Test plan

- [x] `cargo build -p tower-mcp --examples --all-features` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes

Closes #724