### PR TITLE
feat(http)!: return spec-shape UnsupportedProtocolVersion per SEP-2575 (#814 chunk 2)

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -31,6 +31,19 @@ pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 /// ```
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-03-26"];
 
+/// The next protocol version we are tracking toward but have not yet
+/// fully implemented. Documented as a constant so downstream tooling
+/// (codegen, conformance harnesses) can reference it explicitly.
+///
+/// Once the implementation is feature-complete (sessionless transport,
+/// `server/discover`, `messages/listen`, per-request `_meta` capabilities;
+/// see [tower-mcp#814]) this value will move into
+/// [`SUPPORTED_PROTOCOL_VERSIONS`] and become the new
+/// [`LATEST_PROTOCOL_VERSION`].
+///
+/// [tower-mcp#814]: https://github.com/joshrotenberg/tower-mcp/issues/814
+pub const UPCOMING_PROTOCOL_VERSION: &str = "2026-07-28";
+
 /// JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JsonRpcRequest {
@@ -4159,6 +4172,28 @@ impl McpNotification {
 mod tests {
     use super::*;
     use crate::error::JsonRpcError;
+
+    // =========================================================================
+    // Protocol version constants
+    // =========================================================================
+
+    #[test]
+    fn upcoming_version_is_documented_and_not_yet_supported() {
+        // UPCOMING_PROTOCOL_VERSION points at the next protocol we're tracking
+        // toward. Until #814 ships fully, the constant exists for downstream
+        // tooling but the version must NOT appear in SUPPORTED_PROTOCOL_VERSIONS
+        // (otherwise we'd be falsely advertising compatibility).
+        assert_eq!(UPCOMING_PROTOCOL_VERSION, "2026-07-28");
+        assert!(
+            !SUPPORTED_PROTOCOL_VERSIONS.contains(&UPCOMING_PROTOCOL_VERSION),
+            "do not promote UPCOMING_PROTOCOL_VERSION into SUPPORTED until the \
+             impl is complete; current: {:?}",
+            SUPPORTED_PROTOCOL_VERSIONS
+        );
+        // LATEST_PROTOCOL_VERSION is one of the SUPPORTED ones; it isn't
+        // UPCOMING until we ship 2026-07-28.
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&LATEST_PROTOCOL_VERSION));
+    }
 
     // =========================================================================
     // SEP-2575 (server/discover) wire-format tests

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -2137,16 +2137,21 @@ async fn handle_post(
         return json_rpc_error_response(None, JsonRpcError::session_required());
     };
 
-    // Validate protocol version (if present and not init request)
+    // Validate protocol version (if present and not init request).
+    // Per SEP-2575, unsupported versions get a JSON-RPC error with code
+    // -32004 and `{ supported, requested }` data, not a plain-text 400.
     if !is_init
         && let Some(version) = get_protocol_version(&headers)
         && !SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
     {
-        return (
-            StatusCode::BAD_REQUEST,
-            format!("Unsupported protocol version: {}", version),
-        )
-            .into_response();
+        let id = extract_request_id(&parsed);
+        return json_rpc_error_response(
+            id,
+            JsonRpcError::unsupported_protocol_version(
+                version,
+                SUPPORTED_PROTOCOL_VERSIONS.iter().copied(),
+            ),
+        );
     }
 
     // Check if this is a response to one of our outgoing requests (sampling)
@@ -2720,6 +2725,75 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("2025-03-26")
         );
+    }
+
+    #[tokio::test]
+    async fn unsupported_protocol_version_returns_spec_shape_error() {
+        // SEP-2575: requests carrying an unrecognized MCP-Protocol-Version
+        // header (post-initialize) get a JSON-RPC error with code -32004 and
+        // data `{ supported: [...], requested: "..." }`.
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        // Initialize first so we're past the init exemption.
+        let init_request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "t", "version": "0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let init_response = app.clone().oneshot(init_request).await.unwrap();
+        let session_id = init_response
+            .headers()
+            .get(MCP_SESSION_ID_HEADER)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Now send a request with a bogus version header.
+        let bad = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_SESSION_ID_HEADER, &session_id)
+            .header(MCP_PROTOCOL_VERSION_HEADER, "1999-01-01")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 99,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.oneshot(bad).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32004);
+        assert_eq!(json["error"]["data"]["requested"], "1999-01-01");
+        let supported = json["error"]["data"]["supported"]
+            .as_array()
+            .expect("supported must be an array");
+        assert!(supported.contains(&serde_json::json!("2025-11-25")));
+        // The request id must be echoed (we have one in the body).
+        assert_eq!(json["id"], 99);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Second chunk of #814. Wires the spec-correct `UnsupportedProtocolVersion` error from the HTTP transport when a client sends an unrecognized `MCP-Protocol-Version` header.

## Changes

### Wire behavior

Previously: unrecognized `MCP-Protocol-Version` header on a non-init request → HTTP `400 Bad Request` with a plain-text body.

Now: HTTP `200 OK` with a JSON-RPC error response:

```json
{
  "jsonrpc": "2.0",
  "id": <echoed from request>,
  "error": {
    "code": -32004,
    "message": "Unsupported protocol version: ... (supported: ...)",
    "data": { "supported": ["2025-11-25", "2025-03-26"], "requested": "..." }
  }
}
```

This matches the SEP-2575 spec shape (data field is `supported`, not `supportedVersions`; both fields populated; code from `McpErrorCode::UnsupportedProtocolVersion`). Uses the `JsonRpcError::unsupported_protocol_version` constructor introduced in #832.

### New constant

`UPCOMING_PROTOCOL_VERSION = "2026-07-28"` in `tower-mcp-types::protocol`. Documents the version we're tracking toward; not added to `SUPPORTED_PROTOCOL_VERSIONS` yet -- promotion happens when the full implementation lands (sessionless transport, `messages/listen`, per-request capabilities; see #814 design comment).

A guard test (`upcoming_version_is_documented_and_not_yet_supported`) asserts the constant stays out of `SUPPORTED` until the impl catches up, so we don't accidentally advertise compatibility before we're ready.

## Breaking change

The HTTP response shape for unsupported versions changed: status `400` → `200`, plain-text body → JSON-RPC body. Marked `feat!:` so release-plz cuts the right version bump.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] New `unsupported_protocol_version_returns_spec_shape_error` test exercises the full HTTP path: initialize → bogus version header → spec-correct error response
- [x] New `upcoming_version_is_documented_and_not_yet_supported` guard test
- [x] Full sweep: 706 tower-mcp + 119 types + all integration suites green

## What this unblocks

- **#816** (SEP-2243 HTTP standardization headers) — now has the protocol-version surface to gate on
- **#819** (-32602 ResourceNotFound migration) — now has version-aware routing to apply to

Refs #814.