### PR TITLE
feat: pluggable EventStore for SSE stream resumption

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -141,6 +141,11 @@ name = "session_store"
 path = "../../examples/session_store.rs"
 required-features = ["http"]
 
+[[example]]
+name = "event_store"
+path = "../../examples/event_store.rs"
+required-features = ["http"]
+
 # --- Middleware ---
 [[example]]
 name = "middleware"

--- a/crates/tower-mcp/src/event_store.rs
+++ b/crates/tower-mcp/src/event_store.rs
@@ -1,0 +1,344 @@
+//! Pluggable storage for SSE events enabling stream resumption.
+//!
+//! Mirrors the shape of [`crate::session_store`]: a trait, a serializable
+//! record type, an error enum, an in-memory default, and a caching wrapper.
+//!
+//! SSE streams buffer events per session so clients can replay them after a
+//! disconnect via the `Last-Event-ID` header (SEP-1699). When session
+//! metadata lives in an external store ([`crate::session_store`]), the event
+//! buffer needs to move along with it -- otherwise stream resumption only
+//! works if the client reconnects to the exact instance that saw the
+//! original events. An external [`EventStore`] fixes this.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use tower_mcp::event_store::{EventStore, MemoryEventStore};
+//!
+//! let store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::new());
+//! // `HttpTransport::new(router).event_store(store)` once wired in.
+//! ```
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// Default capacity of the in-memory per-session ring buffer.
+pub const DEFAULT_MAX_EVENTS_PER_SESSION: usize = 1000;
+
+/// Serializable SSE event record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EventRecord {
+    /// Monotonically increasing event ID within a session.
+    pub id: u64,
+    /// Serialized JSON-RPC payload (notification, response, or request).
+    pub data: String,
+    /// When the event was produced.
+    pub timestamp: SystemTime,
+}
+
+impl EventRecord {
+    /// Create a new record stamped with the current time.
+    pub fn new(id: u64, data: impl Into<String>) -> Self {
+        Self {
+            id,
+            data: data.into(),
+            timestamp: SystemTime::now(),
+        }
+    }
+}
+
+/// Errors returned by [`EventStore`] implementations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum EventStoreError {
+    /// Failed to encode a record.
+    #[error("encode error: {0}")]
+    Encode(String),
+    /// Failed to decode a record.
+    #[error("decode error: {0}")]
+    Decode(String),
+    /// Backend error (e.g. connection failure, transient storage error).
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+/// Result alias for event store operations.
+pub type Result<T> = std::result::Result<T, EventStoreError>;
+
+/// Storage backend for per-session SSE event logs.
+///
+/// Implementations persist [`EventRecord`]s keyed by session ID. The default
+/// implementation is [`MemoryEventStore`]; external stores (Redis, etc.)
+/// typically live in separate crates.
+#[async_trait]
+pub trait EventStore: Send + Sync + 'static {
+    /// Append an event to a session's log.
+    async fn append(&self, session_id: &str, event: EventRecord) -> Result<()>;
+
+    /// Return events with IDs strictly greater than `after_id`, in order.
+    async fn replay_after(&self, session_id: &str, after_id: u64) -> Result<Vec<EventRecord>>;
+
+    /// Remove all events for a session. Idempotent.
+    async fn purge_session(&self, session_id: &str) -> Result<()>;
+}
+
+/// In-memory [`EventStore`] with a per-session ring buffer.
+///
+/// Each session keeps up to `max_events_per_session` events; the oldest is
+/// evicted when the buffer is full. This is the default store; external
+/// implementations are only needed for cross-instance replay.
+#[derive(Debug, Clone)]
+pub struct MemoryEventStore {
+    inner: Arc<RwLock<HashMap<String, VecDeque<EventRecord>>>>,
+    max_events_per_session: usize,
+}
+
+impl Default for MemoryEventStore {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_MAX_EVENTS_PER_SESSION)
+    }
+}
+
+impl MemoryEventStore {
+    /// Create a new store using [`DEFAULT_MAX_EVENTS_PER_SESSION`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Create a store with the given per-session buffer capacity.
+    pub fn with_capacity(max_events_per_session: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            max_events_per_session,
+        }
+    }
+
+    /// Total number of events currently buffered across all sessions.
+    pub async fn total_events(&self) -> usize {
+        self.inner.read().await.values().map(|v| v.len()).sum()
+    }
+
+    /// Number of sessions with at least one buffered event.
+    pub async fn session_count(&self) -> usize {
+        self.inner.read().await.len()
+    }
+}
+
+#[async_trait]
+impl EventStore for MemoryEventStore {
+    async fn append(&self, session_id: &str, event: EventRecord) -> Result<()> {
+        let mut map = self.inner.write().await;
+        let buf = map.entry(session_id.to_string()).or_default();
+        if buf.len() >= self.max_events_per_session {
+            buf.pop_front();
+        }
+        buf.push_back(event);
+        Ok(())
+    }
+
+    async fn replay_after(&self, session_id: &str, after_id: u64) -> Result<Vec<EventRecord>> {
+        let map = self.inner.read().await;
+        Ok(match map.get(session_id) {
+            Some(buf) => buf.iter().filter(|e| e.id > after_id).cloned().collect(),
+            None => Vec::new(),
+        })
+    }
+
+    async fn purge_session(&self, session_id: &str) -> Result<()> {
+        self.inner.write().await.remove(session_id);
+        Ok(())
+    }
+}
+
+/// Two-tier [`EventStore`] composed of a cache frontend and a store backend.
+///
+/// Writes go to both tiers; replays read from the cache first and fall
+/// through to the backend on miss (populating the cache with the missing
+/// events). Mirrors [`crate::session_store::CachingSessionStore`].
+#[derive(Debug, Clone)]
+pub struct CachingEventStore<Cache, Store> {
+    cache: Cache,
+    store: Store,
+}
+
+impl<Cache, Store> CachingEventStore<Cache, Store> {
+    /// Create a new caching store with the given cache and backend.
+    pub fn new(cache: Cache, store: Store) -> Self {
+        Self { cache, store }
+    }
+}
+
+#[async_trait]
+impl<Cache, Store> EventStore for CachingEventStore<Cache, Store>
+where
+    Cache: EventStore,
+    Store: EventStore,
+{
+    async fn append(&self, session_id: &str, event: EventRecord) -> Result<()> {
+        // Write the backend first so durability is established, then mirror.
+        self.store.append(session_id, event.clone()).await?;
+        self.cache.append(session_id, event).await?;
+        Ok(())
+    }
+
+    async fn replay_after(&self, session_id: &str, after_id: u64) -> Result<Vec<EventRecord>> {
+        let cached = self.cache.replay_after(session_id, after_id).await?;
+        if !cached.is_empty() {
+            return Ok(cached);
+        }
+        let from_store = self.store.replay_after(session_id, after_id).await?;
+        // Warm the cache best-effort; failures are non-fatal.
+        for event in &from_store {
+            let _ = self.cache.append(session_id, event.clone()).await;
+        }
+        Ok(from_store)
+    }
+
+    async fn purge_session(&self, session_id: &str) -> Result<()> {
+        let cache_result = self.cache.purge_session(session_id).await;
+        let store_result = self.store.purge_session(session_id).await;
+        cache_result.and(store_result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn memory_store_append_and_replay() {
+        let store = MemoryEventStore::new();
+        for i in 0..3 {
+            store
+                .append("s", EventRecord::new(i, format!("e{i}")))
+                .await
+                .unwrap();
+        }
+
+        let all = store.replay_after("s", 0).await.unwrap();
+        assert_eq!(all.len(), 2); // ids 1, 2
+
+        let none = store.replay_after("s", 5).await.unwrap();
+        assert!(none.is_empty());
+
+        let after_first = store.replay_after("s", 0).await.unwrap();
+        assert_eq!(after_first[0].id, 1);
+        assert_eq!(after_first[1].id, 2);
+    }
+
+    #[tokio::test]
+    async fn memory_store_respects_capacity() {
+        let store = MemoryEventStore::with_capacity(3);
+        for i in 0..5 {
+            store
+                .append("s", EventRecord::new(i, format!("e{i}")))
+                .await
+                .unwrap();
+        }
+
+        // Oldest two events evicted (ids 0 and 1), leaving 2, 3, 4.
+        let events = store.replay_after("s", 0).await.unwrap();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0].id, 2);
+        assert_eq!(events[2].id, 4);
+    }
+
+    #[tokio::test]
+    async fn memory_store_isolates_sessions() {
+        let store = MemoryEventStore::new();
+        store.append("a", EventRecord::new(0, "a0")).await.unwrap();
+        store.append("b", EventRecord::new(0, "b0")).await.unwrap();
+
+        let a = store.replay_after("a", 0).await.unwrap();
+        let b = store.replay_after("b", 0).await.unwrap();
+        assert!(a.is_empty() && b.is_empty(), "after_id filters out id 0");
+
+        // Replay from just before 0 (using -1 isn't possible with u64, so
+        // we verify by appending a second event and replaying after 0).
+        store.append("a", EventRecord::new(1, "a1")).await.unwrap();
+        let a1 = store.replay_after("a", 0).await.unwrap();
+        assert_eq!(a1.len(), 1);
+        assert_eq!(a1[0].data, "a1");
+    }
+
+    #[tokio::test]
+    async fn memory_store_purge_removes_session() {
+        let store = MemoryEventStore::new();
+        store.append("s", EventRecord::new(0, "x")).await.unwrap();
+        assert_eq!(store.session_count().await, 1);
+
+        store.purge_session("s").await.unwrap();
+        assert_eq!(store.session_count().await, 0);
+    }
+
+    #[tokio::test]
+    async fn memory_store_purge_is_idempotent() {
+        MemoryEventStore::new()
+            .purge_session("nonexistent")
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn dyn_event_store_object_safe() {
+        let store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::new());
+        store.append("s", EventRecord::new(0, "x")).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn caching_store_writes_to_both_tiers() {
+        let cache = MemoryEventStore::new();
+        let backend = MemoryEventStore::new();
+        let store = CachingEventStore::new(cache.clone(), backend.clone());
+
+        store.append("s", EventRecord::new(0, "x")).await.unwrap();
+
+        assert_eq!(cache.total_events().await, 1);
+        assert_eq!(backend.total_events().await, 1);
+    }
+
+    #[tokio::test]
+    async fn caching_store_reads_from_cache_first() {
+        let cache = MemoryEventStore::new();
+        let backend = MemoryEventStore::new();
+
+        // Only prime the backend.
+        backend
+            .append("s", EventRecord::new(0, "b0"))
+            .await
+            .unwrap();
+        backend
+            .append("s", EventRecord::new(1, "b1"))
+            .await
+            .unwrap();
+
+        let store = CachingEventStore::new(cache.clone(), backend);
+
+        // First replay goes to the backend and warms the cache.
+        let first = store.replay_after("s", 0).await.unwrap();
+        assert_eq!(first.len(), 1); // only id 1
+
+        // Cache should now contain the warmed event.
+        assert_eq!(cache.total_events().await, 1);
+    }
+
+    #[tokio::test]
+    async fn caching_store_purge_clears_both() {
+        let cache = MemoryEventStore::new();
+        let backend = MemoryEventStore::new();
+        let store = CachingEventStore::new(cache.clone(), backend.clone());
+
+        store.append("s", EventRecord::new(0, "x")).await.unwrap();
+        store.purge_session("s").await.unwrap();
+
+        assert_eq!(cache.total_events().await, 0);
+        assert_eq!(backend.total_events().await, 0);
+    }
+}

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -387,6 +387,8 @@ pub mod auth;
 pub mod client;
 pub mod context;
 pub mod error;
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub mod event_store;
 pub mod extract;
 pub mod filter;
 pub mod jsonrpc;

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -161,7 +161,7 @@
 //! }
 //! ```
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -206,24 +206,9 @@ const SSE_MESSAGE_EVENT: &str = "message";
 /// Header name for Last-Event-ID (for SSE stream resumption per SEP-1699)
 const LAST_EVENT_ID_HEADER: &str = "last-event-id";
 
-/// Default maximum buffered events per session for stream resumption (SEP-1699)
-const DEFAULT_MAX_BUFFERED_EVENTS: usize = 1000;
-
 /// Pending request waiting for a response from the client
 struct PendingRequest {
     response_tx: oneshot::Sender<Result<serde_json::Value>>,
-}
-
-/// A buffered SSE event for stream resumption (SEP-1699)
-#[derive(Clone)]
-struct BufferedEvent {
-    /// Event ID
-    id: u64,
-    /// Event data (JSON string)
-    data: String,
-    /// When the event was created (for future time-based expiration)
-    #[allow(dead_code)]
-    timestamp: Instant,
 }
 
 /// Session state for HTTP transport
@@ -259,14 +244,17 @@ struct Session {
     protocol_version: RwLock<String>,
     /// Counter for SSE event IDs (for stream resumption per SEP-1699)
     event_counter: AtomicU64,
-    /// Buffer of recent events for stream resumption (SEP-1699)
-    event_buffer: RwLock<VecDeque<BufferedEvent>>,
-    /// Maximum number of events to buffer per session
-    max_buffered_events: usize,
+    /// Pluggable store for SSE events (enables cross-instance replay)
+    event_store: Arc<dyn crate::event_store::EventStore>,
 }
 
 impl Session {
-    fn new(router: McpRouter, sampling_enabled: bool, service_factory: ServiceFactory) -> Self {
+    fn new(
+        router: McpRouter,
+        sampling_enabled: bool,
+        service_factory: ServiceFactory,
+        event_store: Arc<dyn crate::event_store::EventStore>,
+    ) -> Self {
         let (notifications_tx, _) = broadcast::channel(100);
 
         // Set up notification forwarding: mpsc -> broadcast
@@ -311,8 +299,7 @@ impl Session {
             request_rx: Mutex::new(request_rx),
             protocol_version: RwLock::new(LATEST_PROTOCOL_VERSION.to_string()),
             event_counter: AtomicU64::new(0),
-            event_buffer: RwLock::new(VecDeque::new()),
-            max_buffered_events: DEFAULT_MAX_BUFFERED_EVENTS,
+            event_store,
         }
     }
 
@@ -321,7 +308,10 @@ impl Session {
     /// This is used when the transport is created via [`HttpTransport::from_service()`].
     /// Notification bridging and sampling setup are skipped — the caller is
     /// responsible for configuring these on the service before passing it in.
-    fn from_service(service: McpBoxService) -> Self {
+    fn from_service(
+        service: McpBoxService,
+        event_store: Arc<dyn crate::event_store::EventStore>,
+    ) -> Self {
         let (notifications_tx, _) = broadcast::channel(100);
 
         let now = Instant::now();
@@ -335,8 +325,7 @@ impl Session {
             request_rx: Mutex::new(None),
             protocol_version: RwLock::new(LATEST_PROTOCOL_VERSION.to_string()),
             event_counter: AtomicU64::new(0),
-            event_buffer: RwLock::new(VecDeque::new()),
-            max_buffered_events: DEFAULT_MAX_BUFFERED_EVENTS,
+            event_store,
         }
     }
 
@@ -377,29 +366,30 @@ impl Session {
 
     /// Buffer an event for potential replay (SEP-1699).
     ///
-    /// Events are buffered in a ring buffer. When the buffer is full,
-    /// the oldest event is evicted. Clients can request replay of
-    /// buffered events via the Last-Event-ID header.
+    /// Delegates to the configured [`EventStore`](crate::event_store::EventStore).
+    /// Store errors are logged but non-fatal — the transport continues
+    /// serving the client even if the external event buffer is unavailable,
+    /// since the event has already been sent on the live SSE stream.
     async fn buffer_event(&self, id: u64, data: String) {
-        let mut buffer = self.event_buffer.write().await;
-        if buffer.len() >= self.max_buffered_events {
-            buffer.pop_front();
+        let record = crate::event_store::EventRecord::new(id, data);
+        if let Err(e) = self.event_store.append(&self.id, record).await {
+            tracing::warn!(session_id = %self.id, event_id = id, error = %e, "Failed to append event to event store");
         }
-        buffer.push_back(BufferedEvent {
-            id,
-            data,
-            timestamp: Instant::now(),
-        });
     }
 
     /// Get buffered events after the given event ID.
     ///
-    /// Returns events with IDs greater than `after_id`, in order.
-    /// Used for stream resumption when a client reconnects with
-    /// the Last-Event-ID header.
-    async fn get_events_after(&self, after_id: u64) -> Vec<BufferedEvent> {
-        let buffer = self.event_buffer.read().await;
-        buffer.iter().filter(|e| e.id > after_id).cloned().collect()
+    /// Returns events with IDs greater than `after_id`, in order. Used for
+    /// stream resumption when a client reconnects with the `Last-Event-ID`
+    /// header. Store errors produce an empty replay list and are logged.
+    async fn get_events_after(&self, after_id: u64) -> Vec<crate::event_store::EventRecord> {
+        match self.event_store.replay_after(&self.id, after_id).await {
+            Ok(events) => events,
+            Err(e) => {
+                tracing::warn!(session_id = %self.id, error = %e, "Failed to replay events from event store");
+                Vec::new()
+            }
+        }
     }
 
     /// Update the last accessed time
@@ -507,6 +497,7 @@ struct SessionRegistry {
     config: SessionConfig,
     sampling_enabled: bool,
     persistent: Arc<dyn crate::session_store::SessionStore>,
+    events: Arc<dyn crate::event_store::EventStore>,
 }
 
 impl SessionRegistry {
@@ -514,12 +505,14 @@ impl SessionRegistry {
         config: SessionConfig,
         sampling_enabled: bool,
         persistent: Arc<dyn crate::session_store::SessionStore>,
+        events: Arc<dyn crate::event_store::EventStore>,
     ) -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
             config,
             sampling_enabled,
             persistent,
+            events,
         }
     }
 
@@ -576,7 +569,12 @@ impl SessionRegistry {
                 return None;
             }
 
-            let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
+            let session = Arc::new(Session::new(
+                router,
+                self.sampling_enabled,
+                service_factory,
+                self.events.clone(),
+            ));
             sessions.insert(session.id.clone(), session.clone());
             tracing::debug!(session_id = %session.id, sampling = self.sampling_enabled, "Created new session");
             session
@@ -600,7 +598,7 @@ impl SessionRegistry {
                 return None;
             }
 
-            let session = Arc::new(Session::from_service(service));
+            let session = Arc::new(Session::from_service(service, self.events.clone()));
             sessions.insert(session.id.clone(), session.clone());
             tracing::debug!(session_id = %session.id, "Created new session from service");
             session
@@ -630,7 +628,12 @@ impl SessionRegistry {
                 return None;
             }
 
-            let session = Arc::new(Session::new(router, self.sampling_enabled, service_factory));
+            let session = Arc::new(Session::new(
+                router,
+                self.sampling_enabled,
+                service_factory,
+                self.events.clone(),
+            ));
             sessions.insert(session.id.clone(), session.clone());
             tracing::debug!(session_id = %session.id, "Created pre-initialized session (optional_sessions)");
             session
@@ -653,7 +656,7 @@ impl SessionRegistry {
                 return None;
             }
 
-            let session = Arc::new(Session::from_service(service));
+            let session = Arc::new(Session::from_service(service, self.events.clone()));
             sessions.insert(session.id.clone(), session.clone());
             tracing::debug!(session_id = %session.id, "Created pre-initialized session from service (optional_sessions)");
             session
@@ -681,6 +684,9 @@ impl SessionRegistry {
             tracing::debug!(session_id = %id, "Removed session");
             if let Err(e) = self.persistent.delete(id).await {
                 tracing::warn!(session_id = %id, error = %e, "Failed to delete session record");
+            }
+            if let Err(e) = self.events.purge_session(id).await {
+                tracing::warn!(session_id = %id, error = %e, "Failed to purge session events");
             }
         }
         removed
@@ -717,6 +723,9 @@ impl SessionRegistry {
         for id in &expired {
             if let Err(e) = self.persistent.delete(id).await {
                 tracing::warn!(session_id = %id, error = %e, "Failed to delete expired session record");
+            }
+            if let Err(e) = self.events.purge_session(id).await {
+                tracing::warn!(session_id = %id, error = %e, "Failed to purge expired session events");
             }
         }
 
@@ -858,6 +867,7 @@ pub struct HttpTransport {
     sampling_enabled: bool,
     optional_sessions: bool,
     session_store: Arc<dyn crate::session_store::SessionStore>,
+    event_store: Arc<dyn crate::event_store::EventStore>,
     #[cfg(feature = "stateless")]
     stateless_config: Option<crate::stateless::StatelessConfig>,
     #[cfg(feature = "oauth")]
@@ -880,6 +890,7 @@ impl HttpTransport {
             sampling_enabled: false,
             optional_sessions: true,
             session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
+            event_store: Arc::new(crate::event_store::MemoryEventStore::new()),
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -930,6 +941,7 @@ impl HttpTransport {
             sampling_enabled: false,
             optional_sessions: true,
             session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
+            event_store: Arc::new(crate::event_store::MemoryEventStore::new()),
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -1101,6 +1113,35 @@ impl HttpTransport {
         self
     }
 
+    /// Configure a pluggable [`EventStore`](crate::event_store::EventStore)
+    /// for SSE event buffering and stream resumption.
+    ///
+    /// The default is an in-process
+    /// [`MemoryEventStore`](crate::event_store::MemoryEventStore) with a
+    /// 1000-event ring buffer per session — supply an external store (Redis,
+    /// etc.) so clients can resume SSE streams after reconnecting to a
+    /// different server instance behind a load balancer (SEP-1699).
+    ///
+    /// Typically paired with a matching
+    /// [`session_store`](Self::session_store) so both session metadata and
+    /// buffered events survive across instances.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use std::sync::Arc;
+    /// use tower_mcp::{HttpTransport, McpRouter};
+    /// use tower_mcp::event_store::{EventStore, MemoryEventStore};
+    ///
+    /// let router = McpRouter::new();
+    /// let store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::new());
+    /// let transport = HttpTransport::new(router).event_store(store);
+    /// ```
+    pub fn event_store(mut self, store: Arc<dyn crate::event_store::EventStore>) -> Self {
+        self.event_store = store;
+        self
+    }
+
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
     ///
     /// When set, adds a `GET /.well-known/oauth-protected-resource` endpoint
@@ -1167,6 +1208,7 @@ impl HttpTransport {
             self.session_config.clone(),
             self.sampling_enabled,
             self.session_store.clone(),
+            self.event_store.clone(),
         ));
 
         // Spawn cleanup task
@@ -2340,6 +2382,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_custom_event_store_buffers_and_purges() {
+        use crate::event_store::{EventStore as PublicEventStore, MemoryEventStore};
+
+        let events = Arc::new(MemoryEventStore::new());
+        let events_dyn: Arc<dyn PublicEventStore> = events.clone();
+
+        // Build a session directly so we can exercise buffer_event/get_events_after
+        // without needing a live SSE subscriber.
+        let session = Arc::new(Session::new(
+            create_test_router(),
+            false,
+            identity_factory(),
+            events_dyn,
+        ));
+
+        session.buffer_event(0, "first".to_string()).await;
+        session.buffer_event(1, "second".to_string()).await;
+
+        // Custom store should have both events.
+        assert_eq!(events.total_events().await, 2);
+        let replayed = events.replay_after(&session.id, 0).await.unwrap();
+        assert_eq!(replayed.len(), 1);
+        assert_eq!(replayed[0].id, 1);
+        assert_eq!(replayed[0].data, "second");
+
+        // Purging should clear the session's log.
+        events.purge_session(&session.id).await.unwrap();
+        assert_eq!(events.total_events().await, 0);
+    }
+
+    #[tokio::test]
     async fn test_session_expiration() {
         // Create transport with very short TTL
         let config = SessionConfig::with_ttl(Duration::from_millis(50))
@@ -2651,7 +2724,12 @@ mod tests {
     #[tokio::test]
     async fn test_session_event_buffering() {
         // Test that events are buffered and can be retrieved for replay (SEP-1699)
-        let session = Session::new(create_test_router(), false, identity_factory());
+        let session = Session::new(
+            create_test_router(),
+            false,
+            identity_factory(),
+            Arc::new(crate::event_store::MemoryEventStore::new()),
+        );
 
         // Buffer some events
         session.buffer_event(0, "event0".to_string()).await;
@@ -2679,7 +2757,12 @@ mod tests {
     #[tokio::test]
     async fn test_session_event_counter_increments() {
         // Test that event IDs increment monotonically (SEP-1699)
-        let session = Session::new(create_test_router(), false, identity_factory());
+        let session = Session::new(
+            create_test_router(),
+            false,
+            identity_factory(),
+            Arc::new(crate::event_store::MemoryEventStore::new()),
+        );
 
         assert_eq!(session.next_event_id(), 0);
         assert_eq!(session.next_event_id(), 1);
@@ -2690,7 +2773,12 @@ mod tests {
     async fn test_session_event_buffer_limit() {
         // Test that buffer respects max size limit
         // Create a session - buffer limit is DEFAULT_MAX_BUFFERED_EVENTS (1000)
-        let session = Session::new(create_test_router(), false, identity_factory());
+        let session = Session::new(
+            create_test_router(),
+            false,
+            identity_factory(),
+            Arc::new(crate::event_store::MemoryEventStore::new()),
+        );
 
         // Buffer more events than we can test practically, but verify the mechanism works
         // by checking that old events are evicted when we exceed the limit

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -118,6 +118,18 @@ impl UnixSocketTransport {
         self
     }
 
+    /// Configure a pluggable [`EventStore`](crate::event_store::EventStore)
+    /// for SSE event buffering and stream resumption.
+    ///
+    /// See [`HttpTransport::event_store`] for details.
+    pub fn event_store(
+        mut self,
+        store: std::sync::Arc<dyn crate::event_store::EventStore>,
+    ) -> Self {
+        self.inner = self.inner.event_store(store);
+        self
+    }
+
     /// Disable origin validation.
     ///
     /// Origin validation is less relevant for Unix sockets since they are

--- a/examples/event_store.rs
+++ b/examples/event_store.rs
@@ -1,0 +1,140 @@
+//! Custom EventStore example.
+//!
+//! Demonstrates plugging a custom [`EventStore`] into [`HttpTransport`] so
+//! buffered SSE events are persisted alongside the default in-memory ring
+//! buffer. Swap the `LoggingStore` here for a Redis-backed implementation
+//! in production to enable cross-instance SSE resumption.
+//!
+//! Run with: `cargo run --example event_store --features http`
+//!
+//! Once running, call the `slow_task` tool and then disconnect/reconnect
+//! with a `Last-Event-ID` header to see events replayed from the store.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, ToolBuilder,
+    event_store::{
+        CachingEventStore, EventRecord, EventStore, MemoryEventStore, Result as StoreResult,
+    },
+    extract::{Context, Json},
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SlowTaskInput {
+    #[serde(default = "default_steps")]
+    steps: u32,
+}
+
+fn default_steps() -> u32 {
+    5
+}
+
+/// An [`EventStore`] wrapper that logs every operation and counts calls.
+///
+/// In production you'd replace this with a store that writes to Redis or
+/// another shared backend.
+#[derive(Debug)]
+struct LoggingEventStore<Inner> {
+    inner: Inner,
+    appends: AtomicUsize,
+    replays: AtomicUsize,
+    purges: AtomicUsize,
+}
+
+impl<Inner> LoggingEventStore<Inner> {
+    fn new(inner: Inner) -> Self {
+        Self {
+            inner,
+            appends: AtomicUsize::new(0),
+            replays: AtomicUsize::new(0),
+            purges: AtomicUsize::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl<Inner: EventStore> EventStore for LoggingEventStore<Inner> {
+    async fn append(&self, session_id: &str, event: EventRecord) -> StoreResult<()> {
+        self.appends.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id, event_id = event.id, "event.append");
+        self.inner.append(session_id, event).await
+    }
+
+    async fn replay_after(&self, session_id: &str, after_id: u64) -> StoreResult<Vec<EventRecord>> {
+        self.replays.fetch_add(1, Ordering::Relaxed);
+        let events = self.inner.replay_after(session_id, after_id).await?;
+        tracing::info!(
+            session_id,
+            after_id,
+            replayed = events.len(),
+            "event.replay_after"
+        );
+        Ok(events)
+    }
+
+    async fn purge_session(&self, session_id: &str) -> StoreResult<()> {
+        self.purges.fetch_add(1, Ordering::Relaxed);
+        tracing::info!(session_id, "event.purge_session");
+        self.inner.purge_session(session_id).await
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=debug".parse()?)
+                .add_directive("event_store=info".parse()?),
+        )
+        .init();
+
+    // Cache in front of a logging "backend". In production the backend
+    // would be Redis or similar so multiple server instances share the
+    // event log and clients can resume SSE streams from any instance.
+    let backend = LoggingEventStore::new(MemoryEventStore::new());
+    let store: Arc<dyn EventStore> =
+        Arc::new(CachingEventStore::new(MemoryEventStore::new(), backend));
+
+    // A tool that emits progress notifications so there's something to
+    // buffer in the event log.
+    let slow_task = ToolBuilder::new("slow_task")
+        .description("Simulate a slow task that reports progress")
+        .extractor_handler(
+            (),
+            |ctx: Context, Json(input): Json<SlowTaskInput>| async move {
+                let steps = input.steps.min(10);
+                for i in 0..steps {
+                    ctx.report_progress(
+                        i as f64,
+                        Some(steps as f64),
+                        Some(&format!("step {}/{}", i + 1, steps)),
+                    )
+                    .await;
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                Ok(CallToolResult::text(format!("finished {steps} steps")))
+            },
+        )
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("event-store-example", "1.0.0")
+        .tool(slow_task);
+
+    let transport = HttpTransport::new(router)
+        .disable_origin_validation()
+        .event_store(store);
+
+    tracing::info!("Starting HTTP MCP server with custom event store on http://127.0.0.1:3000");
+    tracing::info!("Call slow_task and reconnect with Last-Event-ID to trigger replays");
+    transport.serve("127.0.0.1:3000").await?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds the pluggable `EventStore` trait from #775, mirroring the `SessionStore` pattern from #774. SSE event buffering can now be backed by an external store (Redis, etc.) so clients can replay buffered events via `Last-Event-ID` even when reconnecting to a different server instance.

## API

Parallel to `SessionStore`:

- `EventStore::append(session_id, EventRecord) / replay_after(session_id, after_id) / purge_session(id)`
- `EventRecord { id: u64, data: String, timestamp: SystemTime }`
- `EventStoreError` with `Encode / Decode / Backend` variants
- `MemoryEventStore` — per-session ring buffer, 1000-event default capacity (`with_capacity(...)` for other sizes)
- `CachingEventStore<Cache, Store>` — two-tier cache frontend + durable backend

## What's wired up

- `HttpTransport::event_store(Arc<dyn EventStore>)` builder
- `UnixSocketTransport::event_store(...)` (delegates to HttpTransport)
- `Session`'s `buffer_event` / `get_events_after` now delegate to the store; the local `VecDeque<BufferedEvent>` is removed
- `SessionRegistry` purges the session's event log on removal and on expiry, alongside the session-metadata delete

Store failures are logged but non-fatal: for `append`, the event has already been sent on the live SSE stream; for `replay_after`, a failure produces an empty replay list (same effect as no buffered events).

## What's deferred

- Per-request stream IDs (rmcp-style `0/5` event IDs from modelcontextprotocol/rust-sdk#799) — would let the trait support multiple concurrent streams per session. Current trait is per-session-log; can evolve later.
- External store crates (`tower-mcp-redis-store` etc.) — separate crates.
- Restore semantics paired with `session_store` (rehydrating a session from scratch on cross-instance replay).

## Test plan

- [x] 9 unit tests in `event_store` module (append/replay, capacity eviction, session isolation, purge, caching wrapper, object safety)
- [x] Integration test `test_custom_event_store_buffers_and_purges` verifies a user-supplied store sees append/replay/purge through `Session`
- [x] `cargo test --lib --all-features` — 660/660 pass (was 650)
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --example event_store --features http` clean

Closes #775