### PR TITLE
feat: Unix Domain Socket transport

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -45,10 +45,11 @@ jsonschema = "0.45"
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "stateless"]
+full = ["http", "websocket", "unix", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "stateless"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
+unix = ["http"]
 childproc = []
 # OAuth 2.1 resource server support
 oauth = ["dep:jsonwebtoken", "http"]
@@ -128,6 +129,11 @@ required-features = ["http"]
 name = "websocket_server"
 path = "../../examples/websocket_server.rs"
 required-features = ["websocket"]
+
+[[example]]
+name = "unix_socket_server"
+path = "../../examples/unix_socket_server.rs"
+required-features = ["unix"]
 
 # --- Middleware ---
 [[example]]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -502,8 +502,11 @@ pub use transport::{HttpTransport, SessionHandle, SessionInfo};
 #[cfg(feature = "websocket")]
 pub use transport::WebSocketTransport;
 
-#[cfg(any(feature = "http", feature = "websocket"))]
+#[cfg(any(feature = "http", feature = "websocket", feature = "unix"))]
 pub use transport::McpBoxService;
+
+#[cfg(all(unix, feature = "unix"))]
+pub use transport::UnixSocketTransport;
 
 #[cfg(feature = "childproc")]
 pub use transport::{ChildProcessConnection, ChildProcessTransport};

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -14,6 +14,9 @@ pub mod http;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 
+#[cfg(all(unix, feature = "unix"))]
+pub mod unix;
+
 #[cfg(feature = "childproc")]
 pub mod childproc;
 
@@ -30,8 +33,11 @@ pub use http::{HttpTransport, SessionHandle, SessionInfo};
 #[cfg(feature = "websocket")]
 pub use websocket::WebSocketTransport;
 
+#[cfg(all(unix, feature = "unix"))]
+pub use unix::UnixSocketTransport;
+
 #[cfg(feature = "childproc")]
 pub use childproc::{ChildProcessConnection, ChildProcessTransport};
 
-#[cfg(any(feature = "http", feature = "websocket"))]
+#[cfg(any(feature = "http", feature = "websocket", feature = "unix"))]
 pub use service::McpBoxService;

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -1,0 +1,211 @@
+//! Unix Domain Socket transport for MCP.
+//!
+//! Serves the Streamable HTTP protocol over a Unix socket instead of TCP.
+//! This is useful for local-only server deployments where network exposure
+//! is unnecessary and IPC performance matters (e.g., containerized/sidecar
+//! deployments).
+//!
+//! The transport reuses all HTTP transport machinery (sessions, SSE
+//! notifications, sampling) -- the only difference is the listener type.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::{McpRouter, UnixSocketTransport};
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), tower_mcp::BoxError> {
+//!     let router = McpRouter::new().server_info("unix-example", "1.0.0");
+//!     let transport = UnixSocketTransport::new(router);
+//!     transport.serve("/tmp/mcp.sock").await?;
+//!     Ok(())
+//! }
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use crate::error::Error;
+use crate::router::McpRouter;
+use crate::transport::http::{HttpTransport, SessionConfig, SessionHandle};
+
+/// A transport that serves the MCP Streamable HTTP protocol over a Unix
+/// domain socket.
+///
+/// `UnixSocketTransport` wraps [`HttpTransport`] and delegates all protocol
+/// handling to it. The only difference is that [`serve`](Self::serve) binds
+/// a [`tokio::net::UnixListener`] instead of a TCP listener.
+///
+/// All `HttpTransport` features work identically: sessions, SSE notification
+/// streams, sampling, `.layer()` middleware, and OAuth.
+pub struct UnixSocketTransport {
+    inner: HttpTransport,
+    cleanup_on_bind: bool,
+}
+
+impl UnixSocketTransport {
+    /// Create a new Unix socket transport wrapping an MCP router.
+    pub fn new(router: McpRouter) -> Self {
+        Self {
+            inner: HttpTransport::new(router),
+            cleanup_on_bind: true,
+        }
+    }
+
+    /// Create a Unix socket transport from a pre-built service.
+    ///
+    /// See [`HttpTransport::from_service`] for details.
+    pub fn from_service<S>(service: S) -> Self
+    where
+        S: tower::Service<
+                crate::router::RouterRequest,
+                Response = crate::router::RouterResponse,
+                Error = std::convert::Infallible,
+            > + Clone
+            + Send
+            + 'static,
+        S::Future: Send,
+    {
+        Self {
+            inner: HttpTransport::from_service(service),
+            cleanup_on_bind: true,
+        }
+    }
+
+    /// Enable sampling support.
+    ///
+    /// See [`HttpTransport::with_sampling`] for details.
+    pub fn with_sampling(mut self) -> Self {
+        self.inner = self.inner.with_sampling();
+        self
+    }
+
+    /// Require session headers on every request.
+    ///
+    /// By default sessions are optional (matching [`HttpTransport`] defaults).
+    /// Call this to reject requests without a valid `mcp-session-id`.
+    pub fn require_sessions(mut self) -> Self {
+        self.inner = self.inner.require_sessions();
+        self
+    }
+
+    /// Set session configuration (TTL, max sessions, cleanup interval).
+    pub fn session_config(mut self, config: SessionConfig) -> Self {
+        self.inner = self.inner.session_config(config);
+        self
+    }
+
+    /// Set session time-to-live.
+    pub fn session_ttl(mut self, ttl: std::time::Duration) -> Self {
+        self.inner = self.inner.session_ttl(ttl);
+        self
+    }
+
+    /// Set the maximum number of concurrent sessions.
+    pub fn max_sessions(mut self, max: usize) -> Self {
+        self.inner = self.inner.max_sessions(max);
+        self
+    }
+
+    /// Disable origin validation.
+    ///
+    /// Origin validation is less relevant for Unix sockets since they are
+    /// not accessible over the network, but is still enabled by default
+    /// for consistency with [`HttpTransport`].
+    pub fn disable_origin_validation(mut self) -> Self {
+        self.inner = self.inner.disable_origin_validation();
+        self
+    }
+
+    /// Set allowed origins for CORS validation.
+    pub fn allowed_origins(mut self, origins: Vec<String>) -> Self {
+        self.inner = self.inner.allowed_origins(origins);
+        self
+    }
+
+    /// Apply a tower middleware layer to MCP request processing.
+    ///
+    /// See [`HttpTransport::layer`] for details.
+    pub fn layer<L>(mut self, layer: L) -> Self
+    where
+        L: tower::Layer<McpRouter> + Send + Sync + 'static,
+        L::Service: tower::Service<crate::router::RouterRequest, Response = crate::router::RouterResponse>
+            + Clone
+            + Send
+            + 'static,
+        <L::Service as tower::Service<crate::router::RouterRequest>>::Error:
+            std::fmt::Display + Send,
+        <L::Service as tower::Service<crate::router::RouterRequest>>::Future: Send,
+    {
+        self.inner = self.inner.layer(layer);
+        self
+    }
+
+    /// If `true` (the default), remove an existing socket file before
+    /// binding. Set to `false` if you manage the socket lifecycle yourself.
+    pub fn cleanup_on_bind(mut self, cleanup: bool) -> Self {
+        self.cleanup_on_bind = cleanup;
+        self
+    }
+
+    /// Build the axum router for this transport.
+    ///
+    /// Use this when you want to serve the router yourself with a custom
+    /// [`tokio::net::UnixListener`] setup.
+    pub fn into_router(self) -> axum::Router {
+        self.inner.into_router()
+    }
+
+    /// Build the axum router and return a [`SessionHandle`] for querying
+    /// session metrics.
+    pub fn into_router_with_handle(self) -> (axum::Router, SessionHandle) {
+        self.inner.into_router_with_handle()
+    }
+
+    /// Serve the transport on the given Unix socket path.
+    ///
+    /// If `cleanup_on_bind` is enabled (the default), any existing file at
+    /// `path` is removed before binding. The socket file is **not**
+    /// automatically removed on shutdown -- callers should handle cleanup
+    /// if needed (e.g., via a signal handler or `Drop` guard).
+    pub async fn serve<P: AsRef<Path>>(self, path: P) -> crate::Result<()> {
+        let path = path.as_ref().to_path_buf();
+
+        if self.cleanup_on_bind {
+            cleanup_socket(&path);
+        }
+
+        let listener = tokio::net::UnixListener::bind(&path).map_err(|e| {
+            Error::Transport(format!(
+                "Failed to bind Unix socket {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+
+        tracing::info!("MCP Unix socket transport listening on {}", path.display());
+
+        let router = self.inner.into_router();
+        axum::serve(listener, router)
+            .await
+            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
+
+        Ok(())
+    }
+}
+
+/// Remove an existing socket file, ignoring "not found" errors.
+fn cleanup_socket(path: &PathBuf) {
+    match std::fs::remove_file(path) {
+        Ok(()) => {
+            tracing::debug!("Removed existing socket file: {}", path.display());
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::warn!(
+                "Failed to remove existing socket file {}: {}",
+                path.display(),
+                e
+            );
+        }
+    }
+}

--- a/examples/unix_socket_server.rs
+++ b/examples/unix_socket_server.rs
@@ -129,7 +129,6 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     #[cfg(not(unix))]
     {
         eprintln!("Unix socket transport is only supported on Unix platforms (Linux, macOS, BSD).");
-        std::process::exit(1);
     }
     Ok(())
 }

--- a/examples/unix_socket_server.rs
+++ b/examples/unix_socket_server.rs
@@ -2,6 +2,8 @@
 //!
 //! Run with: cargo run --example unix_socket_server --features unix
 //!
+//! This example only works on Unix platforms (Linux, macOS, BSD).
+//!
 //! Test with curl (requires curl 7.40+ for --unix-socket):
 //! ```bash
 //! # Initialize session
@@ -26,92 +28,108 @@
 //!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":10,"b":32}}}'
 //! ```
 
-use std::time::Duration;
+#[cfg(unix)]
+mod app {
+    use std::time::Duration;
 
-use schemars::JsonSchema;
-use serde::Deserialize;
-use tower::timeout::TimeoutLayer;
-use tower_mcp::{
-    CallToolResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder, UnixSocketTransport,
-};
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+    use tower::timeout::TimeoutLayer;
+    use tower_mcp::{
+        CallToolResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder, UnixSocketTransport,
+    };
 
-#[derive(Debug, Deserialize, JsonSchema)]
-struct AddInput {
-    a: i64,
-    b: i64,
-}
+    #[derive(Debug, Deserialize, JsonSchema)]
+    pub struct AddInput {
+        a: i64,
+        b: i64,
+    }
 
-#[derive(Debug, Deserialize, JsonSchema)]
-struct EchoInput {
-    message: String,
+    #[derive(Debug, Deserialize, JsonSchema)]
+    pub struct EchoInput {
+        message: String,
+    }
+
+    pub async fn run() -> Result<(), tower_mcp::BoxError> {
+        tracing_subscriber::fmt()
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::from_default_env()
+                    .add_directive("tower_mcp=debug".parse()?),
+            )
+            .init();
+
+        let add = ToolBuilder::new("add")
+            .description("Add two numbers together")
+            .handler(|input: AddInput| async move {
+                Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+            })
+            .build();
+
+        let echo = ToolBuilder::new("echo")
+            .description("Echo a message back")
+            .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+            .build();
+
+        let config = ResourceBuilder::new("file:///config.json")
+            .name("Configuration")
+            .description("Server configuration")
+            .json(serde_json::json!({
+                "version": "1.0.0",
+                "transport": "unix-socket"
+            }));
+
+        let greet = PromptBuilder::new("greet")
+            .description("Generate a greeting")
+            .required_arg("name", "Name to greet")
+            .handler(|args| async move {
+                let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+                Ok(tower_mcp::GetPromptResult {
+                    description: Some("A friendly greeting".to_string()),
+                    messages: vec![tower_mcp::PromptMessage {
+                        role: tower_mcp::PromptRole::User,
+                        content: tower_mcp::protocol::Content::Text {
+                            text: format!("Please greet {} warmly.", name),
+                            annotations: None,
+                            meta: None,
+                        },
+                        meta: None,
+                    }],
+                    meta: None,
+                })
+            })
+            .build();
+
+        let router = McpRouter::new()
+            .server_info("unix-socket-example", "1.0.0")
+            .auto_instructions()
+            .tool(add)
+            .tool(echo)
+            .resource(config)
+            .prompt(greet);
+
+        let socket_path = "/tmp/tower-mcp.sock";
+
+        let transport = UnixSocketTransport::new(router)
+            .disable_origin_validation()
+            .layer(TimeoutLayer::new(Duration::from_secs(30)));
+
+        tracing::info!("Starting Unix socket MCP server on {}", socket_path);
+        transport.serve(socket_path).await?;
+
+        Ok(())
+    }
 }
 
 #[tokio::main]
 async fn main() -> Result<(), tower_mcp::BoxError> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("tower_mcp=debug".parse()?),
-        )
-        .init();
-
-    let add = ToolBuilder::new("add")
-        .description("Add two numbers together")
-        .handler(|input: AddInput| async move {
-            Ok(CallToolResult::text(format!("{}", input.a + input.b)))
-        })
-        .build();
-
-    let echo = ToolBuilder::new("echo")
-        .description("Echo a message back")
-        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
-        .build();
-
-    let config = ResourceBuilder::new("file:///config.json")
-        .name("Configuration")
-        .description("Server configuration")
-        .json(serde_json::json!({
-            "version": "1.0.0",
-            "transport": "unix-socket"
-        }));
-
-    let greet = PromptBuilder::new("greet")
-        .description("Generate a greeting")
-        .required_arg("name", "Name to greet")
-        .handler(|args| async move {
-            let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
-            Ok(tower_mcp::GetPromptResult {
-                description: Some("A friendly greeting".to_string()),
-                messages: vec![tower_mcp::PromptMessage {
-                    role: tower_mcp::PromptRole::User,
-                    content: tower_mcp::protocol::Content::Text {
-                        text: format!("Please greet {} warmly.", name),
-                        annotations: None,
-                        meta: None,
-                    },
-                    meta: None,
-                }],
-                meta: None,
-            })
-        })
-        .build();
-
-    let router = McpRouter::new()
-        .server_info("unix-socket-example", "1.0.0")
-        .auto_instructions()
-        .tool(add)
-        .tool(echo)
-        .resource(config)
-        .prompt(greet);
-
-    let socket_path = "/tmp/tower-mcp.sock";
-
-    let transport = UnixSocketTransport::new(router)
-        .disable_origin_validation()
-        .layer(TimeoutLayer::new(Duration::from_secs(30)));
-
-    tracing::info!("Starting Unix socket MCP server on {}", socket_path);
-    transport.serve(socket_path).await?;
-
+    #[cfg(unix)]
+    {
+        app::run().await?;
+    }
+    #[cfg(not(unix))]
+    {
+        eprintln!("Unix socket transport is only supported on Unix platforms (Linux, macOS, BSD).");
+        std::process::exit(1);
+    }
     Ok(())
 }

--- a/examples/unix_socket_server.rs
+++ b/examples/unix_socket_server.rs
@@ -1,0 +1,117 @@
+//! Unix Domain Socket server example for tower-mcp
+//!
+//! Run with: cargo run --example unix_socket_server --features unix
+//!
+//! Test with curl (requires curl 7.40+ for --unix-socket):
+//! ```bash
+//! # Initialize session
+//! curl --unix-socket /tmp/tower-mcp.sock \
+//!   -X POST http://localhost/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "Accept: application/json, text/event-stream" \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
+//!
+//! # List tools (use session ID from initialize response)
+//! curl --unix-socket /tmp/tower-mcp.sock \
+//!   -X POST http://localhost/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id>" \
+//!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+//!
+//! # Call a tool
+//! curl --unix-socket /tmp/tower-mcp.sock \
+//!   -X POST http://localhost/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id>" \
+//!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":10,"b":32}}}'
+//! ```
+
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::timeout::TimeoutLayer;
+use tower_mcp::{
+    CallToolResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder, UnixSocketTransport,
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EchoInput {
+    message: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=debug".parse()?),
+        )
+        .init();
+
+    let add = ToolBuilder::new("add")
+        .description("Add two numbers together")
+        .handler(|input: AddInput| async move {
+            Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+        })
+        .build();
+
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build();
+
+    let config = ResourceBuilder::new("file:///config.json")
+        .name("Configuration")
+        .description("Server configuration")
+        .json(serde_json::json!({
+            "version": "1.0.0",
+            "transport": "unix-socket"
+        }));
+
+    let greet = PromptBuilder::new("greet")
+        .description("Generate a greeting")
+        .required_arg("name", "Name to greet")
+        .handler(|args| async move {
+            let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+            Ok(tower_mcp::GetPromptResult {
+                description: Some("A friendly greeting".to_string()),
+                messages: vec![tower_mcp::PromptMessage {
+                    role: tower_mcp::PromptRole::User,
+                    content: tower_mcp::protocol::Content::Text {
+                        text: format!("Please greet {} warmly.", name),
+                        annotations: None,
+                        meta: None,
+                    },
+                    meta: None,
+                }],
+                meta: None,
+            })
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("unix-socket-example", "1.0.0")
+        .auto_instructions()
+        .tool(add)
+        .tool(echo)
+        .resource(config)
+        .prompt(greet);
+
+    let socket_path = "/tmp/tower-mcp.sock";
+
+    let transport = UnixSocketTransport::new(router)
+        .disable_origin_validation()
+        .layer(TimeoutLayer::new(Duration::from_secs(30)));
+
+    tracing::info!("Starting Unix socket MCP server on {}", socket_path);
+    transport.serve(socket_path).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Adds `UnixSocketTransport` that serves the Streamable HTTP protocol over a Unix domain socket instead of TCP
- Wraps `HttpTransport` internally, reusing all existing machinery (sessions, SSE notifications, sampling, middleware)
- New `unix` feature flag (depends on `http`), `#[cfg(unix)]` gated for Unix platforms only
- Includes `unix_socket_server` example with `curl --unix-socket` instructions

## Motivation

- Avoids TCP overhead for local communication (no port allocation, no loopback)
- Common pattern for containerized/sidecar deployments
- rmcp has UDS client support in progress (modelcontextprotocol/rust-sdk#749)

## Test plan

- [x] `cargo check -p tower-mcp --features unix` compiles clean
- [x] `cargo clippy -p tower-mcp --all-features -- -D warnings` passes
- [x] `cargo test --lib -p tower-mcp --all-features` -- 638/638 pass
- [x] `cargo fmt --all -- --check` passes
- [x] Example builds: `cargo build -p tower-mcp --example unix_socket_server --features unix`

Closes #717