### PR TITLE
ci: verify tower-mcp-types compiles for wasm32-unknown-unknown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets --all-features
 
+  wasm-types:
+    name: WASM (tower-mcp-types)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --target wasm32-unknown-unknown -p tower-mcp-types
+
   fmt:
     name: Format
     runs-on: ubuntu-latest

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -7,6 +7,18 @@
 //! Use this crate directly when you need MCP types for serialization,
 //! code generation, or editor integrations. For a full MCP server/client
 //! implementation, see [`tower-mcp`](https://docs.rs/tower-mcp).
+//!
+//! # Target Support
+//!
+//! `tower-mcp-types` compiles for `wasm32-unknown-unknown` out of the box.
+//! This is covered by a CI job, so downstream WASM tools (browser clients,
+//! edge runtimes, editor extensions) can depend on this crate directly.
+//!
+//! The parent [`tower-mcp`](https://docs.rs/tower-mcp) crate is not
+//! WASM-compatible today; it pulls in Tokio networking features that don't
+//! build for `wasm32`. See
+//! [tower-mcp issue #777](https://github.com/joshrotenberg/tower-mcp/issues/777)
+//! for progress on client-side WASM support in the full crate.
 
 pub mod error;
 pub mod protocol;


### PR DESCRIPTION
## Summary

Tier 1 of the WASM support plan from #777: lock in the fact that \`tower-mcp-types\` already compiles for \`wasm32-unknown-unknown\` so downstream WASM tools can depend on it with confidence.

Zero code changes — the types crate has no runtime dependencies and just works today. This PR adds:

1. A CI job (\`cargo check --target wasm32-unknown-unknown -p tower-mcp-types\`)
2. A doc note in \`tower-mcp-types/src/lib.rs\` explaining target support and pointing at #777 / the Tier 2 follow-up issue for full crate WASM support

## Context

Empirical research on #777 confirmed:
- \`tower-mcp-types\`: clean WASM build, no changes needed
- \`tower-mcp\` main crate: blocked by \`mio\` via \`tokio = { features = [\"full\"] }\` in workspace, plus 266 \`+ Send\` bounds that prevent \`!Send\` handler impls

Client-side WASM support for the full crate (Tier 2) is a ~2-3 day refactor — filed as separate follow-up issue #783 to track without blocking.

Server-side WASM (Tier 3) is a non-goal; servers need listeners and WASM doesn't have them.

## Test plan

- [x] \`cargo check --target wasm32-unknown-unknown -p tower-mcp-types\` clean locally
- [x] \`cargo doc --no-deps -p tower-mcp-types\` clean
- CI job will verify on every PR going forward

Part of #777