### PR TITLE
feat(tasks): repackage as io.modelcontextprotocol/tasks extension per SEP-2663

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -396,13 +396,27 @@ pub enum McpRequest {
     ListPrompts(ListPromptsParams),
     /// Get a prompt
     GetPrompt(GetPromptParams),
-    /// List tasks
+    /// List tasks.
+    ///
+    /// Removed from the core protocol by SEP-2663 (the tasks extension drops
+    /// `tasks/list` entirely). Kept here as a legacy parsing target so 2025-11-25
+    /// clients are not broken; new clients should not send this method.
     ListTasks(ListTasksParams),
-    /// Get task info
+    /// Get task info (`tasks/get`).
     GetTaskInfo(GetTaskInfoParams),
-    /// Get task result
+    /// Update an in-flight task with `inputResponses` (`tasks/update`).
+    ///
+    /// Introduced by SEP-2663 to replace the blocking `tasks/result` method
+    /// from the 2025-11-25 experimental spec. The response is an empty ack;
+    /// task state is observed via `tasks/get`.
+    UpdateTask(UpdateTaskParams),
+    /// Legacy `tasks/result` request from the 2025-11-25 experimental spec.
+    ///
+    /// SEP-2663 removes this method (clients are expected to receive
+    /// `MethodNotFound`), but we keep parsing it so 2025-11-25 servers built
+    /// on this crate continue to handle existing clients.
     GetTaskResult(GetTaskResultParams),
-    /// Cancel a task
+    /// Cancel a task (`tasks/cancel`).
     CancelTask(CancelTaskParams),
     /// Ping (keepalive)
     Ping,
@@ -435,6 +449,7 @@ impl McpRequest {
             McpRequest::GetPrompt(_) => "prompts/get",
             McpRequest::ListTasks(_) => "tasks/list",
             McpRequest::GetTaskInfo(_) => "tasks/get",
+            McpRequest::UpdateTask(_) => "tasks/update",
             McpRequest::GetTaskResult(_) => "tasks/result",
             McpRequest::CancelTask(_) => "tasks/cancel",
             McpRequest::Ping => "ping",
@@ -545,7 +560,14 @@ pub enum McpResponse {
     CreateTask(CreateTaskResult),
     ListTasks(ListTasksResult),
     GetTaskInfo(TaskObject),
+    /// Ack-only response for `tasks/update` (SEP-2663).
+    UpdateTask(EmptyResult),
     GetTaskResult(CallToolResult),
+    /// Response to `tasks/cancel`.
+    ///
+    /// Note: SEP-2663 redefines `tasks/cancel` to return an empty ack, but to
+    /// preserve back-compat for 2025-11-25 clients we still surface the task
+    /// state object here. A future release may migrate to the ack-only shape.
     CancelTask(TaskObject),
     SetLoggingLevel(EmptyResult),
     Complete(CompleteResult),
@@ -3230,6 +3252,21 @@ pub enum PromptRole {
 // Tasks (async operations)
 // =============================================================================
 
+/// Reverse-DNS identifier for the SEP-2663 tasks extension.
+///
+/// This string is the key under which task-extension capabilities are declared
+/// inside `ClientCapabilities.extensions` and `ServerCapabilities.extensions`.
+/// It is **not** a method prefix: per the spec, methods remain unprefixed
+/// (`tasks/get`, `tasks/update`, `tasks/cancel`).
+pub const TASKS_EXTENSION_ID: &str = "io.modelcontextprotocol/tasks";
+
+/// SEP-2322 / SEP-2663 `resultType` discriminator value for task results.
+///
+/// Per SEP-2663, servers **MUST** set `resultType` to `"task"` when returning
+/// a [`CreateTaskResult`], and **MUST NOT** set `resultType` to `"task"` on
+/// any other result shape.
+pub const RESULT_TYPE_TASK: &str = "task";
+
 /// Task support mode for tool execution
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -3330,15 +3367,103 @@ pub struct TaskObject {
 #[deprecated(note = "Use TaskObject instead")]
 pub type TaskInfo = TaskObject;
 
-/// Result of creating a task (returned when tools/call includes task params)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+/// Result of creating a task (returned when `tools/call` is task-augmented).
+///
+/// Per SEP-2663, `CreateTaskResult = Result & Task`: the task fields are
+/// inlined at the top of the result and `resultType` is set to `"task"` so
+/// clients can distinguish a task handle from a normal `CallToolResult` on
+/// the same RPC.
+///
+/// Serialization layout:
+/// ```jsonc
+/// {
+///   "resultType": "task",
+///   "taskId": "...",
+///   "status": "working",
+///   "createdAt": "...",
+///   "lastUpdatedAt": "...",
+///   "ttl": null,
+///   "pollInterval": 5000,
+///   // The nested `task` field is emitted purely for back-compat with the
+///   // 2025-11-25 experimental wire format. New clients should read the
+///   // top-level fields and ignore `task`. This nested mirror will be
+///   // removed in a future release.
+///   "task": { "taskId": ..., "status": ..., ... }
+/// }
+/// ```
+#[derive(Debug, Clone)]
 pub struct CreateTaskResult {
-    /// The created task object
+    /// The created task object. Serialized both inline (per SEP-2663) and
+    /// under the legacy `task` key for back-compat.
     pub task: TaskObject,
     /// Optional protocol-level metadata
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
+}
+
+impl CreateTaskResult {
+    /// Wire-spec discriminator value (always `"task"`).
+    pub const RESULT_TYPE: &'static str = RESULT_TYPE_TASK;
+
+    /// Build a result from a [`TaskObject`], with the SEP-2663 discriminator
+    /// pre-populated when serialized.
+    pub fn new(task: TaskObject) -> Self {
+        Self { task, meta: None }
+    }
+}
+
+impl Serialize for CreateTaskResult {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // Serialize the TaskObject to a JSON object, then inject the
+        // SEP-2663 discriminator and the nested `task` mirror for back-compat.
+        let mut value = serde_json::to_value(&self.task)
+            .map_err(|e| serde::ser::Error::custom(format!("task serialize: {e}")))?;
+        let obj = value
+            .as_object_mut()
+            .ok_or_else(|| serde::ser::Error::custom("task did not serialize to a JSON object"))?;
+        obj.insert(
+            "resultType".to_string(),
+            Value::String(Self::RESULT_TYPE.to_string()),
+        );
+        obj.insert(
+            "task".to_string(),
+            serde_json::to_value(&self.task)
+                .map_err(|e| serde::ser::Error::custom(format!("task mirror: {e}")))?,
+        );
+        if let Some(meta) = &self.meta {
+            obj.insert("_meta".to_string(), meta.clone());
+        }
+        value.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for CreateTaskResult {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // Accept both the SEP-2663 flat layout and the 2025-11-25 nested
+        // layout (`{ "task": { ... } }`) by deserializing as a generic
+        // object and disambiguating.
+        let value = Value::deserialize(deserializer)?;
+        let meta = value.get("_meta").filter(|v| !v.is_null()).cloned();
+        if let Some(task_val) = value.get("task")
+            && task_val.is_object()
+            && task_val
+                .as_object()
+                .is_some_and(|o| o.contains_key("taskId"))
+        {
+            // Nested back-compat shape; trust the nested object.
+            let task: TaskObject =
+                serde_json::from_value(task_val.clone()).map_err(serde::de::Error::custom)?;
+            return Ok(CreateTaskResult { task, meta });
+        }
+        // Otherwise treat the flat top-level fields as the TaskObject.
+        let task: TaskObject = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(CreateTaskResult { task, meta })
+    }
 }
 
 /// Parameters for listing tasks
@@ -3399,6 +3524,30 @@ pub struct CancelTaskParams {
     #[serde(default)]
     pub reason: Option<String>,
     /// Optional protocol-level metadata
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
+}
+
+/// Parameters for the SEP-2663 `tasks/update` request.
+///
+/// When a task is in the `input_required` state the server publishes one or
+/// more requests in the `inputRequests` field of a `tasks/get` response;
+/// clients fulfill those requests by posting responses keyed by the request
+/// identifier in `inputResponses`. The server acknowledges with an empty
+/// result; the post-update task state is observed via a subsequent
+/// `tasks/get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateTaskParams {
+    /// Identifier of the task being updated.
+    pub task_id: String,
+    /// Responses to outstanding `inputRequests` previously surfaced by the
+    /// server, keyed by the request identifier. Opaque to this crate; clients
+    /// supply whatever shape the server expects per its `inputRequest`
+    /// envelope (e.g. an `ElicitResult` or `CreateMessageResult`).
+    #[serde(default)]
+    pub input_responses: HashMap<String, Value>,
+    /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<RequestMeta>,
 }
@@ -4103,6 +4252,14 @@ impl McpRequest {
                 let p: GetPromptParams = serde_json::from_value(params)?;
                 Ok(McpRequest::GetPrompt(p))
             }
+            // Tasks methods. The canonical method names defined by SEP-2663
+            // (`tasks/get`, `tasks/update`, `tasks/cancel`) are unprefixed; the
+            // `io.modelcontextprotocol/tasks` identifier is the *extension*
+            // label used for capability declarations, not a method prefix.
+            // `tasks/list` and `tasks/result` are 2025-11-25 experimental
+            // methods that SEP-2663 removes; we still parse them so legacy
+            // clients receive a structured response instead of a transport
+            // error, but server handlers may reject them at their own discretion.
             "tasks/list" => {
                 let p: ListTasksParams = serde_json::from_value(params).unwrap_or_default();
                 Ok(McpRequest::ListTasks(p))
@@ -4110,6 +4267,10 @@ impl McpRequest {
             "tasks/get" => {
                 let p: GetTaskInfoParams = serde_json::from_value(params)?;
                 Ok(McpRequest::GetTaskInfo(p))
+            }
+            "tasks/update" => {
+                let p: UpdateTaskParams = serde_json::from_value(params)?;
+                Ok(McpRequest::UpdateTask(p))
             }
             "tasks/result" => {
                 let p: GetTaskResultParams = serde_json::from_value(params)?;
@@ -5541,5 +5702,161 @@ mod tests {
             }
             _ => panic!("expected ListTools variant"),
         }
+    }
+
+    // =========================================================================
+    // SEP-2663 tasks extension wire-format tests
+    // =========================================================================
+
+    fn task_obj_for_tests() -> TaskObject {
+        TaskObject {
+            task_id: "task-786512e2".into(),
+            status: TaskStatus::Working,
+            status_message: None,
+            created_at: "2025-11-25T10:30:00Z".into(),
+            last_updated_at: "2025-11-25T10:30:00Z".into(),
+            ttl: Some(60_000),
+            poll_interval: Some(5_000),
+            meta: None,
+        }
+    }
+
+    #[test]
+    fn tasks_extension_id_matches_sep_2663() {
+        // The reverse-DNS identifier MUST match the value defined in the SEP
+        // (used as the key in ClientCapabilities.extensions / ServerCapabilities.extensions).
+        assert_eq!(TASKS_EXTENSION_ID, "io.modelcontextprotocol/tasks");
+    }
+
+    #[test]
+    fn create_task_result_serializes_with_sep_2663_discriminator() {
+        // Per SEP-2663:
+        //   - resultType MUST be "task"
+        //   - the Task fields are inlined at the top of the result object
+        let result = CreateTaskResult::new(task_obj_for_tests());
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["resultType"], serde_json::json!("task"));
+        // SEP-2663 inlined Task fields
+        assert_eq!(json["taskId"], serde_json::json!("task-786512e2"));
+        assert_eq!(json["status"], serde_json::json!("working"));
+        assert_eq!(json["pollInterval"], serde_json::json!(5_000));
+        assert_eq!(json["ttl"], serde_json::json!(60_000));
+        assert_eq!(json["createdAt"], serde_json::json!("2025-11-25T10:30:00Z"));
+        // Back-compat: the nested `task` mirror is still emitted for
+        // 2025-11-25 clients of this crate. New clients should ignore it.
+        assert_eq!(json["task"]["taskId"], serde_json::json!("task-786512e2"));
+    }
+
+    #[test]
+    fn create_task_result_round_trips_via_flat_layout() {
+        let original = CreateTaskResult::new(task_obj_for_tests());
+        let json = serde_json::to_string(&original).unwrap();
+        let parsed: CreateTaskResult = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.task.task_id, "task-786512e2");
+        assert_eq!(parsed.task.status, TaskStatus::Working);
+        assert_eq!(parsed.task.ttl, Some(60_000));
+    }
+
+    #[test]
+    fn create_task_result_accepts_legacy_nested_layout() {
+        // 2025-11-25 wire shape (no resultType, task is nested only).
+        let legacy = serde_json::json!({
+            "task": {
+                "taskId": "legacy-id",
+                "status": "working",
+                "createdAt": "2025-11-25T10:30:00Z",
+                "lastUpdatedAt": "2025-11-25T10:30:00Z",
+                "ttl": null
+            }
+        });
+        let parsed: CreateTaskResult = serde_json::from_value(legacy).unwrap();
+        assert_eq!(parsed.task.task_id, "legacy-id");
+        assert_eq!(parsed.task.status, TaskStatus::Working);
+    }
+
+    #[test]
+    fn tasks_update_method_parses_via_from_jsonrpc() {
+        // SEP-2663 introduces tasks/update with { taskId, inputResponses }.
+        let body = r#"{
+            "jsonrpc": "2.0",
+            "id": 6,
+            "method": "tasks/update",
+            "params": {
+                "taskId": "abc-123",
+                "inputResponses": {
+                    "name": {
+                        "action": "accept",
+                        "content": { "input": "Luca" }
+                    }
+                }
+            }
+        }"#;
+        let req: JsonRpcRequest = serde_json::from_str(body).unwrap();
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        match parsed {
+            McpRequest::UpdateTask(p) => {
+                assert_eq!(p.task_id, "abc-123");
+                let name_resp = p.input_responses.get("name").expect("has 'name' key");
+                assert_eq!(name_resp["action"], "accept");
+            }
+            other => panic!("expected UpdateTask, got {:?}", other.method_name()),
+        }
+        // Verify reverse mapping for `method_name()`.
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        assert_eq!(parsed.method_name(), "tasks/update");
+    }
+
+    #[test]
+    fn legacy_tasks_methods_still_parse_for_back_compat() {
+        // 2025-11-25 method strings remain parseable so servers built against
+        // this crate continue to receive structured requests from legacy clients.
+        for (method, params, expected_name) in [
+            (
+                "tasks/get",
+                serde_json::json!({ "taskId": "x" }),
+                "tasks/get",
+            ),
+            (
+                "tasks/cancel",
+                serde_json::json!({ "taskId": "x" }),
+                "tasks/cancel",
+            ),
+            (
+                "tasks/result",
+                serde_json::json!({ "taskId": "x" }),
+                "tasks/result",
+            ),
+            ("tasks/list", serde_json::json!({}), "tasks/list"),
+        ] {
+            let req = JsonRpcRequest::new(1, method).with_params(params);
+            let parsed = McpRequest::from_jsonrpc(&req)
+                .unwrap_or_else(|e| panic!("failed to parse legacy {method}: {e:?}"));
+            assert_eq!(parsed.method_name(), expected_name);
+        }
+    }
+
+    #[test]
+    fn result_type_task_discriminator_constant() {
+        // SEP-2322/SEP-2663 reserve the "task" discriminator value.
+        assert_eq!(RESULT_TYPE_TASK, "task");
+        assert_eq!(CreateTaskResult::RESULT_TYPE, RESULT_TYPE_TASK);
+    }
+
+    #[test]
+    fn server_capabilities_extensions_keys_match_tasks_extension_id() {
+        // Per SEP-2663, support for the tasks extension is declared by
+        // inserting the extension identifier into ServerCapabilities.extensions
+        // (an empty object value indicates "supported with no settings").
+        let mut extensions = HashMap::new();
+        extensions.insert(TASKS_EXTENSION_ID.to_string(), serde_json::json!({}));
+        let caps = ServerCapabilities {
+            extensions: Some(extensions),
+            ..Default::default()
+        };
+        let json = serde_json::to_value(&caps).unwrap();
+        assert_eq!(
+            json["extensions"]["io.modelcontextprotocol/tasks"],
+            serde_json::json!({})
+        );
     }
 }

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -491,7 +491,9 @@ pub use protocol::{
     TasksCancelCapability, TasksCapability, TasksListCapability, TasksRequestsCapability,
     TasksToolsCallCapability, TasksToolsRequestsCapability, ToolAnnotations, ToolChoice,
     ToolDefinition, ToolExecution, ToolIcon, ToolsCapability, UnsubscribeResourceParams,
+    UpdateTaskParams,
 };
+pub use protocol::{RESULT_TYPE_TASK, TASKS_EXTENSION_ID};
 #[cfg(feature = "dynamic-tools")]
 pub use registry::{
     DynamicPromptRegistry, DynamicResourceRegistry, DynamicResourceTemplateRegistry,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1601,7 +1601,11 @@ impl McpRouter {
             } else {
                 None
             },
-            // Tasks capability is advertised if any tool supports tasks
+            // Tasks capability is advertised if any tool supports tasks.
+            // SEP-2663 moves the declaration to `capabilities.extensions`
+            // under the reverse-DNS key `io.modelcontextprotocol/tasks`; we
+            // continue to set the legacy top-level `tasks` field for back-compat
+            // with 2025-11-25 clients that key off it.
             tasks: {
                 let has_task_support = self
                     .inner
@@ -1629,7 +1633,23 @@ impl McpRouter {
                 None
             },
             experimental: None,
-            extensions: None,
+            extensions: {
+                let has_task_support = self
+                    .inner
+                    .tools
+                    .values()
+                    .any(|t| !matches!(t.task_support, TaskSupportMode::Forbidden));
+                if has_task_support {
+                    let mut map = std::collections::HashMap::new();
+                    map.insert(
+                        tower_mcp_types::protocol::TASKS_EXTENSION_ID.to_string(),
+                        serde_json::json!({}),
+                    );
+                    Some(map)
+                } else {
+                    None
+                }
+            },
         }
     }
 
@@ -1897,10 +1917,7 @@ impl McpRouter {
                         ))
                     })?;
 
