### PR TITLE
feat: HTTP client session expiry detection and automatic recovery

### DIFF
--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -298,6 +298,14 @@ pub enum Error {
     #[error("Transport error: {0}")]
     Transport(String),
 
+    /// The server indicated the session has expired or is not found.
+    ///
+    /// This corresponds to JSON-RPC error code `-32005` (SessionNotFound)
+    /// or an HTTP 404 response when a session ID was attached.
+    /// Clients should re-initialize the connection.
+    #[error("Session expired")]
+    SessionExpired,
+
     #[error("Internal error: {0}")]
     Internal(String),
 }

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -92,6 +92,11 @@ pub struct HttpClientConfig {
     /// Maximum SSE reconnection attempts before giving up.
     /// Default: 5.
     pub max_sse_reconnect_attempts: u32,
+    /// Whether to support automatic session recovery on expiry.
+    /// When enabled, HTTP 404 responses (with a session ID attached) and
+    /// JSON-RPC -32005 errors trigger re-initialization.
+    /// Default: `true`.
+    pub session_recovery: bool,
 }
 
 impl Default for HttpClientConfig {
@@ -104,6 +109,7 @@ impl Default for HttpClientConfig {
             sse_reconnect: true,
             sse_reconnect_delay: Duration::from_secs(1),
             max_sse_reconnect_attempts: 5,
+            session_recovery: true,
         }
     }
 }
@@ -398,6 +404,17 @@ impl HttpClientTransport {
         self
     }
 
+    /// Disable automatic session recovery.
+    ///
+    /// By default, if the server returns a session expired error (HTTP 404
+    /// with session ID or JSON-RPC -32005), the client will automatically
+    /// re-initialize and retry the failed operation. Call this to disable
+    /// that behavior and surface the error to the caller instead.
+    pub fn disable_session_recovery(mut self) -> Self {
+        self.config.session_recovery = false;
+        self
+    }
+
     /// Set a dynamic token provider for authentication.
     ///
     /// The provider's [`TokenProvider::get_token()`] is called before each
