### PR TITLE
test(stdio): expose run_with_streams to enable end-to-end loop tests

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -129,8 +129,11 @@ pub(crate) fn serialize_notification(notification: &ServerNotification) -> Optio
     }
 }
 
-/// Write a line to an async stdout writer and flush.
-async fn write_line_to_stdout(stdout: &mut tokio::io::Stdout, line: &str) -> Result<()> {
+/// Write a line to an async writer and flush.
+async fn write_line_to_stdout<W>(stdout: &mut W, line: &str) -> Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
     stdout
         .write_all(line.as_bytes())
         .await
@@ -238,10 +241,29 @@ impl StdioTransport {
     }
 
     /// Run the transport, processing messages until EOF or error
+    ///
+    /// This is a thin wrapper around [`Self::run_with_streams`] that wires up
+    /// `tokio::io::stdin()` and `tokio::io::stdout()`. Most users want this
+    /// method; use [`Self::run_with_streams`] only for in-process testing.
     pub async fn run(&mut self) -> Result<()> {
-        let stdin = tokio::io::stdin();
-        let mut stdout = tokio::io::stdout();
-        let mut reader = BufReader::new(stdin);
+        self.run_with_streams(tokio::io::stdin(), tokio::io::stdout())
+            .await
+    }
+
+    /// Run the transport, reading from `reader` and writing to `writer`.
+    ///
+    /// This is the streams-generic counterpart of [`Self::run`]. The default
+    /// `run()` calls this with `tokio::io::stdin()` / `tokio::io::stdout()`.
+    ///
+    /// Exposing this lets tests drive the full read-eval-write loop with
+    /// `tokio::io::duplex()` and assert end-to-end behavior (parse-error
+    /// frames, loop continuation across bad input, EOF handling).
+    pub async fn run_with_streams<R, W>(&mut self, reader: R, mut writer: W) -> Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send,
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
+        let mut reader = BufReader::new(reader);
 
         tracing::info!("Stdio transport started, waiting for input");
 
@@ -274,7 +296,7 @@ impl StdioTransport {
                                 Error::Transport(format!("Failed to serialize response: {}", e))
                             })?;
                             tracing::debug!(output = %response_json, "Sending response");
-                            write_line_to_stdout(&mut stdout, &response_json).await?;
+                            write_line_to_stdout(&mut writer, &response_json).await?;
                         }
                         Ok(None) => {
                             // Notification, no response needed
@@ -285,7 +307,7 @@ impl StdioTransport {
                             let response_json = serde_json::to_string(&error_response).map_err(|e| {
                                 Error::Transport(format!("Failed to serialize error: {}", e))
                             })?;
-                            write_line_to_stdout(&mut stdout, &response_json).await?;
+                            write_line_to_stdout(&mut writer, &response_json).await?;
                         }
                     }
                 }
@@ -294,7 +316,7 @@ impl StdioTransport {
                 Some(notification) = self.notification_rx.recv() => {
                     if let Some(json) = serialize_notification(&notification) {
                         tracing::debug!(output = %json, "Sending notification");
-                        write_line_to_stdout(&mut stdout, &json).await?;
+                        write_line_to_stdout(&mut writer, &json).await?;
                     }
                 }
             }
@@ -398,10 +420,24 @@ where
     }
 
     /// Run the transport, processing messages until EOF or error.
+    ///
+    /// Thin wrapper around [`Self::run_with_streams`] that wires up
+    /// `tokio::io::stdin()` / `tokio::io::stdout()`.
     pub async fn run(&mut self) -> Result<()> {
-        let stdin = tokio::io::stdin();
-        let mut stdout = tokio::io::stdout();
-        let mut reader = BufReader::new(stdin);
+        self.run_with_streams(tokio::io::stdin(), tokio::io::stdout())
+            .await
+    }
+
+    /// Run the transport, reading from `reader` and writing to `writer`.
+    ///
+    /// Streams-generic counterpart of [`Self::run`]. Lets tests drive the
+    /// read-eval-write loop with in-memory streams (e.g. `tokio::io::duplex()`).
+    pub async fn run_with_streams<R, W>(&mut self, reader: R, mut writer: W) -> Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send,
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
+        let mut reader = BufReader::new(reader);
 
         tracing::info!("Generic stdio transport started, waiting for input");
 
