### PR TITLE
feat(types): TTL on list results (SEP-2549) + deprecation metadata (SEP-2577/2596)

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -358,6 +358,8 @@ impl From<i32> for RequestId {
 // =============================================================================
 
 /// High-level MCP request (parsed from JSON-RPC)
+// Variant sizes are dictated by the spec, not optimizable without API churn.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum McpRequest {
@@ -511,6 +513,8 @@ pub struct RequestMeta {
 }
 
 /// High-level MCP response
+// Variant sizes are dictated by the spec, not optimizable without API churn.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 #[non_exhaustive]
@@ -667,7 +671,7 @@ pub struct ClientTasksElicitationCreateCapability {}
 /// use tower_mcp_types::protocol::RootsCapability;
 ///
 /// // Client advertising roots with change notification support
-/// let cap = RootsCapability { list_changed: true };
+/// let cap = RootsCapability { list_changed: true, deprecated: None };
 /// assert!(cap.list_changed);
 ///
 /// // The notification method is defined as a constant:
@@ -682,6 +686,11 @@ pub struct RootsCapability {
     /// Whether the client supports roots list changed notifications
     #[serde(default)]
     pub list_changed: bool,
+    /// SEP-2577: roots is deprecated in the 2026-07-28 protocol with a
+    /// 12-month minimum support window. Servers that advertise roots
+    /// can attach a `DeprecationInfo` to signal to clients.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<DeprecationInfo>,
 }
 
 /// Represents a root directory or file that the server can operate on.
@@ -766,6 +775,10 @@ pub struct SamplingCapability {
     /// Support for context inclusion within sampling
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub context: Option<SamplingContextCapability>,
+    /// SEP-2577: sampling is deprecated in the 2026-07-28 protocol with
+    /// a 12-month minimum support window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<DeprecationInfo>,
 }
 
 /// Marker capability for tool use within sampling
@@ -1566,7 +1579,12 @@ pub struct ServerCapabilities {
 
 /// Logging capability declaration
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct LoggingCapability {}
+pub struct LoggingCapability {
+    /// SEP-2577: logging is deprecated in the 2026-07-28 protocol with
+    /// a 12-month minimum support window.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<DeprecationInfo>,
+}
 
 /// Capability for async task management
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -1637,6 +1655,56 @@ pub struct PromptsCapability {
 }
 
 // =============================================================================
+// Lifecycle and caching annotations (SEP-2549, SEP-2577, SEP-2596)
+// =============================================================================
+
+/// Scope of a cached list result.
+///
+/// Per SEP-2549, servers can hint to clients how widely they may share a
+/// cached `tools/list`, `resources/list`, etc. response. `Session` means
+/// the cache is valid for the current client only; `Global` means it
+/// applies to any client of this server. `None` on the parent field
+/// means the server expresses no opinion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum CacheScope {
+    /// Cache is valid for the current session only.
+    Session,
+    /// Cache is valid across sessions (per-server, not per-client).
+    Global,
+}
+
+/// Deprecation metadata for spec features and capabilities.
+///
+/// Per SEP-2577 + SEP-2596, the spec now has a formal Active/Deprecated/
+/// Removed lifecycle for features. Servers can attach this metadata to
+/// capability declarations so clients (and tooling like `manifest.rs`
+/// exporters or codegen) can surface deprecation warnings.
+///
+/// All fields are optional so the struct stays forward-compatible with
+/// future SEP-2596 extensions. Setting any field signals the parent
+/// feature is deprecated.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeprecationInfo {
+    /// Protocol version in which this feature became deprecated
+    /// (e.g. `"2026-07-28"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+    /// Protocol version in which this feature is scheduled for removal.
+    /// Per SEP-2577, the minimum window after `since` is 12 months.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remove_in: Option<String>,
+    /// Human-readable explanation, e.g. why this feature was deprecated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    /// Pointer to the replacement feature or SEP, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<String>,
+}
+
+// =============================================================================
 // Tools
 // =============================================================================
 
