### PR TITLE
fix(types)!: reconcile McpErrorCode against SEP-2575 canonical assignments

### DIFF
--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -15,19 +15,24 @@
 //!
 //! ## MCP-Specific Error Codes
 //!
-//! MCP uses the server error range (-32000 to -32099) for protocol-specific errors:
+//! MCP uses the server error range (-32000 to -32099) for protocol-specific
+//! errors. Codes assigned by the spec are marked **spec**; codes used only by
+//! this implementation (in the JSON-RPC "implementation-defined" subrange) are
+//! marked *impl*.
 //!
-//! | Code   | Name            | Meaning                                  |
-//! |--------|-----------------|------------------------------------------|
-//! | -32000 | ConnectionClosed| Transport connection was closed          |
-//! | -32001 | RequestTimeout  | Request exceeded timeout                 |
-//! | -32002 | ResourceNotFound| Resource not found                       |
-//! | -32003 | AlreadySubscribed| Resource already subscribed             |
-//! | -32004 | NotSubscribed   | Resource not subscribed (for unsubscribe)|
-//! | -32005 | SessionNotFound | Session not found or expired             |
-//! | -32006 | SessionRequired | MCP-Session-Id header is required        |
-//! | -32007 | Forbidden       | Access forbidden (insufficient scope)    |
-//! | -32042 | UrlElicitationRequired | URL elicitation required          |
+//! | Code   | Name                          | Source | Meaning                              |
+//! |--------|-------------------------------|--------|--------------------------------------|
+//! | -32000 | ConnectionClosed              | *impl* | Transport connection was closed      |
+//! | -32001 | RequestTimeout                | *impl* | Request exceeded timeout             |
+//! | -32002 | ResourceNotFound              | *impl* | Resource not found (legacy; **SEP-2164** moves to -32602) |
+//! | -32003 | MissingRequiredClientCapability | **spec** (SEP-2575) | Client lacks a capability required by the request |
+//! | -32004 | UnsupportedProtocolVersion    | **spec** (SEP-2575) | Server does not support the request's protocol version |
+//! | -32005 | SessionNotFound               | *impl* | Session not found or expired (legacy; deprecated by SEP-2567) |
+//! | -32006 | SessionRequired               | *impl* | Mcp-Session-Id header required (legacy; deprecated by SEP-2567) |
+//! | -32007 | Forbidden                     | *impl* | Access forbidden (insufficient scope)|
+//! | -32008 | AlreadySubscribed             | *impl* | Resource already subscribed (moved from -32003 to avoid collision with SEP-2575) |
+//! | -32009 | NotSubscribed                 | *impl* | Resource not subscribed (moved from -32004 to avoid collision with SEP-2575) |
+//! | -32042 | UrlElicitationRequired        | TS SDK | URL elicitation required             |
 
 use serde::{Deserialize, Serialize};
 
@@ -55,28 +60,59 @@ pub enum ErrorCode {
     InternalError = -32603,
 }
 
