### PR TITLE
chore(sep-sync): drop [draft] from tracked statuses

### DIFF
--- a/.github/scripts/sync-seps.js
+++ b/.github/scripts/sync-seps.js
@@ -7,9 +7,9 @@
  * The script:
  * 1. Fetches all issues with the "SEP" label from upstream
  * 2. Matches them against our existing spec-tracking issues by SEP number
- * 3. Creates tracking issues only for SEPs in tracked statuses (draft, in-review, accepted, final)
+ * 3. Creates tracking issues only for SEPs in tracked statuses (in-review, accepted, final)
  * 4. Updates title prefixes when upstream status changes
- * 5. Closes tracking issues when SEPs move to untracked statuses (proposal, dormant, rejected)
+ * 5. Closes tracking issues when SEPs move to untracked statuses (draft, proposal, dormant, rejected)
  * 6. Reopens tracking issues when SEPs advance back to a tracked status
  *
  * @param {Object} params - GitHub Actions context
@@ -34,13 +34,14 @@ module.exports = async ({ github, context, core }) => {
   };
 
   // Only create/keep tracking issues for SEPs in these statuses.
-  // Draft and above are worth tracking; dormant, proposal, and rejected are not
-  // actionable enough to warrant an issue.
+  // In-review and above are worth tracking; draft, proposal, dormant, and
+  // rejected churn too much or are not actionable enough to warrant an issue.
+  // Drafts are still visible in the upstream label view if you want to
+  // browse them; tracking them here just adds noise.
   const TRACKED_STATUSES = new Set([
     '[accepted]',
     '[final]',
     '[in-review]',
-    '[draft]',
   ]);
 
   // SEPs to skip entirely (not actionable for tower-mcp).
@@ -159,7 +160,7 @@ module.exports = async ({ github, context, core }) => {
           repo: context.repo.repo,
           issue_number: existing.number,
           body: `Closing: SEP status is ${prefix.replace(/[\[\]]/g, '')}. ` +
-            'Only draft, in-review, accepted, and final SEPs are tracked. ' +
+            'Only in-review, accepted, and final SEPs are tracked here. ' +
             'This issue will be reopened automatically if the SEP advances.',
         });
         closed++;


### PR DESCRIPTION
## Summary

- Remove `[draft]` from `TRACKED_STATUSES` in `.github/scripts/sync-seps.js` so the weekly SEP sync only creates / keeps tracking issues for `[in-review]`, `[accepted]`, and `[final]`.
- Update doc comment and the auto-generated closing-comment body to match.

## Why

Draft SEPs churn upstream. They land, get rewritten, get withdrawn, get split, etc. Tracking them here generates standing issues that we'd close before ever doing the work, and the noise was making the issue list hard to read. The transitions we actually care about (`in-review`, `accepted`, `final`) are still tracked.

Browse drafts directly via [the upstream `SEP` label](https://github.com/modelcontextprotocol/modelcontextprotocol/labels/SEP) when you want to scan early-stage proposals.

## What happens next

On the next workflow run (Monday 9am UTC, or manual `workflow_dispatch`), the existing untracked-status branch in the script will close the 7 open `[draft]` tracking issues with a comment. I'm also closing them manually now so the list cleans up immediately. Reopens stay automatic if a SEP advances back to a tracked status.

## Test plan

- [x] `node -e "require('./.github/scripts/sync-seps.js')"` (syntax check)
- [ ] Manual `workflow_dispatch` after merge to confirm the 7 drafts close cleanly