### PR TITLE
docs: fix remaining 0.8 version reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Example with features:
 
 ```toml
 [dependencies]
-tower-mcp = { version = "0.8", features = ["full"] }
+tower-mcp = { version = "0.9", features = ["full"] }
 ```
 
 ### Types Only


### PR DESCRIPTION
One  reference survived the v0.9 docs update. Fixes the features example in the Installation section.