@@ -1655,6 +1723,14 @@ pub struct ListToolsResult {
     pub tools: Vec<ToolDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// SEP-2549: client-cache TTL in milliseconds for this list response.
+    /// `None` means "no opinion -- client policy decides".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_ms: Option<u64>,
+    /// SEP-2549: scope the cached result applies to. `None` means
+    /// scope is unspecified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_scope: Option<CacheScope>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -2411,6 +2487,12 @@ pub struct ListResourcesResult {
     pub resources: Vec<ResourceDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// SEP-2549: client-cache TTL in milliseconds for this list response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_ms: Option<u64>,
+    /// SEP-2549: scope the cached result applies to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_scope: Option<CacheScope>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -2702,6 +2784,12 @@ pub struct ListResourceTemplatesResult {
     /// Cursor for next page (if more templates available)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// SEP-2549: client-cache TTL in milliseconds for this list response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_ms: Option<u64>,
+    /// SEP-2549: scope the cached result applies to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_scope: Option<CacheScope>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -2771,6 +2859,12 @@ pub struct ListPromptsResult {
     pub prompts: Vec<PromptDefinition>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// SEP-2549: client-cache TTL in milliseconds for this list response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_ms: Option<u64>,
+    /// SEP-2549: scope the cached result applies to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_scope: Option<CacheScope>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -4119,6 +4213,107 @@ mod tests {
         );
     }
 
