### PR TITLE
feat: WebSocket spec compliance, stateless mode, and resource/prompt context

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -522,6 +522,8 @@ pub enum McpResponse {
     Complete(CompleteResult),
     Pong(EmptyResult),
     Empty(EmptyResult),
+    /// Raw JSON value for experimental/extension methods.
+    Raw(Value),
 }
 
 // =============================================================================

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -42,7 +42,7 @@ jsonschema = "0.45"
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience"]
+full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "stateless"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
@@ -65,6 +65,8 @@ proxy = []
 resilience = ["dep:tower-resilience"]
 # Proc macros for tool/resource/prompt definitions
 macros = ["dep:tower-mcp-macros"]
+# SEP-1442 stateless MCP mode (experimental)
+stateless = []
 
 [dependencies.axum]
 workspace = true

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -402,6 +402,8 @@ pub mod registry;
 pub mod resource;
 pub mod router;
 pub mod session;
+#[cfg(feature = "stateless")]
+pub mod stateless;
 #[cfg(feature = "testing")]
 pub mod testing;
 pub mod tool;

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1897,7 +1897,8 @@ impl McpRouter {
                     }
 
                     tracing::debug!(uri = %params.uri, "Reading static resource");
-                    let result = resource.read().await;
+                    let ctx = self.create_context(request_id, None);
+                    let result = resource.read_with_context(ctx).await;
                     return Ok(McpResponse::ReadResource(result));
                 }
 
@@ -1912,7 +1913,8 @@ impl McpRouter {
                             return Err(filter.denial_error(&params.uri));
                         }
                         tracing::debug!(uri = %params.uri, "Reading dynamic resource");
-                        let result = resource.read().await;
+                        let ctx = self.create_context(request_id, None);
+                        let result = resource.read_with_context(ctx).await;
                         return Ok(McpResponse::ReadResource(result));
                     }
                 }
@@ -2045,7 +2047,8 @@ impl McpRouter {
                 }
 
                 tracing::debug!(name = %params.name, "Getting prompt");
-                let result = prompt.get(params.arguments).await?;
+                let ctx = self.create_context(request_id, None);
+                let result = prompt.get_with_context(ctx, params.arguments).await?;
 
                 Ok(McpResponse::GetPrompt(result))
             }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2179,6 +2179,35 @@ impl McpRouter {
                 }
             }
 
+            McpRequest::Unknown { ref method, .. } if method == "server/discover" => {
+                #[cfg(feature = "stateless")]
+                {
+                    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
+                    let result = crate::stateless::DiscoverResult {
+                        supported_versions: SUPPORTED_PROTOCOL_VERSIONS
+                            .iter()
+                            .map(|v| v.to_string())
+                            .collect(),
+                        capabilities: self.capabilities(),
+                        server_info: Implementation {
+                            name: self.inner.server_name.clone(),
+                            version: self.inner.server_version.clone(),
+                            title: self.inner.server_title.clone(),
+                            description: self.inner.server_description.clone(),
+                            icons: self.inner.server_icons.clone(),
+                            website_url: None,
+                            meta: None,
+                        },
+                        instructions: self.inner.instructions.clone(),
+                    };
+                    Ok(McpResponse::Raw(serde_json::to_value(result).unwrap()))
+                }
+                #[cfg(not(feature = "stateless"))]
+                {
+                    Err(Error::JsonRpc(JsonRpcError::method_not_found(method)))
+                }
+            }
+
             McpRequest::Unknown { method, .. } => {
                 Err(Error::JsonRpc(JsonRpcError::method_not_found(&method)))
             }

