### PR TITLE
feat: add optional_sessions() to HttpTransport for client compatibility

### DIFF
--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -78,6 +78,19 @@
 //! | -32005  | SessionNotFound| Session expired or server restarted      |
 //! | -32006  | SessionRequired| MCP-Session-Id header missing            |
 //!
+//! ## Optional Sessions
+//!
+//! Some MCP clients (Codex CLI, Cursor, etc.) don't carry the `mcp-session-id`
+//! header forward after initialization. Use [`HttpTransport::optional_sessions()`]
+//! to allow requests without a session ID:
+//!
+//! ```rust,ignore
+//! let transport = HttpTransport::new(router).optional_sessions();
+//! ```
+//!
+//! When enabled, requests without a session ID get a transient, pre-initialized
+//! session. Clients that do send session IDs continue to work normally.
+//!
 //! ## CORS Support
 //!
 //! Browser-based MCP clients require CORS headers. Since [`HttpTransport::into_router()`]
@@ -538,6 +551,51 @@ impl SessionStore {
         Some(session)
     }
 
+    /// Create a new session with its router already marked as initialized.
+    ///
+    /// Used by the optional-sessions feature to serve requests from clients
+    /// that skip the initialize handshake.
+    async fn create_initialized(
+        &self,
+        router: McpRouter,
+        service_factory: ServiceFactory,
+    ) -> Option<Arc<Session>> {
+        // Pre-initialize the router's session state so it won't reject requests
+        router.session().mark_initialized();
+
+        let mut sessions = self.sessions.write().await;
+
+        if let Some(max) = self.config.max_sessions
+            && sessions.len() >= max
+        {
+            return None;
+        }
+
+        let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
+        sessions.insert(session.id.clone(), session.clone());
+        tracing::debug!(session_id = %session.id, "Created pre-initialized session (optional_sessions)");
+        Some(session)
+    }
+
+    /// Create a pre-initialized session from a boxed service.
+    async fn create_initialized_from_service(
+        &self,
+        service: McpBoxService,
+    ) -> Option<Arc<Session>> {
+        let mut sessions = self.sessions.write().await;
+
+        if let Some(max) = self.config.max_sessions
+            && sessions.len() >= max
+        {
+            return None;
+        }
+
+        let session = Arc::new(Session::from_service(service));
+        sessions.insert(session.id.clone(), session.clone());
+        tracing::debug!(session_id = %session.id, "Created pre-initialized session from service (optional_sessions)");
+        Some(session)
+    }
+
     async fn get(&self, id: &str) -> Option<Arc<Session>> {
         let sessions = self.sessions.read().await;
         let session = sessions.get(id).cloned();
@@ -678,6 +736,8 @@ struct AppState {
     allowed_origins: Vec<String>,
     /// Whether sampling is enabled
     sampling_enabled: bool,
+    /// Whether sessions are optional (for clients that don't track session IDs)
+    optional_sessions: bool,
 }
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
@@ -714,6 +774,7 @@ pub struct HttpTransport {
     allowed_origins: Vec<String>,
     session_config: SessionConfig,
     sampling_enabled: bool,
+    optional_sessions: bool,
     #[cfg(feature = "oauth")]
     oauth_config: Option<OAuthConfig>,
 }
@@ -732,6 +793,7 @@ impl HttpTransport {
             allowed_origins: vec![],
             session_config: SessionConfig::default(),
             sampling_enabled: false,
+            optional_sessions: false,
             #[cfg(feature = "oauth")]
             oauth_config: None,
         }
@@ -778,6 +840,7 @@ impl HttpTransport {
             allowed_origins: vec![],
             session_config: SessionConfig::default(),
             sampling_enabled: false,
+            optional_sessions: false,
             #[cfg(feature = "oauth")]
             oauth_config: None,
         }
@@ -821,6 +884,37 @@ impl HttpTransport {
     /// ```
     pub fn with_sampling(mut self) -> Self {
         self.sampling_enabled = true;
+        self
+    }
+
+    /// Make sessions optional for compatibility with clients that don't track session IDs.
+    ///
+    /// When enabled, requests without an `mcp-session-id` header are allowed.
+    /// The server creates a transient, pre-initialized session for each such request,
+    /// bypassing the normal `initialize` handshake requirement.
+    ///
+    /// This is useful for clients like Codex CLI, Cursor, and others that perform
+    /// `initialize` + `tools/list` during setup but don't carry the session ID
+    /// forward to subsequent `tools/call` requests.
+    ///
+    /// Clients that do send session IDs continue to work normally.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::McpRouter;
+    /// use tower_mcp::transport::http::HttpTransport;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
+    ///     let transport = HttpTransport::new(router).optional_sessions();
+    ///     transport.serve("127.0.0.1:3000").await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn optional_sessions(mut self) -> Self {
+        self.optional_sessions = true;
         self
     }
 
@@ -937,6 +1031,7 @@ impl HttpTransport {
             validate_origin: self.validate_origin,
             allowed_origins: self.allowed_origins.clone(),
             sampling_enabled: self.sampling_enabled,
+            optional_sessions: self.optional_sessions,
         })
     }
 
