### PR TITLE
feat: add McpProxy::remove_backend() for dynamic backend management

### DIFF
--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -254,17 +254,7 @@ impl McpProxy {
         self.spawn_invalidation_watcher(backend_idx, invalidation_rx);
 
         // Notify downstream clients that capabilities changed
-        if let Some(tx) = &self.shared.notification_tx {
-            let _ = tx
-                .send(crate::context::ServerNotification::ToolsListChanged)
-                .await;
-            let _ = tx
-                .send(crate::context::ServerNotification::ResourcesListChanged)
-                .await;
-            let _ = tx
-                .send(crate::context::ServerNotification::PromptsListChanged)
-                .await;
-        }
+        self.notify_all_changed().await;
 
         Ok(())
     }
@@ -426,6 +416,84 @@ impl McpProxy {
         });
     }
 
+    /// Remove a backend by namespace name.
+    ///
+    /// The backend's tools, resources, and prompts are immediately removed from
+    /// aggregated lists. Downstream clients are notified via list-changed
+    /// notifications.
+    ///
+    /// Returns `true` if the backend was found and removed, `false` if no
+    /// backend with that namespace exists.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// if proxy.remove_backend("old-db").await {
+    ///     println!("Backend removed");
+    /// }
+    /// ```
+    pub async fn remove_backend(&self, namespace: &str) -> bool {
+        // Remove from entries (synchronous)
+        let found = {
+            let mut entries = self.entries.lock().expect("entries lock poisoned");
+            let before = entries.len();
+            entries.retain(|e| e.namespace != namespace);
+            entries.len() < before
+        };
+
+        if !found {
+            return false;
+        }
+
+        // Remove from backends (async)
+        // Dropping the Backend drops its invalidation_tx sender, which
+        // causes the spawned invalidation watcher to exit naturally.
+        {
+            let mut backends = self.shared.backends.write().await;
+            backends.retain(|b| b.namespace != namespace);
+        }
+
+        // Notify downstream clients that capabilities changed
+        self.notify_all_changed().await;
+
+        tracing::info!(namespace, "Backend removed");
+        true
+    }
+
+    /// Replace a backend by removing the old one and adding a new one with
+    /// the same namespace.
+    ///
+    /// This is a convenience for `remove_backend()` + `add_backend()`. If
+    /// the add fails, the old backend is already gone (no rollback).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// proxy.replace_backend("db", new_transport).await?;
+    /// ```
+    pub async fn replace_backend(
+        &self,
+        namespace: impl Into<String>,
+        transport: impl ClientTransport,
+    ) -> Result<(), AddBackendError> {
+        let namespace = namespace.into();
+        self.remove_backend(&namespace).await;
+        self.add_backend(namespace, transport).await
+    }
+
+    /// Return the namespaces of all currently registered backends.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let namespaces = proxy.backend_namespaces();
+    /// println!("Backends: {:?}", namespaces);
+    /// ```
+    pub fn backend_namespaces(&self) -> Vec<String> {
+        let entries = self.entries.lock().expect("entries lock poisoned");
+        entries.iter().map(|e| e.namespace.clone()).collect()
+    }
+
     /// Return the number of currently registered backends.
     pub fn backend_count(&self) -> usize {
         self.entries.lock().expect("entries lock poisoned").len()
@@ -451,6 +519,21 @@ impl McpProxy {
         drop(backends);
 
         futures::future::join_all(futures).await
+    }
+
+    /// Notify downstream clients that all capability lists have changed.
+    async fn notify_all_changed(&self) {
+        if let Some(tx) = &self.shared.notification_tx {
+            let _ = tx
+                .send(crate::context::ServerNotification::ToolsListChanged)
+                .await;
+            let _ = tx
+                .send(crate::context::ServerNotification::ResourcesListChanged)
+                .await;
+            let _ = tx
+                .send(crate::context::ServerNotification::PromptsListChanged)
+                .await;
+        }
     }
 
     /// Extract Send-safe info from entries (synchronous, no borrow across await).

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -1551,4 +1551,130 @@ mod proxy_tests {
         let results = handle.await.unwrap();
         assert!(!results.is_empty());
     }
+
+    // ========================================================================
+    // Remove / replace / namespaces
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_remove_backend() {
+        let proxy = build_test_proxy().await;
+        assert_eq!(proxy.backend_count(), 2);
+        assert!(proxy.backend_namespaces().contains(&"math".to_string()));
+
+        // Remove the math backend
+        assert!(proxy.remove_backend("math").await);
+        assert_eq!(proxy.backend_count(), 1);
+        assert!(!proxy.backend_namespaces().contains(&"math".to_string()));
+        assert!(proxy.backend_namespaces().contains(&"text".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_remove_backend_not_found() {
+        let proxy = build_test_proxy().await;
+        assert!(!proxy.remove_backend("nonexistent").await);
+        assert_eq!(proxy.backend_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_remove_backend_tools_no_longer_listed() {
+        let mut proxy = build_test_proxy().await;
+
+        // Before removal: math/add should be listed
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .unwrap();
+        let tools = match resp {
+            McpResponse::ListTools(r) => r.tools,
+            _ => panic!("expected ListTools"),
+        };
+        assert!(tools.iter().any(|t| t.name.contains("math")));
+
+        // Remove math
+        proxy.remove_backend("math").await;
+
+        // After removal: math tools should be gone
+        let resp = call_proxy(&mut proxy, McpRequest::ListTools(Default::default()))
+            .await
+            .unwrap();
+        let tools = match resp {
+            McpResponse::ListTools(r) => r.tools,
+            _ => panic!("expected ListTools"),
+        };
+        assert!(!tools.iter().any(|t| t.name.contains("math")));
+        // text tools should still be there
+        assert!(tools.iter().any(|t| t.name.contains("text")));
+    }
+
+    #[tokio::test]
+    async fn test_remove_backend_tool_calls_fail() {
+        let mut proxy = build_test_proxy().await;
+        proxy.remove_backend("math").await;
+
+        // Calling a removed backend's tool should fail
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math_add".to_string(),
+                arguments: json!({"a": 1, "b": 2}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        assert!(resp.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_replace_backend() {
+        let mut proxy = build_test_proxy().await;
+
+        // Replace math with a new math backend
+        let new_math_transport = ChannelTransport::new(math_router());
+        proxy
+            .replace_backend("math", new_math_transport)
+            .await
+            .expect("replace should succeed");
+
+        assert_eq!(proxy.backend_count(), 2);
+
+        // The replaced backend should still work
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                name: "math_add".to_string(),
+                arguments: json!({"a": 10, "b": 20}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        match resp {
+            McpResponse::CallTool(r) => {
+                let text = r.content[0].as_text().unwrap();
+                assert_eq!(text, "30");
+            }
+            _ => panic!("expected CallTool"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_backend_namespaces() {
+        let proxy = build_test_proxy().await;
+        let mut namespaces = proxy.backend_namespaces();
+        namespaces.sort();
+        assert_eq!(namespaces, vec!["math", "text"]);
+    }
+
+    #[tokio::test]
+    async fn test_remove_all_backends() {
+        let proxy = build_test_proxy().await;
+        proxy.remove_backend("math").await;
+        proxy.remove_backend("text").await;
+        assert_eq!(proxy.backend_count(), 0);
+        assert!(proxy.backend_namespaces().is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Add `remove_backend(namespace)` -- removes a backend and its capabilities, notifies downstream clients
- Add `replace_backend(namespace, transport)` -- convenience for remove + add
- Add `backend_namespaces()` -- returns list of all registered namespace names
- Refactor notification code into shared `notify_all_changed()` helper

## Details

Dropping the `Backend` struct closes its invalidation channel sender, which causes the spawned invalidation watcher task to exit naturally via `rx.recv() -> None`.

## Test plan

- [x] 7 new tests (48 total proxy tests, all passing)
- [x] `cargo clippy --all-features` clean
- [x] `cargo fmt` clean

Closes #729