@@ -421,13 +457,13 @@ where
                             break;
                         }
 
-                        self.process_input(&line, &mut stdout).await?;
+                        Self::process_input(&mut self.service, &line, &mut writer).await?;
                     }
 
                     Some(notification) = notif_rx.recv() => {
                         if let Some(json) = serialize_notification(&notification) {
                             tracing::debug!(output = %json, "Sending notification");
-                            write_line_to_stdout(&mut stdout, &json).await?;
+                            write_line_to_stdout(&mut writer, &json).await?;
                         }
                     }
                 }
@@ -442,14 +478,21 @@ where
                     break;
                 }
 
-                self.process_input(&line, &mut stdout).await?;
+                Self::process_input(&mut self.service, &line, &mut writer).await?;
             }
         }
 
         Ok(())
     }
 
-    async fn process_input(&mut self, line: &str, stdout: &mut tokio::io::Stdout) -> Result<()> {
+    async fn process_input<W>(
+        service: &mut JsonRpcService<S>,
+        line: &str,
+        writer: &mut W,
+    ) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
         let trimmed = clean_input_line(line);
         if trimmed.is_empty() {
             return Ok(());
@@ -461,7 +504,7 @@ where
         let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
             Ok(v) => v,
             Err(e) => {
-                self.write_error(stdout, None, &e.to_string()).await?;
+                Self::write_error(writer, None, &e.to_string()).await?;
                 return Ok(());
             }
         };
@@ -479,33 +522,35 @@ where
         let message: JsonRpcMessage = match serde_json::from_str(trimmed) {
             Ok(m) => m,
             Err(e) => {
-                self.write_error(stdout, None, &e.to_string()).await?;
+                Self::write_error(writer, None, &e.to_string()).await?;
                 return Ok(());
             }
         };
 
-        match self.service.call_message(message).await {
+        match service.call_message(message).await {
             Ok(response) => {
                 let response_json = serde_json::to_string(&response).map_err(|e| {
                     Error::Transport(format!("Failed to serialize response: {}", e))
                 })?;
                 tracing::debug!(output = %response_json, "Sending response");
-                write_line_to_stdout(stdout, &response_json).await?;
+                write_line_to_stdout(writer, &response_json).await?;
             }
             Err(e) => {
                 tracing::error!(error = %e, "Error processing message");
-                self.write_error(stdout, None, &e.to_string()).await?;
+                Self::write_error(writer, None, &e.to_string()).await?;
             }
         }
         Ok(())
     }
 
-    async fn write_error(
-        &self,
-        stdout: &mut tokio::io::Stdout,
+    async fn write_error<W>(
+        writer: &mut W,
         id: Option<crate::protocol::RequestId>,
         message: &str,
-    ) -> Result<()> {
+    ) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
         // `id` is currently always `None` from every call site (parse-error
         // path), so use the shared helper; preserve the parameter for callers
         // that may want to surface a known-id error in future.
@@ -516,7 +561,7 @@ where
         };
         let response_json = serde_json::to_string(&error_response)
             .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
-        write_line_to_stdout(stdout, &response_json).await
+        write_line_to_stdout(writer, &response_json).await
     }
 }
 
@@ -693,10 +738,28 @@ impl BidirectionalStdioTransport {
     }
 
     /// Run the transport, processing messages until EOF or error
