### PR TITLE
ci: add cargo audit job + investigate dep findings from #824

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,17 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    # Don't fail PRs for advisories with no upgrade path -- those need
+    # human triage. Vulnerabilities with a fix available are blocking.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,13 @@ jobs:
   audit:
     name: Security Audit
     runs-on: ubuntu-latest
-    # Don't fail PRs for advisories with no upgrade path -- those need
-    # human triage. Vulnerabilities with a fix available are blocking.
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Cargo.lock is gitignored (library convention), so generate one
+      # before the audit step so cargo-audit has something to read.
+      - run: cargo generate-lockfile
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a `Security Audit` job to `.github/workflows/ci.yml` using `rustsec/audit-check@v2`. Runs on every PR and push; fails the build on known vulnerabilities with an available upgrade path.
- This is the CI half of #824. See below for the dep audit conclusions.

## Conclusions from the #824 audit

**The original 10 advisories were a stale-Cargo.lock issue, not a "we ship vulnerable code" issue.**

When I ran `cargo audit` locally I got 10 hits -- 4 `aws-lc-sys` (CVSS 5.9-7.5), 1 `quinn-proto` DoS (CVSS 8.7), 1 `rustls-webpki` panic, etc. All transitive through `reqwest` / `jsonwebtoken` / `axum`.

`cargo update` alone resolved every one of them. The fixes already exist on crates.io; I just hadn't refreshed my local lock.

Since `Cargo.lock` is gitignored in this repo (see `.gitignore` line 2), **CI generates a fresh lock on every run** and consistently picks the latest semver-compatible versions, including the fixed ones. So we haven't been shipping the vulnerabilities -- only stale local dev environments would have shown them.

The new audit job catches the case where an advisory lands against a version cargo would freshly resolve (i.e. the latest one is also vulnerable). That's the bug class CI should catch automatically.

## Outstanding questions raised by #824

- **Commit `Cargo.lock`?** For a workspace with binary targets (conformance-server, codegen-mcp, etc.), the Rust convention is to commit it. The trade-off: reproducible builds and audit results vs. a noisier diff stream from dependency churn. Worth a separate discussion. I haven't changed the policy here.
- **MSRV 1.90 pins three transitive deps below their latest** (`crypto-common` 0.1.6 vs 0.1.7, `matchit` 0.8.4 vs 0.8.6, `sec1` 0.7.3 vs 0.8.1). None of these had advisories at audit time. rmcp is at MSRV 1.92 already. If we bump our MSRV, document the user-impact trade-off in `crates/tower-mcp/Cargo.toml` and CLAUDE.md. Not blocking; tracked in #824.

## Test plan

- [x] `cargo audit` locally with refreshed lock: 0 vulnerabilities, exit 0
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --lib --all-features` (all suites green)
- [x] `cargo test --test '*' --all-features`
- [ ] New `Security Audit` CI job passes (verify on this PR's run)

Refs #824.