### PR TITLE
docs: update all top-level docs for v0.9 and example reorganization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,15 +5,9 @@ This repo has MCP servers configured in `.mcp.json` that you can use directly.
 ## Available MCP Servers
 
 ### tower-mcp-example
-Simple demo server with `echo`, `add`, `reverse` tools.
+Simple demo server with `echo`, `add`, `reverse` tools and a `greet` prompt.
 
-Resources: `source://stdio_server.rs` - serves its own source code
-
-### markdownlint-mcp
-Lint markdown files with 66 rules.
-
-Tools: `lint_content`, `lint_file`, `lint_url`, `list_rules`,
-`explain_rule`, `fix_content`
+Resources: `source://getting_started.rs` - serves its own source code
 
 ### weather
 Weather forecasts via NWS API (US only).
@@ -21,27 +15,18 @@ Weather forecasts via NWS API (US only).
 Tools: `get_forecast` (lat/lon), `get_alerts` (state code)
 
 ### codegen-mcp
-MCP server that helps build MCP servers (meta!).
+MCP server that helps build MCP servers.
 
 Tools: `init_project`, `add_tool`, `remove_tool`, `get_project`,
 `generate`, `validate`, `reset`
 
 Resources: `project://Cargo.toml`, `project://src/main.rs`, `project://state.json`
 
-### notes-mcp
-Full-featured MCP server with tools, resources, and prompts.
-
-Tools: note management (create, list, search, delete)
-
-Resources: `notes://` URI scheme for individual notes
-
-Prompts: note summarization and analysis
-
 ## Getting Started
 
-1. Read `examples/README.md` for a guided tour of the examples
-2. That file has intentional markdown errors - try linting and fixing them
-3. Read the `source://stdio_server.rs` resource to see how a server is built
+1. Read `examples/README.md` for an index of all examples
+2. Read the `source://getting_started.rs` resource to see how a server is built
+3. Run any example: `cargo run --example getting_started`
 
 ## Development
 
@@ -51,12 +36,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build commands, PR guidelines, and co
 
 - `crates/tower-mcp/src/` - Main library code
 - `crates/tower-mcp-types/src/` - Protocol types (no runtime deps)
-- `examples/` - Example MCP servers
-  - `markdownlint-mcp/` - Markdown linting server
+- `crates/tower-mcp-macros/src/` - Optional proc macros
+- `examples/` - Example servers and clients (23 standalone `.rs` files)
   - `codegen-mcp/` - MCP server builder (generates tower-mcp code)
-  - `notes-mcp/` - Full-featured note-taking server
   - `conformance-server/` - MCP spec conformance tests (39/39)
-  - `conformance-client/` - MCP spec conformance client (265/265 checks)
-  - `stdio_server.rs` - Minimal example
-  - `http_server.rs` - HTTP transport example
-  - `weather_server.rs` - External API example
+  - `conformance-client/` - MCP conformance client (265/265 checks)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tower-mcp = "0.8"
+tower-mcp = "0.9"
 ```
 
 ### Feature Flags
@@ -107,6 +107,8 @@ tower-mcp = "0.8"
 | `dynamic-tools` | Runtime registration/deregistration of tools, prompts, and resources |
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
+| `resilience` | Re-export tower-resilience circuit breaker, rate limiter, and bulkhead layers |
+| `stateless` | SEP-1442 stateless MCP mode (experimental) -- serve requests without sessions |
 
 Example with features:
 
@@ -124,7 +126,7 @@ any context where you want to serialize/deserialize MCP messages without a runti
 
 ```toml
 [dependencies]