+    ///
+    /// Thin wrapper around [`Self::run_with_streams`] that wires up
+    /// `tokio::io::stdin()` / `tokio::io::stdout()`.
     pub async fn run(&mut self) -> Result<()> {
-        let stdin = tokio::io::stdin();
-        let stdout = Arc::new(Mutex::new(tokio::io::stdout()));
-        let mut reader = BufReader::new(stdin);
+        self.run_with_streams(tokio::io::stdin(), tokio::io::stdout())
+            .await
+    }
+
+    /// Run the transport, reading from `reader` and writing to `writer`.
+    ///
+    /// Streams-generic counterpart of [`Self::run`]. The writer is held
+    /// behind an `Arc<Mutex<_>>` so the outgoing-request and notification
+    /// paths can share it with the incoming-message branch -- the same
+    /// concurrency model `run()` has always used, just with the streams
+    /// supplied by the caller.
+    pub async fn run_with_streams<R, W>(&mut self, reader: R, writer: W) -> Result<()>
+    where
+        R: tokio::io::AsyncRead + Unpin + Send,
+        W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+    {
+        let writer = Arc::new(Mutex::new(writer));
+        let mut reader = BufReader::new(reader);
 
         tracing::info!("Bidirectional stdio transport started, waiting for input");
 
@@ -720,19 +783,19 @@ impl BidirectionalStdioTransport {
                         continue;
                     }
 
-                    self.handle_incoming_message(trimmed, stdout.clone()).await?;
+                    self.handle_incoming_message(trimmed, writer.clone()).await?;
                 }
 
                 // Handle outgoing requests to send to the client
                 Some(outgoing) = self.request_rx.recv() => {
-                    self.send_outgoing_request(outgoing, stdout.clone()).await?;
+                    self.send_outgoing_request(outgoing, writer.clone()).await?;
                 }
 
                 // Forward server notifications to the client
                 Some(notification) = self.notification_rx.recv() => {
                     if let Some(json) = serialize_notification(&notification) {
                         tracing::debug!(output = %json, "Sending notification");
-                        self.write_line(&json, stdout.clone()).await?;
+                        self.write_line(&json, writer.clone()).await?;
                     }
                 }
             }
@@ -742,11 +805,10 @@ impl BidirectionalStdioTransport {
     }
 
     /// Handle an incoming message from stdin
-    async fn handle_incoming_message(
-        &mut self,
-        line: &str,
-        stdout: Arc<Mutex<tokio::io::Stdout>>,
-    ) -> Result<()> {
+    async fn handle_incoming_message<W>(&mut self, line: &str, writer: Arc<Mutex<W>>) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
         tracing::debug!(input = %line, "Received message");
 
         // Malformed JSON must produce a JSON-RPC parse error response, not
@@ -756,7 +818,7 @@ impl BidirectionalStdioTransport {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(error = %e, "Malformed JSON on stdin");
-                return self.write_parse_error(&e.to_string(), stdout).await;
+                return self.write_parse_error(&e.to_string(), writer).await;
             }
         };
 
@@ -781,7 +843,7 @@ impl BidirectionalStdioTransport {
             Ok(m) => m,
             Err(e) => {
                 tracing::warn!(error = %e, "JSON did not match JSON-RPC request shape");
-                return self.write_parse_error(&e.to_string(), stdout).await;
+                return self.write_parse_error(&e.to_string(), writer).await;
             }
         };
         match self.service.call_message(message).await {
@@ -790,29 +852,28 @@ impl BidirectionalStdioTransport {
                     Error::Transport(format!("Failed to serialize response: {}", e))
                 })?;
                 tracing::debug!(output = %response_json, "Sending response");
-                self.write_line(&response_json, stdout).await?;
+                self.write_line(&response_json, writer).await?;
             }
             Err(e) => {
                 tracing::error!(error = %e, "Error processing message");
                 let error_response = parse_error_response(e.to_string());
                 let response_json = serde_json::to_string(&error_response)
                     .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
-                self.write_line(&response_json, stdout).await?;
+                self.write_line(&response_json, writer).await?;
             }
         }
 
         Ok(())
     }
 