@@ -536,6 +553,19 @@ impl ClientTransport for HttpClientTransport {
 
                 if !status.is_success() {
                     let body = response.text().await.unwrap_or_default();
+
+                    // Try to parse the error body as JSON-RPC and forward it
+                    // so the message loop can detect -32005 (SessionNotFound)
+                    // and trigger session recovery.
+                    if !body.is_empty()
+                        && serde_json::from_str::<serde_json::Value>(&body)
+                            .ok()
+                            .is_some_and(|v| v.get("error").is_some())
+                    {
+                        let _ = tx.send(body).await;
+                        return;
+                    }
+
                     tracing::error!(status = %status, body = %body, "HTTP error from server");
                     connected.store(false, Ordering::Release);
                     return;
@@ -642,6 +672,9 @@ impl ClientTransport for HttpClientTransport {
         }
 
         if !status.is_success() {
+            if status == reqwest::StatusCode::NOT_FOUND && self.config.session_recovery {
+                return Err(Error::SessionExpired);
+            }
             let body = response.text().await.unwrap_or_default();
             return Err(Error::Transport(format!(
                 "HTTP {} from server: {}",
@@ -725,6 +758,28 @@ impl ClientTransport for HttpClientTransport {
 
         self.session_id = None;
         Ok(())
+    }
+
+    async fn reset_session(&mut self) {
+        tracing::info!("Resetting session for re-initialization");
+
+        // Abort SSE task
+        if let Some(task) = self.sse_task.take() {
+            task.abort();
+        }
+
+        // Clear session state but keep the transport alive
+        self.session_id = None;
+        self.protocol_version = None;
+        *self.last_event_id.write().await = None;
+        *self.sse_retry_delay.write().await = None;
+
+        // Drain any stale messages from the channel
+        while self.incoming_rx.try_recv().is_ok() {}
+    }
+
+    fn supports_session_recovery(&self) -> bool {
+        self.config.session_recovery
     }
 }
 

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -51,10 +51,10 @@ pub use stdio::StdioClientTransport;
 pub use transport::ClientTransport;
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
-use std::sync::{Arc, OnceLock};
 
-use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 use crate::error::{Error, Result};
@@ -83,6 +83,8 @@ enum LoopCommand {
         method: String,
         params: serde_json::Value,
     },
+    /// Reset the transport's session state for re-initialization.
+    ResetSession { done_tx: oneshot::Sender<()> },
     /// Graceful shutdown.
     Shutdown,
 }
@@ -124,13 +126,19 @@ pub struct McpClient {
     /// Whether `initialize()` has been called successfully.
     initialized: AtomicBool,
     /// Server info (set after successful initialization).
-    server_info: OnceLock<InitializeResult>,
+    server_info: RwLock<Option<InitializeResult>>,
     /// Client capabilities declared during initialization.
     capabilities: ClientCapabilities,
     /// Current roots (shared with the loop for roots/list responses).
     roots: Arc<RwLock<Vec<Root>>>,
     /// Whether the transport is still connected.
     connected: Arc<AtomicBool>,
+    /// Whether the transport supports session recovery.
+    supports_session_recovery: bool,
+    /// Stored init params for session recovery re-initialization.
+    init_params: RwLock<Option<(String, String)>>,
+    /// Lock to prevent concurrent session recovery attempts.
+    recovery_lock: Mutex<()>,
 }
 
 /// Builder for configuring and connecting an [`McpClient`].
@@ -263,6 +271,7 @@ impl McpClient {
         T: ClientTransport,
         H: ClientHandler,
     {
+        let supports_session_recovery = transport.supports_session_recovery();
         let (command_tx, command_rx) = mpsc::channel::<LoopCommand>(64);
         let connected = Arc::new(AtomicBool::new(true));
         let roots = Arc::new(RwLock::new(roots));
@@ -278,10 +287,13 @@ impl McpClient {
             command_tx,
             task: Some(task),
             initialized: AtomicBool::new(false),
-            server_info: OnceLock::new(),
+            server_info: RwLock::new(None),
             capabilities,
             roots,
             connected,
+            supports_session_recovery,
+            init_params: RwLock::new(None),
+            recovery_lock: Mutex::new(()),
         })
     }
 
@@ -296,8 +308,17 @@ impl McpClient {
     }
 
     /// Get the server info (available after initialization).
-    pub fn server_info(&self) -> Option<&InitializeResult> {
-        self.server_info.get()
+    pub async fn server_info(&self) -> Option<InitializeResult> {
+        self.server_info.read().await.clone()
+    }
+
+    /// Get the server info synchronously (best-effort, non-blocking).
+    ///
+    /// Returns `None` if the lock is currently held by a writer or if
+    /// initialization hasn't completed. Prefer [`server_info()`](Self::server_info)
+    /// in async contexts.
+    pub fn server_info_blocking(&self) -> Option<InitializeResult> {
+        self.server_info.try_read().ok()?.clone()
     }
 
     /// Initialize the MCP connection.
@@ -308,7 +329,7 @@ impl McpClient {
         &self,
         client_name: &str,
         client_version: &str,
-    ) -> Result<&InitializeResult> {
+    ) -> Result<InitializeResult> {
         let params = InitializeParams {
             protocol_version: crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
             capabilities: self.capabilities.clone(),
@@ -321,14 +342,18 @@ impl McpClient {
         };
 
         let result: InitializeResult = self.send_request("initialize", &params).await?;
-        let _ = self.server_info.set(result);
+        *self.server_info.write().await = Some(result.clone());
+
+        // Store init params for potential session recovery
+        *self.init_params.write().await =
+            Some((client_name.to_string(), client_version.to_string()));
 
         // Send initialized notification
         self.send_notification("notifications/initialized", &serde_json::json!({}))
             .await?;
         self.initialized.store(true, Ordering::Release);
 
-        Ok(self.server_info.get().unwrap())
+        Ok(result)
     }
 
     /// List available tools.
@@ -673,6 +698,23 @@ impl McpClient {
         method: &str,
         params: &P,
     ) -> Result<R> {
+        match self.send_request_once(method, params).await {
+            Err(Error::SessionExpired)
+                if self.supports_session_recovery && method != "initialize" =>
+            {
+                tracing::info!(method = %method, "Session expired, attempting recovery");
+                self.recover_session().await?;
+                self.send_request_once(method, params).await
+            }
+            other => other,
+        }
+    }
+
+    async fn send_request_once<P: serde::Serialize, R: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        params: &P,
+    ) -> Result<R> {
         self.ensure_connected()?;
         let params_value = serde_json::to_value(params)
             .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
@@ -693,6 +735,60 @@ impl McpClient {
 
         serde_json::from_value(result)
             .map_err(|e| Error::Transport(format!("Failed to deserialize response: {}", e)))
+    }
+
+    /// Recover from a session expiry by resetting the transport and re-initializing.
+    async fn recover_session(&self) -> Result<()> {
+        // Serialize recovery attempts
+        let _guard = self.recovery_lock.lock().await;
+
+        // Check if another task already recovered while we waited
+        // (the init_params being present means we were initialized before)
+        let init_params = self.init_params.read().await.clone();
+        let (client_name, client_version) = match init_params {
+            Some(params) => params,
+            None => {
+                return Err(Error::Transport(
+                    "Cannot recover: never initialized".to_string(),
+                ));
+            }
+        };
+
+        // Tell the message loop to reset the transport
+        let (done_tx, done_rx) = oneshot::channel();
+        self.command_tx
+            .send(LoopCommand::ResetSession { done_tx })
+            .await
+            .map_err(|_| Error::Transport("Connection closed".to_string()))?;
+        done_rx
+            .await
+            .map_err(|_| Error::Transport("Connection closed during recovery".to_string()))?;
+
+        // Clear initialized state
+        self.initialized.store(false, Ordering::Release);
+        *self.server_info.write().await = None;
+
+        // Re-initialize (using send_request_once to avoid recursion)
+        tracing::info!("Re-initializing session after expiry");
+        let params = InitializeParams {
+            protocol_version: crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
+            capabilities: self.capabilities.clone(),
+            client_info: Implementation {
+                name: client_name,
+                version: client_version,
+                ..Default::default()
+            },
+            meta: None,
+        };
+
+        let result: InitializeResult = self.send_request_once("initialize", &params).await?;
+        *self.server_info.write().await = Some(result);
+
+        self.send_notification("notifications/initialized", &serde_json::json!({}))
+            .await?;
+        self.initialized.store(true, Ordering::Release);
+
+        Ok(())
     }
 
     async fn send_notification<P: serde::Serialize>(&self, method: &str, params: &P) -> Result<()> {
@@ -792,6 +888,15 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
                             let _ = transport.send(&json).await;
                         }
                     }
+                    Some(LoopCommand::ResetSession { done_tx }) => {
+                        tracing::info!("Resetting transport session for re-initialization");
+                        transport.reset_session().await;
+                        // Fail any pending requests with session expired
+                        for (_, pending) in pending_requests.drain() {
+                            let _ = pending.response_tx.send(Err(Error::SessionExpired));
+                        }
+                        let _ = done_tx.send(());
+                    }
                     Some(LoopCommand::Shutdown) | None => {
                         tracing::debug!("Message loop shutting down");
                         break;
@@ -850,6 +955,22 @@ async fn handle_incoming<T: ClientTransport, H: ClientHandler>(
     if parsed.get("method").is_none()
         && (parsed.get("result").is_some() || parsed.get("error").is_some())
     {
+        // Check for session-level errors (id: null with -32005) that affect
+        // all pending requests, not just a specific one.
+        if let Some(error) = parsed.get("error") {
+            let code = error.get("code").and_then(|c| c.as_i64()).unwrap_or(0) as i32;
+            let id_missing_or_null = parsed.get("id").is_none_or(|id| id.is_null());
+            if code == -32005 && id_missing_or_null {
+                tracing::warn!(
+                    "Session expired (-32005 with null id), failing all pending requests"
+                );
+                for (_, pending) in pending_requests.drain() {
+                    let _ = pending.response_tx.send(Err(Error::SessionExpired));
+                }
+                return;
+            }
+        }
+
         handle_response(&parsed, pending_requests);
         return;
     }
@@ -933,6 +1054,13 @@ fn handle_response(
             .unwrap_or("Unknown error")
             .to_string();
         let data = error.get("data").cloned();
+
+        // -32005 = SessionNotFound: signal session expiry for recovery
+        if code == -32005 {
+            let _ = pending.response_tx.send(Err(Error::SessionExpired));
+            return;
+        }
+
         let json_rpc_error = JsonRpcError {
             code,
             message,
@@ -1205,7 +1333,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(client.is_initialized());
 
-        let server_info = client.server_info().unwrap();
+        let server_info = client.server_info().await.unwrap();
         assert_eq!(server_info.server_info.name, "test-server");
     }
 

--- a/crates/tower-mcp/src/client/transport.rs
+++ b/crates/tower-mcp/src/client/transport.rs
@@ -65,4 +65,24 @@ pub trait ClientTransport: Send + 'static {
     ///
     /// After calling this, `recv()` should return `Ok(None)`.
     async fn close(&mut self) -> Result<()>;
+
+    /// Reset the transport's session state for re-initialization.
+    ///
+    /// Called when the server indicates the session has expired. The
+    /// transport should clear its session ID, stop any SSE streams,
+    /// and prepare for a new `initialize` handshake.
+    ///
+    /// The default implementation is a no-op (for transports like stdio
+    /// that don't have sessions).
+    async fn reset_session(&mut self) {}
+
+    /// Whether this transport supports automatic session recovery.
+    ///
+    /// When true, the client will attempt to re-initialize and retry
+    /// failed operations when the server returns a session expired error.
+    ///
+    /// Default: `false`.
+    fn supports_session_recovery(&self) -> bool {
+        false
+    }
 }

--- a/crates/tower-mcp/src/proxy/backend.rs
+++ b/crates/tower-mcp/src/proxy/backend.rs
@@ -92,7 +92,7 @@ impl Backend {
     /// Create a backend from an already-connected client (no notification forwarding).
     pub fn from_client(namespace: impl Into<String>, client: McpClient, separator: String) -> Self {
         let instructions = client
-            .server_info()
+            .server_info_blocking()
             .and_then(|info| info.instructions.clone());
         Self {
             namespace: namespace.into(),

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2496,3 +2496,79 @@ mod stateless_tests {
         assert!(result["capabilities"].is_object());
     }
 }
+
+// ---------------------------------------------------------------------------
+// Session recovery (#762) -- automatic re-initialization on session expiry
+// ---------------------------------------------------------------------------
+
+/// Start a server that returns a handle for session management.
+async fn start_server_with_handle() -> (
+    String,
+    tower_mcp::transport::http::SessionHandle,
+    tokio::task::JoinHandle<()>,
+) {
+    let router = test_router();
+    let transport = HttpTransport::new(router).disable_origin_validation();
+    let (axum_router, handle) = transport.into_router_with_handle();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("http://127.0.0.1:{}", addr.port());
+
+    let server = tokio::spawn(async move {
+        axum::serve(listener, axum_router).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (url, handle, server)
+}
+
+/// Verify that the client automatically recovers from session expiry.
+#[tokio::test]
+async fn test_session_recovery_after_expiry() {
+    let (url, handle, _server) = start_server_with_handle().await;
+
+    let transport = HttpClientTransport::new(&url);
+    let client = McpClient::connect(transport).await.unwrap();
+    let init_result = client.initialize("test-recovery", "1.0.0").await.unwrap();
+    assert_eq!(init_result.server_info.name, "test-http-server");
+
+    // Verify tools work
+    let tools = client.list_tools().await.unwrap();
+    assert_eq!(tools.tools.len(), 2);
+
+    // Terminate the session to simulate expiry
+    let sessions = handle.list_sessions().await;
+    assert_eq!(sessions.len(), 1);
+    let terminated = handle.terminate_session(&sessions[0].id).await;
+    assert!(terminated, "Session should have been terminated");
+
+    // The next request should fail with session expired, but auto-recover
+    let tools = client.list_tools().await.unwrap();
+    assert_eq!(tools.tools.len(), 2, "Should recover and list tools again");
+
+    // Verify a new session was created
+    let sessions = handle.list_sessions().await;
+    assert_eq!(sessions.len(), 1, "Should have exactly one new session");
+}
+
+/// Verify that session recovery is disabled when configured.
+#[tokio::test]
+async fn test_session_recovery_disabled() {
+    let (url, handle, _server) = start_server_with_handle().await;
+
+    let transport = HttpClientTransport::new(&url).disable_session_recovery();
+    let client = McpClient::connect(transport).await.unwrap();
+    client
+        .initialize("test-no-recovery", "1.0.0")
+        .await
+        .unwrap();
+
+    // Terminate the session
+    let sessions = handle.list_sessions().await;
+    handle.terminate_session(&sessions[0].id).await;
+
+    // Without recovery, the next request should fail
+    let result = client.list_tools().await;
+    assert!(result.is_err(), "Should fail without session recovery");
+}


### PR DESCRIPTION
## Summary

- HTTP client now automatically detects session expiry (-32005 JSON-RPC errors) and transparently re-initializes + retries
- Handles server restarts, session expiration, and load balancer failovers without caller intervention
- Enabled by default for `HttpClientTransport`, opt-out via `.disable_session_recovery()`

## What changed

- **`Error::SessionExpired`** variant in tower-mcp-types
- **`ClientTransport` trait** gains `reset_session()` and `supports_session_recovery()` default methods (no-op for stdio/channel)
- **`HttpClientTransport`** implements `reset_session()` (clears session, stops SSE, drains channel), forwards JSON-RPC error bodies from non-success HTTP responses
- **`McpClient`** detects -32005 with missing/null id in message loop, `recover_session()` with mutex-protected re-init, `send_request()` retries once on `SessionExpired`
- **`server_info`** changed from `OnceLock` to `RwLock` to support re-initialization (adds `server_info_blocking()` for sync contexts)

## Context

Closes #762. This was the #1 gap identified between tower-mcp's HTTP client and production requirements, uncovered while investigating Codex CLI session failures ([openai/codex#15815](https://github.com/openai/codex/issues/15815)).

## Breaking changes

- `McpClient::server_info()` is now `async` and returns `Option<InitializeResult>` (was `Option<&InitializeResult>`)
- `McpClient::initialize()` returns `Result<InitializeResult>` (was `Result<&InitializeResult>`)

## Test plan

- [x] `test_session_recovery_after_expiry` - terminate session via handle, verify client auto-recovers and retries
- [x] `test_session_recovery_disabled` - verify error propagates when recovery is disabled
- [x] All 596 lib tests pass
- [x] All 57 HTTP client tests pass (55 existing + 2 new)
- [x] clippy clean, fmt clean