-tower-mcp-types = "0.8"
+tower-mcp-types = "0.9"
 ```
 
 `tower-mcp-types` provides all types from `tower_mcp::protocol` and `tower_mcp::error`
@@ -601,27 +603,32 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](https://github.com/joshrotenberg/tower-mcp/issues?q=label%3Asep). A weekly workflow syncs status from the upstream spec repository.
 
-## Examples and Live Demo
+## Examples
 
 A full-featured MCP server for querying [crates.io](https://crates.io) is available as a standalone project: [cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp). A demo instance is deployed at **https://cratesio-mcp.fly.dev** -- connect with any MCP client that supports HTTP transport.
 
-The repo includes several example servers you can try with any MCP-enabled agent (like Claude Code). Clone the repo and the `.mcp.json` configures them automatically:
+The repo includes 23 focused examples organized by topic:
 
-| Server | Description |
-|--------|-------------|
-| `tower-mcp-example` | Simple demo with `echo`, `add`, `reverse` tools |
-| `markdownlint-mcp` | Lint markdown with 66 rules |
-| `codegen-mcp` | Helps AI agents build tower-mcp servers |
-| `weather` | Weather forecasts via NWS API |
-| `notes-mcp` | Full-featured server with tools, resources, and prompts |
+| Category | Examples |
+|----------|----------|
+| **Getting started** | [`getting_started`](examples/getting_started.rs) -- tools, resources, prompts, stdio transport |
+| **Transports** | [`http_server`](examples/http_server.rs), [`websocket_server`](examples/websocket_server.rs) |
+| **Middleware** | [`middleware`](examples/middleware.rs) (transport, per-tool, per-resource, per-prompt, guards), [`rate_limiting`](examples/rate_limiting.rs), [`capability_filtering`](examples/capability_filtering.rs), [`tool_selection`](examples/tool_selection.rs) |
+| **Authentication** | [`http_auth`](examples/http_auth.rs), [`oauth_client`](examples/oauth_client.rs), [`external_api_auth`](examples/external_api_auth.rs) |
+| **Clients** | [`client_cli`](examples/client_cli.rs), [`http_client`](examples/http_client.rs), [`http_sse_client`](examples/http_sse_client.rs) |
+| **Bidirectional** | [`sampling_server`](examples/sampling_server.rs), [`client_handler`](examples/client_handler.rs) |
+| **Dynamic** | [`dynamic_capabilities`](examples/dynamic_capabilities.rs) -- runtime tool/prompt/resource registration |
+| **Advanced** | [`proxy`](examples/proxy.rs), [`resource_templates`](examples/resource_templates.rs), [`structured_output`](examples/structured_output.rs), [`error_handling`](examples/error_handling.rs), [`testing`](examples/testing.rs) |
+| **Real-world** | [`weather_server`](examples/weather_server.rs) -- external API integration |
+| **Macros** | [`tool_macro`](examples/tool_macro.rs) -- `#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]` |
+
+Clone the repo and the `.mcp.json` configures example servers automatically:
 
 ```bash
 git clone https://github.com/joshrotenberg/tower-mcp
 cd tower-mcp
 # Run your MCP agent here - servers will be available automatically
 ```
-
-For a guided tour, ask your agent to read [`examples/README.md`](examples/README.md).
 
 ## Development
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,84 +1,63 @@
 # Roadmap
 
-This document tracks tower-mcp's path from Tier 3 to Tier 2 (and eventually Tier 1) per the [MCP SDK Tiering System](https://modelcontextprotocol.io/community/sdk-tiers).
-
 ## Current Status
 
-- **Tier**: 3
+- **Version**: 0.9.x
 - **Spec version**: 2025-11-25
-- **Server conformance**: 30/30 (100%)
-- **Client conformance**: Not yet tested (no conformance client)
+- **Server conformance**: 39/39 (100%)
+- **Client conformance**: 265/265 checks, 24/24 scenarios (100%)
+- **MSRV**: 1.90 (Rust 2024 edition)
 
-## Tier 2 Requirements
+## SDK Tier Assessment
 