-/// MCP-specific error codes (in the -32000 to -32099 range)
+/// MCP-specific error codes (in the -32000 to -32099 range).
+///
+/// Codes marked **spec** are assigned by an MCP SEP. Others are
+/// implementation-defined within the JSON-RPC server-error range; using them
+/// is permitted by JSON-RPC 2.0 but they are not part of the MCP wire spec.
+///
+/// Recently-changed assignments:
+/// - `MissingRequiredClientCapability` (-32003) and `UnsupportedProtocolVersion`
+///   (-32004) are spec assignments from SEP-2575.
+/// - `AlreadySubscribed` and `NotSubscribed` previously occupied -32003 and
+///   -32004; they moved to -32008 and -32009 to make room. **This is a
+///   breaking change on the wire** for any subscribe/unsubscribe responses
+///   that relied on the old codes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 #[non_exhaustive]
 pub enum McpErrorCode {
-    /// Transport connection was closed
+    /// Transport connection was closed.
     ConnectionClosed = -32000,
-    /// Request exceeded timeout
+    /// Request exceeded timeout.
     RequestTimeout = -32001,
-    /// Resource not found
+    /// Resource not found.
+    ///
+    /// SEP-2164 (FINAL) moves this to the standard JSON-RPC `InvalidParams`
+    /// code (-32602). The migration is gated on protocol-version negotiation
+    /// landing (see #819); for now we keep emitting -32002 for back-compat
+    /// with 2025-11-25 clients.
     ResourceNotFound = -32002,
-    /// Resource already subscribed
-    AlreadySubscribed = -32003,
-    /// Resource not subscribed (for unsubscribe)
-    NotSubscribed = -32004,
-    /// Session not found or expired - client should re-initialize
+    /// SEP-2575: client capabilities advertised on the request do not
+    /// include a capability required by the called method.
+    MissingRequiredClientCapability = -32003,
+    /// SEP-2575: server does not support the protocol version the client
+    /// requested (via `MCP-Protocol-Version` header or per-request `_meta`).
+    /// Use [`JsonRpcError::unsupported_protocol_version`] to construct.
+    UnsupportedProtocolVersion = -32004,
+    /// Session not found or expired -- client should re-initialize.
+    ///
+    /// SEP-2567 deprecates sessions entirely. This code stays for the
+    /// 2025-11-25 protocol path; sessionless deployments will never emit it.
     SessionNotFound = -32005,
-    /// Session ID is required but was not provided
+    /// Session ID is required but was not provided.
+    ///
+    /// SEP-2567 deprecates sessions entirely. Same caveat as `SessionNotFound`.
     SessionRequired = -32006,
-    /// Access forbidden (insufficient scope or authorization)
+    /// Access forbidden (insufficient scope or authorization).
     Forbidden = -32007,
-    /// URL elicitation is required before processing the request
+    /// Resource already subscribed. Moved from -32003 to avoid the
+    /// SEP-2575 `MissingRequiredClientCapability` collision.
+    AlreadySubscribed = -32008,
+    /// Resource not subscribed (for unsubscribe). Moved from -32004 to
+    /// avoid the SEP-2575 `UnsupportedProtocolVersion` collision.
+    NotSubscribed = -32009,
+    /// URL elicitation is required before processing the request.
     UrlElicitationRequired = -32042,
 }
 
@@ -220,6 +256,53 @@ impl JsonRpcError {
     pub fn url_elicitation_required(message: impl Into<String>) -> Self {
         Self::mcp_error(McpErrorCode::UrlElicitationRequired, message)
     }
+
+    /// SEP-2575: server does not support the protocol version the client
+    /// requested. The error data carries both the AS-supported versions
+    /// and the version the client asked for, matching the spec shape:
+    ///
+    /// ```text
+    /// data: { supported: [...], requested: "..." }
+    /// ```
+    pub fn unsupported_protocol_version(
+        requested: impl Into<String>,
+        supported: impl IntoIterator<Item = impl Into<String>>,
+    ) -> Self {
+        let data = UnsupportedProtocolVersionData {
+            supported: supported.into_iter().map(Into::into).collect(),
+            requested: requested.into(),
+        };
+        Self {
+            code: McpErrorCode::UnsupportedProtocolVersion.code(),
+            message: format!(
+                "Unsupported protocol version: {} (supported: {})",
+                data.requested,
+                data.supported.join(", "),
+            ),
+            data: Some(
+                serde_json::to_value(&data)
+                    .expect("UnsupportedProtocolVersionData is serializable"),
+            ),
+        }
+    }
+}
+
+/// SEP-2575 error data for `UnsupportedProtocolVersion` (-32004).
+///
+/// Wire shape per the draft schema:
+/// ```json
+/// {
+///   "supported": ["2026-07-28", "2025-11-25"],
+///   "requested": "2027-01-01"
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnsupportedProtocolVersionData {
+    /// Protocol versions the server supports. The client should pick a
+    /// mutually-supported version from this list and retry.
+    pub supported: Vec<String>,
+    /// The protocol version that was requested by the client.
+    pub requested: String,
 }
 
 /// Tool execution error with context
