### PR TITLE
test: close critical test coverage gaps

### DIFF
--- a/crates/tower-mcp/src/client/stdio.rs
+++ b/crates/tower-mcp/src/client/stdio.rs
@@ -185,3 +185,84 @@ impl ClientTransport for StdioClientTransport {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_spawn_nonexistent_program() {
+        let result = StdioClientTransport::spawn("nonexistent-program-xyz", &[]).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_send_and_recv_via_cat() {
+        // `cat` echoes stdin to stdout line-by-line
+        let mut transport = StdioClientTransport::spawn("cat", &[]).await.unwrap();
+
+        assert!(transport.is_connected());
+
+        // Send a JSON message
+        let msg = r#"{"jsonrpc":"2.0","id":1,"method":"test"}"#;
+        transport.send(msg).await.unwrap();
+
+        // cat echoes it back
+        let received = transport.recv().await.unwrap();
+        assert_eq!(received.as_deref(), Some(msg));
+    }
+
+    #[tokio::test]
+    async fn test_close_signals_eof() {
+        let mut transport = StdioClientTransport::spawn("cat", &[]).await.unwrap();
+        assert!(transport.is_connected());
+
+        transport.close().await.unwrap();
+        assert!(!transport.is_connected());
+    }
+
+    #[tokio::test]
+    async fn test_recv_returns_none_on_eof() {
+        // `true` exits immediately with no output
+        let mut transport = StdioClientTransport::spawn("true", &[]).await.unwrap();
+
+        // Should get None (EOF) since `true` produces no output and exits
+        let result = transport.recv().await.unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn test_send_after_close_fails() {
+        let mut transport = StdioClientTransport::spawn("cat", &[]).await.unwrap();
+        transport.close().await.unwrap();
+
+        let result = transport.send("hello").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_command_with_env() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo $TEST_VAR"]);
+        cmd.env("TEST_VAR", "hello_from_test");
+
+        let mut transport = StdioClientTransport::spawn_command(&mut cmd).await.unwrap();
+
+        let received = transport.recv().await.unwrap();
+        assert_eq!(received.as_deref(), Some("hello_from_test"));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_send_recv_roundtrips() {
+        let mut transport = StdioClientTransport::spawn("cat", &[]).await.unwrap();
+
+        for i in 0..5 {
+            let msg = format!(r#"{{"id":{i},"msg":"test"}}"#);
+            transport.send(&msg).await.unwrap();
+            let received = transport.recv().await.unwrap();
+            assert_eq!(received.as_deref(), Some(msg.as_str()));
+        }
+
+        transport.close().await.unwrap();
+    }
+}

--- a/crates/tower-mcp/src/middleware/tool_call_logging.rs
+++ b/crates/tower-mcp/src/middleware/tool_call_logging.rs
@@ -333,4 +333,111 @@ mod tests {
         // The response should be an error (tool not found)
         assert!(result.unwrap().inner.is_err());
     }
+
+    #[tokio::test]
+    async fn test_list_tools_passthrough() {
+        use crate::protocol::ListToolsParams;
+
+        let router = crate::McpRouter::new().server_info("test", "1.0.0");
+        let layer = ToolCallLoggingLayer::new();
+        let mut service = layer.layer(router);
+
+        // ListTools should pass through without tool call logging
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ListTools(ListToolsParams {
+                cursor: None,
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let result = Service::call(&mut service, req).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_tool_call_success_response() {
+        let tool = crate::ToolBuilder::new("add")
+            .description("Add numbers")
+            .handler(|_: serde_json::Value| async move { Ok(crate::CallToolResult::text("42")) })
+            .build();
+
+        let mut router = crate::McpRouter::new()
+            .server_info("test", "1.0.0")
+            .tool(tool);
+
+        // Manually initialize the session so tool calls work
+        use crate::router::RouterRequest;
+        use tower_service::Service;
+
+        let init_req = RouterRequest {
+            id: RequestId::Number(0),
+            inner: McpRequest::Initialize(crate::protocol::InitializeParams {
+                protocol_version: "2025-11-25".to_string(),
+                capabilities: crate::protocol::ClientCapabilities::default(),
+                client_info: crate::protocol::Implementation {
+                    name: "test".to_string(),
+                    version: "1.0".to_string(),
+                    ..Default::default()
+                },
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let _ = Service::call(&mut router, init_req).await;
+
+        // Now send initialized notification to transition session state
+        // (handled internally by the router)
+
+        let layer = ToolCallLoggingLayer::new();
+        let mut service = layer.layer(router);
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                name: "add".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let result = Service::call(&mut service, req).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        // After initialization, tool calls should succeed
+        assert!(response.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_resource_read_passthrough() {
+        use crate::protocol::ReadResourceParams;
+
+        let router = crate::McpRouter::new().server_info("test", "1.0.0");
+        let layer = ToolCallLoggingLayer::new();
+        let mut service = layer.layer(router);
+
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::ReadResource(ReadResourceParams {
+                uri: "file:///test".to_string(),
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+
+        let result = Service::call(&mut service, req).await;
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_layer_copy() {
+        let layer = ToolCallLoggingLayer::new().level(Level::DEBUG);
+        let copied = layer; // Copy, not clone
+        assert_eq!(copied.level, Level::DEBUG);
+        // Original is still usable (Copy)
+        assert_eq!(layer.level, Level::DEBUG);
+    }
 }

--- a/crates/tower-mcp/src/middleware/tracing.rs
+++ b/crates/tower-mcp/src/middleware/tracing.rs
@@ -354,4 +354,139 @@ mod tests {
         assert_eq!(name, Some("ping"));
         assert_eq!(target, None);
     }
+
+    #[test]
+    fn test_extract_operation_details_list_operations() {
+        use crate::protocol::{
+            ListPromptsParams, ListResourceTemplatesParams, ListResourcesParams, ListToolsParams,
+        };
+
+        let (name, target) = extract_operation_details(&McpRequest::ListTools(ListToolsParams {
+            cursor: None,
+            meta: None,
+        }));
+        assert_eq!(name, Some("list"));
+        assert_eq!(target, Some("tools".to_string()));
+
+        let (name, target) =
+            extract_operation_details(&McpRequest::ListResources(ListResourcesParams {
+                cursor: None,
+                meta: None,
+            }));
+        assert_eq!(name, Some("list"));
+        assert_eq!(target, Some("resources".to_string()));
+
+        let (name, target) = extract_operation_details(&McpRequest::ListResourceTemplates(
+            ListResourceTemplatesParams {
+                cursor: None,
+                meta: None,
+            },
+        ));
+        assert_eq!(name, Some("list"));
+        assert_eq!(target, Some("resource_templates".to_string()));
+
+        let (name, target) =
+            extract_operation_details(&McpRequest::ListPrompts(ListPromptsParams {
+                cursor: None,
+                meta: None,
+            }));
+        assert_eq!(name, Some("list"));
+        assert_eq!(target, Some("prompts".to_string()));
+    }
+
+    #[test]
+    fn test_extract_operation_details_initialize() {
+        use crate::protocol::{ClientCapabilities, Implementation, InitializeParams};
+
+        let req = McpRequest::Initialize(InitializeParams {
+            protocol_version: "2025-11-25".to_string(),
+            capabilities: ClientCapabilities::default(),
+            client_info: Implementation {
+                name: "test".to_string(),
+                version: "1.0".to_string(),
+                ..Default::default()
+            },
+            meta: None,
+        });
+        let (name, target) = extract_operation_details(&req);
+        assert_eq!(name, Some("init"));
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn test_extract_operation_details_subscribe() {
+        use crate::protocol::SubscribeResourceParams;
+
+        let req = McpRequest::SubscribeResource(SubscribeResourceParams {
+            uri: "file:///watched.txt".to_string(),
+            meta: None,
+        });
+        let (name, target) = extract_operation_details(&req);
+        assert_eq!(name, Some("subscribe"));
+        assert_eq!(target, Some("file:///watched.txt".to_string()));
+    }
+
+    #[test]
+    fn test_extract_operation_details_logging_level() {
+        use crate::protocol::{LogLevel, SetLogLevelParams};
+
+        let req = McpRequest::SetLoggingLevel(SetLogLevelParams {
+            level: LogLevel::Debug,
+            meta: None,
+        });
+        let (name, target) = extract_operation_details(&req);
+        assert_eq!(name, Some("logging"));
+        assert!(target.is_some());
+    }
+
+    #[test]
+    fn test_extract_operation_details_completion() {
+        use crate::protocol::{CompleteParams, CompletionArgument, CompletionReference};
+
+        let req = McpRequest::Complete(CompleteParams {
+            reference: CompletionReference::Prompt {
+                name: "my-prompt".to_string(),
+            },
+            argument: CompletionArgument::new("arg1", "val"),
+            context: None,
+            meta: None,
+        });
+        let (name, target) = extract_operation_details(&req);
+        assert_eq!(name, Some("complete"));
+        assert_eq!(target, Some("prompt:my-prompt".to_string()));
+
+        let req = McpRequest::Complete(CompleteParams {
+            reference: CompletionReference::Resource {
+                uri: "file:///test".to_string(),
+            },
+            argument: CompletionArgument::new("arg1", "val"),
+            context: None,
+            meta: None,
+        });
+        let (_, target) = extract_operation_details(&req);
+        assert_eq!(target, Some("resource:file:///test".to_string()));
+    }
+
+    #[test]
+    fn test_extract_operation_details_unknown_method() {
+        let req = McpRequest::Unknown {
+            method: "custom/method".to_string(),
+            params: None,
+        };
+        let (name, target) = extract_operation_details(&req);
+        assert_eq!(name, Some("unknown"));
+        assert_eq!(target, Some("custom/method".to_string()));
+    }
+
+    #[test]
+    fn test_layer_level_configuration() {
+        let layer = McpTracingLayer::new().level(Level::TRACE);
+        assert_eq!(layer.level, Level::TRACE);
+
+        let layer = McpTracingLayer::new().level(Level::ERROR);
+        assert_eq!(layer.level, Level::ERROR);
+
+        let layer = McpTracingLayer::new().level(Level::WARN);
+        assert_eq!(layer.level, Level::WARN);
+    }
 }

--- a/crates/tower-mcp/src/transport/childproc.rs
+++ b/crates/tower-mcp/src/transport/childproc.rs
@@ -331,4 +331,66 @@ mod tests {
 
         assert_eq!(transport.args, vec!["--flag1", "--flag2"]);
     }
+
+    #[tokio::test]
+    async fn test_transport_env() {
+        let transport = ChildProcessTransport::new("prog")
+            .env("KEY1", "val1")
+            .env("KEY2", "val2");
+
+        assert_eq!(transport.envs.len(), 2);
+        assert_eq!(transport.envs[0], ("KEY1".to_string(), "val1".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_nonexistent_fails() {
+        let result = ChildProcessTransport::new("nonexistent-program-xyz-123")
+            .spawn()
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_spawn_and_communicate() {
+        // Use `cat` as a simple echo server
+        let mut conn = ChildProcessTransport::new("cat").spawn().await.unwrap();
+
+        assert!(conn.is_running());
+
+        // Send a JSON-RPC request
+        let response = conn
+            .send_request("echo", serde_json::json!({"msg": "hello"}))
+            .await;
+
+        // cat will echo our request back, but it won't be a valid JSON-RPC response.
+        // That's OK - we're testing that I/O works, not protocol correctness.
+        // The response will be a parse error since cat echoes the request verbatim.
+        assert!(response.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_graceful() {
+        let conn = ChildProcessTransport::new("cat").spawn().await.unwrap();
+        // Shutdown should succeed - cat exits when stdin is closed
+        conn.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_is_running_after_exit() {
+        // `true` exits immediately
+        let mut conn = ChildProcessTransport::new("true").spawn().await.unwrap();
+        // Give it a moment to exit
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert!(!conn.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_send_notification() {
+        let mut conn = ChildProcessTransport::new("cat").spawn().await.unwrap();
+        // Notification should succeed (no response expected)
+        conn.send_notification("test/notify", serde_json::json!({"data": 1}))
+            .await
+            .unwrap();
+        conn.shutdown().await.unwrap();
+    }
 }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1201,9 +1201,18 @@ fn is_localhost_origin(origin: &str) -> bool {
         .strip_prefix("http://")
         .or_else(|| origin.strip_prefix("https://"))
     {
-        // Strip port if present
-        let host = rest.split(':').next().unwrap_or(rest);
-        matches!(host, "localhost" | "127.0.0.1" | "[::1]" | "::1")
+        // Handle bracketed IPv6 (e.g., [::1]:3000)
+        let host = if rest.starts_with('[') {
+            // Extract everything between [ and ]
+            rest.split(']')
+                .next()
+                .unwrap_or(rest)
+                .trim_start_matches('[')
+        } else {
+            // Strip port if present
+            rest.split(':').next().unwrap_or(rest)
+        };
+        matches!(host, "localhost" | "127.0.0.1" | "::1")
     } else {
         false
     }
@@ -2885,5 +2894,218 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["error"]["code"].as_i64().unwrap(), -32005);
+    }
+
+    // -----------------------------------------------------------------------
+    // Origin validation / DNS rebinding protection
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_localhost_origin_http() {
+        assert!(is_localhost_origin("http://localhost"));
+        assert!(is_localhost_origin("http://localhost:3000"));
+        assert!(is_localhost_origin("http://127.0.0.1"));
+        assert!(is_localhost_origin("http://127.0.0.1:8080"));
+        assert!(is_localhost_origin("http://[::1]"));
+        assert!(is_localhost_origin("http://[::1]:3000"));
+    }
+
+    #[test]
+    fn test_is_localhost_origin_https() {
+        assert!(is_localhost_origin("https://localhost"));
+        assert!(is_localhost_origin("https://127.0.0.1:443"));
+    }
+
+    #[test]
+    fn test_is_not_localhost_origin() {
+        assert!(!is_localhost_origin("http://example.com"));
+        assert!(!is_localhost_origin("http://evil-localhost.com"));
+        assert!(!is_localhost_origin("http://localhost.evil.com"));
+        assert!(!is_localhost_origin("ftp://localhost"));
+        assert!(!is_localhost_origin("localhost"));
+        assert!(!is_localhost_origin(""));
+    }
+
+    #[tokio::test]
+    async fn test_origin_validation_rejects_cross_origin() {
+        let transport = HttpTransport::new(create_test_router());
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Origin", "http://evil.com")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_origin_validation_allows_localhost() {
+        let transport = HttpTransport::new(create_test_router());
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Origin", "http://localhost:3000")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_origin_validation_allows_configured_origin() {
+        let transport = HttpTransport::new(create_test_router())
+            .allowed_origins(vec!["https://my-app.example.com".to_string()]);
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Origin", "https://my-app.example.com")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_origin_validation_rejects_unconfigured_origin() {
+        let transport = HttpTransport::new(create_test_router())
+            .allowed_origins(vec!["https://my-app.example.com".to_string()]);
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Origin", "https://other-app.example.com")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_origin_validation_no_header_allowed() {
+        // Requests without Origin header should be allowed (same-origin)
+        let transport = HttpTransport::new(create_test_router());
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            // No Origin header
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_disabled_origin_validation_allows_any() {
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Origin", "http://evil.com")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Summary

Adds 33 new unit tests across 5 previously undertested modules, bringing lib test count from 605 to 638. Also fixes a real bug found during testing.

## Bug fix

`is_localhost_origin` in `transport/http.rs` failed to parse bracketed IPv6 addresses (`http://[::1]:3000`). The `split(':')` approach broke on `[::1]`. Fixed to handle bracketed IPv6 by detecting `[` and splitting on `]` instead.

## New tests by module

| Module | Before | After | Coverage added |
|--------|--------|-------|----------------|
| `transport/http.rs` | 20 | 29 | Origin validation, DNS rebinding, localhost detection (HTTP/HTTPS/IPv6), configured origins, disabled validation |
| `client/stdio.rs` | 0 | 7 | Spawn failure, send/recv roundtrip (cat), close/EOF, env vars, multiple roundtrips |
| `transport/childproc.rs` | 2 | 8 | Spawn failure, process communication, graceful shutdown, running state, notifications |
| `middleware/tracing.rs` | 2 | 10 | All request types: list ops, initialize, subscribe, logging level, completion, unknown methods |
| `middleware/tool_call_logging.rs` | 6 | 10 | Non-tool passthrough, successful tool response, resource read passthrough, Copy trait |

## Remaining gaps from #757

- `transport/http.rs`: SSE stream resumption (Last-Event-ID / SEP-1699), concurrent sessions
- `context.rs`: Concurrent progress reports, cancellation during operations
- Functional: cancellation propagation through middleware stack, dynamic capability changes

Partial close of #757.

## Test plan

- [x] 638 lib tests pass
- [x] 44 integration tests pass
- [x] clippy clean, fmt clean