### PR TITLE
feat: SEP-1442 stateless HTTP transport

### DIFF
--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -209,6 +209,36 @@ impl StatelessConfig {
 }
 
 // =============================================================================
+// Protocol version validation
+// =============================================================================
+
+/// Validate a protocol version string against supported versions.
+///
+/// Returns `Ok(())` if valid, or a JSON-RPC error with the SEP-1442 error code
+/// and `supportedVersions` data if the version is not supported.
+pub fn validate_protocol_version(
+    version: &str,
+) -> std::result::Result<(), crate::error::JsonRpcError> {
+    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
+
+    if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
+        Ok(())
+    } else {
+        let data = UnsupportedVersionData {
+            supported_versions: SUPPORTED_PROTOCOL_VERSIONS
+                .iter()
+                .map(|v| v.to_string())
+                .collect(),
+        };
+        Err(crate::error::JsonRpcError {
+            code: error_codes::UNSUPPORTED_VERSION,
+            message: format!("Unsupported protocol version: {}", version),
+            data: Some(serde_json::to_value(data).unwrap()),
+        })
+    }
+}
+
+// =============================================================================
 // Helper functions
 // =============================================================================
 

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -738,6 +738,9 @@ struct AppState {
     sampling_enabled: bool,
     /// Whether sessions are optional (for clients that don't track session IDs)
     optional_sessions: bool,
+    /// SEP-1442 stateless mode configuration
+    #[cfg(feature = "stateless")]
+    stateless_config: Option<crate::stateless::StatelessConfig>,
 }
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
@@ -775,6 +778,8 @@ pub struct HttpTransport {
     session_config: SessionConfig,
     sampling_enabled: bool,
     optional_sessions: bool,
+    #[cfg(feature = "stateless")]
+    stateless_config: Option<crate::stateless::StatelessConfig>,
     #[cfg(feature = "oauth")]
     oauth_config: Option<OAuthConfig>,
 }
@@ -794,6 +799,8 @@ impl HttpTransport {
             session_config: SessionConfig::default(),
             sampling_enabled: false,
             optional_sessions: false,
+            #[cfg(feature = "stateless")]
+            stateless_config: None,
             #[cfg(feature = "oauth")]
             oauth_config: None,
         }
@@ -841,6 +848,8 @@ impl HttpTransport {
             session_config: SessionConfig::default(),
             sampling_enabled: false,
             optional_sessions: false,
+            #[cfg(feature = "stateless")]
+            stateless_config: None,
             #[cfg(feature = "oauth")]
             oauth_config: None,
         }
@@ -915,6 +924,41 @@ impl HttpTransport {
     /// ```
     pub fn optional_sessions(mut self) -> Self {
         self.optional_sessions = true;
+        self
+    }
+
+    /// Enable SEP-1442 stateless mode (experimental).
+    ///
+    /// When enabled, requests with an `MCP-Protocol-Version` header (or
+    /// `_meta.protocolVersion` in the body) are processed without requiring a
+    /// session. Each stateless request gets an ephemeral, pre-initialized
+    /// router that is discarded after the response is sent.
+    ///
+    /// This enables horizontal scaling and serverless deployments where
+    /// sessions cannot be maintained across instances.
+    ///
+    /// Stateful clients (those that send `mcp-session-id`) continue to work
+    /// normally alongside stateless clients.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::McpRouter;
+    /// use tower_mcp::transport::http::HttpTransport;
+    /// use tower_mcp::stateless::StatelessConfig;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
+    ///     let transport = HttpTransport::new(router)
+    ///         .stateless(StatelessConfig::new());
+    ///     transport.serve("127.0.0.1:3000").await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(feature = "stateless")]
+    pub fn stateless(mut self, config: crate::stateless::StatelessConfig) -> Self {
+        self.stateless_config = Some(config);
         self
     }
 
@@ -1032,6 +1076,8 @@ impl HttpTransport {
             allowed_origins: self.allowed_origins.clone(),
             sampling_enabled: self.sampling_enabled,
             optional_sessions: self.optional_sessions,
+            #[cfg(feature = "stateless")]
+            stateless_config: self.stateless_config.clone(),
         })
     }
 