-| # | Requirement | Status | Tracking |
-|---|-------------|--------|----------|
-| 1 | Server conformance >= 80% | 100% (30/30) | Done |
-| 2 | Client conformance >= 80% | No client yet | #538 |
-| 3 | Issue triage within 1 month | 97% within 2BD | Done |
-| 4 | P0 resolution within 2 weeks | 0 open | Done |
-| 5 | Stable release >= 1.0.0 | 0.7.0 | #539 |
-| 6 | Spec tracking within 6 months | 64-day gap | #540 |
-| 7 | Documentation coverage | Not assessed | #541 |
-| 8 | Dependency update policy | dependabot.yml | Done |
-| 9 | Roadmap | This file | Done |
+tower-mcp targets Tier 2 per the [MCP SDK Tiering System](https://modelcontextprotocol.io/community/sdk-tiers).
 
-## Tier 2 Blockers
+| # | Requirement | Status |
+|---|-------------|--------|
+| 1 | Server conformance >= 80% | 100% (39/39) |
+| 2 | Client conformance >= 80% | 100% (265/265) |
+| 3 | Issue triage within 1 month | Active |
+| 4 | P0 resolution within 2 weeks | 0 open |
+| 5 | Stable release >= 1.0.0 | 0.9.x -- pre-1.0 |
+| 6 | Spec tracking within 6 months | Current (2025-11-25) |
+| 7 | Documentation coverage | In progress |
+| 8 | Dependency update policy | dependabot.yml |
+| 9 | Roadmap | This file |
 
-### Conformance client (#538)
+### Remaining for Tier 2
 
-Build a conformance client binary that exercises all 20 scored client scenarios (4 core + 16 auth). This overlaps with the planned CLI client (#172) and should share infrastructure.
-
-### Stable release (#539)
-
-Resolve before 1.0.0:
-- Workspace layout migration (#526)
-- Public API audit (ensure nothing leaks that shouldn't)
-- Feature flag naming finalized
-- Error type stability review
-
-### Documentation gaps (#541)
-
-The tier assessment evaluates 48 features across tools, resources, prompts, sampling, elicitation, roots, logging, completions, transports, and protocol mechanics. Audit against this list and fill gaps.
+- **1.0.0 release**: Public API audit, feature flag naming finalized, error type stability
+- **Documentation**: Audit against tier assessment feature checklist
 
 ## Spec Tracking
 
-### Accepted SEPs (implemented)
+### Implemented SEPs
 
-tower-mcp tracks the 2025-11-25 spec. All features from accepted SEPs in that version are implemented, including:
-- Streamable HTTP transport
-- WebSocket transport
+All features from the 2025-11-25 spec are implemented, including:
+- Streamable HTTP transport with session management
+- WebSocket transport (SEP-1288 compliant)
 - OAuth 2.1 resource server support (with JWKS)
-- Elicitation (form mode, enum inference, defaults)
-- Tool annotations (readOnlyHint, idempotentHint, etc.)
-- DNS rebinding protection
-- Session management (mcp-session-id)
+- Elicitation (form and URL modes)
+- Tool annotations
+- Async tasks with lifecycle management
+- SSE event IDs and stream resumption (SEP-1699)
+- Sampling (all transports)
+- Completion (autocomplete)
 
-### Draft SEPs (monitoring)
-
-| SEP | Title | Impact | Issue |
-|-----|-------|--------|-------|
-| 2357 | `application/mcp+json` media type | Low | #528 |
-| 2356 | File input support | Medium | #529 |
-| 2339 | Task continuity | Medium | #530 |
-| 2342 | Memory interchange format | Low | #531 |
-| 2350/2351/2352 | OAuth clarifications | Medium | #532 |
-| 2322 | Multi round-trip requests | High | #533 |
-| 2317 | Content negotiation | Low | #534 |
-| 2325 | SSH transport | Low | #535 |
-
-### Existing spec feature tracking
+### In Progress
 
 | SEP | Title | Status | Issue |
 |-----|-------|--------|-------|
-| 1442 | Stateless mode | Draft | #263 |
-| 2127 | Server cards / .well-known | Draft | #155 |
+| 1442 | Stateless MCP mode | Implemented (experimental, `stateless` feature) | #748 |
+| 1288 | WebSocket transport | Implemented (binary rejection, subprotocols, zombie prevention) | #745-#747 |
 
-## Tier 1 Path
+### Monitoring
 
-Tier 1 requirements (beyond Tier 2) are not yet fully published but are expected to include:
-- 95%+ conformance pass rate (server and client)
-- Comprehensive documentation (all 48 features)
-- Published versioning policy (VERSIONING.md)
-- Published security policy (SECURITY.md)
-- Active maintenance with rapid spec tracking
+Open SEPs are tracked automatically via `.github/workflows/sep-sync.yml` and labeled `spec-tracking` in issues.
+
+## Future Directions
+
+- **1.0.0 stable release**: API freeze and stability guarantees
+- **SEP-1442 transport completion**: WebSocket stateless mode, per-request capabilities wiring
+- **SEP-1763 interceptors**: tower middleware maps naturally to this proposal
+- **Distributed session support**: sticky routing documentation, stateless mode as primary solution

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@
 
 | Version | Supported |
 |---------|-----------|
-| 0.7.x   | Yes       |
-| < 0.7   | No        |
+| 0.9.x   | Yes       |
+| < 0.9   | No        |
 
 ## Reporting a Vulnerability
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,206 +1,116 @@
-# tower-mcp Examples Tour
+# tower-mcp Examples
 
+Focused examples demonstrating tower-mcp features. Each file is self-contained
+and covers a specific topic.
 
-Welcome! This guide walks through the example MCP servers in tower-mcp.
+## Running Examples
 
-## Getting Started
+```bash
+# Stdio examples (no feature flags needed)
+cargo run --example getting_started
+cargo run --example middleware
+cargo run --example rate_limiting
 
-Make sure you're in the tower-mcp directory with your MCP-enabled agent
-(like Claude Code). The `.mcp.json` file configures all example servers.
+# HTTP transport
+cargo run --example http_server --features http
 
-#### Wait, Did You Notice?
+# WebSocket transport
+cargo run --example websocket_server --features websocket
 
-This README has some markdown issues! Try asking your agent:
+# Clients (start http_server first)
+cargo run --example http_client --features http-client
+cargo run --example http_sse_client --features http
 
-> "Lint examples/README.md for markdown issues"
+# Dynamic capabilities
+cargo run --example dynamic_capabilities --features dynamic-tools
 
-The markdownlint-mcp server will find them. Then try:
+# Testing
+cargo run --example testing --features testing
 
-> "Fix the markdown issues in examples/README.md"
-
-## Interactive MCP Servers
-
-These servers are configured in `.mcp.json` and available to MCP agents
-automatically.
-
-### 1. markdownlint-mcp
-
-Lint markdown files with 66 rules from mdbook-lint. Demonstrates tools
-with different input types and auto-fix capabilities.
-
-**Try these:**
-
-- "Lint this file: examples/README.md"
-- "What does rule MD001 check for?"
-- "List all available markdown lint rules"
-
-**Source:** `examples/markdownlint-mcp/`
-
-### 3. weather
-
-Weather forecasts using the National Weather Service API. A simple
-example showing external API integration.
-
-**Try these:**
-
-- "What's the weather forecast for Seattle?"
-- "Are there any weather alerts in California?"
-- "Get the forecast for coordinates 40.7128, -74.0060"
-
-**Source:** `examples/weather_server.rs`
-
-### 3. tower-mcp-example
-
-The simplest possible MCP server - echo, add, and reverse tools. Good
-starting point for understanding the basics. This server is
-self-documenting: it serves its own source code as a resource!
-
-**Try these:**
-
-- "Echo 'Hello World' using tower-mcp-example"
-- "Reverse the string 'tower-mcp'"
-- "Read the source://stdio_server.rs resource from tower-mcp-example"
-
-**Source:** `examples/stdio_server.rs`
-
-### 4. codegen-mcp
-
-An MCP server that helps you build MCP servers. Define your server
-incrementally through tool calls, then generate complete Rust code.
-
-**Try these (tools):**
-
-- "Initialize a project called my-server with stdio transport"
-- "Add an echo tool that takes a message string"
-- "Remove the echo tool"
-- "Validate that the generated code compiles"
-- "Generate the code for my server"
-
-**Try these (resources):**
-
-- "Read project://Cargo.toml from codegen-mcp"
-- "Read project://src/main.rs from codegen-mcp"
-- "Read project://state.json from codegen-mcp"
-
-**Source:** `examples/codegen-mcp/`
-
-## Standalone Examples
-
-These demonstrate specific features. Run them individually with `cargo run`.
-
-| Example | Feature | Run |
-|---------|---------|-----|
-| `basic` | Core `JsonRpcService` without transport | `cargo run --example basic` |
-| `http_server` | HTTP/SSE transport, progress, resources, prompts | `cargo run --example http_server --features http` |
-| `websocket_server` | WebSocket transport with middleware | `cargo run --example websocket_server --features websocket` |
-| `transport_middleware` | Tower middleware on HTTP and stdio transports | `cargo run --example transport_middleware --features http -- --transport http` |
-| `http_auth` | API key and OAuth/JWT authentication | `cargo run --example http_auth --features oauth -- --auth apikey` |
-| `tool_middleware` | Per-tool timeout and concurrency limits | `cargo run --example tool_middleware` |
-| `middleware_showcase` | Config validation via shared guards and middleware | `cargo run --example middleware_showcase` |
-| `tool_selection` | Multi-layered tool filtering for large servers | `cargo run --example tool_selection` |
-| `capability_filtering` | Session-based tool/resource/prompt visibility | `cargo run --example capability_filtering --features http` |
-| `dynamic_tools` | Runtime tool registration/deregistration | `cargo run --example dynamic_tools --features dynamic-tools` |
-| `external_api_auth` | Four patterns for downstream API authentication | `cargo run --example external_api_auth` |
-| `testing` | In-process testing with `TestClient` | `cargo run --example testing --features testing` |
-| `client_cli` | MCP client connecting to a subprocess server | `cargo run --example client_cli` |
-| `http_sse_client` | HTTP SSE client with stream resumption | `cargo run --example http_sse_client --features http` |
-| `conformance-server` | Full MCP conformance server (39/39 tests) | `cargo run -p conformance-server` |
-
-## How It's Built
-
-Ask your agent to read the `source://stdio_server.rs` resource from
-tower-mcp-example. You'll see the complete server in ~90 lines.
-
-Here's the key pattern - defining a tool:
-
-```rust
-let echo = ToolBuilder::new("echo")
-    .description("Echo a message back")
-    .handler(|input: EchoInput| async move {
-        Ok(CallToolResult::text(input.message))
-    })
-    .build();
+# Macros
+cargo run --example tool_macro --features macros
 ```
 
-And the input type with automatic JSON Schema generation:
+## Example Index
 
-```rust
-#[derive(Debug, Deserialize, JsonSchema)]
-struct EchoInput {
-    /// The message to echo back  <-- becomes the schema description
-    message: String,
-}
-```
+### Getting Started
 
-That's the core pattern. For more complex examples:
+| Example | What it shows |
+|---------|---------------|
+| [getting_started](getting_started.rs) | Tools, resources, prompts, and stdio transport |
 
-- **In-process testing**: `examples/testing.rs` - test servers with `TestClient`
-- **Shared state**: `examples/markdownlint-mcp/src/tools.rs` - tools
-  sharing a lint engine via `Arc<LintState>`
-- **External APIs**: `examples/weather_server.rs` - calling the NWS API
-- **Full application**: See [cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp) for a complete MCP server with tools, resources, and prompts
+### Transports
 
-## What You Just Explored
+| Example | What it shows |
+|---------|---------------|
+| [http_server](http_server.rs) | HTTP/SSE transport with sessions, progress, resources |
+| [websocket_server](websocket_server.rs) | WebSocket transport with sampling support |
 
-If you linted and fixed this README, you've seen:
+### Middleware
 
-1. **Tool discovery** - Your agent found the markdownlint-mcp tools
-2. **Tool execution** - lint_file analyzed this document
-3. **Structured output** - Violations returned as JSON
-4. **Auto-fix** - fix_content corrected the issues
+| Example | What it shows |
+|---------|---------------|
+| [middleware](middleware.rs) | All four levels: transport, per-tool, per-resource, per-prompt, and guards |
+| [rate_limiting](rate_limiting.rs) | Per-tool rate limiting with tower-resilience |
+| [capability_filtering](capability_filtering.rs) | Session-based tool/resource/prompt visibility |
+| [tool_selection](tool_selection.rs) | Tool groups, safety tiers, allow/deny lists |
 
-The intentional errors were:
+### Authentication
 
-- Extra blank lines after the title (MD012)
-- Skipped heading level - jumped from h2 to h4 (MD001)
-- Extra space before a list item (MD030)
+| Example | What it shows |
+|---------|---------------|
+| [http_auth](http_auth.rs) | API key and OAuth/JWT server-side auth |
+| [oauth_client](oauth_client.rs) | Client-side OAuth token acquisition |
+| [external_api_auth](external_api_auth.rs) | Downstream API authentication patterns |
 
-## Build Your Own
+### Clients
 
-Now that you've seen what's possible, want to build your own MCP server?
+| Example | What it shows |
+|---------|---------------|
+| [client_cli](client_cli.rs) | Stdio client connecting to subprocess servers |
+| [http_client](http_client.rs) | HTTP client with McpClient API |
+| [http_sse_client](http_sse_client.rs) | SSE stream resumption (Last-Event-ID) |
 
-The codegen-mcp server can help. Here's the workflow:
+### Bidirectional Communication
 
-1. **Design your server** - Tell codegen-mcp what you want:
-   - "Initialize a project called my-server"
-   - "Add a tool that does X with inputs Y and Z"
-   - "Validate the generated code compiles"
+| Example | What it shows |
+|---------|---------------|
+| [sampling_server](sampling_server.rs) | Server-to-client LLM requests and elicitation |
+| [client_handler](client_handler.rs) | Client-side sampling and notification handling |
 
-2. **Generate and iterate** - Get complete Rust code:
-   - "Generate the code for my server"
-   - Write it to disk, customize the handlers, run it
+### Dynamic Capabilities
 
-### Ideas to Get Started
+| Example | What it shows |
+|---------|---------------|
+| [dynamic_capabilities](dynamic_capabilities.rs) | Runtime tool/prompt/resource registration |
 
-Ask your agent to help you build:
+### Advanced Patterns
 
-- **A Hacker News server** - The [HN API](https://github.com/HackerNews/API)
-  is perfect for learning: no auth required, simple JSON responses, and
-  lots of tool ideas (top stories, new stories, get item, get user, etc.)
-- **A Git MCP server** - Wrap git commands (status, diff, log, blame)
-- **A Docker MCP server** - Container and image management
-- **A database MCP server** - Query SQLite, PostgreSQL, or Redis
-- **A file search server** - Ripgrep or fd wrapper
-- **An API client** - Wrap any REST API you use frequently
+| Example | What it shows |
+|---------|---------------|
+| [proxy](proxy.rs) | Multi-server aggregation with namespace isolation |
+| [resource_templates](resource_templates.rs) | URI template matching (RFC 6570) |
+| [structured_output](structured_output.rs) | Typed JSON output with schemas |
+| [error_handling](error_handling.rs) | Tool error patterns and propagation |
+| [testing](testing.rs) | In-process testing with TestClient |
+| [weather_server](weather_server.rs) | External API integration (NWS) |
 
-Or tell your agent what problem you're trying to solve and let it
-suggest what tools your server should have.
+### Macros
 
-### Example Session
+| Example | What it shows |
+|---------|---------------|
+| [tool_macro](tool_macro.rs) | `#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]` proc macros |
 
-```text
-You: "I want to build an MCP server that searches my notes"
+## Workspace Examples
 
-Agent: [uses codegen-mcp to design tools: index_directory, search, get_document]
-Agent: [generates and validates the code]
-Agent: "Here's your server. The search tool uses tantivy for full-text
-        search. Want me to write this to examples/notes-mcp/?"
-```
+These are standalone crates in the workspace:
 
-The codegen-mcp server lets you go from idea to working server quickly.
+| Crate | Purpose |
+|-------|---------|
+| [conformance-server](conformance-server/) | MCP conformance test suite server (39/39) |
+| [conformance-client](conformance-client/) | MCP conformance test suite client (265/265) |
+| [codegen-mcp](codegen-mcp/) | MCP server that helps build MCP servers |
 
-## Learn More
+## Full Application
 
-- Browse the source code in `examples/` to see how each server is built
-- Check the main [README](../README.md) for API documentation
-- Read the generated code from codegen-mcp to understand the patterns
+For a complete production MCP server, see [cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp).


### PR DESCRIPTION
## Summary

Full audit and update of all top-level documentation after the example consolidation (#755), SEP-1442 (#753), and WebSocket compliance (#751).

### README.md
- Version numbers: 0.8 -> 0.9
- Feature flags table: add `stateless` and `resilience`
- Examples section: organized table by category matching current files
- Remove references to deleted examples

### examples/README.md
- Complete rewrite: clean index tables with run commands
- Workspace examples section (conformance-server/client, codegen-mcp)

### AGENTS.md
- Remove markdownlint-mcp and notes-mcp entries
- Update resource reference from stdio_server.rs to getting_started.rs
- Update project structure

### ROADMAP.md
- Full rewrite: was referencing v0.7, 30/30 conformance, "no client yet"
- Now reflects v0.9.x, 39/39 + 265/265 conformance, implemented SEPs, current tier status

### SECURITY.md
- Bump supported version from 0.7.x to 0.9.x

### No changes needed
- CONTRIBUTING.md -- still accurate
- VERSIONING.md -- still accurate
- CHANGELOG.md -- auto-generated by release-plz

## Test plan
- [x] All examples build
- [ ] CI passes

Refs #725, #754