--- a/crates/tower-mcp/src/session.rs
+++ b/crates/tower-mcp/src/session.rs
@@ -197,7 +197,8 @@ impl SessionState {
     pub fn is_request_allowed(&self, method: &str) -> bool {
         match self.phase() {
             SessionPhase::Uninitialized => {
-                matches!(method, "initialize" | "ping")
+                // server/discover (SEP-1442) is allowed before initialization
+                matches!(method, "initialize" | "ping" | "server/discover")
             }
             SessionPhase::Initializing | SessionPhase::Initialized => true,
         }

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -1,0 +1,360 @@
+//! SEP-1442 Stateless MCP support (experimental)
+//!
+//! This module provides experimental support for stateless MCP as defined in
+//! [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442).
+//!
+//! ## Feature Flag
+//!
+//! This module is gated behind the `stateless` feature flag:
+//!
+//! ```toml
+//! tower-mcp = { version = "0.9", features = ["stateless"] }
+//! ```
+//!
+//! ## Key Changes from Standard MCP
+//!
+//! 1. **Per-request protocol version**: Every request includes the protocol version
+//! 2. **Optional discovery**: `server/discover` RPC for capability discovery
+//! 3. **Optional sessions**: Sessions are no longer mandatory
+//! 4. **Per-request client capabilities**: Clients can specify capabilities per-request
+//!
+//! ## Warning
+//!
+//! SEP-1442 is still in-review. The API may change as the specification evolves.
+
+use serde::{Deserialize, Serialize};
+
+use crate::protocol::{
+    ClientCapabilities, Implementation, ProgressToken, Root, ServerCapabilities,
+};
+
+// =============================================================================
+// Extended _meta fields for stateless mode
+// =============================================================================
+
+/// Extended request metadata for stateless MCP (SEP-1442).
+///
+/// In stateless mode, each request must be self-contained. This extended metadata
+/// allows passing protocol version, session ID, and client capabilities per-request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatelessRequestMeta {
+    /// Progress token for receiving progress notifications.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub progress_token: Option<ProgressToken>,
+
+    /// The MCP protocol version for this request (SEP-1442).
+    ///
+    /// For HTTP transport, this must match the `MCP-Protocol-Version` header.
+    #[serde(
+        rename = "modelcontextprotocol.io/mcpProtocolVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub protocol_version: Option<String>,
+
+    /// Optional session ID for requests that need session affinity (SEP-1442).
+    ///
+    /// For HTTP transport, this must match the `MCP-Session-Id` header.
+    #[serde(
+        rename = "modelcontextprotocol.io/sessionId",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub session_id: Option<String>,
+
+    /// Client capabilities for this specific request (SEP-1442).
+    ///
+    /// Allows the server to know what optional features the client can handle
+    /// for this specific transaction.
+    #[serde(
+        rename = "modelcontextprotocol.io/clientCapabilities",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_capabilities: Option<ClientCapabilities>,
+
+    /// Client roots for this request (SEP-1442).
+    #[serde(
+        rename = "modelcontextprotocol.io/roots",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub roots: Option<Vec<Root>>,
+
+    /// Log level for this request (SEP-1442).
+    #[serde(
+        rename = "modelcontextprotocol.io/logLevel",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub log_level: Option<LogLevel>,
+}
+
+/// Log levels for stateless per-request log level control.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LogLevel {
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+    Critical,
+    Alert,
+    Emergency,
+}
+
+// =============================================================================
+// server/discover RPC
+// =============================================================================
+
+/// Request parameters for the `server/discover` RPC (SEP-1442).
+///
+/// Allows clients to query server capabilities without establishing a session.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiscoverParams {}
+
+/// Response for the `server/discover` RPC (SEP-1442).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    /// Protocol versions supported by this server.
+    pub supported_versions: Vec<String>,
+
+    /// Server capabilities.
+    pub capabilities: ServerCapabilities,
+
+    /// Server implementation info.
+    pub server_info: Implementation,
+
+    /// Optional instructions for using this server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+}
+
+// =============================================================================
+// Error codes (SEP-1442)
+// =============================================================================
+
+/// SEP-1442 error codes.
+pub mod error_codes {
+    /// Unsupported protocol version (-32000).
+    ///
+    /// The error data MUST include `supportedVersions` array.
+    pub const UNSUPPORTED_VERSION: i32 = -32000;
+
+    /// Invalid or missing required session ID (-32001).
+    pub const INVALID_SESSION: i32 = -32001;
+}
+
+/// Error data for unsupported protocol version errors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnsupportedVersionData {
+    /// Protocol versions supported by this server.
+    pub supported_versions: Vec<String>,
+}
+
+// =============================================================================
+// Stateless mode configuration
+// =============================================================================
+
+/// Configuration for stateless MCP mode.
+///
+/// Controls which SEP-1442 features are enabled and their strictness.
+#[derive(Debug, Clone)]
+pub struct StatelessConfig {
+    /// Whether to require protocol version in every request.
+    ///
+    /// Default: true (as per SEP-1442)
+    pub require_protocol_version: bool,
+
+    /// Whether sessions are optional.
+    ///
+    /// When true, requests without session IDs are allowed and
+    /// the initialize handshake is not required.
+    ///
+    /// Default: true
+    pub optional_sessions: bool,
+
+    /// Whether to enable the `server/discover` RPC.
+    ///
+    /// Default: true
+    pub enable_discover: bool,
+}
+
+impl Default for StatelessConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatelessConfig {
+    /// Create a new stateless configuration with SEP-1442 defaults.
+    pub fn new() -> Self {
+        Self {
+            require_protocol_version: true,
+            optional_sessions: true,
+            enable_discover: true,
+        }
+    }
+
+    /// Create a configuration that maintains backward compatibility.
+    ///
+    /// This enables stateless features but doesn't require them,
+    /// allowing gradual migration from stateful to stateless.
+    pub fn backward_compatible() -> Self {
+        Self {
+            require_protocol_version: false,
+            optional_sessions: true,
+            enable_discover: true,
+        }
+    }
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+impl StatelessRequestMeta {
+    /// Extract stateless request metadata from JSON-RPC request params.
+    ///
+    /// The metadata is expected in the `_meta` field of the params object.
+    pub fn from_params(params: &serde_json::Value) -> Option<Self> {
+        params
+            .get("_meta")
+            .and_then(|meta| serde_json::from_value(meta.clone()).ok())
+    }
+
+    /// Check if this request includes client capabilities.
+    pub fn has_client_capabilities(&self) -> bool {
+        self.client_capabilities.is_some()
+    }
+
+    /// Check if this request includes roots.
+    pub fn has_roots(&self) -> bool {
+        self.roots.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_stateless_meta_serialization() {
+        let meta = StatelessRequestMeta {
+            progress_token: None,
+            protocol_version: Some("2025-11-25".to_string()),
+            session_id: Some("abc123".to_string()),
+            client_capabilities: None,
+            roots: None,
+            log_level: Some(LogLevel::Info),
+        };
+
+        let json = serde_json::to_string(&meta).unwrap();
+        assert!(json.contains("modelcontextprotocol.io/mcpProtocolVersion"));
+        assert!(json.contains("modelcontextprotocol.io/sessionId"));
+        assert!(json.contains("modelcontextprotocol.io/logLevel"));
+    }
+
+    #[test]
+    fn test_stateless_meta_deserialization() {
+        let json = r#"{
+            "modelcontextprotocol.io/mcpProtocolVersion": "2025-11-25",
+            "modelcontextprotocol.io/sessionId": "test-session",
+            "modelcontextprotocol.io/logLevel": "debug"
+        }"#;
+
+        let meta: StatelessRequestMeta = serde_json::from_str(json).unwrap();
+        assert_eq!(meta.protocol_version, Some("2025-11-25".to_string()));
+        assert_eq!(meta.session_id, Some("test-session".to_string()));
+        assert_eq!(meta.log_level, Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_discover_result_serialization() {
+        let result = DiscoverResult {
+            supported_versions: vec!["2025-11-25".to_string(), "2025-03-26".to_string()],
+            capabilities: ServerCapabilities::default(),
+            server_info: Implementation {
+                name: "test-server".to_string(),
+                version: "1.0.0".to_string(),
+                title: None,
+                description: None,
+                icons: None,
+                website_url: None,
+                meta: None,
+            },
+            instructions: Some("Test instructions".to_string()),
+        };
+
+        let json = serde_json::to_value(&result).unwrap();
+        assert!(json["supportedVersions"].is_array());
+        assert_eq!(json["serverInfo"]["name"], "test-server");
+    }
+
+    #[test]
+    fn test_unsupported_version_data() {
+        let data = UnsupportedVersionData {
+            supported_versions: vec!["2025-11-25".to_string()],
+        };
+
+        let json = serde_json::to_value(&data).unwrap();
+        assert_eq!(json["supportedVersions"][0], "2025-11-25");
+    }
+
+    #[test]
+    fn test_config_defaults() {
+        let config = StatelessConfig::new();
+        assert!(config.require_protocol_version);
+        assert!(config.optional_sessions);
+        assert!(config.enable_discover);
+    }
+
+    #[test]
+    fn test_config_backward_compatible() {
+        let config = StatelessConfig::backward_compatible();
+        assert!(!config.require_protocol_version);
+        assert!(config.optional_sessions);
+    }
+
+    #[test]
+    fn test_from_params() {
+        let params = serde_json::json!({
+            "name": "test-tool",
+            "_meta": {
+                "modelcontextprotocol.io/mcpProtocolVersion": "2025-11-25",
+                "modelcontextprotocol.io/sessionId": "session-123",
+                "modelcontextprotocol.io/logLevel": "debug"
+            }
+        });
+
+        let meta = StatelessRequestMeta::from_params(&params).unwrap();
+        assert_eq!(meta.protocol_version, Some("2025-11-25".to_string()));
+        assert_eq!(meta.session_id, Some("session-123".to_string()));
+        assert_eq!(meta.log_level, Some(LogLevel::Debug));
+    }
+
+    #[test]
+    fn test_from_params_no_meta() {
+        let params = serde_json::json!({
+            "name": "test-tool"
+        });
+
+        let meta = StatelessRequestMeta::from_params(&params);
+        assert!(meta.is_none());
+    }
+
+    #[test]
+    fn test_has_client_capabilities() {
+        let meta = StatelessRequestMeta {
+            progress_token: None,
+            protocol_version: None,
+            session_id: None,
+            client_capabilities: Some(ClientCapabilities::default()),
+            roots: None,
+            log_level: None,
+        };
+        assert!(meta.has_client_capabilities());
+
+        let meta_without = StatelessRequestMeta::default();
+        assert!(!meta_without.has_client_capabilities());
+    }
+}

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -80,7 +80,7 @@ use axum::{
     routing::get,
 };
 use futures::{SinkExt, StreamExt};
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, watch};
 
 use crate::context::{
     ChannelClientRequester, ClientRequesterHandle, OutgoingRequest, OutgoingRequestReceiver,
@@ -102,20 +102,42 @@ struct Session {
     id: String,
     router: McpRouter,
     service_factory: ServiceFactory,
+    /// Sender to signal the active connection to close (zombie prevention).
+    /// Sending `true` tells the current connection to shut down.
+    cancel_tx: Mutex<watch::Sender<bool>>,
 }
 
 impl Session {
     fn new(router: McpRouter, service_factory: ServiceFactory) -> Self {
+        let (cancel_tx, _) = watch::channel(false);
         Self {
             id: uuid::Uuid::new_v4().to_string(),
             router,
             service_factory,
+            cancel_tx: Mutex::new(cancel_tx),
         }
     }
 
     /// Create a middleware-wrapped service from this session's router.
     fn make_service(&self) -> McpBoxService {
         (self.service_factory)(self.router.clone())
+    }
+
+    /// Get a receiver that will be notified when this connection should close.
+    async fn cancel_receiver(&self) -> watch::Receiver<bool> {
+        self.cancel_tx.lock().await.subscribe()
+    }
+
+    /// Signal the current active connection to close and create a fresh
+    /// cancellation channel for the replacement connection.
+    async fn replace_connection(&self) -> watch::Receiver<bool> {
+        let mut tx = self.cancel_tx.lock().await;
+        // Signal the old connection to shut down
+        let _ = tx.send(true);
+        // Replace with a fresh channel so new subscribers start clean
+        let (new_tx, new_rx) = watch::channel(false);
+        *tx = new_tx;
+        new_rx
     }
 }
 
@@ -139,12 +161,30 @@ impl SessionStore {
         Self::default()
     }
 
-    async fn create(&self, router: McpRouter, service_factory: ServiceFactory) -> Arc<Session> {
+    async fn create(
+        &self,
+        router: McpRouter,
+        service_factory: ServiceFactory,
+    ) -> (Arc<Session>, watch::Receiver<bool>) {
         let session = Arc::new(Session::new(router, service_factory));
+        let cancel_rx = session.cancel_receiver().await;
         let mut sessions = self.sessions.write().await;
         sessions.insert(session.id.clone(), session.clone());
         tracing::debug!(session_id = %session.id, "Created WebSocket session");
-        session
+        (session, cancel_rx)
+    }
+
+    /// Look up an existing session by ID and replace its active connection.
+    ///
+    /// Signals the previous connection to close and returns a new cancellation
+    /// receiver for the replacement connection.
+    #[cfg_attr(not(test), allow(dead_code))]
+    async fn reconnect(&self, id: &str) -> Option<(Arc<Session>, watch::Receiver<bool>)> {
+        let sessions = self.sessions.read().await;
+        let session = sessions.get(id)?;
+        let cancel_rx = session.replace_connection().await;
+        tracing::info!(session_id = %id, "Replaced active WebSocket connection (zombie prevention)");
+        Some((session.clone(), cancel_rx))
     }
 
     async fn remove(&self, id: &str) -> bool {
@@ -369,11 +409,59 @@ fn add_oauth_route(
     }
 }
 
+/// Parsed MCP WebSocket subprotocols from `Sec-WebSocket-Protocol` header.
+///
+/// Per SEP-1288, clients send `mcp.auth.{token}` and `mcp.version.{version}`
+/// as WebSocket subprotocols for authentication and version negotiation.
+#[derive(Debug, Default)]
+struct McpSubprotocols {
+    /// Authentication token extracted from `mcp.auth.{token}` subprotocol.
+    auth_token: Option<String>,
+    /// Protocol version extracted from `mcp.version.{version}` subprotocol.
+    protocol_version: Option<String>,
+    /// All matched subprotocol strings to echo back in the upgrade response.
+    selected: Vec<String>,
+}
+
+/// Parse MCP subprotocols from the `Sec-WebSocket-Protocol` header.
+///
+/// Returns the parsed subprotocols and the negotiated protocol version (if valid).
+fn parse_mcp_subprotocols(headers: &axum::http::HeaderMap) -> McpSubprotocols {
+    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
+
+    let mut result = McpSubprotocols::default();
+
+    let Some(header) = headers.get("sec-websocket-protocol") else {
+        return result;
+    };
+    let Ok(header_str) = header.to_str() else {
+        return result;
+    };
+
+    for protocol in header_str.split(',').map(|s| s.trim()) {
+        if let Some(token) = protocol.strip_prefix("mcp.auth.") {
+            if !token.is_empty() {
+                result.auth_token = Some(token.to_string());
+                result.selected.push(protocol.to_string());
+            }
+        } else if let Some(version) = protocol.strip_prefix("mcp.version.") {
+            if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
+                result.protocol_version = Some(version.to_string());
+                result.selected.push(protocol.to_string());
+            } else {
+                tracing::warn!(version = %version, "Unsupported MCP protocol version in subprotocol");
+            }
+        }
+    }
+
+    result
+}
+
 /// Handle WebSocket upgrade.
 ///
 /// Uses a raw `Request` extractor and performs the WebSocket upgrade manually
 /// so we can access HTTP request extensions (e.g., `TokenClaims` from OAuth
-/// middleware) before upgrading.
+/// middleware) and parse MCP subprotocols before upgrading.
 async fn handle_websocket(
     State(state): State<Arc<AppState>>,
     request: axum::extract::Request,
@@ -382,6 +470,12 @@ async fn handle_websocket(
     use axum::response::IntoResponse;
 
     let (mut parts, _body) = request.into_parts();
+
+    // Parse MCP subprotocols (mcp.auth.*, mcp.version.*) from Sec-WebSocket-Protocol
+    let subprotocols = parse_mcp_subprotocols(&parts.headers);
+    if let Some(ref version) = subprotocols.protocol_version {
+        tracing::debug!(version = %version, "Client requested MCP protocol version via subprotocol");
+    }
 
     // Bridge TokenClaims from HTTP extensions to MCP extensions
     #[allow(unused_mut)]
@@ -393,14 +487,33 @@ async fn handle_websocket(
         }
     }
 
+    // Store subprotocol auth token in extensions for downstream use
+    if let Some(ref token) = subprotocols.auth_token {
+        mcp_extensions.insert(WebSocketAuthToken(token.clone()));
+    }
+
     // Perform the WebSocket upgrade from request parts
     let ws: WebSocketUpgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
         Ok(ws) => ws,
         Err(e) => return e.into_response(),
     };
 
+    // Echo back the matched subprotocols in the upgrade response
+    let ws = if !subprotocols.selected.is_empty() {
+        ws.protocols(subprotocols.selected)
+    } else {
+        ws
+    };
+
     ws.on_upgrade(move |socket| handle_socket(socket, state, mcp_extensions))
 }
+
+/// Auth token extracted from the `mcp.auth.{token}` WebSocket subprotocol.
+///
+/// This is inserted into the MCP extensions map and can be accessed by
+/// middleware or tool handlers via `Extensions::get::<WebSocketAuthToken>()`.
+#[derive(Debug, Clone)]
+pub struct WebSocketAuthToken(pub String);
 
 /// Handle an individual WebSocket connection
 async fn handle_socket(
@@ -409,7 +522,7 @@ async fn handle_socket(
     mcp_extensions: crate::router::Extensions,
 ) {
     // Use with_fresh_session() to ensure each session has its own state
-    let session = state
+    let (session, cancel_rx) = state
         .sessions
         .create(
             state.router_template.with_fresh_session(),
@@ -421,9 +534,9 @@ async fn handle_socket(
     tracing::info!(session_id = %session_id, "WebSocket connection established");
 
     if state.sampling_enabled {
-        handle_socket_bidirectional(socket, session, &session_id, mcp_extensions).await;
+        handle_socket_bidirectional(socket, session, &session_id, mcp_extensions, cancel_rx).await;
     } else {
-        handle_socket_simple(socket, session, &session_id, mcp_extensions).await;
+        handle_socket_simple(socket, session, &session_id, mcp_extensions, cancel_rx).await;
     }
 
     // Cleanup session
@@ -437,12 +550,32 @@ async fn handle_socket_simple(
     session: Arc<Session>,
     session_id: &str,
     mcp_extensions: crate::router::Extensions,
+    mut cancel_rx: watch::Receiver<bool>,
 ) {
     let mut service = JsonRpcService::new(session.make_service()).with_extensions(mcp_extensions);
     let (mut sender, mut receiver) = socket.split();
 
-    // Process incoming messages
-    while let Some(msg) = receiver.next().await {
+    // Process incoming messages, also watching for cancellation (zombie prevention)
+    loop {
+        let msg = tokio::select! {
+            msg = receiver.next() => {
+                match msg {
+                    Some(msg) => msg,
+                    None => break,
+                }
+            }
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!(session_id = %session_id, "Connection superseded by new connection, closing");
+                    let _ = sender.send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: 1000,
+                        reason: "Connection replaced by newer WebSocket connection".into(),
+                    }))).await;
+                    break;
+                }
+                continue;
+            }
+        };
         let msg = match msg {
             Ok(m) => m,
             Err(e) => {
@@ -483,21 +616,17 @@ async fn handle_socket_simple(
                     }
                 }
             }
-            Message::Binary(data) => {
-                // Try to parse binary as UTF-8 text
-                if let Ok(text) = String::from_utf8(data.to_vec()) {
-                    match process_message(&mut service, &session.router, &text).await {
-                        Ok(Some(response)) => {
-                            if let Ok(json) = serde_json::to_string(&response) {
-                                let _ = sender.send(Message::Text(json.into())).await;
-                            }
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            tracing::error!(error = %e, "Error processing binary message");
-                        }
-                    }
-                }
+            Message::Binary(_) => {
+                // MCP spec (SEP-1288) requires text frames only.
+                // Binary frames MUST result in close code 1003 (Unsupported Data).
+                tracing::warn!(session_id = %session_id, "Received binary frame, closing with 1003");
+                let _ = sender
+                    .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: 1003,
+                        reason: "Binary frames are not supported by MCP".into(),
+                    })))
+                    .await;
+                break;
             }
             Message::Ping(data) => {
                 if let Err(e) = sender.send(Message::Pong(data)).await {
@@ -522,6 +651,7 @@ async fn handle_socket_bidirectional(
     session: Arc<Session>,
     session_id: &str,
     _mcp_extensions: crate::router::Extensions,
+    mut cancel_rx: watch::Receiver<bool>,
 ) {
     // Create channels for outgoing requests
     let (request_tx, mut request_rx): (OutgoingRequestSender, OutgoingRequestReceiver) =
@@ -573,19 +703,16 @@ async fn handle_socket_bidirectional(
                             tracing::error!(error = %e, "Error handling incoming message");
                         }
                     }
-                    Message::Binary(data) => {
-                        if let Ok(text) = String::from_utf8(data.to_vec()) {
-                            let result = handle_incoming_message(
-                                &text,
-                                &mut service,
-                                &router,
-                                pending_requests.clone(),
-                                sender.clone(),
-                            ).await;
-                            if let Err(e) = result {
-                                tracing::error!(error = %e, "Error handling binary message");
-                            }
-                        }
+                    Message::Binary(_) => {
+                        // MCP spec (SEP-1288) requires text frames only.
+                        // Binary frames MUST result in close code 1003 (Unsupported Data).
+                        tracing::warn!(session_id = %session_id_owned, "Received binary frame, closing with 1003");
+                        let mut s = sender.lock().await;
+                        let _ = s.send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                            code: 1003,
+                            reason: "Binary frames are not supported by MCP".into(),
+                        }))).await;
+                        break;
                     }
                     Message::Ping(data) => {
                         let mut sender = sender.lock().await;
@@ -611,6 +738,19 @@ async fn handle_socket_bidirectional(
                 ).await;
                 if let Err(e) = result {
                     tracing::error!(error = %e, "Error sending outgoing request");
+                }
+            }
+
+            // Handle cancellation (zombie prevention)
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!(session_id = %session_id_owned, "Connection superseded by new connection, closing");
+                    let mut s = sender.lock().await;
+                    let _ = s.send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: 1000,
+                        reason: "Connection replaced by newer WebSocket connection".into(),
+                    }))).await;
+                    break;
                 }
             }
         }
