### PR TITLE
chore(sep-sync): stop auto-reopening closed tracking issues

### DIFF
--- a/.github/scripts/sync-seps.js
+++ b/.github/scripts/sync-seps.js
@@ -9,8 +9,12 @@
  * 2. Matches them against our existing spec-tracking issues by SEP number
  * 3. Creates tracking issues only for SEPs in tracked statuses (in-review, accepted, final)
  * 4. Updates title prefixes when upstream status changes
- * 5. Closes tracking issues when SEPs move to untracked statuses (draft, proposal, dormant, rejected)
- * 6. Reopens tracking issues when SEPs advance back to a tracked status
+ * 5. Closes open tracking issues when SEPs move to untracked statuses (draft, proposal, dormant, rejected)
+ *
+ * Closed issues stay closed -- they were triaged by a human (implemented,
+ * not-applicable, etc.) and the workflow does not re-open them. If a SEP
+ * regresses upstream and later advances again, the summary log surfaces it
+ * and the human can reopen by hand.
  *
  * @param {Object} params - GitHub Actions context
  * @param {Object} params.github - Octokit REST client
@@ -120,27 +124,13 @@ module.exports = async ({ github, context, core }) => {
     if (sepToIssue.has(sepNumber)) {
       const existing = sepToIssue.get(sepNumber);
 
-      // Reopen closed issues if the SEP has advanced to a tracked status
+      // Closed issues stay closed. A human closed them deliberately
+      // (implemented, not-applicable, etc.) and the workflow has no
+      // business resurrecting them. If upstream genuinely needs new
+      // attention, the human will see it in the weekly sync summary
+      // and reopen by hand.
       if (existing.state === 'closed') {
-        if (isTracked) {
-          core.info(`Reopening SEP-${sepNumber}: status advanced to ${prefix}`);
-          await github.rest.issues.update({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: existing.number,
-            title: newTitle,
-            state: 'open',
-          });
-          await github.rest.issues.createComment({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: existing.number,
-            body: `Reopening: SEP status advanced to ${prefix.replace(/[\[\]]/g, '')}.`,
-          });
-          updated++;
-        } else {
-          skipped++;
-        }
+        skipped++;
         continue;
       }
 
@@ -161,7 +151,7 @@ module.exports = async ({ github, context, core }) => {
           issue_number: existing.number,
           body: `Closing: SEP status is ${prefix.replace(/[\[\]]/g, '')}. ` +
             'Only in-review, accepted, and final SEPs are tracked here. ' +
-            'This issue will be reopened automatically if the SEP advances.',
+            'Reopen by hand if this SEP advances back to a tracked status.',
         });
         closed++;
         continue;


### PR DESCRIPTION
## Summary

- Remove the auto-reopen branch from `.github/scripts/sync-seps.js`. When the workflow encounters a closed-but-tracked SEP issue, leave it closed.
- Update doc comment and close-on-untracked-status comment text to match.
- Keep everything else (create new issues for newly accepted SEPs, close issues whose upstream SEP regressed to a non-tracked status, update titles when prefix changes).

## Why

All 17 of our currently-open `[accepted]` spec-tracking issues had been opened by the workflow, closed by a human ("implemented" or "not-applicable"), reopened by the workflow on 2026-03-16, closed again, and reopened again on 2026-03-23. The reopen branch was generating noise without information -- the SEP hadn't advanced past "accepted", it just stayed there, so the workflow kept resurrecting issues that had already been triaged.

The right semantics: the workflow surfaces newly-tracked SEPs as fresh issues. A human decides what to do with each one. Closed means done. If a SEP regresses upstream and later re-advances, the weekly sync summary log shows it and the human can reopen by hand.

## What happens next

After this merges I'm closing the 17 accumulated `[accepted]` zombies with `state_reason: completed` and applying the appropriate `implemented` / `not-applicable` label so the audit trail is clean. After that, only `#536` (Rust SDK Tier 2 assessment) stays open in spec-tracking.

## Test plan

- [x] `node -e "require('./.github/scripts/sync-seps.js')"` syntax check
- [x] Diffed against the previous flow: create / update-title / close-on-untracked-status branches all still in place
- [ ] Manual `workflow_dispatch` after merge to confirm no spurious reopens