@@ -452,6 +535,85 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =========================================================================
+    // SEP-2575 UnsupportedProtocolVersion (-32004) wire-format tests
+    // =========================================================================
+
+    #[test]
+    fn unsupported_protocol_version_code_is_negative_32004() {
+        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32004);
+    }
+
+    #[test]
+    fn unsupported_protocol_version_constructor_has_spec_shape() {
+        let err =
+            JsonRpcError::unsupported_protocol_version("2027-01-01", ["2026-07-28", "2025-11-25"]);
+        assert_eq!(err.code, -32004);
+        let data = err.data.expect("data must be present");
+        assert_eq!(
+            data["supported"],
+            serde_json::json!(["2026-07-28", "2025-11-25"])
+        );
+        assert_eq!(data["requested"], "2027-01-01");
+        assert!(
+            data.get("supportedVersions").is_none(),
+            "spec field name is 'supported', not 'supportedVersions'"
+        );
+    }
+
+    #[test]
+    fn unsupported_protocol_version_data_round_trip() {
+        let original = UnsupportedProtocolVersionData {
+            supported: vec!["2026-07-28".into(), "2025-11-25".into()],
+            requested: "2027-01-01".into(),
+        };
+        let json = serde_json::to_value(&original).unwrap();
+        let parsed: UnsupportedProtocolVersionData = serde_json::from_value(json.clone()).unwrap();
+        assert_eq!(parsed.supported, original.supported);
+        assert_eq!(parsed.requested, original.requested);
+    }
+
+    // =========================================================================
+    // Subscribe-code migration (avoid SEP-2575 collision)
+    // =========================================================================
+
+    #[test]
+    fn subscribe_codes_moved_off_spec_assignments() {
+        // -32003 and -32004 belong to SEP-2575 spec codes; our subscribe codes
+        // moved to -32008/-32009 to avoid collision.
+        assert_eq!(McpErrorCode::AlreadySubscribed.code(), -32008);
+        assert_eq!(McpErrorCode::NotSubscribed.code(), -32009);
+        assert_eq!(McpErrorCode::MissingRequiredClientCapability.code(), -32003);
+        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32004);
+    }
+
+    #[test]
+    fn no_two_mcp_codes_share_a_value() {
+        let all = [
+            McpErrorCode::ConnectionClosed.code(),
+            McpErrorCode::RequestTimeout.code(),
+            McpErrorCode::ResourceNotFound.code(),
+            McpErrorCode::MissingRequiredClientCapability.code(),
+            McpErrorCode::UnsupportedProtocolVersion.code(),
+            McpErrorCode::SessionNotFound.code(),
+            McpErrorCode::SessionRequired.code(),
+            McpErrorCode::Forbidden.code(),
+            McpErrorCode::AlreadySubscribed.code(),
+            McpErrorCode::NotSubscribed.code(),
+            McpErrorCode::UrlElicitationRequired.code(),
+        ];
+        let mut sorted = all.to_vec();
+        sorted.sort_unstable();
+        let original_len = sorted.len();
+        sorted.dedup();
+        assert_eq!(
+            sorted.len(),
+            original_len,
+            "collision in McpErrorCode values: {:?}",
+            all
+        );
+    }
 
     #[test]
     fn test_box_error_from_io_error() {

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -110,26 +110,41 @@ pub enum LogLevel {
 pub use crate::protocol::{DiscoverParams, DiscoverResult};
 
 // =============================================================================
-// Error codes (SEP-1442)
+// Error codes -- the SEP-1442 draft assignments were wrong; SEP-2575 FINAL
+// canonicalized them in the spec's draft schema. Re-export the corrected
+// values from the always-available error module.
 // =============================================================================
 
-/// SEP-1442 error codes.
+/// Re-exported for SEP-2575 compatibility. Prefer importing from
+/// [`crate::error::McpErrorCode::UnsupportedProtocolVersion`] directly.
+#[doc(inline)]
+pub use crate::error::UnsupportedProtocolVersionData;
+
+/// Legacy SEP-1442 error code constants.
+///
+/// These were wrong: SEP-1442 (draft) placed `UNSUPPORTED_VERSION` at -32000,
+/// which collides with the established `ConnectionClosed` assignment.
+/// SEP-2575 (FINAL) moved it to -32004. Use
+/// [`crate::error::McpErrorCode::UnsupportedProtocolVersion`] or
+/// [`crate::error::JsonRpcError::unsupported_protocol_version`] instead.
 pub mod error_codes {
-    /// Unsupported protocol version (-32000).
-    ///
-    /// The error data MUST include `supportedVersions` array.
+    /// Spec-correct unsupported protocol version code (SEP-2575).
+    pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32004;
+
+    /// Wrong assignment from SEP-1442 draft. Kept temporarily for
+    /// back-compat; new code should use [`UNSUPPORTED_PROTOCOL_VERSION`].
+    #[deprecated(
+        since = "0.12.0",
+        note = "SEP-1442 draft assignment was wrong; SEP-2575 FINAL uses -32004. \
+                Use `UNSUPPORTED_PROTOCOL_VERSION` or \
+                `crate::error::McpErrorCode::UnsupportedProtocolVersion`."
+    )]
     pub const UNSUPPORTED_VERSION: i32 = -32000;
 
-    /// Invalid or missing required session ID (-32001).
+    /// Invalid or missing required session ID (-32001) per SEP-1442.
+    /// SEP-2567 (FINAL) removes sessions entirely; this constant is
+    /// retained only for the 2025-11-25 protocol path.
     pub const INVALID_SESSION: i32 = -32001;
-}
-
-/// Error data for unsupported protocol version errors.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct UnsupportedVersionData {
-    /// Protocol versions supported by this server.
-    pub supported_versions: Vec<String>,
 }
 
 // =============================================================================