@@ -848,5 +988,132 @@ mod tests {
                 .into_inner(),
         );
         let _router = transport.into_router();
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_empty() {
+        let headers = axum::http::HeaderMap::new();
+        let result = parse_mcp_subprotocols(&headers);
+        assert!(result.auth_token.is_none());
+        assert!(result.protocol_version.is_none());
+        assert!(result.selected.is_empty());
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_auth_and_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "mcp.auth.my-secret-token, mcp.version.2025-11-25"
+                .parse()
+                .unwrap(),
+        );
+        let result = parse_mcp_subprotocols(&headers);
+        assert_eq!(result.auth_token.as_deref(), Some("my-secret-token"));
+        assert_eq!(result.protocol_version.as_deref(), Some("2025-11-25"));
+        assert_eq!(result.selected.len(), 2);
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_unsupported_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "mcp.version.1999-01-01".parse().unwrap(),
+        );
+        let result = parse_mcp_subprotocols(&headers);
+        assert!(result.protocol_version.is_none());
+        assert!(result.selected.is_empty());
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_older_supported_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "mcp.version.2025-03-26".parse().unwrap(),
+        );
+        let result = parse_mcp_subprotocols(&headers);
+        assert_eq!(result.protocol_version.as_deref(), Some("2025-03-26"));
+        assert_eq!(result.selected.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_auth_only() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "mcp.auth.bearer-xyz123".parse().unwrap(),
+        );
+        let result = parse_mcp_subprotocols(&headers);
+        assert_eq!(result.auth_token.as_deref(), Some("bearer-xyz123"));
+        assert!(result.protocol_version.is_none());
+    }
+
+    #[test]
+    fn test_parse_mcp_subprotocols_ignores_unknown() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "graphql-ws, mcp.auth.token, mcp.version.2025-11-25, other-protocol"
+                .parse()
+                .unwrap(),
+        );
+        let result = parse_mcp_subprotocols(&headers);
+        assert_eq!(result.auth_token.as_deref(), Some("token"));
+        assert_eq!(result.protocol_version.as_deref(), Some("2025-11-25"));
+        // Only MCP subprotocols are selected
+        assert_eq!(result.selected.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_session_cancel_receiver() {
+        let router = create_test_router();
+        let session = Session::new(router, identity_factory());
+        let mut rx = session.cancel_receiver().await;
+
+        // Should not be cancelled initially
+        assert!(!*rx.borrow());
+
+        // After replace_connection, old receiver should see cancellation
+        let _new_rx = session.replace_connection().await;
+        rx.changed().await.unwrap();
+        assert!(*rx.borrow());
+    }
+
+    #[tokio::test]
+    async fn test_session_replace_connection_new_rx_starts_clean() {
+        let router = create_test_router();
+        let session = Session::new(router, identity_factory());
+
+        // First connection
+        let _rx1 = session.cancel_receiver().await;
+
+        // Replace: old connection cancelled, new starts clean
+        let rx2 = session.replace_connection().await;
+        assert!(!*rx2.borrow(), "New receiver should start as not-cancelled");
+    }
+
+    #[tokio::test]
+    async fn test_session_store_reconnect() {
+        let router = create_test_router();
+        let store = SessionStore::new();
+
+        let (session, mut rx1) = store
+            .create(router.with_fresh_session(), identity_factory())
+            .await;
+        let session_id = session.id.clone();
+
+        // Reconnect should cancel the first connection
+        let result = store.reconnect(&session_id).await;
+        assert!(result.is_some());
+        let (_session2, rx2) = result.unwrap();
+
+        // Old receiver should see cancellation
+        rx1.changed().await.unwrap();
+        assert!(*rx1.borrow());
+
+        // New receiver should be clean
+        assert!(!*rx2.borrow());
     }
 }


### PR DESCRIPTION
## Summary

- **WebSocket SEP-1288 compliance**: reject binary frames with close code 1003, parse `mcp.auth.*`/`mcp.version.*` subprotocols, add zombie connection prevention infrastructure
- **Resource/prompt context**: router now passes `RequestContext` to resource and prompt dispatch, enabling middleware on these capability types to access context
- **SEP-1442 stateless mode** (experimental, behind `stateless` feature flag): types for `StatelessRequestMeta`, `StatelessConfig`, `DiscoverResult`; `server/discover` RPC wired into router; allowed before session initialization
- **`McpResponse::Raw(Value)`** variant for extension/experimental method responses

## Test plan

- [x] All 575 lib tests pass
- [x] All 44 integration tests pass
- [x] All 45 doc tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [ ] CI passes
- [ ] Verify WebSocket binary frame rejection with a test client
- [ ] Verify `server/discover` returns capabilities without session

Closes #745, closes #746, closes #747, refs #748, refs #749