### PR TITLE
fix(client): use match guard for OAuth error_description fallback

### DIFF
--- a/crates/tower-mcp/src/client/oauth_authcode.rs
+++ b/crates/tower-mcp/src/client/oauth_authcode.rs
@@ -632,11 +632,7 @@ fn parse_callback_query(path: &str, expected_state: &str) -> Result<CallbackResu
             "code" => code = Some(decoded),
             "state" => state = Some(decoded),
             "error" => error = Some(decoded),
-            "error_description" => {
-                if error.is_none() {
-                    error = Some(decoded);
-                }
-            }
+            "error_description" if error.is_none() => error = Some(decoded),
             _ => {}
         }
     }


### PR DESCRIPTION
## Summary

Rust 1.95 introduces a `clippy::collapsible_match` lint that flags the existing nested `if` inside the `parse_authorization_response` match in `client/oauth_authcode.rs`. The new lint started failing CI on every open PR (#791, #792, #793) once the GitHub stable runner moved to 1.95.

The fix: replace the nested `if error.is_none()` check with a match guard. Equivalent behavior, lint-clean on both old and new clippy.

```rust
// before
\"error_description\" => {
    if error.is_none() {
        error = Some(decoded);
    }
}

// after
\"error_description\" if error.is_none() => error = Some(decoded),
```

Unblocks the three open PRs.

## Test plan

- [ ] CI clippy passes on Rust 1.95
- [ ] Existing OAuth tests still green