### PR TITLE
feat: derive Serialize/Deserialize on RouterResponse and inner types

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -499,7 +499,7 @@ pub struct RequestMeta {
 }
 
 /// High-level MCP response
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[non_exhaustive]
 pub enum McpResponse {
@@ -3194,7 +3194,7 @@ pub struct ListTasksParams {
 }
 
 /// Result of listing tasks
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListTasksResult {
     /// List of tasks
@@ -3883,7 +3883,7 @@ pub struct ElicitationCompleteParams {
 // Common
 // =============================================================================
 
-#[derive(Debug, Clone, Default, Serialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct EmptyResult {}
 
 // =============================================================================
@@ -5070,5 +5070,39 @@ mod tests {
             meta: None,
         };
         assert!(result.as_json().is_none());
+    }
+
+    #[test]
+    fn test_mcp_response_serde_roundtrip() {
+        // CallToolResult variant - has distinctive fields
+        let response = McpResponse::CallTool(CallToolResult {
+            content: vec![Content::text("hello")],
+            structured_content: None,
+            is_error: false,
+            meta: None,
+        });
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: McpResponse = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            McpResponse::CallTool(result) => {
+                assert_eq!(result.content[0].as_text(), Some("hello"));
+            }
+            _ => panic!("expected CallTool variant"),
+        }
+
+        // ListToolsResult variant
+        let response = McpResponse::ListTools(ListToolsResult {
+            tools: vec![],
+            next_cursor: Some("cursor123".to_string()),
+            meta: None,
+        });
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: McpResponse = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            McpResponse::ListTools(result) => {
+                assert_eq!(result.next_cursor.as_deref(), Some("cursor123"));
+            }
+            _ => panic!("expected ListTools variant"),
+        }
     }
 }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2410,7 +2410,7 @@ impl RouterRequest {
 }
 
 /// Response type for the tower Service implementation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RouterResponse {
     /// The JSON-RPC request ID this response corresponds to.
     pub id: RequestId,
@@ -6199,5 +6199,28 @@ mod tests {
 
         ext.insert(String::from("hello"));
         assert_eq!(ext.len(), 2);
+    }
+
+    #[test]
+    fn test_router_response_serde_roundtrip() {
+        // Success response
+        let response = RouterResponse {
+            id: RequestId::Number(1),
+            inner: Ok(McpResponse::Empty(EmptyResult {})),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: RouterResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, RequestId::Number(1));
+        assert!(!deserialized.is_error());
+
+        // Error response
+        let response = RouterResponse {
+            id: RequestId::String("req-2".into()),
+            inner: Err(JsonRpcError::method_not_found("unknown")),
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: RouterResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.id, RequestId::String("req-2".into()));
+        assert!(deserialized.is_error());
     }
 }


### PR DESCRIPTION
## Summary
- Add `Serialize`/`Deserialize` derives to `RouterResponse`, `McpResponse`, `ListTasksResult`, and `EmptyResult`
- Enables external cache backends (Redis, Memcached) that need to serialize responses
- `JsonRpcError` already had both derives, no change needed

## Test plan
- [x] Added `test_mcp_response_serde_roundtrip` for `McpResponse` variants
- [x] Added `test_router_response_serde_roundtrip` for success and error responses
- [x] All existing tests pass
- [x] Clippy clean

Closes #732