-    async fn write_parse_error(
-        &self,
-        message: &str,
-        stdout: Arc<Mutex<tokio::io::Stdout>>,
-    ) -> Result<()> {
+    async fn write_parse_error<W>(&self, message: &str, writer: Arc<Mutex<W>>) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
         let error_response = parse_error_response(message);
         let response_json = serde_json::to_string(&error_response)
             .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
-        self.write_line(&response_json, stdout).await
+        self.write_line(&response_json, writer).await
     }
 
     /// Handle a response to one of our pending requests
@@ -871,11 +932,14 @@ impl BidirectionalStdioTransport {
     }
 
     /// Send an outgoing request to the client
-    async fn send_outgoing_request(
+    async fn send_outgoing_request<W>(
         &mut self,
         outgoing: OutgoingRequest,
-        stdout: Arc<Mutex<tokio::io::Stdout>>,
-    ) -> Result<()> {
+        writer: Arc<Mutex<W>>,
+    ) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
         // Build JSON-RPC request
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
@@ -901,23 +965,26 @@ impl BidirectionalStdioTransport {
         }
 
         // Send the request
-        self.write_line(&request_json, stdout).await?;
+        self.write_line(&request_json, writer).await?;
 
         Ok(())
     }
 
-    /// Write a line to stdout
-    async fn write_line(&self, line: &str, stdout: Arc<Mutex<tokio::io::Stdout>>) -> Result<()> {
-        let mut stdout = stdout.lock().await;
-        stdout
+    /// Write a line to the shared writer
+    async fn write_line<W>(&self, line: &str, writer: Arc<Mutex<W>>) -> Result<()>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
+        let mut writer = writer.lock().await;
+        writer
             .write_all(line.as_bytes())
             .await
             .map_err(|e| Error::Transport(format!("Failed to write to stdout: {}", e)))?;
-        stdout
+        writer
             .write_all(b"\n")
             .await
             .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
-        stdout
+        writer
             .flush()
             .await
             .map_err(|e| Error::Transport(format!("Failed to flush stdout: {}", e)))?;

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -1,0 +1,277 @@
+//! End-to-end integration tests for the stdio transport read-eval-write loop.
+//!
+//! These tests drive [`StdioTransport`] and [`BidirectionalStdioTransport`]
+//! with in-memory `tokio::io::duplex()` streams via their `run_with_streams`
+//! entrypoints. That capability is what makes loop-level assertions possible
+//! at all -- the lib-level tests in `transport::stdio::tests` can only
+//! exercise helpers like `parse_error_response()` and `process_line()`, not
+//! the actual loop that wires them together.
+//!
+//! Regression coverage for #797 (bidi closed instead of writing a parse-error
+//! response) and follow-up to #812.
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tower_mcp::transport::stdio::BidirectionalStdioTransport;
+use tower_mcp::{McpRouter, StdioTransport};
+use tower_mcp_types::testing::assert_jsonrpc_error_response;
+
+/// Build a minimal router used for the e2e tests. `ping` works without
+/// session initialization, so tests can call it on a fresh transport.
+fn router() -> McpRouter {
+    McpRouter::new().server_info("stdio-loop-test", "0.0.0")
+}
+
+/// Read newline-delimited JSON-RPC frames from `reader` until either the
+/// expected count is reached or EOF is observed. Returns the parsed
+/// `serde_json::Value` for each frame in order.
+async fn read_n_frames<R>(mut reader: BufReader<R>, expected: usize) -> Vec<serde_json::Value>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut out = Vec::with_capacity(expected);
+    while out.len() < expected {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .expect("read from server output");
+        if n == 0 {
+            break; // EOF before we got everything
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(trimmed)
+            .unwrap_or_else(|e| panic!("invalid JSON on output: {e}: {trimmed}"));
+        out.push(v);
+    }
+    out
+}
+
+// ============================================================================
+// StdioTransport
+// ============================================================================
+
+/// Test 1: malformed JSON on stdin produces a JSON-RPC parse-error frame
+/// (`-32700`, `id: null`) on stdout, and the response is a valid wire frame.
+#[tokio::test]
+async fn stdio_transport_parse_error_wire_shape() {
+    let mut transport = StdioTransport::new(router());
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+
+    // Drive the loop in the background.
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    // Write malformed input, then close the writer so the server hits EOF.
+    let mut stdin_writer = server_stdin_writer;
+    stdin_writer
+        .write_all(b"not valid json{{{\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    drop(stdin_writer); // EOF -> loop exits cleanly
+
+    let reader = BufReader::new(server_stdout_reader);
+    let frames = read_n_frames(reader, 1).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+
+    assert_eq!(
+        frames.len(),
+        1,
+        "expected one parse-error frame, got: {frames:?}"
+    );
+    let frame = &frames[0];
+    assert_jsonrpc_error_response(frame);
+    assert!(
+        frame["id"].is_null(),
+        "parse error id must be null, got: {frame}"
+    );
+    assert_eq!(frame["error"]["code"].as_i64().unwrap(), -32700);
+}
+
+/// Test 2 (#797 regression): a parse error must NOT close the loop. The
+/// server must keep reading and respond to subsequent valid input on the
+/// same stream.
+#[tokio::test]
+async fn stdio_transport_loop_continues_after_parse_error() {
+    let mut transport = StdioTransport::new(router());
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let mut stdin_writer = server_stdin_writer;
+    // First: malformed JSON -- should produce a -32700 parse error
+    stdin_writer.write_all(b"this is not json\n").await.unwrap();
+    // Then: a valid ping request on the same stream -- should be processed
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":42,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    drop(stdin_writer);
+
+    let reader = BufReader::new(server_stdout_reader);
+    let frames = read_n_frames(reader, 2).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+
+    assert_eq!(
+        frames.len(),
+        2,
+        "expected parse-error frame + ping response, got: {frames:?}"
+    );
+
+    // Frame 1: the parse error
+    assert_jsonrpc_error_response(&frames[0]);
+    assert!(frames[0]["id"].is_null());
+    assert_eq!(frames[0]["error"]["code"].as_i64().unwrap(), -32700);
+
+    // Frame 2: the ping response that proves the loop kept running
+    assert_eq!(frames[1]["jsonrpc"], "2.0");
+    assert_eq!(frames[1]["id"], 42);
+    assert!(
+        frames[1].get("result").is_some(),
+        "ping must return a successful result frame, got: {}",
+        frames[1]
+    );
+}
+
+/// Test 3: closing the writer side of the input stream (EOF) cleanly
+/// terminates the loop -- `run_with_streams` returns `Ok(())`.
+#[tokio::test]
+async fn stdio_transport_eof_returns_ok() {
+    let mut transport = StdioTransport::new(router());
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, _server_stdout_reader) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    // Close the input side immediately -- the read should return 0 bytes
+    // (EOF) and the loop should break and return Ok.
+    drop(server_stdin_writer);
+
+    let result = handle.await.expect("transport task join");
+    assert!(
+        result.is_ok(),
+        "run_with_streams must return Ok on EOF, got: {result:?}"
+    );
+}
+
+// ============================================================================
+// BidirectionalStdioTransport
+// ============================================================================
+//
+// The same parse-error coverage as the unidirectional transport, this time
+// directly exercising the bug fixed in #797 (bidi closed instead of writing
+// a parse-error response). The bidi transport multiplexes stdin / outgoing
+// requests / notifications inside a single `tokio::select!`, so a bug in
+// any branch could silently drop the loop -- these tests pin the desired
+// behavior end-to-end.
+
+#[tokio::test]
+async fn bidi_transport_parse_error_wire_shape() {
+    let mut transport = BidirectionalStdioTransport::new(router());
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let mut stdin_writer = server_stdin_writer;
+    stdin_writer
+        .write_all(b"not valid json{{{\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    drop(stdin_writer);
+
+    let reader = BufReader::new(server_stdout_reader);
+    let frames = read_n_frames(reader, 1).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+
+    assert_eq!(
+        frames.len(),
+        1,
+        "expected one parse-error frame, got: {frames:?}"
+    );
+    assert_jsonrpc_error_response(&frames[0]);
+    assert!(frames[0]["id"].is_null());
+    assert_eq!(frames[0]["error"]["code"].as_i64().unwrap(), -32700);
+}
+
+#[tokio::test]
+async fn bidi_transport_loop_continues_after_parse_error() {
+    let mut transport = BidirectionalStdioTransport::new(router());
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let mut stdin_writer = server_stdin_writer;
+    stdin_writer.write_all(b"this is not json\n").await.unwrap();
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    drop(stdin_writer);
+
+    let reader = BufReader::new(server_stdout_reader);
+    let frames = read_n_frames(reader, 2).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+
+    assert_eq!(
+        frames.len(),
+        2,
+        "expected parse-error frame + ping response, got: {frames:?}"
+    );
+    assert_jsonrpc_error_response(&frames[0]);
+    assert!(frames[0]["id"].is_null());
+    assert_eq!(frames[0]["error"]["code"].as_i64().unwrap(), -32700);
+
+    assert_eq!(frames[1]["jsonrpc"], "2.0");
+    assert_eq!(frames[1]["id"], 7);
+    assert!(
+        frames[1].get("result").is_some(),
+        "ping must return a successful result frame, got: {}",
+        frames[1]
+    );
+}


### PR DESCRIPTION
## Summary

Extract the per-transport read-eval-write loop into a streams-generic
`run_with_streams<R: AsyncRead + Unpin + Send, W: AsyncWrite + Unpin + Send>`
on `StdioTransport`, `GenericStdioTransport`, and `BidirectionalStdioTransport`.
The existing `run()` becomes a one-line wrapper that calls `run_with_streams`
with `tokio::io::stdin()` / `tokio::io::stdout()` -- no public API change for
downstream users; the new method is purely additive.

This unlocks end-to-end loop tests that previously couldn't exist -- helper-level
coverage (`parse_error_response`, `process_line`) landed in #812, but the loop
that wires them together was untestable while stdin/stdout were hardcoded.

## New tests (`crates/tower-mcp/tests/stdio_loop.rs`)

Driven via `tokio::io::duplex()` against each transport's new `run_with_streams`:

- `stdio_transport_parse_error_wire_shape` -- malformed JSON produces a
  spec-correct parse-error frame (`-32700`, `id: null`).
- `stdio_transport_loop_continues_after_parse_error` -- a parse error followed
  by a valid `ping` on the same input stream produces both responses in order.
  Regression coverage for #797 in unidirectional form.
- `stdio_transport_eof_returns_ok` -- dropping the input writer (EOF) makes
  `run_with_streams` return `Ok(())`.
- `bidi_transport_parse_error_wire_shape` -- same wire-shape check against
  `BidirectionalStdioTransport`.
- `bidi_transport_loop_continues_after_parse_error` -- direct regression test
  for the original #797 bug where bidi closed instead of writing the parse-error
  response.

## Quality gates

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --lib --all-features` -- 694 passing
- `cargo test --test stdio_loop --all-features` -- 5 passing
- `cargo test --test '*' --all-features` -- full integration sweep passing
- `cargo test --doc --all-features` clean

## Notes

`GenericStdioTransport` also got the same `run_with_streams` treatment for
consistency; its internal `process_input` / `write_error` helpers became
generic over `W: AsyncWrite` (and associated functions rather than methods,
since the writer is no longer threaded through `self`).

Closes #813. Provides regression coverage for #797.

## Test plan

- [x] `cargo test -p tower-mcp --test stdio_loop --all-features`
- [x] `cargo test -p tower-mcp --lib --all-features`
- [x] `cargo test -p tower-mcp --test '*' --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`