### PR TITLE
feat: pluggable SessionStore for horizontal scaling

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -136,6 +136,11 @@ name = "unix_socket_server"
 path = "../../examples/unix_socket_server.rs"
 required-features = ["unix"]
 
+[[example]]
+name = "session_store"
+path = "../../examples/session_store.rs"
+required-features = ["http"]
+
 # --- Middleware ---
 [[example]]
 name = "middleware"

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -27,6 +27,7 @@ async-trait.workspace = true
 tracing.workspace = true
 regex = "1"
 base64.workspace = true
+thiserror = { workspace = true }
 sha2 = { workspace = true, optional = true }
 getrandom = { workspace = true, optional = true }
 urlencoding = { workspace = true, optional = true }

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -402,6 +402,8 @@ pub mod registry;
 pub mod resource;
 pub mod router;
 pub mod session;
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub mod session_store;
 #[cfg(feature = "stateless")]
 pub mod stateless;
 #[cfg(feature = "testing")]

--- a/crates/tower-mcp/src/session_store.rs
+++ b/crates/tower-mcp/src/session_store.rs
@@ -1,0 +1,321 @@
+//! Pluggable session storage for HTTP and WebSocket transports.
+//!
+//! Session state is split into two layers:
+//! - **Persistent metadata** ([`SessionRecord`]) -- serializable, can be stored
+//!   in Redis, Postgres, etc. Persisted via the [`SessionStore`] trait.
+//! - **Runtime state** -- broadcast channels, pending request handles, service
+//!   instances. Held in-memory per server instance; cannot be serialized.
+//!
+//! By default transports use [`MemorySessionStore`], which keeps metadata in an
+//! in-process `HashMap` (behavior identical to earlier versions). External
+//! stores (Redis, Postgres, etc.) can be plugged in to share session metadata
+//! across server instances behind a load balancer.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use tower_mcp::session_store::{MemorySessionStore, SessionStore};
+//!
+//! let store: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+//! // `HttpTransport::new(router).session_store(store)` (once wired in).
+//! ```
+//!
+//! This API follows the shape of
+//! [`tower-sessions`](https://docs.rs/tower-sessions), adapted for MCP's session
+//! model (header-based `mcp-session-id`, structured metadata instead of
+//! arbitrary `HashMap<String, Value>`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+use crate::protocol::{ClientCapabilities, Implementation};
+
+/// Serializable session metadata persisted by a [`SessionStore`].
+///
+/// Contains everything needed to reconstruct a session after a restart or
+/// across server instances. Does **not** contain runtime state (channels,
+/// pending requests) -- those are rebuilt locally on restore.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct SessionRecord {
+    /// Session ID (as used in the `mcp-session-id` header).
+    pub id: String,
+    /// Negotiated MCP protocol version (e.g. `"2025-11-25"`).
+    pub protocol_version: String,
+    /// Client implementation info from the `initialize` request.
+    pub client_info: Option<Implementation>,
+    /// Client capabilities from the `initialize` request.
+    pub client_capabilities: Option<ClientCapabilities>,
+    /// When this session was created.
+    pub created_at: SystemTime,
+    /// When this session was last accessed.
+    pub last_accessed: SystemTime,
+    /// When this session expires. Implementations may remove expired records.
+    pub expires_at: SystemTime,
+}
+
+impl SessionRecord {
+    /// Create a new record with a generated ID and timestamps.
+    ///
+    /// `ttl` is used to derive `expires_at` from `now`.
+    pub fn new(id: impl Into<String>, protocol_version: impl Into<String>, ttl: Duration) -> Self {
+        let now = SystemTime::now();
+        Self {
+            id: id.into(),
+            protocol_version: protocol_version.into(),
+            client_info: None,
+            client_capabilities: None,
+            created_at: now,
+            last_accessed: now,
+            expires_at: now + ttl,
+        }
+    }
+
+    /// Refresh `last_accessed` and `expires_at` using the given TTL.
+    pub fn touch(&mut self, ttl: Duration) {
+        let now = SystemTime::now();
+        self.last_accessed = now;
+        self.expires_at = now + ttl;
+    }
+
+    /// Returns `true` if `expires_at` is in the past.
+    pub fn is_expired(&self) -> bool {
+        SystemTime::now() >= self.expires_at
+    }
+}
+
+/// Errors returned by [`SessionStore`] implementations.
+///
+/// Mirrors the three-variant shape used by `tower-sessions`: encode/decode
+/// errors from the record (de)serialization, and catch-all backend errors
+/// from the storage layer.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum SessionStoreError {
+    /// Failed to encode a [`SessionRecord`] (e.g. serde serialization error).
+    #[error("encode error: {0}")]
+    Encode(String),
+    /// Failed to decode a [`SessionRecord`] (e.g. corrupt data in the backend).
+    #[error("decode error: {0}")]
+    Decode(String),
+    /// Backend error (e.g. connection failure, transient storage error).
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+/// Result alias for session store operations.
+pub type Result<T> = std::result::Result<T, SessionStoreError>;
+
+/// Storage backend for MCP session metadata.
+///
+/// Implementations persist [`SessionRecord`]s keyed by session ID. The default
+/// implementation is [`MemorySessionStore`]; external stores (Redis, Postgres,
+/// etc.) typically live in separate crates.
+///
+/// # Semantics
+///
+/// - [`create`](Self::create) must ensure the ID in the record is unique,
+///   retrying ID generation if necessary.
+/// - [`save`](Self::save) trusts the caller's ID and performs an upsert.
+/// - [`load`](Self::load) returns `None` for unknown or expired sessions.
+///   Implementations may choose to return expired records and let the caller
+///   decide, or filter them out.
+/// - [`delete`](Self::delete) is idempotent -- removing a non-existent ID is
+///   not an error.
+#[async_trait]
+pub trait SessionStore: Send + Sync + 'static {
+    /// Create a new session record.
+    ///
+    /// The implementation must ensure `record.id` does not collide with an
+    /// existing session, regenerating the ID if needed.
+    async fn create(&self, record: &mut SessionRecord) -> Result<()>;
+
+    /// Persist an existing session record. The ID is trusted.
+    async fn save(&self, record: &SessionRecord) -> Result<()>;
+
+    /// Load a session record by ID. Returns `None` if unknown or expired.
+    async fn load(&self, id: &str) -> Result<Option<SessionRecord>>;
+
+    /// Remove a session record. Idempotent.
+    async fn delete(&self, id: &str) -> Result<()>;
+}
+
+/// In-memory [`SessionStore`] backed by a `HashMap`.
+///
+/// This is the default store. Suitable for single-instance deployments. For
+/// horizontal scaling, use an external store that shares state across
+/// instances.
+#[derive(Debug, Default, Clone)]
+pub struct MemorySessionStore {
+    inner: Arc<RwLock<HashMap<String, SessionRecord>>>,
+}
+
+impl MemorySessionStore {
+    /// Create a new empty in-memory session store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of records currently in the store.
+    ///
+    /// Useful for metrics endpoints; not part of the [`SessionStore`] trait.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns `true` if the store has no records.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+
+    /// Remove all expired records. Returns the number removed.
+    pub async fn cleanup_expired(&self) -> usize {
+        let mut map = self.inner.write().await;
+        let before = map.len();
+        map.retain(|_, record| !record.is_expired());
+        before - map.len()
+    }
+}
+
+#[async_trait]
+impl SessionStore for MemorySessionStore {
+    async fn create(&self, record: &mut SessionRecord) -> Result<()> {
+        let mut map = self.inner.write().await;
+        // Ensure uniqueness. UUIDs collide with negligible probability, but
+        // retry to be safe and to let callers pass a preferred ID.
+        while map.contains_key(&record.id) {
+            record.id = uuid::Uuid::new_v4().to_string();
+        }
+        map.insert(record.id.clone(), record.clone());
+        Ok(())
+    }
+
+    async fn save(&self, record: &SessionRecord) -> Result<()> {
+        self.inner
+            .write()
+            .await
+            .insert(record.id.clone(), record.clone());
+        Ok(())
+    }
+
+    async fn load(&self, id: &str) -> Result<Option<SessionRecord>> {
+        let map = self.inner.read().await;
+        Ok(map.get(id).filter(|r| !r.is_expired()).cloned())
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        self.inner.write().await.remove(id);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn sample_record(id: &str) -> SessionRecord {
+        SessionRecord::new(id, "2025-11-25", Duration::from_secs(60))
+    }
+
+    #[tokio::test]
+    async fn memory_store_create_load_delete() {
+        let store = MemorySessionStore::new();
+        let mut record = sample_record("abc");
+        store.create(&mut record).await.unwrap();
+
+        let loaded = store.load("abc").await.unwrap();
+        assert!(loaded.is_some());
+        assert_eq!(loaded.unwrap().id, "abc");
+
+        store.delete("abc").await.unwrap();
+        assert!(store.load("abc").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_store_create_regenerates_id_on_collision() {
+        let store = MemorySessionStore::new();
+        let mut first = sample_record("dup");
+        store.create(&mut first).await.unwrap();
+
+        let mut second = sample_record("dup");
+        store.create(&mut second).await.unwrap();
+
+        assert_ne!(first.id, second.id);
+        assert!(store.load(&first.id).await.unwrap().is_some());
+        assert!(store.load(&second.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn memory_store_save_upserts() {
+        let store = MemorySessionStore::new();
+        let mut record = sample_record("upsert");
+        store.create(&mut record).await.unwrap();
+
+        record.protocol_version = "2025-06-18".into();
+        store.save(&record).await.unwrap();
+
+        let loaded = store.load("upsert").await.unwrap().unwrap();
+        assert_eq!(loaded.protocol_version, "2025-06-18");
+    }
+
+    #[tokio::test]
+    async fn memory_store_hides_expired_records() {
+        let store = MemorySessionStore::new();
+        let mut record = SessionRecord::new("expired", "2025-11-25", Duration::from_millis(1));
+        store.create(&mut record).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        assert!(store.load("expired").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn memory_store_cleanup_removes_expired() {
+        let store = MemorySessionStore::new();
+
+        let mut live = SessionRecord::new("live", "2025-11-25", Duration::from_secs(60));
+        store.create(&mut live).await.unwrap();
+
+        let mut dead = SessionRecord::new("dead", "2025-11-25", Duration::from_millis(1));
+        store.create(&mut dead).await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let removed = store.cleanup_expired().await;
+        assert_eq!(removed, 1);
+        assert_eq!(store.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn memory_store_delete_is_idempotent() {
+        let store = MemorySessionStore::new();
+        store.delete("nonexistent").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn record_touch_updates_timestamps() {
+        let mut record = SessionRecord::new("t", "2025-11-25", Duration::from_secs(60));
+        let original_expiry = record.expires_at;
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        record.touch(Duration::from_secs(60));
+
+        assert!(record.expires_at > original_expiry);
+    }
+
+    #[tokio::test]
+    async fn dyn_session_store_object_safe() {
+        // Compile-time check that SessionStore is object-safe.
+        let store: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+        let mut record = sample_record("dyn");
+        store.create(&mut record).await.unwrap();
+        assert!(store.load(&record.id).await.unwrap().is_some());
+    }
+}

--- a/crates/tower-mcp/src/session_store.rs
+++ b/crates/tower-mcp/src/session_store.rs
@@ -215,6 +215,84 @@ impl SessionStore for MemorySessionStore {
     }
 }
 
+/// Two-tier [`SessionStore`] composed of a cache frontend and a store backend.
+///
+/// Reads hit the cache first; on miss, they fall through to the backend and
+/// populate the cache. Writes go to both tiers. Deletes remove from both.
+///
+/// This lets users pair a fast in-process cache (e.g. [`MemorySessionStore`])
+/// with a durable backend (e.g. a Redis-backed store), keeping in-memory
+/// read performance while gaining cross-instance durability.
+///
+/// Mirrors `tower_sessions_core::session_store::CachingSessionStore`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use std::sync::Arc;
+/// use tower_mcp::session_store::{CachingSessionStore, MemorySessionStore, SessionStore};
+///
+/// // let backend: Arc<dyn SessionStore> = Arc::new(RedisSessionStore::new(...));
+/// # let backend: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+/// let cache = MemorySessionStore::new();
+/// let store: Arc<dyn SessionStore> =
+///     Arc::new(CachingSessionStore::new(cache, backend));
+/// ```
+#[derive(Debug, Clone)]
+pub struct CachingSessionStore<Cache, Store> {
+    cache: Cache,
+    store: Store,
+}
+
+impl<Cache, Store> CachingSessionStore<Cache, Store> {
+    /// Create a new caching store with the given cache and backend.
+    pub fn new(cache: Cache, store: Store) -> Self {
+        Self { cache, store }
+    }
+}
+
+#[async_trait]
+impl<Cache, Store> SessionStore for CachingSessionStore<Cache, Store>
+where
+    Cache: SessionStore,
+    Store: SessionStore,
+{
+    async fn create(&self, record: &mut SessionRecord) -> Result<()> {
+        // Create in the backend first so the authoritative ID is established,
+        // then mirror into the cache.
+        self.store.create(record).await?;
+        self.cache.save(record).await?;
+        Ok(())
+    }
+
+    async fn save(&self, record: &SessionRecord) -> Result<()> {
+        self.store.save(record).await?;
+        self.cache.save(record).await?;
+        Ok(())
+    }
+
+    async fn load(&self, id: &str) -> Result<Option<SessionRecord>> {
+        if let Some(record) = self.cache.load(id).await? {
+            return Ok(Some(record));
+        }
+        match self.store.load(id).await? {
+            Some(record) => {
+                // Populate the cache for subsequent reads. Failures here are
+                // non-fatal — we still return the record.
+                let _ = self.cache.save(&record).await;
+                Ok(Some(record))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn delete(&self, id: &str) -> Result<()> {
+        let cache_result = self.cache.delete(id).await;
+        let store_result = self.store.delete(id).await;
+        cache_result.and(store_result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -317,5 +395,50 @@ mod tests {
         let mut record = sample_record("dyn");
         store.create(&mut record).await.unwrap();
         assert!(store.load(&record.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn caching_store_writes_to_both_tiers() {
+        let cache = MemorySessionStore::new();
+        let backend = MemorySessionStore::new();
+        let store = CachingSessionStore::new(cache.clone(), backend.clone());
+
+        let mut record = sample_record("cached");
+        store.create(&mut record).await.unwrap();
+
+        assert!(cache.load(&record.id).await.unwrap().is_some());
+        assert!(backend.load(&record.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn caching_store_populates_cache_on_miss() {
+        let cache = MemorySessionStore::new();
+        let backend = MemorySessionStore::new();
+
+        // Prime the backend directly; cache is empty.
+        let mut record = sample_record("warm");
+        backend.create(&mut record).await.unwrap();
+        let id = record.id.clone();
+        assert!(cache.load(&id).await.unwrap().is_none());
+
+        // A load through the caching store should populate the cache.
+        let store = CachingSessionStore::new(cache.clone(), backend);
+        let loaded = store.load(&id).await.unwrap();
+        assert!(loaded.is_some());
+        assert!(cache.load(&id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn caching_store_delete_clears_both() {
+        let cache = MemorySessionStore::new();
+        let backend = MemorySessionStore::new();
+        let store = CachingSessionStore::new(cache.clone(), backend.clone());
+
+        let mut record = sample_record("gone");
+        store.create(&mut record).await.unwrap();
+        store.delete(&record.id).await.unwrap();
+
+        assert!(cache.load(&record.id).await.unwrap().is_none());
+        assert!(backend.load(&record.id).await.unwrap().is_none());
     }
 }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -493,19 +493,66 @@ impl SessionConfig {
     }
 }
 
-/// Session store for managing multiple client sessions
-struct SessionStore {
+/// Registry coordinating live session runtime state with a pluggable
+/// persistent [`SessionStore`](crate::session_store::SessionStore).
+///
+/// - Runtime state (broadcast channels, pending requests, live services) is
+///   kept in the in-process `sessions` map and cannot be serialized.
+/// - Persistent metadata (IDs, timestamps, protocol version) is mirrored into
+///   the caller-supplied [`SessionStore`]. The default
+///   [`MemorySessionStore`](crate::session_store::MemorySessionStore) keeps
+///   metadata in-process (same behavior as before this trait existed).
+struct SessionRegistry {
     sessions: RwLock<HashMap<String, Arc<Session>>>,
     config: SessionConfig,
     sampling_enabled: bool,
+    persistent: Arc<dyn crate::session_store::SessionStore>,
 }
 
-impl SessionStore {
-    fn new(config: SessionConfig, sampling_enabled: bool) -> Self {
+impl SessionRegistry {
+    fn new(
+        config: SessionConfig,
+        sampling_enabled: bool,
+        persistent: Arc<dyn crate::session_store::SessionStore>,
+    ) -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
             config,
             sampling_enabled,
+            persistent,
+        }
+    }
+
+    /// Build a SessionRecord reflecting the given live Session.
+    async fn record_for(&self, session: &Session) -> crate::session_store::SessionRecord {
+        let protocol_version = session.protocol_version.read().await.clone();
+        let last_accessed = session.last_accessed.read().await;
+        let mut record = crate::session_store::SessionRecord::new(
+            session.id.clone(),
+            protocol_version,
+            self.config.ttl,
+        );
+        // Convert from monotonic Instant to SystemTime approximation. We
+        // don't persist the client_info/capabilities here -- those can be
+        // populated by a future restore-aware refactor.
+        let now = std::time::SystemTime::now();
+        let created_ago = session.created_at.elapsed();
+        let last_accessed_ago = last_accessed.elapsed();
+        record.created_at = now.checked_sub(created_ago).unwrap_or(now);
+        record.last_accessed = now.checked_sub(last_accessed_ago).unwrap_or(now);
+        record.expires_at = record.last_accessed + self.config.ttl;
+        record
+    }
+
+    /// Persist metadata for a newly created session, logging on failure.
+    ///
+    /// Persistence errors are intentionally non-fatal: the live runtime
+    /// session is already registered locally, so the transport can continue
+    /// serving requests even if the external store is briefly unavailable.
+    async fn persist_new(&self, session: &Session) {
+        let record = self.record_for(session).await;
+        if let Err(e) = self.persistent.create(&mut record.clone()).await {
+            tracing::warn!(session_id = %session.id, error = %e, "Failed to persist session record");
         }
     }
 
@@ -514,43 +561,51 @@ impl SessionStore {
         router: McpRouter,
         service_factory: ServiceFactory,
     ) -> Option<Arc<Session>> {
-        let mut sessions = self.sessions.write().await;
+        let session = {
+            let mut sessions = self.sessions.write().await;
 
-        // Check max sessions limit
-        if let Some(max) = self.config.max_sessions
-            && sessions.len() >= max
-        {
-            tracing::warn!(
-                max_sessions = max,
-                current = sessions.len(),
-                "Session limit reached, rejecting new session"
-            );
-            return None;
-        }
+            // Check max sessions limit
+            if let Some(max) = self.config.max_sessions
+                && sessions.len() >= max
+            {
+                tracing::warn!(
+                    max_sessions = max,
+                    current = sessions.len(),
+                    "Session limit reached, rejecting new session"
+                );
+                return None;
+            }
 
-        let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
-        sessions.insert(session.id.clone(), session.clone());
-        tracing::debug!(session_id = %session.id, sampling = self.sampling_enabled, "Created new session");
+            let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
+            sessions.insert(session.id.clone(), session.clone());
+            tracing::debug!(session_id = %session.id, sampling = self.sampling_enabled, "Created new session");
+            session
+        };
+        self.persist_new(&session).await;
         Some(session)
     }
 
     async fn create_from_service(&self, service: McpBoxService) -> Option<Arc<Session>> {
-        let mut sessions = self.sessions.write().await;
+        let session = {
+            let mut sessions = self.sessions.write().await;
 
-        if let Some(max) = self.config.max_sessions
-            && sessions.len() >= max
-        {
-            tracing::warn!(
-                max_sessions = max,
-                current = sessions.len(),
-                "Session limit reached, rejecting new session"
-            );
-            return None;
-        }
+            if let Some(max) = self.config.max_sessions
+                && sessions.len() >= max
+            {
+                tracing::warn!(
+                    max_sessions = max,
+                    current = sessions.len(),
+                    "Session limit reached, rejecting new session"
+                );
+                return None;
+            }
 
-        let session = Arc::new(Session::from_service(service));
-        sessions.insert(session.id.clone(), session.clone());
-        tracing::debug!(session_id = %session.id, "Created new session from service");
+            let session = Arc::new(Session::from_service(service));
+            sessions.insert(session.id.clone(), session.clone());
+            tracing::debug!(session_id = %session.id, "Created new session from service");
+            session
+        };
+        self.persist_new(&session).await;
         Some(session)
     }
 
@@ -566,17 +621,21 @@ impl SessionStore {
         // Pre-initialize the router's session state so it won't reject requests
         router.session().mark_initialized();
 
-        let mut sessions = self.sessions.write().await;
+        let session = {
+            let mut sessions = self.sessions.write().await;
 
-        if let Some(max) = self.config.max_sessions
-            && sessions.len() >= max
-        {
-            return None;
-        }
+            if let Some(max) = self.config.max_sessions
+                && sessions.len() >= max
+            {
+                return None;
+            }
 
-        let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
-        sessions.insert(session.id.clone(), session.clone());
-        tracing::debug!(session_id = %session.id, "Created pre-initialized session (optional_sessions)");
+            let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
+            sessions.insert(session.id.clone(), session.clone());
+            tracing::debug!(session_id = %session.id, "Created pre-initialized session (optional_sessions)");
+            session
+        };
+        self.persist_new(&session).await;
         Some(session)
     }
 
@@ -585,17 +644,21 @@ impl SessionStore {
         &self,
         service: McpBoxService,
     ) -> Option<Arc<Session>> {
-        let mut sessions = self.sessions.write().await;
+        let session = {
+            let mut sessions = self.sessions.write().await;
 
-        if let Some(max) = self.config.max_sessions
-            && sessions.len() >= max
-        {
-            return None;
-        }
+            if let Some(max) = self.config.max_sessions
+                && sessions.len() >= max
+            {
+                return None;
+            }
 
-        let session = Arc::new(Session::from_service(service));
-        sessions.insert(session.id.clone(), session.clone());
-        tracing::debug!(session_id = %session.id, "Created pre-initialized session from service (optional_sessions)");
+            let session = Arc::new(Session::from_service(service));
+            sessions.insert(session.id.clone(), session.clone());
+            tracing::debug!(session_id = %session.id, "Created pre-initialized session from service (optional_sessions)");
+            session
+        };
+        self.persist_new(&session).await;
         Some(session)
     }
 
@@ -610,41 +673,54 @@ impl SessionStore {
     }
 
     async fn remove(&self, id: &str) -> bool {
-        let mut sessions = self.sessions.write().await;
-        let removed = sessions.remove(id).is_some();
+        let removed = {
+            let mut sessions = self.sessions.write().await;
+            sessions.remove(id).is_some()
+        };
         if removed {
             tracing::debug!(session_id = %id, "Removed session");
+            if let Err(e) = self.persistent.delete(id).await {
+                tracing::warn!(session_id = %id, error = %e, "Failed to delete session record");
+            }
         }
         removed
     }
 
     /// Remove expired sessions, returns count of removed sessions
     async fn cleanup_expired(&self) -> usize {
-        let mut sessions = self.sessions.write().await;
-        let ttl = self.config.ttl;
+        let expired = {
+            let mut sessions = self.sessions.write().await;
+            let ttl = self.config.ttl;
 
-        let mut expired = Vec::new();
-        for (id, session) in sessions.iter() {
-            if session.is_expired(ttl).await {
-                expired.push(id.clone());
+            let mut expired = Vec::new();
+            for (id, session) in sessions.iter() {
+                if session.is_expired(ttl).await {
+                    expired.push(id.clone());
+                }
+            }
+
+            for id in &expired {
+                sessions.remove(id);
+                tracing::debug!(session_id = %id, "Expired session removed");
+            }
+
+            if !expired.is_empty() {
+                tracing::info!(
+                    expired_count = expired.len(),
+                    remaining = sessions.len(),
+                    "Session cleanup completed"
+                );
+            }
+            expired
+        };
+
+        for id in &expired {
+            if let Err(e) = self.persistent.delete(id).await {
+                tracing::warn!(session_id = %id, error = %e, "Failed to delete expired session record");
             }
         }
 
-        let count = expired.len();
-        for id in expired {
-            sessions.remove(&id);
-            tracing::debug!(session_id = %id, "Expired session removed");
-        }
-
-        if count > 0 {
-            tracing::info!(
-                expired_count = count,
-                remaining = sessions.len(),
-                "Session cleanup completed"
-            );
-        }
-
-        count
+        expired.len()
     }
 }
 
@@ -684,7 +760,7 @@ pub struct SessionInfo {
 /// ```
 #[derive(Clone)]
 pub struct SessionHandle {
-    store: Arc<SessionStore>,
+    store: Arc<SessionRegistry>,
 }
 
 impl SessionHandle {
@@ -732,7 +808,7 @@ struct AppState {
     /// Source for creating new session services
     service_source: ServiceSource,
     /// Session store
-    sessions: Arc<SessionStore>,
+    sessions: Arc<SessionRegistry>,
     /// Whether to validate Origin header
     validate_origin: bool,
     /// Allowed origins (if validation is enabled)
@@ -781,6 +857,7 @@ pub struct HttpTransport {
     session_config: SessionConfig,
     sampling_enabled: bool,
     optional_sessions: bool,
+    session_store: Arc<dyn crate::session_store::SessionStore>,
     #[cfg(feature = "stateless")]
     stateless_config: Option<crate::stateless::StatelessConfig>,
     #[cfg(feature = "oauth")]
@@ -802,6 +879,7 @@ impl HttpTransport {
             session_config: SessionConfig::default(),
             sampling_enabled: false,
             optional_sessions: true,
+            session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -851,6 +929,7 @@ impl HttpTransport {
             session_config: SessionConfig::default(),
             sampling_enabled: false,
             optional_sessions: true,
+            session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -994,6 +1073,34 @@ impl HttpTransport {
         self
     }
 
+    /// Configure a pluggable [`SessionStore`](crate::session_store::SessionStore)
+    /// for persisting session metadata.
+    ///
+    /// The default is an in-process
+    /// [`MemorySessionStore`](crate::session_store::MemorySessionStore) —
+    /// supply an external store (Redis, Postgres, etc.) to share session
+    /// metadata across server instances behind a load balancer.
+    ///
+    /// Runtime state (broadcast channels, pending requests, service
+    /// instances) is always kept per-instance; only persistent metadata is
+    /// mirrored to the store.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use std::sync::Arc;
+    /// use tower_mcp::{HttpTransport, McpRouter};
+    /// use tower_mcp::session_store::{MemorySessionStore, SessionStore};
+    ///
+    /// let router = McpRouter::new();
+    /// let store: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+    /// let transport = HttpTransport::new(router).session_store(store);
+    /// ```
+    pub fn session_store(mut self, store: Arc<dyn crate::session_store::SessionStore>) -> Self {
+        self.session_store = store;
+        self
+    }
+
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
     ///
     /// When set, adds a `GET /.well-known/oauth-protected-resource` endpoint
@@ -1056,9 +1163,10 @@ impl HttpTransport {
     }
 
     fn build_state(&self) -> Arc<AppState> {
-        let sessions = Arc::new(SessionStore::new(
+        let sessions = Arc::new(SessionRegistry::new(
             self.session_config.clone(),
             self.sampling_enabled,
+            self.session_store.clone(),
         ));
 
         // Spawn cleanup task
@@ -2174,6 +2282,61 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(json.get("error").is_some());
         assert_eq!(json["error"]["code"], -32005); // SessionNotFound
+    }
+
+    #[tokio::test]
+    async fn test_custom_session_store_receives_create_and_delete() {
+        use crate::session_store::{MemorySessionStore, SessionStore as PublicSessionStore};
+
+        let store = Arc::new(MemorySessionStore::new());
+        let store_dyn: Arc<dyn PublicSessionStore> = store.clone();
+
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .session_store(store_dyn);
+        let (app, handle) = transport.into_router_with_handle();
+
+        // Initialize to create a session.
+        let init_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "test-client", "version": "1.0.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.clone().oneshot(init_request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let session_id = response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Custom store should have the record.
+        assert_eq!(store.len().await, 1);
+        let record = store.load(&session_id).await.unwrap();
+        assert!(record.is_some(), "expected session to be persisted");
+        assert_eq!(record.unwrap().id, session_id);
+
+        // Terminate session via the handle — store should be cleared.
+        assert!(handle.terminate_session(&session_id).await);
+        assert_eq!(store.len().await, 0);
+        assert!(store.load(&session_id).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -106,6 +106,18 @@ impl UnixSocketTransport {
         self
     }
 
+    /// Configure a pluggable [`SessionStore`](crate::session_store::SessionStore)
+    /// for persisting session metadata.
+    ///
+    /// See [`HttpTransport::session_store`] for details.
+    pub fn session_store(
+        mut self,
+        store: std::sync::Arc<dyn crate::session_store::SessionStore>,
+    ) -> Self {
+        self.inner = self.inner.session_store(store);
+        self
+    }
+
     /// Disable origin validation.
     ///
     /// Origin validation is less relevant for Unix sockets since they are

--- a/examples/session_store.rs
+++ b/examples/session_store.rs
@@ -1,0 +1,108 @@
+//! Custom SessionStore example.
+//!
+//! Demonstrates plugging a custom [`SessionStore`] into [`HttpTransport`] so
+//! session metadata is persisted alongside the default in-memory runtime
+//! state. Swap the `LoggingStore` here for a real Redis/Postgres-backed
+//! implementation in production.
+//!
+//! Run with: `cargo run --example session_store --features http`
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use async_trait::async_trait;
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, ToolBuilder,
+    session_store::{
+        CachingSessionStore, MemorySessionStore, Result as StoreResult, SessionRecord, SessionStore,
+    },
+};
+
+/// A [`SessionStore`] wrapper that logs every operation and counts calls.
+///
+/// In production you'd replace this with a store that writes to Redis,
+/// Postgres, DynamoDB, etc.
+#[derive(Debug)]
+struct LoggingStore<Inner> {
+    inner: Inner,
+    creates: AtomicUsize,
+    saves: AtomicUsize,
+    loads: AtomicUsize,
+    deletes: AtomicUsize,
+}
+
+impl<Inner> LoggingStore<Inner> {
+    fn new(inner: Inner) -> Self {
+        Self {
+            inner,
+            creates: AtomicUsize::new(0),
+            saves: AtomicUsize::new(0),
+            loads: AtomicUsize::new(0),
+            deletes: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl<Inner: SessionStore> SessionStore for LoggingStore<Inner> {
+    async fn create(&self, record: &mut SessionRecord) -> StoreResult<()> {
+        self.creates.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id = %record.id, "store.create");
+        self.inner.create(record).await
+    }
+
+    async fn save(&self, record: &SessionRecord) -> StoreResult<()> {
+        self.saves.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id = %record.id, "store.save");
+        self.inner.save(record).await
+    }
+
+    async fn load(&self, id: &str) -> StoreResult<Option<SessionRecord>> {
+        self.loads.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id = %id, "store.load");
+        self.inner.load(id).await
+    }
+
+    async fn delete(&self, id: &str) -> StoreResult<()> {
+        self.deletes.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id = %id, "store.delete");
+        self.inner.delete(id).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=debug".parse()?)
+                .add_directive("session_store=info".parse()?),
+        )
+        .init();
+
+    // Layer an in-memory cache in front of a logging "backend". In real
+    // deployments the backend would be Redis/Postgres/DynamoDB so multiple
+    // server instances share session metadata.
+    let backend = LoggingStore::new(MemorySessionStore::new());
+    let store: Arc<dyn SessionStore> =
+        Arc::new(CachingSessionStore::new(MemorySessionStore::new(), backend));
+
+    let tool = ToolBuilder::new("ping")
+        .description("Returns pong")
+        .handler(|_: tower_mcp::NoParams| async move { Ok(CallToolResult::text("pong")) })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("session-store-example", "1.0.0")
+        .tool(tool);
+
+    let transport = HttpTransport::new(router)
+        .disable_origin_validation()
+        .session_store(store);
+
+    tracing::info!("Starting HTTP MCP server with custom session store on http://127.0.0.1:3000");
+    tracing::info!("Each initialize/terminate will appear in the logs as store.create/delete");
+    transport.serve("127.0.0.1:3000").await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Implements the `SessionStore` trait from #774, enabling MCP server session metadata to be persisted to external backends (Redis, Postgres, etc.) for horizontal scaling behind load balancers.

## Architecture

Session state is split into two layers:

- **Persistent metadata** (`SessionRecord`) — serializable. Goes through the pluggable `SessionStore` trait.
- **Runtime state** — broadcast channels, pending requests, live service instances. Always per-instance, never serialized.

The API mirrors [`tower-sessions`](https://docs.rs/tower-sessions) (2.2M downloads, the de facto axum session layer):

- `SessionStore::create/save/load/delete`
- `SessionRecord { id, protocol_version, client_info, client_capabilities, timestamps }`
- `SessionStoreError` with `Encode/Decode/Backend` variants
- `MemorySessionStore` as the default in-process implementation
- `CachingSessionStore<Cache, Store>` for two-tier caching (in-memory frontend + durable backend)

## What's wired up

- `HttpTransport::session_store(Arc<dyn SessionStore>)` builder method
- `UnixSocketTransport::session_store(...)` (delegates to HttpTransport)
- Internal `SessionStore` struct renamed to `SessionRegistry`; now holds both the live session map and an `Arc<dyn SessionStore>` for metadata
- Persistence on create + delete + cleanup-expired. Touches are not persisted (too expensive; documented tradeoff).
- Store errors are logged but non-fatal — the transport continues serving requests even if the external store is briefly unavailable.

## What's deferred

- **Restore semantics**: when a request arrives with an unknown `mcp-session-id`, we don't yet rehydrate from the store. Follows up in a separate PR — same trait, just adds a fallback-on-miss code path.
- **WebSocket integration**: WS has a different session model (one session per connection, with zombie prevention). Can adopt this trait later or share where applicable.
- **External store crates** (`tower-mcp-redis-store` etc.) — separate crates, out of scope.

## Test plan

- [x] 12 unit tests in `session_store` module (trait, memory impl, caching wrapper)
- [x] Integration test: `test_custom_session_store_receives_create_and_delete` verifies a user-supplied store sees create/delete calls through the full HTTP flow
- [x] `cargo test --lib --all-features` — 650/650 pass (was 638)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Example builds: `cargo build --example session_store --features http`

Closes #774