+    // =========================================================================
+    // SEP-2549 (TTL on list results) wire-format tests
+    // =========================================================================
+
+    #[test]
+    fn list_tools_result_omits_ttl_and_cache_scope_by_default() {
+        let r = ListToolsResult {
+            tools: vec![],
+            next_cursor: None,
+            ttl_ms: None,
+            cache_scope: None,
+            meta: None,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert!(
+            json.get("ttlMs").is_none(),
+            "ttlMs must be omitted when None, got: {json}"
+        );
+        assert!(
+            json.get("cacheScope").is_none(),
+            "cacheScope must be omitted when None, got: {json}"
+        );
+    }
+
+    #[test]
+    fn list_tools_result_emits_ttl_and_cache_scope_when_set() {
+        let r = ListToolsResult {
+            tools: vec![],
+            next_cursor: None,
+            ttl_ms: Some(60_000),
+            cache_scope: Some(CacheScope::Global),
+            meta: None,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json["ttlMs"], 60_000);
+        assert_eq!(json["cacheScope"], "global");
+    }
+
+    #[test]
+    fn cache_scope_roundtrips_via_lowercase_strings() {
+        for (scope, wire) in [
+            (CacheScope::Session, "session"),
+            (CacheScope::Global, "global"),
+        ] {
+            let s = serde_json::to_value(scope).unwrap();
+            assert_eq!(s, serde_json::json!(wire));
+            let back: CacheScope = serde_json::from_value(s).unwrap();
+            assert_eq!(back, scope);
+        }
+    }
+
+    // =========================================================================
+    // SEP-2577 / SEP-2596 (deprecation metadata) wire-format tests
+    // =========================================================================
+
+    #[test]
+    fn roots_capability_omits_deprecated_by_default() {
+        let cap = RootsCapability {
+            list_changed: true,
+            deprecated: None,
+        };
+        let json = serde_json::to_value(&cap).unwrap();
+        assert!(
+            json.get("deprecated").is_none(),
+            "deprecated must be omitted when None to avoid changing wire output for existing servers, got: {json}"
+        );
+    }
+
+    #[test]
+    fn capability_emits_deprecation_info_when_flagged() {
+        let cap = LoggingCapability {
+            deprecated: Some(DeprecationInfo {
+                since: Some("2026-07-28".into()),
+                remove_in: Some("2027-07-28".into()),
+                message: Some("Logging moves to OpenTelemetry per SEP-2577".into()),
+                replacement: Some(
+                    "https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2577"
+                        .into(),
+                ),
+            }),
+        };
+        let json = serde_json::to_value(&cap).unwrap();
+        let dep = &json["deprecated"];
+        assert_eq!(dep["since"], "2026-07-28");
+        assert_eq!(dep["removeIn"], "2027-07-28");
+        assert!(dep["message"].as_str().unwrap().contains("OpenTelemetry"));
+        assert!(dep["replacement"].as_str().unwrap().contains("2577"));
+    }
+
+    #[test]
+    fn deprecation_info_round_trip_with_partial_fields() {
+        // Forward-compatible: a server that only sets `since` round-trips
+        // without losing or adding fields.
+        let wire = r#"{"since":"2026-07-28"}"#;
+        let info: DeprecationInfo = serde_json::from_str(wire).unwrap();
+        assert_eq!(info.since.as_deref(), Some("2026-07-28"));
+        assert!(info.remove_in.is_none());
+        let back = serde_json::to_string(&info).unwrap();
+        assert_eq!(back, wire);
+    }
+
     #[test]
     fn cancelled_params_serializes_request_id_when_present() {
         let p = CancelledParams {
@@ -4431,7 +4626,10 @@ mod tests {
 
     #[test]
     fn test_roots_capability_serialization() {
-        let cap = RootsCapability { list_changed: true };
+        let cap = RootsCapability {
+            list_changed: true,
+            deprecated: None,
+        };
         let json = serde_json::to_value(&cap).unwrap();
         assert_eq!(json["listChanged"], true);
     }
@@ -4439,7 +4637,10 @@ mod tests {
     #[test]
     fn test_client_capabilities_with_roots() {
         let caps = ClientCapabilities {
-            roots: Some(RootsCapability { list_changed: true }),
+            roots: Some(RootsCapability {
+                list_changed: true,
+                deprecated: None,
+            }),
             sampling: None,
             elicitation: None,
             tasks: None,
@@ -5293,6 +5494,8 @@ mod tests {
         let response = McpResponse::ListTools(ListToolsResult {
             tools: vec![],
             next_cursor: Some("cursor123".to_string()),
+            ttl_ms: None,
+            cache_scope: None,
             meta: None,
         });
         let json = serde_json::to_string(&response).unwrap();

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -184,7 +184,10 @@ impl McpClientBuilder {
     /// respond to `roots/list` requests with these roots.
     pub fn with_roots(mut self, roots: Vec<Root>) -> Self {
         self.roots = roots;
-        self.capabilities.roots = Some(RootsCapability { list_changed: true });
+        self.capabilities.roots = Some(RootsCapability {
+            list_changed: true,
+            deprecated: None,
+        });
         self
     }
 

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -628,6 +628,8 @@ async fn handle_list_tools(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonRpc
     Ok(McpResponse::ListTools(ListToolsResult {
         tools,
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     }))
 }
@@ -670,6 +672,8 @@ async fn handle_list_resources(infos: Vec<EntryInfo>) -> Result<McpResponse, Jso
     Ok(McpResponse::ListResources(ListResourcesResult {
         resources,
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     }))
 }
@@ -691,6 +695,8 @@ async fn handle_list_resource_templates(
         ListResourceTemplatesResult {
             resource_templates,
             next_cursor: None,
+            ttl_ms: None,
+            cache_scope: None,
             meta: None,
         },
     ))
@@ -731,6 +737,8 @@ async fn handle_list_prompts(infos: Vec<EntryInfo>) -> Result<McpResponse, JsonR
     Ok(McpResponse::ListPrompts(ListPromptsResult {
         prompts,
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     }))
 }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1762,6 +1762,8 @@ impl McpRouter {
                 Ok(McpResponse::ListTools(ListToolsResult {
                     tools,
                     next_cursor,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 }))
             }
@@ -1978,6 +1980,8 @@ impl McpRouter {
                 Ok(McpResponse::ListResources(ListResourcesResult {
                     resources,
                     next_cursor,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 }))
             }
@@ -2016,6 +2020,8 @@ impl McpRouter {
                     ListResourceTemplatesResult {
                         resource_templates,
                         next_cursor,
+                        ttl_ms: None,
+                        cache_scope: None,
                         meta: None,
                     },
                 ))
@@ -2169,6 +2175,8 @@ impl McpRouter {
                 Ok(McpResponse::ListPrompts(ListPromptsResult {
                     prompts,
                     next_cursor,
+                    ttl_ms: None,
+                    cache_scope: None,
                     meta: None,
                 }))
             }

--- a/crates/tower-mcp/tests/schema_validation.rs
+++ b/crates/tower-mcp/tests/schema_validation.rs
@@ -79,6 +79,8 @@ fn validate_list_tools_result() {
             meta: None,
         }],
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     };
     validate_against_def(&result, "ListToolsResult");
@@ -99,6 +101,8 @@ fn validate_list_resources_result() {
             meta: None,
         }],
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     };
     validate_against_def(&result, "ListResourcesResult");
@@ -135,6 +139,8 @@ fn validate_list_prompts_result() {
             meta: None,
         }],
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     };
     validate_against_def(&result, "ListPromptsResult");
