### PR TITLE
feat(types,router): wire server/discover RPC end-to-end per SEP-2575

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -395,6 +395,8 @@ pub enum McpRequest {
     SetLoggingLevel(SetLogLevelParams),
     /// Request completion suggestions
     Complete(CompleteParams),
+    /// SEP-2575: discover server capabilities without an initialize handshake
+    Discover(DiscoverParams),
     /// Unknown method
     Unknown {
         method: String,
@@ -423,6 +425,7 @@ impl McpRequest {
             McpRequest::Ping => "ping",
             McpRequest::SetLoggingLevel(_) => "logging/setLevel",
             McpRequest::Complete(_) => "completion/complete",
+            McpRequest::Discover(_) => "server/discover",
             McpRequest::Unknown { method, .. } => method,
         }
     }
@@ -530,6 +533,8 @@ pub enum McpResponse {
     SetLoggingLevel(EmptyResult),
     Complete(CompleteResult),
     Pong(EmptyResult),
+    /// SEP-2575 `server/discover` response.
+    Discover(DiscoverResult),
     Empty(EmptyResult),
     /// Raw JSON value for experimental/extension methods.
     Raw(Value),
@@ -1490,6 +1495,46 @@ pub struct InitializeResult {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
     /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+// =============================================================================
+// server/discover (SEP-2575)
+// =============================================================================
+
+/// Parameters for the `server/discover` RPC (SEP-2575).
+///
+/// `server/discover` lets clients fetch server capabilities, supported
+/// protocol versions, and implementation info **without** establishing a
+/// session or going through the initialize handshake. It is the stateless
+/// replacement for `initialize` in the 2026-07-28 protocol.
+///
+/// The request takes no parameters today; the empty struct is reserved
+/// so future SEPs can add optional fields without breaking callers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DiscoverParams {}
+
+/// Result of the `server/discover` RPC (SEP-2575).
+///
+/// Shape mirrors `InitializeResult` with the singular `protocol_version`
+/// replaced by `supported_versions` -- a `server/discover` call is
+/// version-independent, so the server enumerates every version it can
+/// speak and the client picks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResult {
+    /// All protocol versions this server can speak. The client picks one
+    /// and signals it via `MCP-Protocol-Version` on subsequent requests.
+    pub supported_versions: Vec<String>,
+    /// Server capabilities (same shape as the `initialize` result).
+    pub capabilities: ServerCapabilities,
+    /// Server implementation info.
+    pub server_info: Implementation,
+    /// Optional instructions describing how to use this server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+    /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
 }
@@ -3976,6 +4021,11 @@ impl McpRequest {
                 let p: CompleteParams = serde_json::from_value(params)?;
                 Ok(McpRequest::Complete(p))
             }
+            "server/discover" => {
+                // SEP-2575: empty-or-missing params is valid.
+                let p: DiscoverParams = serde_json::from_value(params).unwrap_or_default();
+                Ok(McpRequest::Discover(p))
+            }
             method => Ok(McpRequest::Unknown {
                 method: method.to_string(),
                 params: req.params.clone(),
@@ -4015,6 +4065,59 @@ impl McpNotification {
 mod tests {
     use super::*;
     use crate::error::JsonRpcError;
+
+    // =========================================================================
+    // SEP-2575 (server/discover) wire-format tests
+    // =========================================================================
+
+    #[test]
+    fn discover_request_round_trips_with_no_params() {
+        // Per SEP-2575 the params field is empty/optional. Both shapes
+        // round-trip into McpRequest::Discover.
+        let no_params = r#"{"jsonrpc":"2.0","id":1,"method":"server/discover"}"#;
+        let req: JsonRpcRequest = serde_json::from_str(no_params).unwrap();
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        assert!(matches!(parsed, McpRequest::Discover(_)));
+        assert_eq!(parsed.method_name(), "server/discover");
+
+        let empty_params = r#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}"#;
+        let req: JsonRpcRequest = serde_json::from_str(empty_params).unwrap();
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        assert!(matches!(parsed, McpRequest::Discover(_)));
+    }
+
+    #[test]
+    fn discover_result_serializes_supported_versions_array() {
+        let r = DiscoverResult {
+            supported_versions: vec!["2026-07-28".into(), "2025-11-25".into()],
+            capabilities: ServerCapabilities::default(),
+            server_info: Implementation {
+                name: "test-server".into(),
+                version: "1.0.0".into(),
+                title: None,
+                description: None,
+                icons: None,
+                website_url: None,
+                meta: None,
+            },
+            instructions: None,
+            meta: None,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(
+            json["supportedVersions"],
+            serde_json::json!(["2026-07-28", "2025-11-25"])
+        );
+        assert!(
+            json.get("protocolVersion").is_none(),
+            "server/discover must use supportedVersions, not protocolVersion, got: {json}"
+        );
+        assert_eq!(json["serverInfo"]["name"], "test-server");
+        assert!(
+            json.get("instructions").is_none(),
+            "instructions must be omitted when None, got: {json}"
+        );
+    }
 
     #[test]
     fn cancelled_params_serializes_request_id_when_present() {

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1691,6 +1691,38 @@ impl McpRouter {
                 }))
             }
 
+            McpRequest::Discover(_) => {
+                // SEP-2575 server/discover -- stateless capability advertisement.
+                // Unlike initialize, this does NOT transition session state and
+                // does not require a session at all. Returns the same capability
+                // surface plus the full set of protocol versions we can speak,
+                // so clients can pick one and signal it via MCP-Protocol-Version
+                // on subsequent requests.
+                tracing::debug!("Stateless server/discover request");
+                Ok(McpResponse::Discover(DiscoverResult {
+                    supported_versions: crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                        .iter()
+                        .map(|v| (*v).to_string())
+                        .collect(),
+                    capabilities: self.capabilities(),
+                    server_info: Implementation {
+                        name: self.inner.server_name.clone(),
+                        version: self.inner.server_version.clone(),
+                        title: self.inner.server_title.clone(),
+                        description: self.inner.server_description.clone(),
+                        icons: self.inner.server_icons.clone(),
+                        website_url: self.inner.server_website_url.clone(),
+                        meta: None,
+                    },
+                    instructions: if let Some(config) = &self.inner.auto_instructions {
+                        Some(self.inner.generate_instructions(config))
+                    } else {
+                        self.inner.instructions.clone()
+                    },
+                    meta: None,
+                }))
+            }
+
             McpRequest::ListTools(params) => {
                 let filter = self.inner.tool_filter.as_ref();
                 let disabled = self.inner.disabled_tools.read().unwrap().clone();
@@ -2309,35 +2341,6 @@ impl McpRouter {
                 } else {
                     // No completion handler registered, return empty completions
                     Ok(McpResponse::Complete(CompleteResult::new(vec![])))
-                }
-            }
-
-            McpRequest::Unknown { ref method, .. } if method == "server/discover" => {
-                #[cfg(feature = "stateless")]
-                {
-                    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
-                    let result = crate::stateless::DiscoverResult {
-                        supported_versions: SUPPORTED_PROTOCOL_VERSIONS
-                            .iter()
-                            .map(|v| v.to_string())
-                            .collect(),
-                        capabilities: self.capabilities(),
-                        server_info: Implementation {
-                            name: self.inner.server_name.clone(),
-                            version: self.inner.server_version.clone(),
-                            title: self.inner.server_title.clone(),
-                            description: self.inner.server_description.clone(),
-                            icons: self.inner.server_icons.clone(),
-                            website_url: None,
-                            meta: None,
-                        },
-                        instructions: self.inner.instructions.clone(),
-                    };
-                    Ok(McpResponse::Raw(serde_json::to_value(result).unwrap()))
-                }
-                #[cfg(not(feature = "stateless"))]
-                {
-                    Err(Error::JsonRpc(JsonRpcError::method_not_found(method)))
                 }
             }
 

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -24,9 +24,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::protocol::{
-    ClientCapabilities, Implementation, ProgressToken, Root, ServerCapabilities,
-};
+use crate::protocol::{ClientCapabilities, ProgressToken, Root};
 
 // =============================================================================
 // Extended _meta fields for stateless mode
@@ -104,29 +102,12 @@ pub enum LogLevel {
 // server/discover RPC
 // =============================================================================
 
-/// Request parameters for the `server/discover` RPC (SEP-1442).
-///
-/// Allows clients to query server capabilities without establishing a session.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct DiscoverParams {}
+// SEP-1442's `server/discover` shape was promoted to the always-available
+// `protocol` module when SEP-2575 finalized. Re-export from here so existing
+// imports keep working; new code should import from `protocol` directly.
 
-/// Response for the `server/discover` RPC (SEP-1442).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DiscoverResult {
-    /// Protocol versions supported by this server.
-    pub supported_versions: Vec<String>,
-
-    /// Server capabilities.
-    pub capabilities: ServerCapabilities,
-
-    /// Server implementation info.
-    pub server_info: Implementation,
-
-    /// Optional instructions for using this server.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub instructions: Option<String>,
-}
+#[doc(inline)]
+pub use crate::protocol::{DiscoverParams, DiscoverResult};
 
 // =============================================================================
 // Error codes (SEP-1442)
@@ -300,6 +281,8 @@ mod tests {
 
     #[test]
     fn test_discover_result_serialization() {
+        use crate::protocol::{Implementation, ServerCapabilities};
+
         let result = DiscoverResult {
             supported_versions: vec!["2025-11-25".to_string(), "2025-03-26".to_string()],
             capabilities: ServerCapabilities::default(),
@@ -313,6 +296,7 @@ mod tests {
                 meta: None,
             },
             instructions: Some("Test instructions".to_string()),
+            meta: None,
         };
 
         let json = serde_json::to_value(&result).unwrap();

--- a/crates/tower-mcp/tests/server_discover.rs
+++ b/crates/tower-mcp/tests/server_discover.rs
@@ -1,0 +1,100 @@
+//! End-to-end tests for the `server/discover` RPC (SEP-2575).
+//!
+//! `server/discover` is the stateless replacement for `initialize` in the
+//! 2026-07-28 protocol. It MUST work without an `Mcp-Session-Id`, without
+//! a prior `initialize` handshake, and without affecting any session
+//! state -- multiple calls are idempotent.
+//!
+//! These tests exercise the HTTP transport to confirm the wire shape and
+//! the session-independence invariant.
+
+#![cfg(feature = "http")]
+
+use axum::body::Body;
+use axum::http::Request;
+use tower::ServiceExt;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+fn router() -> McpRouter {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a value")
+        .read_only()
+        .handler(|v: serde_json::Value| async move { Ok(CallToolResult::text(v.to_string())) })
+        .build();
+    McpRouter::new()
+        .server_info("discover-test-server", "9.9.9")
+        .tool(echo)
+}
+
+async fn post_discover() -> serde_json::Value {
+    let app = HttpTransport::new(router())
+        .disable_origin_validation()
+        .into_router();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        // Deliberately no Mcp-Session-Id and no prior initialize.
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":1,"method":"server/discover"}"#,
+        ))
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    assert!(
+        response.status().is_success(),
+        "expected 2xx, got {}",
+        response.status()
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn discover_returns_supported_versions_and_server_info() {
+    let resp = post_discover().await;
+    assert_eq!(resp["jsonrpc"], "2.0");
+    assert_eq!(resp["id"], 1);
+    let result = &resp["result"];
+    assert!(
+        result["supportedVersions"].is_array(),
+        "supportedVersions must be an array, got: {result}"
+    );
+    let versions = result["supportedVersions"].as_array().unwrap();
+    assert!(
+        !versions.is_empty(),
+        "supportedVersions must list at least one version"
+    );
+    assert!(
+        versions.iter().all(|v| v.is_string()),
+        "supportedVersions entries must be strings"
+    );
+    assert_eq!(result["serverInfo"]["name"], "discover-test-server");
+    assert_eq!(result["serverInfo"]["version"], "9.9.9");
+    assert!(
+        result.get("protocolVersion").is_none(),
+        "server/discover must NOT include singular protocolVersion -- that's the initialize shape: {result}"
+    );
+}
+
+#[tokio::test]
+async fn discover_does_not_require_initialize() {
+    // The whole point of SEP-2575: this works without any prior handshake.
+    // post_discover above does exactly that; this test exists as the
+    // documented invariant.
+    let resp = post_discover().await;
+    assert!(resp["result"].is_object());
+    assert!(resp.get("error").is_none());
+}
+
+#[tokio::test]
+async fn discover_is_idempotent() {
+    // SEP-2567: tools/list and discovery RPCs MUST NOT depend on per-
+    // connection state. Two discover calls back-to-back must return
+    // identical capability data.
+    let a = post_discover().await;
+    let b = post_discover().await;
+    assert_eq!(a["result"], b["result"]);
+}


### PR DESCRIPTION
## Summary

First concrete piece of the #814 SEP-2575/2567 work. Wires the `server/discover` RPC as a real handler instead of a feature-gated type definition.

- Promote `DiscoverParams` and `DiscoverResult` from the experimental `stateless` module to the always-available `protocol` module. Both also get the SEP-2575-correct shape (added `_meta` field, doc updates).
- Add `Discover(DiscoverParams)` to `McpRequest` and `Discover(DiscoverResult)` to `McpResponse`. Update `method_name()` and `from_jsonrpc()` so `"server/discover"` parses to the typed variant.
- Add the dispatch in `McpRouter`. Returns the full `SUPPORTED_PROTOCOL_VERSIONS` plus the same capabilities, server-info, and instructions that `initialize` surfaces -- but **does not** touch session state.
- Remove the dead `Unknown { method: "server/discover" }` branch that previously synthesized a response only when the `stateless` feature was enabled.
- `stateless.rs` re-exports the promoted types via `pub use` for backward compat.

## Why this first

Per the design comment in #814, item 1 in the sequenced plan. Builds the test infrastructure and dispatch pattern that subsequent SEP-2575/2567 work (`messages/listen`, per-request capabilities, version-gated session-bypass) will reuse.

This change is also safe to land standalone: no behavior change for existing clients, just adds support for a new method that wasn't dispatched before.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` -- 2 new wire-format tests pass, 107 in types crate green, 694 in tower-mcp green
- [x] `cargo test --test '*' --all-features` -- 3 new e2e HTTP integration tests in `tests/server_discover.rs` pass:
  - `discover_returns_supported_versions_and_server_info`
  - `discover_does_not_require_initialize` (no handshake, no session id)
  - `discover_is_idempotent` (per-SEP-2567 state-purity invariant)

## Follow-ups

Per the #814 design plan, queued for subsequent PRs:
- Add `2026-07-28` to `SUPPORTED_PROTOCOL_VERSIONS` and wire `UnsupportedVersionError` from the HTTP transport.
- Per-request capabilities in `_meta`.
- `messages/listen` RPC.
- Stateless-by-default for `2026-07-28`.
- SEP-1442 -> SEP-2567/2575 doc migration across `stateless.rs`.

Refs #814.