@@ -1301,6 +1347,75 @@ async fn handle_post(
 
     // Check if this is an initialize request (creates new session)
     let is_init = is_initialize_request(&parsed);
+
+    // SEP-1442: Handle stateless requests (no session needed).
+    // Stateless requests have a protocol version but no session ID and are not
+    // initialize requests. They are processed with an ephemeral service and
+    // return immediately without storing any session state.
+    #[cfg(feature = "stateless")]
+    if !is_init && state.stateless_config.is_some() && get_session_id(&headers).is_none() {
+        let version_from_header = get_protocol_version(&headers);
+        let params = parsed.get("params").unwrap_or(&parsed);
+        let version_from_meta = crate::stateless::StatelessRequestMeta::from_params(params)
+            .and_then(|m| m.protocol_version);
+
+        if let Some(version) = version_from_header.or(version_from_meta) {
+            if let Err(err) = crate::stateless::validate_protocol_version(&version) {
+                return json_rpc_error_response(None, err);
+            }
+
+            // Notifications and responses don't make sense without a session
+            if parsed.get("id").is_none() || is_response(&parsed) {
+                return StatusCode::ACCEPTED.into_response();
+            }
+
+            let request: JsonRpcRequest = match serde_json::from_value(parsed) {
+                Ok(r) => r,
+                Err(e) => {
+                    return json_rpc_error_response(
+                        None,
+                        JsonRpcError::parse_error(format!("Invalid request: {}", e)),
+                    );
+                }
+            };
+
+            // Ephemeral pre-initialized service -- no session stored
+            let mut service = match &state.service_source {
+                ServiceSource::Router { router, factory } => {
+                    let ephemeral = router.with_fresh_session();
+                    ephemeral.session().mark_initialized();
+                    JsonRpcService::new(factory(ephemeral))
+                }
+                ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
+            };
+
+            #[cfg(feature = "oauth")]
+            {
+                if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
+                    let mut ext = crate::router::Extensions::new();
+                    ext.insert(claims.clone());
+                    service = service.with_extensions(ext);
+                }
+            }
+
+            let response = match service.call_single(request).await {
+                Ok(resp) => resp,
+                Err(e) => {
+                    return json_rpc_error_response(
+                        None,
+                        JsonRpcError::internal_error(e.to_string()),
+                    );
+                }
+            };
+
+            let mut resp = axum::Json(response).into_response();
+            resp.headers_mut().insert(
+                MCP_PROTOCOL_VERSION_HEADER,
+                HeaderValue::from_str(&version).unwrap(),
+            );
+            return resp;
+        }
+    }
 
     // Get or create session
     let session = if is_init {

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2173,3 +2173,308 @@ async fn test_optional_sessions_with_session_id_still_works() {
         "session works"
     );
 }