@@ -195,8 +210,12 @@ impl StatelessConfig {
 
 /// Validate a protocol version string against supported versions.
 ///
-/// Returns `Ok(())` if valid, or a JSON-RPC error with the SEP-1442 error code
-/// and `supportedVersions` data if the version is not supported.
+/// Returns `Ok(())` if valid, or a JSON-RPC `UnsupportedProtocolVersion`
+/// error (-32004 per SEP-2575) with the spec-shape data:
+///
+/// ```json
+/// { "supported": ["..."], "requested": "..." }
+/// ```
 pub fn validate_protocol_version(
     version: &str,
 ) -> std::result::Result<(), crate::error::JsonRpcError> {
@@ -205,17 +224,10 @@ pub fn validate_protocol_version(
     if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
         Ok(())
     } else {
-        let data = UnsupportedVersionData {
-            supported_versions: SUPPORTED_PROTOCOL_VERSIONS
-                .iter()
-                .map(|v| v.to_string())
-                .collect(),
-        };
-        Err(crate::error::JsonRpcError {
-            code: error_codes::UNSUPPORTED_VERSION,
-            message: format!("Unsupported protocol version: {}", version),
-            data: Some(serde_json::to_value(data).unwrap()),
-        })
+        Err(crate::error::JsonRpcError::unsupported_protocol_version(
+            version,
+            SUPPORTED_PROTOCOL_VERSIONS.iter().copied(),
+        ))
     }
 }
 
@@ -305,13 +317,21 @@ mod tests {
     }
 
     #[test]
-    fn test_unsupported_version_data() {
-        let data = UnsupportedVersionData {
-            supported_versions: vec!["2025-11-25".to_string()],
+    fn test_unsupported_protocol_version_data_shape() {
+        // Per SEP-2575 the wire shape is `supported`, not `supportedVersions`,
+        // and the data also carries `requested`.
+        let data = UnsupportedProtocolVersionData {
+            supported: vec!["2026-07-28".to_string(), "2025-11-25".to_string()],
+            requested: "2027-01-01".to_string(),
         };
 
         let json = serde_json::to_value(&data).unwrap();
-        assert_eq!(json["supportedVersions"][0], "2025-11-25");
+        assert_eq!(json["supported"][0], "2026-07-28");
+        assert_eq!(json["requested"], "2027-01-01");
+        assert!(
+            json.get("supportedVersions").is_none(),
+            "spec field name is 'supported', not 'supportedVersions': {json}"
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2298,7 +2298,9 @@ mod stateless_tests {
         );
     }
 
-    /// Unsupported protocol version returns SEP-1442 error code -32000.
+    /// Unsupported protocol version returns SEP-2575 error code -32004
+    /// with the spec-shape data: `{ supported: [...], requested: "..." }`.
+    /// (SEP-1442 draft used -32000 / `supportedVersions`; both were wrong.)
     #[tokio::test]
     async fn test_stateless_unsupported_version() {
         let (url, _server) = start_stateless_server().await;
@@ -2324,8 +2326,12 @@ mod stateless_tests {
 
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
-        assert_eq!(body["error"]["code"].as_i64().unwrap(), -32000);
-        assert!(body["error"]["data"]["supportedVersions"].is_array());
+        assert_eq!(body["error"]["code"].as_i64().unwrap(), -32004);
+        assert!(
+            body["error"]["data"]["supported"].is_array(),
+            "spec data field is 'supported': {body}"
+        );
+        assert_eq!(body["error"]["data"]["requested"], "1999-01-01");
     }
 
     /// Protocol version in _meta field (body) works as alternative to header.


### PR DESCRIPTION
## Summary

Reconciles `McpErrorCode` against the spec's draft schema after auditing [modelcontextprotocol/modelcontextprotocol/schema/draft/schema.ts](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/draft/schema.ts). Closes #832.

## Breaking changes (wire)

- **`AlreadySubscribed`: -32003 -> -32008** (collided with SEP-2575's `MissingRequiredClientCapability`)
- **`NotSubscribed`: -32004 -> -32009** (collided with SEP-2575's `UnsupportedProtocolVersion`)
- **`UnsupportedProtocolVersion` error**:
  - Code: -32000 (wrong SEP-1442 draft) -> -32004 (SEP-2575 FINAL)
  - Data shape: `{ supportedVersions: [...] }` -> `{ supported: [...], requested: "..." }`

Downstream clients matching on the old codes will not recognize the new ones. Pre-1.0 so this is acceptable; flagged via `feat!:`.

## What didn't change

- `ResourceNotFound = -32002` -- SEP-2164 migrates this to -32602 (`InvalidParams`), but the migration is gated on protocol-version negotiation. Tracked in #819 and queued to land after #814 chunk 2.
- `ConnectionClosed`, `RequestTimeout`, `Forbidden`, `SessionNotFound`, `SessionRequired` -- still in the JSON-RPC implementation-defined range; not spec-assigned but valid per JSON-RPC 2.0. `SessionNotFound`/`SessionRequired` are documented as legacy since SEP-2567 removes sessions.

## Additions

- `McpErrorCode::MissingRequiredClientCapability` (-32003) -- new spec code from SEP-2575
- `McpErrorCode::UnsupportedProtocolVersion` (-32004) -- new spec code from SEP-2575
- `error::UnsupportedProtocolVersionData { supported, requested }` -- new struct with the spec shape
- `JsonRpcError::unsupported_protocol_version(requested, supported)` constructor
- `stateless::UnsupportedVersionData` is now a re-export of the new type for back-compat
- `stateless::error_codes::UNSUPPORTED_VERSION` is `#[deprecated]` pointing at the spec-correct constant
- Doc table in `error.rs` lists every MCP code with **spec** vs *impl* attribution

## Tests

- `unsupported_protocol_version_code_is_negative_32004`
- `unsupported_protocol_version_constructor_has_spec_shape`
- `unsupported_protocol_version_data_round_trip`
- `subscribe_codes_moved_off_spec_assignments`
- `no_two_mcp_codes_share_a_value` -- collision guard against future repeats
- `test_unsupported_protocol_version_data_shape` in `stateless` module
- Updated `test_stateless_unsupported_version` integration test asserting new code + data shape

## What this unblocks

- **#814 chunk 2**: UnsupportedVersionError wiring from the HTTP transport (now has a spec-correct constructor to call)
- **#819**: ResourceNotFound -> -32602 migration (will follow once protocol-version gating lands in #814)

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` -- 705 tower-mcp + 118 types passing
- [x] `cargo test --test '*' --all-features` -- all integration suites green

Closes #832.