@@ -1233,16 +1328,8 @@ async fn handle_post(
                     .into_response();
             }
         }
-    } else {
-        // Require existing session
-        let session_id = match get_session_id(&headers) {
-            Some(id) => id,
-            None => {
-                // Return JSON-RPC error so clients can detect and handle this
-                return json_rpc_error_response(None, JsonRpcError::session_required());
-            }
-        };
-
+    } else if let Some(session_id) = get_session_id(&headers) {
+        // Client sent a session ID -- look it up
         match state.sessions.get(&session_id).await {
             Some(s) => s,
             None => {
@@ -1253,6 +1340,40 @@ async fn handle_post(
                 );
             }
         }
+    } else if state.optional_sessions {
+        // No session ID, but sessions are optional -- create a transient,
+        // pre-initialized session so the router won't reject the request.
+        // This supports clients (Codex CLI, Cursor, etc.) that perform
+        // initialize + tools/list during setup but don't carry the session
+        // ID forward to subsequent requests.
+        let create_result = match &state.service_source {
+            ServiceSource::Router { router, factory } => {
+                state
+                    .sessions
+                    .create_initialized(router.with_fresh_session(), factory.clone())
+                    .await
+            }
+            ServiceSource::Service(mutex) => {
+                let service = mutex.lock().unwrap().clone();
+                state
+                    .sessions
+                    .create_initialized_from_service(service)
+                    .await
+            }
+        };
+        match create_result {
+            Some(s) => s,
+            None => {
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Maximum session limit reached",
+                )
+                    .into_response();
+            }
+        }
+    } else {
+        // No session ID and sessions are required
+        return json_rpc_error_response(None, JsonRpcError::session_required());
     };
 
     // Validate protocol version (if present and not init request)

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -1856,3 +1856,320 @@ async fn test_http_client_session_expiry_error() {
         "Expected SessionNotFound error code (-32005)"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Optional sessions (#742) -- Codex CLI / Cursor compatibility
+// ---------------------------------------------------------------------------
+
+/// Start a server with optional_sessions enabled.
+async fn start_optional_sessions_server() -> (String, tokio::task::JoinHandle<()>) {
+    let router = test_router();
+    let transport = HttpTransport::new(router)
+        .disable_origin_validation()
+        .optional_sessions();
+    let axum_router = transport.into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, axum_router).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (url, handle)
+}
+
+/// Simulate Codex CLI behavior: initialize + tools/list during setup,
+/// then tools/call without session ID on a fresh connection.
+#[tokio::test]
+async fn test_optional_sessions_codex_pattern() {
+    let (url, _server) = start_optional_sessions_server().await;
+    let client = reqwest::Client::new();
+
+    // Phase 1: Setup -- Codex initializes and discovers tools (normal flow)
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "codex-cli", "version": "0.1.0" }
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // tools/list with session ID (setup phase)
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("mcp-session-id", &session_id)
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/list",
+                "params": {}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let tools = body["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 2, "Should discover echo and add tools");
+
+    // Phase 2: Execution -- Codex sends tools/call WITHOUT session ID
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        // No mcp-session-id header!
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "arguments": { "message": "hello from codex" }
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("error").is_none(),
+        "tools/call without session ID should succeed with optional_sessions, got: {body}"
+    );
+    let content = &body["result"]["content"][0]["text"];
+    assert_eq!(content.as_str().unwrap(), "hello from codex");
+}
+
+/// Simulate Cursor behavior: tools/list without session ID.
+#[tokio::test]
+async fn test_optional_sessions_cursor_tools_list_no_session() {
+    let (url, _server) = start_optional_sessions_server().await;
+    let client = reqwest::Client::new();
+
+    // Cursor sends tools/list directly without initializing or session ID
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        // No mcp-session-id header!
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("error").is_none(),
+        "tools/list without session ID should succeed with optional_sessions, got: {body}"
+    );
+    let tools = body["result"]["tools"].as_array().unwrap();
+    assert_eq!(tools.len(), 2);
+}
+
+/// Multiple sessionless requests should each work independently.
+#[tokio::test]
+async fn test_optional_sessions_multiple_stateless_calls() {
+    let (url, _server) = start_optional_sessions_server().await;
+    let client = reqwest::Client::new();
+
+    // Send multiple tools/call requests without session IDs
+    for i in 0..3 {
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": i + 1,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "add",
+                        "arguments": { "a": i, "b": 10 }
+                    }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(
+            body.get("error").is_none(),
+            "Stateless call {i} failed: {body}"
+        );
+        let expected = format!("{}", i + 10);
+        assert_eq!(
+            body["result"]["content"][0]["text"].as_str().unwrap(),
+            expected
+        );
+    }
+}
+
+/// Without optional_sessions, missing session ID should still be rejected.
+#[tokio::test]
+async fn test_sessions_required_rejects_without_session_id() {
+    let (url, _server) = start_server().await; // Uses default (sessions required)
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        // No mcp-session-id header!
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/list",
+                "params": {}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let error = body
+        .get("error")
+        .expect("Expected JSON-RPC error when session ID is missing");
+    assert_eq!(
+        error["code"].as_i64().unwrap(),
+        -32006,
+        "Expected SessionRequired error code (-32006)"
+    );
+}
+
+/// With optional_sessions, clients that DO send session IDs should still work.
+#[tokio::test]
+async fn test_optional_sessions_with_session_id_still_works() {
+    let (url, _server) = start_optional_sessions_server().await;
+    let client = reqwest::Client::new();
+
+    // Initialize normally
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "good-client", "version": "1.0.0" }
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // Send initialized notification
+    let _resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("mcp-session-id", &session_id)
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized",
+                "params": {}
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    // Use session normally
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("mcp-session-id", &session_id)
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "echo",
+                    "arguments": { "message": "session works" }
+                }
+            })
+            .to_string(),
+        )
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("error").is_none(),
+        "Session-based call should work: {body}"
+    );
+    assert_eq!(
+        body["result"]["content"][0]["text"].as_str().unwrap(),
+        "session works"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `HttpTransport::optional_sessions()` builder method that allows requests without an `mcp-session-id` header
- When enabled, sessionless requests get a transient, pre-initialized session so the router doesn't reject them
- Clients that do send session IDs continue to work normally (no behavior change)
- Default behavior unchanged: sessions are still required unless explicitly opted out

This fixes compatibility with clients like Codex CLI, Codex Desktop, and Cursor that perform `initialize` + `tools/list` during setup but don't carry the session ID forward to `tools/call` requests.

### Usage

```rust
let transport = HttpTransport::new(router).optional_sessions();
```

## Test plan

- [x] `test_optional_sessions_codex_pattern` -- initialize + tools/list with session, then tools/call without (exact Codex CLI pattern)
- [x] `test_optional_sessions_cursor_tools_list_no_session` -- tools/list directly without any session
- [x] `test_optional_sessions_multiple_stateless_calls` -- multiple independent sessionless requests
- [x] `test_sessions_required_rejects_without_session_id` -- default behavior still rejects missing session ID
- [x] `test_optional_sessions_with_session_id_still_works` -- session-based clients work when optional_sessions is enabled
- [x] All 49 existing HTTP client tests pass
- [x] Full test suite passes (86 lib + 44 integration + 45 doc tests)

Closes #742