### PR TITLE
ci: disable cargo-semver-checks until 1.0 (closes #830)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --target wasm32-unknown-unknown -p tower-mcp-types
 
-  semver:
-    name: SemVer
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - uses: obi1kenobi/cargo-semver-checks-action@v2
-        with:
-          package: tower-mcp,tower-mcp-types
+  # SemVer check is disabled pre-1.0 -- see the tracking issue for the
+  # re-enable plan. While the crate is in active 0.x development tracking
+  # rapid MCP spec change, essentially every PR is a `feat!:` breaking
+  # change by strict semver rules, so the check is pure noise. Convention
+  # is to mark breaking commits with `!` (per CLAUDE.md) and let
+  # release-plz drive 0.x -> 0.(x+1).0 bumps from the commit log.
+  #
+  # semver:
+  #   name: SemVer
+  #   if: github.event_name == 'pull_request'
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: dtolnay/rust-toolchain@stable
+  #     - uses: Swatinem/rust-cache@v2
+  #     - uses: obi1kenobi/cargo-semver-checks-action@v2
+  #       with:
+  #         package: tower-mcp,tower-mcp-types
 
   fmt:
     name: Format


### PR DESCRIPTION
## Summary

Disable the `SemVer` CI job (commented out, not deleted) while the crate is in active pre-1.0 spec-tracking. The check was firing on every PR with no signal value -- breaking changes are expected and marked via the project's `feat!:` convention; release-plz drives 0.x -> 0.(x+1).0 bumps from there.

Re-enable when we hit 1.0; tracked in #830. The job is one-line away from being restored.

## Why now

We've spent the last few PRs (#826, #829) hitting semver failures that are technically correct but completely expected for a 0.x crate tracking rapid MCP spec change. Either every spec-driven PR shows red, or we ignore the red and stop noticing real failures. Neither is good CI hygiene.

## Test plan

- [x] Workflow file syntax checks (`gh workflow view` would parse it)
- [ ] First PR after this lands shows no SemVer check on the PR view

Refs #830.