-                    Ok(McpResponse::CreateTask(CreateTaskResult {
-                        task,
-                        meta: None,
-                    }))
+                    Ok(McpResponse::CreateTask(CreateTaskResult::new(task)))
                 } else {
                     // Synchronous request: validate task_support != Required
                     if matches!(tool.task_support, TaskSupportMode::Required) {
@@ -2291,6 +2308,27 @@ impl McpRouter {
                         Ok(McpResponse::GetTaskResult(call_result))
                     }
                 }
+            }
+
+            McpRequest::UpdateTask(params) => {
+                // SEP-2663 `tasks/update`: validate the task exists and
+                // acknowledge with an empty result. tower-mcp does not yet
+                // model server-initiated `inputRequests` for tasks (that's a
+                // future MRTR-flavored feature), so we currently treat any
+                // submitted `inputResponses` as ignorable per spec ("A server
+                // SHOULD ignore any inputResponses mapped to a key that is
+                // not currently outstanding").
+                let _ = self
+                    .inner
+                    .task_store
+                    .get_task(&params.task_id)
+                    .ok_or_else(|| {
+                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
+                            "Task not found: {}",
+                            params.task_id
+                        )))
+                    })?;
+                Ok(McpResponse::UpdateTask(EmptyResult {}))
             }
 
             McpRequest::CancelTask(params) => {

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -1946,13 +1946,26 @@ async fn test_task_capabilities_advertised() {
             let caps = r.result.get("capabilities").unwrap();
             let tasks = caps
                 .get("tasks")
-                .expect("capabilities should include 'tasks'");
+                .expect("capabilities should include 'tasks' (back-compat)");
             assert!(tasks.get("list").is_some(), "tasks should have 'list'");
             assert!(tasks.get("cancel").is_some(), "tasks should have 'cancel'");
             let requests = tasks.get("requests").expect("tasks should have 'requests'");
             assert!(
                 requests.get("tools").is_some(),
                 "requests should have 'tools'"
+            );
+
+            // SEP-2663: support is also declared in `capabilities.extensions`
+            // under the reverse-DNS identifier.
+            let extensions = caps
+                .get("extensions")
+                .expect("SEP-2663: capabilities should include 'extensions'");
+            let tasks_ext = extensions
+                .get("io.modelcontextprotocol/tasks")
+                .expect("SEP-2663: extensions should include tasks identifier");
+            assert!(
+                tasks_ext.is_object(),
+                "tasks extension value should be an object (no settings)"
             );
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
@@ -2026,6 +2039,113 @@ async fn test_task_tool_definition_includes_execution() {
             }
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_task_create_includes_sep_2663_result_type_discriminator() {
+    // SEP-2663 mandates `resultType: "task"` on CreateTaskResult, with the
+    // Task fields inlined at the top of the result. tower-mcp also keeps the
+    // legacy nested `task` field for 2025-11-25 back-compat.
+    let router = create_router_with_tasks();
+    let mut service = JsonRpcService::new(router.clone());
+    init_service(&router, &mut service).await;
+
+    let call_req = JsonRpcRequest::new(2, "tools/call").with_params(serde_json::json!({
+        "name": "echo",
+        "arguments": { "message": "hello" },
+        "task": {}
+    }));
+    let resp = service.call_single(call_req).await.unwrap();
+
+    match resp {
+        JsonRpcResponse::Result(r) => {
+            assert_eq!(
+                r.result["resultType"], "task",
+                "SEP-2663: resultType MUST be \"task\" on CreateTaskResult"
+            );
+            // Inlined Task fields:
+            assert!(
+                r.result["taskId"].as_str().is_some(),
+                "SEP-2663: taskId MUST be present at the top of the result"
+            );
+            assert_eq!(r.result["status"], "working");
+            // Legacy nested mirror kept for 2025-11-25 clients:
+            assert_eq!(
+                r.result["task"]["taskId"], r.result["taskId"],
+                "back-compat: nested task.taskId should mirror the inlined taskId"
+            );
+        }
+        JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_task_update_acks_with_empty_result() {
+    // SEP-2663 `tasks/update`: the server acknowledges with an empty result.
+    let router = create_router_with_tasks();
+    let mut service = JsonRpcService::new(router.clone());
+    init_service(&router, &mut service).await;
+
+    // Spin up a working task we can address.
+    let call_req = JsonRpcRequest::new(2, "tools/call").with_params(serde_json::json!({
+        "name": "slow",
+        "arguments": {},
+        "task": {}
+    }));
+    let resp = service.call_single(call_req).await.unwrap();
+    let task_id = match &resp {
+        JsonRpcResponse::Result(r) => r.result["taskId"].as_str().unwrap().to_string(),
+        JsonRpcResponse::Error(e) => panic!("create task failed: {:?}", e),
+        _ => panic!("unexpected response variant"),
+    };
+
+    let update_req = JsonRpcRequest::new(3, "tasks/update").with_params(serde_json::json!({
+        "taskId": task_id,
+        "inputResponses": {
+            "ignored-key": { "action": "accept", "content": { "input": "noop" } }
+        }
+    }));
+    let resp = service.call_single(update_req).await.unwrap();
+
+    match resp {
+        JsonRpcResponse::Result(r) => {
+            // Empty object ack -- no fields beyond the JSON-RPC envelope.
+            assert!(
+                r.result.as_object().is_some_and(|o| o.is_empty()),
+                "tasks/update should ack with empty result, got: {}",
+                r.result
+            );
+        }
+        JsonRpcResponse::Error(e) => panic!("tasks/update should ack; got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
+    }
+}
+
+#[tokio::test]
+async fn test_task_update_returns_error_for_unknown_task() {
+    // SEP-2663 says servers SHOULD return a JSON-RPC error for unknown
+    // taskIds on tasks/update.
+    let router = create_router_with_tasks();
+    let mut service = JsonRpcService::new(router.clone());
+    init_service(&router, &mut service).await;
+
+    let update_req = JsonRpcRequest::new(3, "tasks/update").with_params(serde_json::json!({
+        "taskId": "task-does-not-exist",
+        "inputResponses": {}
+    }));
+    let resp = service.call_single(update_req).await.unwrap();
+    match resp {
+        JsonRpcResponse::Error(e) => {
+            assert!(
+                e.error.message.contains("not found"),
+                "expected 'not found' in error message, got: {}",
+                e.error.message
+            );
+        }
+        JsonRpcResponse::Result(r) => panic!("expected error, got result: {}", r.result),
         _ => panic!("unexpected response variant"),
     }
 }


### PR DESCRIPTION
## Summary

Implements SEP-2663 (FINAL 2026-05-15), which moves the previously
experimental 2025-11-25 tasks feature out into an official MCP extension
under the reverse-DNS namespace `io.modelcontextprotocol/tasks`.
Back-compat with 2025-11-25 wire shapes and method strings is preserved.

## Method-string mappings

| Method            | Status (SEP-2663) | Status (this PR)                                |
|-------------------|-------------------|-------------------------------------------------|
| `tasks/get`       | Canonical         | Parses to `McpRequest::GetTaskInfo` (unchanged) |
| `tasks/update`    | **New**           | **Added**: `McpRequest::UpdateTask` -> empty ack |
| `tasks/cancel`    | Canonical         | Parses to `McpRequest::CancelTask` (unchanged)  |
| `tasks/list`      | Removed by SEP    | Still parses (back-compat alias)                |
| `tasks/result`    | Removed by SEP    | Still parses (back-compat alias)                |

Per the SEP, methods remain unprefixed: `io.modelcontextprotocol/tasks`
is the **extension identifier** used for capability declaration, not a
method prefix.

## `resultType` discriminator (SEP-2322 + SEP-2663)

`CreateTaskResult` is now serialized per SEP-2663:

```jsonc
{
  "resultType": "task",
  "taskId": "...",
  "status": "working",
  "createdAt": "...",
  "lastUpdatedAt": "...",
  "ttl": null,
  "pollInterval": 5000,
  "task": { /* legacy nested mirror, will be removed in a future release */ }
}
```

Deserialization accepts both the new flat layout and the 2025-11-25
nested layout. Exposes `tower_mcp::RESULT_TYPE_TASK` and
`CreateTaskResult::RESULT_TYPE` (both `"task"`).

## Capability declaration

`ServerCapabilities.extensions` is populated with
`io.modelcontextprotocol/tasks: {}` whenever any registered tool
advertises task support. The legacy top-level `tasks` capability object
is still emitted for 2025-11-25 clients.

## Back-compat strategy

- All four legacy method strings remain parseable into structured
  `McpRequest` variants -- 2025-11-25 clients continue to receive
  structured responses instead of transport-level errors.
- `CreateTaskResult` emits both the SEP-2663 flat fields and the
  2025-11-25 nested `task` mirror; deserializer accepts either shape.
- `ServerCapabilities` emits both legacy `tasks: { ... }` and SEP-2663
  `extensions: { "io.modelcontextprotocol/tasks": {} }`.
- `McpRequest` / `McpResponse` are both `#[non_exhaustive]`, so adding
  `UpdateTask` variants is non-breaking.

This commit is therefore **not** a breaking wire-compat change. The
SEP-2663 "Backward Compatibility" section calls out a hard incompat for
the protocol itself, but tower-mcp implements the bridging shim it
describes (parallel surfaces).

## Test coverage

New wire-format tests in `crates/tower-mcp-types/src/protocol.rs`:

- `tasks_extension_id_matches_sep_2663`
- `create_task_result_serializes_with_sep_2663_discriminator`
- `create_task_result_round_trips_via_flat_layout`
- `create_task_result_accepts_legacy_nested_layout`
- `tasks_update_method_parses_via_from_jsonrpc`
- `legacy_tasks_methods_still_parse_for_back_compat`
- `result_type_task_discriminator_constant`
- `server_capabilities_extensions_keys_match_tasks_extension_id`

New router integration tests in
`crates/tower-mcp/tests/integration.rs`:

- `test_task_create_includes_sep_2663_result_type_discriminator`
- `test_task_update_acks_with_empty_result`
- `test_task_update_returns_error_for_unknown_task`

Existing `test_task_capabilities_advertised` extended to assert the new
`extensions["io.modelcontextprotocol/tasks"]` declaration.

Totals: 129 `tower-mcp-types` lib tests (+8), 65 `tower-mcp` integration
tests (+3). All gates green: `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings`,
`cargo test --all-features`, `cargo doc --no-deps --all-features`.

## Out of scope / known gaps

- SEP-2663 renames Task fields `ttl` -> `ttlMs` and `pollInterval` ->
  `pollIntervalMs`. Renaming would break every existing tower-mcp tasks
  consumer and is therefore left for a follow-up; tracked alongside any
  future `2026-07-28` protocol-version bump.
- SEP-2663 reduces `tasks/cancel` to an empty ack; we still surface a
  `TaskObject` for back-compat. Documented inline in `McpResponse`.
- `inputRequests` / `inputResponses` server-initiated input flow is
  parsed but not yet plumbed into the task store. `tasks/update` ack
  paths only validate that the `taskId` is known.

No examples needed updating -- no current example demonstrates tasks.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features`
- [x] `cargo test --test '*' --all-features`
- [x] `cargo test --doc --all-features`
- [x] `cargo build --examples --all-features`
- [x] `cargo build --manifest-path examples/conformance-server/Cargo.toml`
- [x] `cargo build --manifest-path examples/codegen-mcp/Cargo.toml`

Closes #815.