### PR TITLE
feat!: default to optional sessions for HTTP transport

### DIFF
--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -78,18 +78,21 @@
 //! | -32005  | SessionNotFound| Session expired or server restarted      |
 //! | -32006  | SessionRequired| MCP-Session-Id header missing            |
 //!
-//! ## Optional Sessions
+//! ## Session Handling
 //!
-//! Some MCP clients (Codex CLI, Cursor, etc.) don't carry the `mcp-session-id`
-//! header forward after initialization. Use [`HttpTransport::optional_sessions()`]
-//! to allow requests without a session ID:
+//! By default, sessions are optional: requests without an `mcp-session-id`
+//! header are allowed and receive a transient, pre-initialized session. This
+//! ensures compatibility with clients (Codex CLI, Cursor, etc.) that don't
+//! carry the session ID forward after initialization.
+//!
+//! Clients that do send session IDs continue to work normally.
+//!
+//! To require strict session management (reject requests without a session ID),
+//! use [`HttpTransport::require_sessions()`]:
 //!
 //! ```rust,ignore
-//! let transport = HttpTransport::new(router).optional_sessions();
+//! let transport = HttpTransport::new(router).require_sessions();
 //! ```
-//!
-//! When enabled, requests without a session ID get a transient, pre-initialized
-//! session. Clients that do send session IDs continue to work normally.
 //!
 //! ## CORS Support
 //!
@@ -798,7 +801,7 @@ impl HttpTransport {
             allowed_origins: vec![],
             session_config: SessionConfig::default(),
             sampling_enabled: false,
-            optional_sessions: false,
+            optional_sessions: true,
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -847,7 +850,7 @@ impl HttpTransport {
             allowed_origins: vec![],
             session_config: SessionConfig::default(),
             sampling_enabled: false,
-            optional_sessions: false,
+            optional_sessions: true,
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -896,17 +899,16 @@ impl HttpTransport {
         self
     }
 
-    /// Make sessions optional for compatibility with clients that don't track session IDs.
+    /// Require strict session management.
     ///
-    /// When enabled, requests without an `mcp-session-id` header are allowed.
-    /// The server creates a transient, pre-initialized session for each such request,
-    /// bypassing the normal `initialize` handshake requirement.
+    /// When enabled, requests without an `mcp-session-id` header are rejected
+    /// with a `SessionRequired` error (-32006). Clients must complete the
+    /// `initialize` handshake and include the session ID on all subsequent
+    /// requests, as specified by the MCP 2025-11-25 spec.
     ///
-    /// This is useful for clients like Codex CLI, Cursor, and others that perform
-    /// `initialize` + `tools/list` during setup but don't carry the session ID
-    /// forward to subsequent `tools/call` requests.
-    ///
-    /// Clients that do send session IDs continue to work normally.
+    /// By default, sessions are optional for compatibility with clients
+    /// (Codex CLI, Cursor, etc.) that don't carry the session ID forward
+    /// after initialization.
     ///
     /// # Example
     ///
@@ -917,13 +919,13 @@ impl HttpTransport {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
-    ///     let transport = HttpTransport::new(router).optional_sessions();
+    ///     let transport = HttpTransport::new(router).require_sessions();
     ///     transport.serve("127.0.0.1:3000").await?;
     ///     Ok(())
     /// }
     /// ```
-    pub fn optional_sessions(mut self) -> Self {
-        self.optional_sessions = true;
+    pub fn require_sessions(mut self) -> Self {
+        self.optional_sessions = false;
         self
     }
 
@@ -2054,7 +2056,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_without_session_fails() {
-        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .require_sessions();
         let app = transport.into_router();
 
         let request = Request::builder()
@@ -2618,7 +2622,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_request_without_session_id_rejected() {
-        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .require_sessions();
         let app = transport.into_router();
 
         let request = Request::builder()

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -1858,15 +1858,33 @@ async fn test_http_client_session_expiry_error() {
 }
 
 // ---------------------------------------------------------------------------
-// Optional sessions (#742) -- Codex CLI / Cursor compatibility
+// Session handling -- optional by default, strict via require_sessions()
 // ---------------------------------------------------------------------------
 
-/// Start a server with optional_sessions enabled.
-async fn start_optional_sessions_server() -> (String, tokio::task::JoinHandle<()>) {
+/// Start a server with require_sessions() for strict session enforcement.
+async fn start_required_sessions_server() -> (String, tokio::task::JoinHandle<()>) {
     let router = test_router();
     let transport = HttpTransport::new(router)
         .disable_origin_validation()
-        .optional_sessions();
+        .require_sessions();
+    let axum_router = transport.into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, axum_router).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (url, handle)
+}
+
+/// Start a server with optional sessions (the default).
+async fn start_optional_sessions_server() -> (String, tokio::task::JoinHandle<()>) {
+    let router = test_router();
+    let transport = HttpTransport::new(router).disable_origin_validation();
     let axum_router = transport.into_router();
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -2051,10 +2069,10 @@ async fn test_optional_sessions_multiple_stateless_calls() {
     }
 }
 
-/// Without optional_sessions, missing session ID should still be rejected.
+/// With require_sessions(), missing session ID should be rejected.
 #[tokio::test]
 async fn test_sessions_required_rejects_without_session_id() {
-    let (url, _server) = start_server().await; // Uses default (sessions required)
+    let (url, _server) = start_required_sessions_server().await;
     let client = reqwest::Client::new();
 
     let resp = client


### PR DESCRIPTION
## Summary

- Sessions are now optional by default in `HttpTransport`, creating transient pre-initialized sessions for requests without an `mcp-session-id` header
- Replaces `optional_sessions()` with `require_sessions()` for strict spec-compliant enforcement
- Ensures out-of-the-box compatibility with clients that don't forward the session ID after initialization (Codex CLI, Cursor, older rmcp versions)

## Context

Filed as part of investigating Codex CLI / Cursor HTTP MCP failures. The root cause appears to be Codex's pinned `rmcp = "0.15.0"` dependency which may not correctly forward `mcp-session-id` after initialization ([openai/codex#15815](https://github.com/openai/codex/issues/15815)). The previous `optional_sessions()` was a server-side workaround; this PR makes it the default so tower-mcp servers work out of the box with any client.

Verified with rmcp 1.2 (passes with both optional and strict sessions) and against live cratesio-mcp deployment.

## Breaking change

`HttpTransport` now defaults to optional sessions. Callers that relied on strict session enforcement must add `.require_sessions()`.

## Test plan

- [x] Existing `optional_sessions` tests pass (now testing the default behavior)
- [x] New `start_required_sessions_server` helper + test verifies strict mode still works
- [x] `cargo test --lib --all-features -p tower-mcp` (596 passed)
- [x] `cargo test --test '*' --all-features -p tower-mcp` (44 passed)
- [x] `cargo clippy --all-targets --all-features -p tower-mcp -- -D warnings` clean
- [x] `cargo test --doc --all-features -p tower-mcp` clean