+
+// =============================================================================
+// SEP-1442 Stateless mode tests
+// =============================================================================
+
+#[cfg(feature = "stateless")]
+mod stateless_tests {
+    use super::*;
+    use tower_mcp::stateless::StatelessConfig;
+
+    /// Start a server with stateless mode enabled.
+    async fn start_stateless_server() -> (String, tokio::task::JoinHandle<()>) {
+        let router = test_router();
+        let transport = HttpTransport::new(router)
+            .disable_origin_validation()
+            .stateless(StatelessConfig::new());
+        let axum_router = transport.into_router();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, axum_router).await.unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        (url, handle)
+    }
+
+    /// tools/list works without initialize or session, just protocol version header.
+    #[tokio::test]
+    async fn test_stateless_tools_list() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-protocol-version", "2025-11-25")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        // Should echo back the protocol version
+        assert_eq!(
+            resp.headers()
+                .get("mcp-protocol-version")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "2025-11-25"
+        );
+        // Should NOT have a session ID
+        assert!(resp.headers().get("mcp-session-id").is_none());
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        let tools = body["result"]["tools"].as_array().unwrap();
+        assert!(tools.len() >= 2, "Should list tools without session");
+    }
+
+    /// tools/call works in stateless mode.
+    #[tokio::test]
+    async fn test_stateless_tools_call() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-protocol-version", "2025-11-25")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "echo",
+                        "arguments": { "message": "stateless!" }
+                    }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(
+            body["result"]["content"][0]["text"].as_str().unwrap(),
+            "stateless!"
+        );
+    }
+
+    /// Unsupported protocol version returns SEP-1442 error code -32000.
+    #[tokio::test]
+    async fn test_stateless_unsupported_version() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-protocol-version", "1999-01-01")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["error"]["code"].as_i64().unwrap(), -32000);
+        assert!(body["error"]["data"]["supportedVersions"].is_array());
+    }
+
+    /// Protocol version in _meta field (body) works as alternative to header.
+    #[tokio::test]
+    async fn test_stateless_version_in_meta() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            // No mcp-protocol-version header!
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {
+                        "_meta": {
+                            "modelcontextprotocol.io/mcpProtocolVersion": "2025-11-25"
+                        }
+                    }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body["result"]["tools"].is_array());
+    }
+
+    /// Stateful clients (with session ID) still work alongside stateless.
+    #[tokio::test]
+    async fn test_stateless_mixed_mode() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        // Stateful: initialize and get session
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let session_id = resp
+            .headers()
+            .get("mcp-session-id")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Send initialized notification
+        client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("mcp-session-id", &session_id)
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized"
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        // Stateful request with session ID
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-session-id", &session_id)
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert!(body["result"]["tools"].is_array());
+
+        // Stateless request on same server (no session ID, protocol version header)
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-protocol-version", "2025-11-25")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "add",
+                        "arguments": { "a": 10, "b": 20 }
+                    }
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        let body: serde_json::Value = resp.json().await.unwrap();
+        assert_eq!(body["result"]["content"][0]["text"].as_str().unwrap(), "30");
+    }
+
+    /// server/discover works without any session or protocol version.
+    #[tokio::test]
+    async fn test_stateless_discover() {
+        let (url, _server) = start_stateless_server().await;
+        let client = reqwest::Client::new();
+
+        // server/discover should work even without protocol version header
+        // (it's allowed before initialization per session.rs)
+        let resp = client
+            .post(&url)
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header("mcp-protocol-version", "2025-11-25")
+            .body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "server/discover",
+                    "params": {}
+                })
+                .to_string(),
+            )
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.unwrap();
+        let result = &body["result"];
+        assert!(result["supportedVersions"].is_array());
+        assert!(result["serverInfo"]["name"].is_string());
+        assert!(result["capabilities"].is_object());
+    }
+}


### PR DESCRIPTION
## Summary

Implement SEP-1442 stateless MCP mode for the HTTP transport, enabling horizontal scaling and serverless deployments.

- Add `stateless` feature flag with `StatelessConfig` for opt-in stateless mode
- Requests with `MCP-Protocol-Version` header (or `_meta.protocolVersion` in params) but no session ID are processed without creating/storing sessions
- Each stateless request gets an ephemeral pre-initialized router, discarded after response
- Protocol version validated per SEP-1442 (error code -32000 with `supportedVersions` data)
- Stateful clients (with `mcp-session-id`) continue working alongside stateless on the same server
- `server/discover` RPC works in stateless mode (from #751)
- `validate_protocol_version()` helper with proper SEP-1442 error formatting

## Usage

```rust
use tower_mcp::stateless::StatelessConfig;

let transport = HttpTransport::new(router)
    .stateless(StatelessConfig::new());
```

Clients can then call tools without initializing:
```
POST /
MCP-Protocol-Version: 2025-11-25
Content-Type: application/json

{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}
```

## Test plan

- [x] 575 lib tests pass
- [x] 55 integration tests pass (including 7 new stateless tests)
- [x] 45 doc tests pass
- [x] clippy clean, fmt clean
- [x] Stateless tools/list without session
- [x] Stateless tools/call without session
- [x] Unsupported version returns -32000 with supportedVersions
- [x] Protocol version via _meta field (body) works
- [x] Mixed mode: stateful + stateless clients on same server
- [x] server/discover in stateless mode
- [ ] CI passes

Closes #748