### PR TITLE
ci: add cargo-semver-checks job for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,19 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --target wasm32-unknown-unknown -p tower-mcp-types
 
+  semver:
+    name: SemVer
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          package: tower-mcp,tower-mcp-types
+
   fmt:
     name: Format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a `cargo-semver-checks` job to CI that runs on PRs and flags accidental breaking changes to the public APIs of `tower-mcp` and `tower-mcp-types`.

- Runs only on `pull_request` events (post-merge enforcement is too late).
- `continue-on-error: true` initially to surface false positives without blocking PRs. Once we have a few clean runs we can flip it to required.
- Targets both published crates explicitly via `package:`.

Closes #789.

## Test plan

- [ ] PR triggers the new SemVer job
- [ ] Job either passes or surfaces actionable findings without blocking merge (continue-on-error)
- [ ] No effect on push-to-main runs (job gated on `pull_request`)