### PR TITLE
feat: session restore from store + auto-reinitialize fallback

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -146,6 +146,11 @@ name = "event_store"
 path = "../../examples/event_store.rs"
 required-features = ["http"]
 
+[[example]]
+name = "horizontal_scaling"
+path = "../../examples/horizontal_scaling.rs"
+required-features = ["http"]
+
 # --- Middleware ---
 [[example]]
 name = "middleware"

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -329,6 +329,92 @@ impl Session {
         }
     }
 
+    /// Rebuild a session from a [`SessionRecord`] so a request for an
+    /// unknown session ID can be served transparently.
+    ///
+    /// The router is pre-marked initialized and the protocol version is
+    /// restored from the record. Runtime state (broadcast channels,
+    /// pending-request table) is freshly allocated — in-flight state from
+    /// before the rebuild is not recovered. The `event_counter` is left at
+    /// zero; the [`SessionRegistry`] seeds it from the event store so
+    /// future event IDs don't collide with buffered ones.
+    fn restored(
+        record: &crate::session_store::SessionRecord,
+        router: McpRouter,
+        sampling_enabled: bool,
+        service_factory: ServiceFactory,
+        event_store: Arc<dyn crate::event_store::EventStore>,
+    ) -> Self {
+        // Skip the Initializing intermediate state — this session was
+        // already initialized on the original instance.
+        router.session().mark_initialized();
+
+        let (notifications_tx, _) = broadcast::channel(100);
+        let (notif_sender, mut notif_receiver) = notification_channel(256);
+        let router = router.with_notification_sender(notif_sender);
+
+        let broadcast_tx = notifications_tx.clone();
+        tokio::spawn(async move {
+            while let Some(notification) = notif_receiver.recv().await {
+                if let Some(json) = crate::transport::stdio::serialize_notification(&notification) {
+                    let _ = broadcast_tx.send(json);
+                }
+            }
+        });
+
+        let (router, request_rx) = if sampling_enabled {
+            let (request_tx, request_rx) = outgoing_request_channel(32);
+            let client_requester: ClientRequesterHandle =
+                Arc::new(ChannelClientRequester::new(request_tx));
+            let router = router.with_client_requester(client_requester);
+            (router, Some(request_rx))
+        } else {
+            (router, None)
+        };
+
+        let now = Instant::now();
+        Self {
+            id: record.id.clone(),
+            service_source: SessionServiceSource::Router {
+                router,
+                factory: service_factory,
+            },
+            notifications_tx,
+            created_at: now,
+            last_accessed: RwLock::new(now),
+            pending_requests: Mutex::new(HashMap::new()),
+            request_rx: Mutex::new(request_rx),
+            protocol_version: RwLock::new(record.protocol_version.clone()),
+            event_counter: AtomicU64::new(0),
+            event_store,
+        }
+    }
+
+    /// Rebuild a session from a [`SessionRecord`] for transports built
+    /// with [`HttpTransport::from_service`]. The service's internal state
+    /// (if any) is not restored — the caller is responsible for anything
+    /// beyond the metadata in the record.
+    fn from_service_restored(
+        service: McpBoxService,
+        record: &crate::session_store::SessionRecord,
+        event_store: Arc<dyn crate::event_store::EventStore>,
+    ) -> Self {
+        let (notifications_tx, _) = broadcast::channel(100);
+        let now = Instant::now();
+        Self {
+            id: record.id.clone(),
+            service_source: SessionServiceSource::Boxed(std::sync::Mutex::new(service)),
+            notifications_tx,
+            created_at: now,
+            last_accessed: RwLock::new(now),
+            pending_requests: Mutex::new(HashMap::new()),
+            request_rx: Mutex::new(None),
+            protocol_version: RwLock::new(record.protocol_version.clone()),
+            event_counter: AtomicU64::new(0),
+            event_store,
+        }
+    }
+
     /// Create a middleware-wrapped service from this session's service source.
     fn make_service(&self) -> McpBoxService {
         match &self.service_source {
@@ -498,6 +584,13 @@ struct SessionRegistry {
     sampling_enabled: bool,
     persistent: Arc<dyn crate::session_store::SessionStore>,
     events: Arc<dyn crate::event_store::EventStore>,
+    /// Source for rebuilding services when restoring a session.
+    service_source: ServiceSource,
+    /// If `true`, a request for an unknown session ID whose record is not
+    /// in the persistent store spins up a new session with synthetic
+    /// client info instead of returning 404 (see anubis-mcp #125 for the
+    /// precedent).
+    auto_reinit: bool,
 }
 
 impl SessionRegistry {
@@ -506,6 +599,8 @@ impl SessionRegistry {
         sampling_enabled: bool,
         persistent: Arc<dyn crate::session_store::SessionStore>,
         events: Arc<dyn crate::event_store::EventStore>,
+        service_source: ServiceSource,
+        auto_reinit: bool,
     ) -> Self {
         Self {
             sessions: RwLock::new(HashMap::new()),
@@ -513,6 +608,8 @@ impl SessionRegistry {
             sampling_enabled,
             persistent,
             events,
+            service_source,
+            auto_reinit,
         }
     }
 
@@ -666,13 +763,146 @@ impl SessionRegistry {
     }
 
     async fn get(&self, id: &str) -> Option<Arc<Session>> {
-        let sessions = self.sessions.read().await;
-        let session = sessions.get(id).cloned();
-        if let Some(ref s) = session {
-            // Touch the session to update last_accessed
-            s.touch().await;
+        // Fast path: the session is live in this process.
+        {
+            let sessions = self.sessions.read().await;
+            if let Some(s) = sessions.get(id).cloned() {
+                s.touch().await;
+                return Some(s);
+            }
         }
-        session
+
+        // Slow path #1: the session is unknown locally but the persistent
+        // store has a record — rebuild it.
+        match self.persistent.load(id).await {
+            Ok(Some(record)) => {
+                tracing::info!(session_id = %id, "Restoring session from persistent store");
+                if let Some(session) = self.restore_from_record(record).await {
+                    return Some(session);
+                }
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!(session_id = %id, error = %e, "Failed to load session record");
+            }
+        }
+
+        // Slow path #2 (opt-in): auto-reinitialize with synthetic client
+        // info so the client can continue without a re-handshake. Useful
+        // for single-instance restarts where no external store is
+        // configured; loses original client identity.
+        if self.auto_reinit {
+            tracing::info!(session_id = %id, "Auto-reinitializing unknown session");
+            return self.auto_reinitialize(id).await;
+        }
+
+        None
+    }
+
+    /// Restore a live [`Session`] from a persisted [`SessionRecord`].
+    ///
+    /// The caller must ensure the record's ID is not already live locally;
+    /// on success the session is inserted into the local registry, the
+    /// event counter is seeded so new event IDs don't collide with
+    /// buffered ones, and the record's `last_accessed` is refreshed and
+    /// saved back to the store.
+    async fn restore_from_record(
+        &self,
+        record: crate::session_store::SessionRecord,
+    ) -> Option<Arc<Session>> {
+        let session = {
+            let mut sessions = self.sessions.write().await;
+
+            if let Some(max) = self.config.max_sessions
+                && sessions.len() >= max
+            {
+                tracing::warn!(
+                    max_sessions = max,
+                    "Session limit reached, cannot restore session"
+                );
+                return None;
+            }
+
+            // Guard against a concurrent create that beat us here.
+            if let Some(existing) = sessions.get(&record.id).cloned() {
+                existing.touch().await;
+                return Some(existing);
+            }
+
+            let session: Arc<Session> = match &self.service_source {
+                ServiceSource::Router { router, factory } => Arc::new(Session::restored(
+                    &record,
+                    router.with_fresh_session(),
+                    self.sampling_enabled,
+                    factory.clone(),
+                    self.events.clone(),
+                )),
+                ServiceSource::Service(svc) => {
+                    let service = svc.lock().unwrap().clone();
+                    Arc::new(Session::from_service_restored(
+                        service,
+                        &record,
+                        self.events.clone(),
+                    ))
+                }
+            };
+
+            sessions.insert(record.id.clone(), session.clone());
+            tracing::debug!(session_id = %session.id, "Restored session into local registry");
+            session
+        };
+
+        // Seed the event counter past the highest buffered event ID so new
+        // SSE events don't collide with ones the client may still replay.
+        if let Ok(events) = self.events.replay_after(&record.id, 0).await
+            && let Some(max_id) = events.iter().map(|e| e.id).max()
+        {
+            session
+                .event_counter
+                .store(max_id + 1, std::sync::atomic::Ordering::SeqCst);
+        }
+
+        // Refresh last_accessed in the store so the record doesn't expire
+        // immediately after restore.
+        let mut refreshed = record;
+        refreshed.touch(self.config.ttl);
+        if let Err(e) = self.persistent.save(&refreshed).await {
+            tracing::warn!(session_id = %refreshed.id, error = %e, "Failed to refresh restored session record");
+        }
+
+        Some(session)
+    }
+
+    /// Create a new session with the requested ID and synthetic client
+    /// info, skipping the initialize handshake. Used when `auto_reinit`
+    /// is enabled and no stored record exists.
+    ///
+    /// Loses the original client's identity and capabilities — the server
+    /// sees a session from client `"auto-recovered"`.
+    async fn auto_reinitialize(&self, id: &str) -> Option<Arc<Session>> {
+        let mut record = crate::session_store::SessionRecord::new(
+            id.to_string(),
+            LATEST_PROTOCOL_VERSION.to_string(),
+            self.config.ttl,
+        );
+        record.client_info = Some(crate::protocol::Implementation {
+            name: "auto-recovered".into(),
+            version: "unknown".into(),
+            title: None,
+            description: None,
+            icons: None,
+            website_url: None,
+            meta: None,
+        });
+        record.client_capabilities = Some(crate::protocol::ClientCapabilities::default());
+
+        // Persist first so a concurrent request sees the record. Ignore
+        // persistence errors; the in-memory session will still work.
+        if let Err(e) = self.persistent.create(&mut record).await {
+            tracing::warn!(session_id = %id, error = %e, "Failed to persist auto-reinitialized session");
+        }
+
+        self.restore_from_record(record).await
     }
 
     async fn remove(&self, id: &str) -> bool {
@@ -868,6 +1098,7 @@ pub struct HttpTransport {
     optional_sessions: bool,
     session_store: Arc<dyn crate::session_store::SessionStore>,
     event_store: Arc<dyn crate::event_store::EventStore>,
+    auto_reinit_sessions: bool,
     #[cfg(feature = "stateless")]
     stateless_config: Option<crate::stateless::StatelessConfig>,
     #[cfg(feature = "oauth")]
@@ -891,6 +1122,7 @@ impl HttpTransport {
             optional_sessions: true,
             session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
             event_store: Arc::new(crate::event_store::MemoryEventStore::new()),
+            auto_reinit_sessions: false,
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -942,6 +1174,7 @@ impl HttpTransport {
             optional_sessions: true,
             session_store: Arc::new(crate::session_store::MemorySessionStore::new()),
             event_store: Arc::new(crate::event_store::MemoryEventStore::new()),
+            auto_reinit_sessions: false,
             #[cfg(feature = "stateless")]
             stateless_config: None,
             #[cfg(feature = "oauth")]
@@ -1142,6 +1375,38 @@ impl HttpTransport {
         self
     }
 
+    /// Enable auto-reinitialization for unknown session IDs.
+    ///
+    /// When a request arrives with an `mcp-session-id` that is not live
+    /// locally and has no record in the configured
+    /// [`session_store`](Self::session_store), the transport normally
+    /// returns a session-not-found error. With this flag enabled, the
+    /// transport instead spins up a new session claiming that ID and
+    /// completes the initialize handshake internally with synthetic
+    /// client info (`name = "auto-recovered"`, empty capabilities).
+    ///
+    /// This lets tolerant clients continue after a server restart without
+    /// repeating the handshake, at the cost of losing the original
+    /// client's identity and negotiated capabilities. Prefer pairing this
+    /// with a real [`session_store`](Self::session_store) — the store
+    /// path runs first and preserves full identity when a record exists.
+    ///
+    /// Disabled by default. This is the pattern established by
+    /// [anubis-mcp #125](https://github.com/zoedsoupe/anubis-mcp/pull/125).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{HttpTransport, McpRouter};
+    ///
+    /// let router = McpRouter::new();
+    /// let transport = HttpTransport::new(router).auto_reinitialize_sessions(true);
+    /// ```
+    pub fn auto_reinitialize_sessions(mut self, enabled: bool) -> Self {
+        self.auto_reinit_sessions = enabled;
+        self
+    }
+
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
     ///
     /// When set, adds a `GET /.well-known/oauth-protected-resource` endpoint
@@ -1209,6 +1474,8 @@ impl HttpTransport {
             self.sampling_enabled,
             self.session_store.clone(),
             self.event_store.clone(),
+            self.service_source.clone(),
+            self.auto_reinit_sessions,
         ));
 
         // Spawn cleanup task
@@ -2410,6 +2677,128 @@ mod tests {
         // Purging should clear the session's log.
         events.purge_session(&session.id).await.unwrap();
         assert_eq!(events.total_events().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_restore_from_store_serves_unknown_session_id() {
+        use crate::session_store::{MemorySessionStore, SessionRecord, SessionStore};
+
+        // Two transports share a single session store (simulating two
+        // server instances behind a load balancer).
+        let store = Arc::new(MemorySessionStore::new());
+        let store_dyn: Arc<dyn SessionStore> = store.clone();
+
+        // Seed the store with a record as if a peer instance had created it.
+        let mut seeded = SessionRecord::new(
+            "shared-session".to_string(),
+            "2025-11-25".to_string(),
+            Duration::from_secs(60),
+        );
+        store.create(&mut seeded).await.unwrap();
+        let seeded_id = seeded.id;
+
+        // This transport has never seen the session locally.
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .session_store(store_dyn);
+        let app = transport.into_router();
+
+        let list_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header(MCP_SESSION_ID_HEADER, &seeded_id)
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(list_request).await.unwrap();
+        // Without restore this would produce a SessionNotFound JSON-RPC
+        // error; with restore the request is served normally.
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("result").is_some(),
+            "expected tools/list result, got {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_auto_reinitialize_serves_unknown_session_without_store_record() {
+        // No seeded store record — the client just shows up with a
+        // session ID the server has never heard of. With auto-reinit
+        // enabled the transport spins up a synthetic session.
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .auto_reinitialize_sessions(true);
+        let app = transport.into_router();
+
+        let list_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header(MCP_SESSION_ID_HEADER, "client-made-up-id")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(list_request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json.get("result").is_some(),
+            "expected tools/list result, got {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unknown_session_without_restore_or_auto_reinit_returns_error() {
+        // Default transport: no store seeded, no auto-reinit.
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        let list_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header(MCP_SESSION_ID_HEADER, "never-seen-before")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(list_request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("error").is_some(), "expected error, got {json}");
+        assert_eq!(json["error"]["code"], -32005); // SessionNotFound
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -130,6 +130,14 @@ impl UnixSocketTransport {
         self
     }
 
+    /// Enable auto-reinitialization for unknown session IDs.
+    ///
+    /// See [`HttpTransport::auto_reinitialize_sessions`] for details.
+    pub fn auto_reinitialize_sessions(mut self, enabled: bool) -> Self {
+        self.inner = self.inner.auto_reinitialize_sessions(enabled);
+        self
+    }
+
     /// Disable origin validation.
     ///
     /// Origin validation is less relevant for Unix sockets since they are

--- a/examples/horizontal_scaling.rs
+++ b/examples/horizontal_scaling.rs
@@ -1,0 +1,176 @@
+//! Horizontal scaling example: two HTTP transports, one shared store.
+//!
+//! Spawns two independent [`HttpTransport`] instances on different ports
+//! that share the same [`SessionStore`] and [`EventStore`]. A small
+//! in-process client:
+//!
+//! 1. Initializes against instance A (port 3000). Instance A creates a
+//!    session and writes its record to the shared store.
+//! 2. Drops the connection and reconnects to instance B (port 3001) with
+//!    the same `mcp-session-id`. Instance B has never seen the session
+//!    locally, but finds it in the shared store and restores it
+//!    transparently. The follow-up `tools/list` call succeeds.
+//!
+//! This simulates what happens behind a load balancer without session
+//! affinity, or after an instance restarts.
+//!
+//! Run with: `cargo run --example horizontal_scaling --features http`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, ToolBuilder,
+    event_store::{EventStore, MemoryEventStore},
+    session_store::{MemorySessionStore, SessionStore},
+};
+
+fn build_router(server_label: &str) -> McpRouter {
+    let label = server_label.to_string();
+    let who = ToolBuilder::new("whoami")
+        .description("Returns which server instance handled the request")
+        .handler(move |_: tower_mcp::NoParams| {
+            let label = label.clone();
+            async move { Ok(CallToolResult::text(label)) }
+        })
+        .build();
+
+    McpRouter::new()
+        .server_info("horizontal-scaling-demo", "1.0.0")
+        .tool(who)
+}
+
+async fn run_server(
+    port: u16,
+    label: &str,
+    sessions: Arc<dyn SessionStore>,
+    events: Arc<dyn EventStore>,
+) {
+    let transport = HttpTransport::new(build_router(label))
+        .disable_origin_validation()
+        .session_store(sessions)
+        .event_store(events);
+
+    tracing::info!(port, label, "starting instance");
+    if let Err(e) = transport.serve(&format!("127.0.0.1:{port}")).await {
+        tracing::error!(error = %e, "server exited");
+    }
+}
+
+async fn post_json(
+    url: &str,
+    session_id: Option<&str>,
+    body: serde_json::Value,
+) -> Result<(reqwest::StatusCode, Option<String>, serde_json::Value), tower_mcp::BoxError> {
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(url)
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream");
+    if let Some(id) = session_id {
+        req = req.header("mcp-session-id", id);
+    }
+    let resp = req.json(&body).send().await?;
+    let status = resp.status();
+    let sid = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let payload: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
+    Ok((status, sid, payload))
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("tower_mcp=info".parse()?)
+                .add_directive("horizontal_scaling=info".parse()?),
+        )
+        .init();
+
+    // Shared stores — in production these would be Redis-backed.
+    let session_store: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+    let event_store: Arc<dyn EventStore> = Arc::new(MemoryEventStore::new());
+
+    // Spawn two instances.
+    tokio::spawn(run_server(
+        3000,
+        "instance-A",
+        session_store.clone(),
+        event_store.clone(),
+    ));
+    tokio::spawn(run_server(
+        3001,
+        "instance-B",
+        session_store.clone(),
+        event_store.clone(),
+    ));
+
+    // Give the servers a moment to bind.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let a = "http://127.0.0.1:3000/";
+    let b = "http://127.0.0.1:3001/";
+
+    tracing::info!("step 1: initialize against instance A");
+    let (status, session_id, _) = post_json(
+        a,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": { "name": "demo-client", "version": "1.0.0" }
+            }
+        }),
+    )
+    .await?;
+    assert!(status.is_success(), "initialize failed: {status}");
+    let session_id = session_id.expect("expected mcp-session-id header");
+    tracing::info!(session_id = %session_id, "instance A issued session id");
+
+    tracing::info!("step 2: call whoami on instance A");
+    let (_, _, resp) = post_json(
+        a,
+        Some(&session_id),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": { "name": "whoami", "arguments": {} }
+        }),
+    )
+    .await?;
+    tracing::info!(result = ?resp["result"], "A says");
+
+    tracing::info!("step 3: same session id against instance B (never seen it locally)");
+    let (_, _, resp) = post_json(
+        b,
+        Some(&session_id),
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": { "name": "whoami", "arguments": {} }
+        }),
+    )
+    .await?;
+
+    // Instance B finds the record in the shared SessionStore, rebuilds the
+    // runtime session locally, and serves the request.
+    tracing::info!(result = ?resp["result"], "B says (after restore)");
+
+    if resp.get("result").is_some() {
+        tracing::info!("success: session continued transparently on instance B");
+    } else {
+        tracing::error!(response = ?resp, "instance B did not restore the session");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes the horizontal-scaling loop the \`SessionStore\` (#778) and \`EventStore\` (#779) traits left open. Two new code paths:

### 1. Store-backed restore (primary)

On a session-id lookup that misses the local registry, \`SessionRegistry\` now consults the persistent store. If a record exists, \`Session::restored\` rebuilds the runtime session:

- Fresh router clone, pre-marked \`Initialized\`
- \`protocol_version\` set from the record
- Fresh broadcast / notification channels (in-flight state doesn't survive)
- \`event_counter\` seeded past the highest buffered event ID so new SSE events don't collide with ones the client may still replay via \`Last-Event-ID\`
- Record saved back with refreshed \`last_accessed\`

### 2. Auto-reinitialize (opt-in)

\`HttpTransport::auto_reinitialize_sessions(true)\` — when no record exists and the flag is set, the transport spins up a new session claiming the client's requested ID with synthetic client info (\`name = \"auto-recovered\"\`, empty capabilities). This is the pattern from [anubis-mcp #125](https://github.com/zoedsoupe/anubis-mcp/pull/125). Cheap, no store required, loses original client identity — suitable for single-instance restart scenarios.

Lookup order: local registry → persistent store → optional auto-reinit → \`SessionNotFound\`.

## End-to-end demo

\`examples/horizontal_scaling.rs\` runs two \`HttpTransport\` instances on different ports sharing the same \`SessionStore\` + \`EventStore\`:

\`\`\`
step 1: initialize against instance A
instance A issued session id session_id=b7f6b950-...
step 2: call whoami on instance A
A says result=\"instance-A\"
step 3: same session id against instance B (never seen it locally)
Restoring session from persistent store session_id=b7f6b950-...
B says (after restore) result=\"instance-B\"
success: session continued transparently on instance B
\`\`\`

Different process instances, same session ID, no client-side rehandshake.

## Test plan

- [x] \`test_restore_from_store_serves_unknown_session_id\` — pre-seed store, prove transport serves session it's never seen locally
- [x] \`test_auto_reinitialize_serves_unknown_session_without_store_record\` — opt-in flag spins up synthetic session
- [x] \`test_unknown_session_without_restore_or_auto_reinit_returns_error\` — default behavior preserved
- [x] \`horizontal_scaling\` example verified end-to-end (log above)
- [x] \`cargo test --lib --all-features\` — 663/663 (+3)
- [x] \`cargo clippy --all-features -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

## Deferred

- **Populating \`client_info\` / \`client_capabilities\` on the record post-initialize.** Currently records are saved at session-create time with default \`protocol_version\` and empty client info. Fine for the restore mechanics (store a record → get it back → rebuild router); improves fidelity once the initialize handler calls \`save()\` with negotiated values. Small follow-up.
- **Per-request stream IDs** for SEP-1699-style \`0/5\` event IDs. Out of scope.