### PR TITLE
fix(jsonrpc): serialize null id on error responses per spec

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -91,8 +91,9 @@ pub struct JsonRpcResultResponse {
 pub struct JsonRpcErrorResponse {
     /// JSON-RPC version, always "2.0".
     pub jsonrpc: String,
-    /// Request identifier (may be null for parse errors).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Request identifier. MUST be present per JSON-RPC 2.0; serialized as
+    /// `null` when the id could not be determined (e.g. parse errors).
+    #[serde(default)]
     pub id: Option<RequestId>,
     /// The error details.
     pub error: JsonRpcError,
@@ -4005,6 +4006,40 @@ impl McpNotification {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::JsonRpcError;
+
+    #[test]
+    fn error_response_serializes_id_null_when_unknown() {
+        let resp = JsonRpcResponse::error(None, JsonRpcError::parse_error("bad json"));
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(
+            json.get("id").is_some(),
+            "id field must be present per JSON-RPC 2.0, got: {json}"
+        );
+        assert!(
+            json["id"].is_null(),
+            "id must serialize as null when unknown, got: {}",
+            json["id"]
+        );
+    }
+
+    #[test]
+    fn error_response_serializes_id_when_known() {
+        let resp =
+            JsonRpcResponse::error(Some(RequestId::Number(7)), JsonRpcError::parse_error("bad"));
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["id"], serde_json::json!(7));
+    }
+
+    #[test]
+    fn error_response_deserializes_null_id() {
+        let wire = r#"{"jsonrpc":"2.0","id":null,"error":{"code":-32700,"message":"x"}}"#;
+        let resp: JsonRpcResponse = serde_json::from_str(wire).unwrap();
+        match resp {
+            JsonRpcResponse::Error(e) => assert!(e.id.is_none()),
+            _ => panic!("expected Error variant"),
+        }
+    }
 
     #[test]
     fn test_content_text_constructor() {


### PR DESCRIPTION
## Summary

- Per JSON-RPC 2.0, `id` is required on error responses and must be `null` when the request id can't be determined (parse errors, invalid request). The field had `skip_serializing_if = Option::is_none`, so error responses with `id: None` omitted the field entirely, which can break strict clients (e.g. rmcp).
- Drop the `skip_serializing_if` and add `#[serde(default)]` so `None` serializes as `"id": null` while deserialization still tolerates missing/null.
- Add three wire-format regression tests in `tower-mcp-types` (`error_response_serializes_id_null_when_unknown`, `..._serializes_id_when_known`, `..._deserializes_null_id`).

## How this slipped through

Existing error tests asserted on the deserialized `JsonRpcResponse::Error(e)` object (code, message) but never inspected the serialized JSON. Because the field is `Option<RequestId>`, omitted and `null` both deserialize to `None`, so the missing wire-level check let the violation through. The conformance client also has no parse-error scenario; that'll be a follow-up.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features`  (89 tests in `tower-mcp-types`, all suites green)
- [x] `cargo test --test '*' --all-features`  (all integration suites green)
- [x] New wire-format tests pass and fail without the fix

Closes #802.