@@ -215,6 +221,8 @@ fn validate_list_resource_templates_result() {
             meta: None,
         }],
         next_cursor: None,
+        ttl_ms: None,
+        cache_scope: None,
         meta: None,
     };
     validate_against_def(&result, "ListResourceTemplatesResult");
@@ -633,7 +641,7 @@ fn validate_create_message_result() {
 fn validate_server_capabilities() {
     let caps = ServerCapabilities {
         experimental: None,
-        logging: Some(LoggingCapability {}),
+        logging: Some(LoggingCapability::default()),
         completions: None,
         prompts: Some(PromptsCapability { list_changed: true }),
         resources: Some(ResourcesCapability {
@@ -651,10 +659,14 @@ fn validate_server_capabilities() {
 fn validate_client_capabilities() {
     let caps = ClientCapabilities {
         experimental: None,
-        roots: Some(RootsCapability { list_changed: true }),
+        roots: Some(RootsCapability {
+            list_changed: true,
+            deprecated: None,
+        }),
         sampling: Some(SamplingCapability {
             tools: None,
             context: None,
+            deprecated: None,
         }),
         elicitation: Some(ElicitationCapability {
             form: None,


### PR DESCRIPTION
## Summary

Two adjacent post-April spec additions, bundled because they're both small, pure-additive, and live next to each other in the protocol type tree.

### #817 / SEP-2549 -- TTL on list results

- Add `ttl_ms: Option<u64>` and `cache_scope: Option<CacheScope>` to `ListToolsResult`, `ListResourcesResult`, `ListResourceTemplatesResult`, and `ListPromptsResult`. Lets servers hint to clients how long a list response is cacheable and at what scope (`Session` vs `Global`).
- Defaults to `None` -- existing servers' wire output is unchanged; opt-in only.
- New `CacheScope` enum, lowercase wire form.

### #821 / SEP-2577 + SEP-2596 -- deprecation metadata

- Add a `DeprecationInfo` struct (`since`, `remove_in`, `message`, `replacement`, all optional) for marking spec features as deprecated per SEP-2596's lifecycle policy.
- Add `deprecated: Option<DeprecationInfo>` to `RootsCapability`, `SamplingCapability`, `LoggingCapability` -- the three SEP-2577 deprecates with a 12-month support window.
- Defaults to `None`; servers can opt in to emit the deprecation signal in their capability declarations. **Tower-mcp's own defaults are not flagged** -- that's a separate decision (it'd change wire output for anyone using those features).

## What's NOT in this PR

#819 (resource-not-found error code `-32002` -> `-32602` per SEP-2164) was originally part of the bundle. Pulled because it's a hard wire-format break for current users on protocol 2025-11-25 and we don't yet have protocol-version gating (that's #814's work). Will revisit once #814 lands the negotiation infrastructure, or do it in its own PR with explicit discussion.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (added `#[allow(clippy::large_enum_variant)]` on McpRequest/McpResponse -- variants are spec-dictated and were already at-threshold)
- [x] `cargo test --lib --all-features` (6 new wire-format regression tests; all 111 in types crate green; 694 in tower-mcp green)
- [x] `cargo test --test '*' --all-features` (all integration suites green)
- [x] `cargo test --doc --all-features` (doctest updated for new `RootsCapability` field)

Closes #817, #821.