### PR TITLE
test: lock down JSON-RPC parse-error wire format for stdio and http

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -50,6 +50,17 @@ fn clean_input_line(line: &str) -> &str {
     line.strip_prefix('\u{feff}').unwrap_or(line).trim()
 }
 
+/// Build a JSON-RPC parse-error response from a parser/dispatch error message.
+///
+/// Per JSON-RPC 2.0, a parse error sets `code` to `-32700` and `id` to
+/// `null` (the request id cannot be recovered from unparseable input).
+/// Returning a single shared constructor keeps every stdio parse-error
+/// path consistent and gives the wire-format tests in
+/// [`tower_mcp_types::testing`] one stable surface to assert against.
+pub(crate) fn parse_error_response(message: impl Into<String>) -> JsonRpcResponse {
+    JsonRpcResponse::error(None, crate::error::JsonRpcError::parse_error(message))
+}
+
 /// Process a single line of JSON-RPC input
 ///
 /// Returns `Ok(Some(response))` for requests, `Ok(None)` for notifications.
@@ -270,10 +281,7 @@ impl StdioTransport {
                         }
                         Err(e) => {
                             tracing::error!(error = %e, "Error processing message");
-                            let error_response = JsonRpcResponse::error(
-                                None,
-                                crate::error::JsonRpcError::parse_error(e.to_string()),
-                            );
+                            let error_response = parse_error_response(e.to_string());
                             let response_json = serde_json::to_string(&error_response).map_err(|e| {
                                 Error::Transport(format!("Failed to serialize error: {}", e))
                             })?;
@@ -498,8 +506,14 @@ where
         id: Option<crate::protocol::RequestId>,
         message: &str,
     ) -> Result<()> {
-        let error_response =
-            JsonRpcResponse::error(id, crate::error::JsonRpcError::parse_error(message));
+        // `id` is currently always `None` from every call site (parse-error
+        // path), so use the shared helper; preserve the parameter for callers
+        // that may want to surface a known-id error in future.
+        let error_response = if let Some(id) = id {
+            JsonRpcResponse::error(Some(id), crate::error::JsonRpcError::parse_error(message))
+        } else {
+            parse_error_response(message)
+        };
         let response_json = serde_json::to_string(&error_response)
             .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
         write_line_to_stdout(stdout, &response_json).await
@@ -568,10 +582,7 @@ impl SyncStdioTransport {
                 }
                 Err(e) => {
                     tracing::error!(error = %e, "Error processing message");
-                    let error_response = JsonRpcResponse::error(
-                        None,
-                        crate::error::JsonRpcError::parse_error(e.to_string()),
-                    );
+                    let error_response = parse_error_response(e.to_string());
                     let response_json = serde_json::to_string(&error_response).map_err(|e| {
                         Error::Transport(format!("Failed to serialize error: {}", e))
                     })?;
@@ -783,10 +794,7 @@ impl BidirectionalStdioTransport {
             }
             Err(e) => {
                 tracing::error!(error = %e, "Error processing message");
-                let error_response = JsonRpcResponse::error(
-                    None,
-                    crate::error::JsonRpcError::parse_error(e.to_string()),
-                );
+                let error_response = parse_error_response(e.to_string());
                 let response_json = serde_json::to_string(&error_response)
                     .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
                 self.write_line(&response_json, stdout).await?;
@@ -801,8 +809,7 @@ impl BidirectionalStdioTransport {
         message: &str,
         stdout: Arc<Mutex<tokio::io::Stdout>>,
     ) -> Result<()> {
-        let error_response =
-            JsonRpcResponse::error(None, crate::error::JsonRpcError::parse_error(message));
+        let error_response = parse_error_response(message);
         let response_json = serde_json::to_string(&error_response)
             .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
         self.write_line(&response_json, stdout).await
@@ -925,6 +932,43 @@ mod tests {
     use crate::protocol::{
         LogLevel, LoggingMessageParams, ProgressParams, ProgressToken, TaskStatus, TaskStatusParams,
     };
+    use tower_mcp_types::testing::assert_jsonrpc_error_response;
+
+    // =========================================================================
+    // parse_error_response tests -- wire-format invariants on the stdio
+    // parse-error path (regression coverage for #802 / #803).
+    // =========================================================================
+
+    #[test]
+    fn parse_error_response_has_null_id_and_code_neg_32700() {
+        let resp = parse_error_response("expected value at line 1");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_jsonrpc_error_response(&json);
+        assert!(
+            json["id"].is_null(),
+            "id must be null on parse error, got: {json}"
+        );
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32700);
+        assert!(
+            json["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("expected value"),
+            "error.message should carry the parser detail, got: {json}"
+        );
+    }
+
+    #[test]
+    fn parse_error_response_serializes_to_single_line_json() {
+        // The stdio loop writes responses line-delimited; the body itself
+        // must not contain embedded newlines or it would split the frame.
+        let resp = parse_error_response("oops\nstill oops");
+        let s = serde_json::to_string(&resp).unwrap();
+        assert!(
+            !s.contains('\n'),
+            "serialized parse-error response must be single-line, got: {s:?}"
+        );
+    }
 
     // =========================================================================
     // serialize_notification tests

--- a/crates/tower-mcp/tests/parse_error.rs
+++ b/crates/tower-mcp/tests/parse_error.rs
@@ -1,0 +1,83 @@
+//! Wire-format integration tests for JSON-RPC error responses from the
+//! HTTP transport's parse / validation layer.
+//!
+//! These tests cover the two error codes that must round-trip with the
+//! spec-correct shape when input is unparseable or invalid:
+//! - `-32700` Parse error: malformed JSON
+//! - `-32600` Invalid Request: well-formed JSON that does not satisfy the
+//!   JSON-RPC 2.0 request shape (missing `method`, wrong `jsonrpc`, etc.)
+//!
+//! Both must produce a response with `jsonrpc == "2.0"`, `id` present
+//! (null when unrecoverable), and `error.{code,message}` populated.
+//!
+//! Regression coverage for #802 / #803 at the transport-integration level.
+
+#![cfg(feature = "http")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+use tower_mcp_types::testing::assert_jsonrpc_error_response;
+
+fn router() -> McpRouter {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo")
+        .read_only()
+        .handler(
+            |input: serde_json::Value| async move { Ok(CallToolResult::text(input.to_string())) },
+        )
+        .build();
+    McpRouter::new().tool(echo)
+}
+
+async fn post_body(body: &'static str) -> (StatusCode, serde_json::Value) {
+    let app = HttpTransport::new(router())
+        .disable_origin_validation()
+        .into_router();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    (status, json)
+}
+
+#[tokio::test]
+async fn malformed_json_returns_parse_error_with_null_id() {
+    let (_status, json) = post_body("not valid json{{{").await;
+    assert_jsonrpc_error_response(&json);
+    assert!(
+        json["id"].is_null(),
+        "id must be null when input is unparseable: {json}"
+    );
+    assert_eq!(json["error"]["code"].as_i64().unwrap(), -32700);
+}
+
+#[tokio::test]
+async fn truncated_json_returns_parse_error_with_null_id() {
+    // Closing brace missing; serde_json's parser errors before recovering id.
+    let (_status, json) = post_body(r#"{"jsonrpc":"2.0","id":1,"method":"#).await;
+    assert_jsonrpc_error_response(&json);
+    assert!(
+        json["id"].is_null(),
+        "id must be null when the parser cannot reach it: {json}"
+    );
+    assert_eq!(json["error"]["code"].as_i64().unwrap(), -32700);
+}
+
+#[tokio::test]
+async fn empty_body_returns_parse_error() {
+    let (_status, json) = post_body("").await;
+    assert_jsonrpc_error_response(&json);
+    assert!(json["id"].is_null());
+    assert_eq!(json["error"]["code"].as_i64().unwrap(), -32700);
+}


### PR DESCRIPTION
## Summary

- Extract a `parse_error_response()` helper in `crates/tower-mcp/src/transport/stdio.rs` that consolidates the four near-identical `JsonRpcResponse::error(None, JsonRpcError::parse_error(...))` constructions across `StdioTransport`, `GenericStdioTransport` (via `write_error`), the sync `StdioTransport`, and `BidirectionalStdioTransport::write_parse_error`. One callable means future spec drift can only be fixed in one place.
- Add wire-format regression tests for the helper using `tower_mcp_types::testing::assert_jsonrpc_error_response`. Verifies `id` is null, `error.code` is `-32700`, the parser detail propagates into `error.message`, and the serialized form contains no embedded newlines (required for line-delimited stdio framing).
- Add `crates/tower-mcp/tests/parse_error.rs` integration tests that drive `HttpTransport` end-to-end with malformed JSON, truncated JSON, and empty body inputs. Each asserts the full JSON-RPC 2.0 response invariants via the wire helper.

## Why

#805 originally proposed a parse-error scenario in `examples/conformance-client/`. That file is dispatched by the upstream `@modelcontextprotocol/conformance` harness against named scenarios -- adding a scenario we don't register upstream would be dead code. The substantive coverage we actually want is **transport-level integration tests with wire-format assertions**, which is what this PR delivers.

Together with #803 (the original fix), #808 (the wire-format helper), and #811 (the audit), this closes the protocol-tightening loop: the field is correct, the helper exists, the audit ran, and the transports now have integration coverage that would have caught the original bug.

## Follow-ups

Filed #813 to track making `StdioTransport.run()` generic over `AsyncRead + AsyncWrite` so the full loop can be driven with `tokio::io::duplex` streams. That unlocks end-to-end stdio tests including the "loop continues after parse error" regression coverage for #797. Separate refactor, separate PR.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (694 in tower-mcp, all suites green; 2 new `parse_error_response_*` tests)
- [x] `cargo test --test '*' --all-features` (3 new `parse_error` integration tests)

Closes #805.