### PR TITLE
feat(http,context): thread SEP-2575 per-request _meta through RequestContext (#814 chunk 3b)

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -433,6 +433,22 @@ impl RequestContext {
         &self.extensions
     }
 
+    /// SEP-2575 per-request `_meta` (protocol version, client info, client
+    /// capabilities, log level) if the transport extracted it.
+    ///
+    /// Returns `None` when:
+    /// - The request had no `_meta` field, or
+    /// - The transport does not stash per-request metadata (only the HTTP
+    ///   transport currently does), or
+    /// - The `stateless` feature is not enabled.
+    ///
+    /// Equivalent to `self.extension::<StatelessRequestMeta>()` but typed
+    /// so handlers don't have to repeat the import.
+    #[cfg(feature = "stateless")]
+    pub fn per_request_meta(&self) -> Option<&crate::stateless::StatelessRequestMeta> {
+        self.extension::<crate::stateless::StatelessRequestMeta>()
+    }
+
     /// Get the request ID
     pub fn request_id(&self) -> &RequestId {
         &self.request_id

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -625,6 +625,19 @@ impl McpRouter {
         request_id: RequestId,
         progress_token: Option<ProgressToken>,
     ) -> RequestContext {
+        self.create_context_with_extensions(request_id, progress_token, &Extensions::new())
+    }
+
+    /// Internal: build a `RequestContext` and additionally merge per-request
+    /// extensions on top of the router's extensions. Used by [`Service::call`]
+    /// to thread `RouterRequest.extensions` (e.g. SEP-2575 per-request
+    /// `_meta`) through to handlers.
+    pub(crate) fn create_context_with_extensions(
+        &self,
+        request_id: RequestId,
+        progress_token: Option<ProgressToken>,
+        per_request: &Extensions,
+    ) -> RequestContext {
         let ctx = RequestContext::new(request_id.clone());
 
         // Set up progress token if provided
@@ -648,8 +661,12 @@ impl McpRouter {
             ctx
         };
 
-        // Include router extensions (for with_state() and middleware data)
-        let ctx = ctx.with_extensions(self.inner.extensions.clone());
+        // Start with router-level extensions, then layer per-request extensions
+        // on top so they win on type collision. with_state() data stays
+        // visible; per-request meta (SEP-2575) is now reachable too.
+        let mut merged = (*self.inner.extensions).clone();
+        merged.merge(per_request);
+        let ctx = ctx.with_extensions(Arc::new(merged));
 
         // Set up log level filtering
         let ctx = ctx.with_min_log_level(self.inner.min_log_level.clone());
@@ -1634,7 +1651,12 @@ impl McpRouter {
     }
 
     /// Handle an MCP request
-    async fn handle(&self, request_id: RequestId, request: McpRequest) -> Result<McpResponse> {
+    async fn handle(
+        &self,
+        request_id: RequestId,
+        request: McpRequest,
+        extensions: Extensions,
+    ) -> Result<McpResponse> {
         // Enforce session state - reject requests before initialization
         let method = request.method_name();
         if !self.session.is_request_allowed(method) {
@@ -1842,7 +1864,11 @@ impl McpRouter {
 
                     // Create a context for the async task execution
                     let progress_token = params.meta.and_then(|m| m.progress_token);
-                    let ctx = self.create_context(request_id, progress_token);
+                    let ctx = self.create_context_with_extensions(
+                        request_id,
+                        progress_token,
+                        &extensions,
+                    );
 
                     // Spawn the task execution in the background
                     let task_store = self.inner.task_store.clone();
@@ -1912,7 +1938,11 @@ impl McpRouter {
 
                     // Extract progress token from request metadata
                     let progress_token = params.meta.and_then(|m| m.progress_token);
-                    let ctx = self.create_context(request_id, progress_token);
+                    let ctx = self.create_context_with_extensions(
+                        request_id,
+                        progress_token,
+                        &extensions,
+                    );
 
                     let start = std::time::Instant::now();
                     let result = tool.call_with_context(ctx, params.arguments).await;
@@ -2051,7 +2081,7 @@ impl McpRouter {
                     }
 
                     tracing::debug!(uri = %params.uri, "Reading static resource");
-                    let ctx = self.create_context(request_id, None);
+                    let ctx = self.create_context_with_extensions(request_id, None, &extensions);
                     let result = resource.read_with_context(ctx).await;
                     return Ok(McpResponse::ReadResource(result));
                 }
@@ -2067,7 +2097,8 @@ impl McpRouter {
                             return Err(filter.denial_error(&params.uri));
                         }
                         tracing::debug!(uri = %params.uri, "Reading dynamic resource");
-                        let ctx = self.create_context(request_id, None);
+                        let ctx =
+                            self.create_context_with_extensions(request_id, None, &extensions);
                         let result = resource.read_with_context(ctx).await;
                         return Ok(McpResponse::ReadResource(result));
                     }
@@ -2220,7 +2251,7 @@ impl McpRouter {
                 }
 
                 tracing::debug!(name = %params.name, "Getting prompt");
-                let ctx = self.create_context(request_id, None);
+                let ctx = self.create_context_with_extensions(request_id, None, &extensions);
                 let result = prompt.get_with_context(ctx, params.arguments).await?;
 
                 Ok(McpResponse::GetPrompt(result))
@@ -2646,7 +2677,7 @@ impl Service<RouterRequest> for McpRouter {
         let router = self.clone();
         let request_id = req.id.clone();
         Box::pin(async move {
-            let result = router.handle(req.id, req.inner).await;
+            let result = router.handle(req.id, req.inner, req.extensions).await;
             // Clean up tracking after request completes
             router.complete_request(&request_id);
             Ok(RouterResponse {

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -194,6 +194,19 @@ use crate::transport::service::{
 };
 use tower::util::BoxCloneService;
 
+/// SEP-2575 per-request `_meta` extraction. Pulls `StatelessRequestMeta` from
+/// the parsed request params and inserts it into the per-request `Extensions`
+/// so handlers can read it via `ctx.per_request_meta()`. No-op if the request
+/// has no `_meta`, params aren't an object, or the meta can't deserialize.
+#[cfg(feature = "stateless")]
+fn stash_per_request_meta(req: &JsonRpcRequest, ext: &mut crate::router::Extensions) {
+    if let Some(params) = req.params.as_ref()
+        && let Some(meta) = crate::stateless::StatelessRequestMeta::from_params(params)
+    {
+        ext.insert(meta);
+    }
+}
+
 /// Header name for MCP session ID
 pub const MCP_SESSION_ID_HEADER: &str = "mcp-session-id";
 
@@ -2074,13 +2087,15 @@ async fn handle_post(
                 ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
             };
 
+            let mut ext = crate::router::Extensions::new();
             #[cfg(feature = "oauth")]
-            {
-                if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
-                    let mut ext = crate::router::Extensions::new();
-                    ext.insert(claims.clone());
-                    service = service.with_extensions(ext);
-                }
+            if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
+                ext.insert(claims.clone());
+            }
+            #[cfg(feature = "stateless")]
+            stash_per_request_meta(&request, &mut ext);
+            if !ext.is_empty() {
+                service = service.with_extensions(ext);
             }
 
             let response = match service.call_single(request).await {
@@ -2268,14 +2283,18 @@ async fn handle_post(
     // Process the request through the middleware-wrapped service
     let mut service = JsonRpcService::new(session.make_service());
 
-    // Bridge TokenClaims from HTTP request extensions to MCP extensions
+    // Bridge per-request data from HTTP into MCP Extensions: OAuth claims,
+    // SEP-2575 `_meta` (clientInfo, clientCapabilities, etc.). Empty ext is
+    // skipped to avoid pointless allocation.
+    let mut ext = crate::router::Extensions::new();
     #[cfg(feature = "oauth")]
-    {
-        if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
-            let mut ext = crate::router::Extensions::new();
-            ext.insert(claims.clone());
-            service = service.with_extensions(ext);
-        }
+    if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
+        ext.insert(claims.clone());
+    }
+    #[cfg(feature = "stateless")]
+    stash_per_request_meta(&request, &mut ext);
+    if !ext.is_empty() {
+        service = service.with_extensions(ext);
     }
     let response = match service.call_single(request).await {
         Ok(resp) => resp,

--- a/crates/tower-mcp/tests/per_request_meta.rs
+++ b/crates/tower-mcp/tests/per_request_meta.rs
@@ -1,0 +1,149 @@
+//! SEP-2575 per-request `_meta` plumbing: when an incoming JSON-RPC request
+//! has an `_meta` object with the spec-keyed fields, the HTTP transport
+//! deserializes it into `StatelessRequestMeta` and stashes it on the
+//! `RequestContext` extensions so handlers can read it via
+//! `ctx.per_request_meta()`.
+
+#![cfg(all(feature = "http", feature = "stateless"))]
+
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use axum::body::Body;
+use axum::http::Request;
+use tower::ServiceExt;
+use tower_mcp::extract::{Context, RawArgs, State};
+use tower_mcp::stateless::StatelessRequestMeta;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+/// Captures the per-request meta the handler saw, so the test can assert
+/// on it after the HTTP round-trip.
+#[derive(Default, Clone)]
+struct Captured(Arc<Mutex<Option<StatelessRequestMeta>>>);
+
+fn router(captured: Captured) -> McpRouter {
+    let tool = ToolBuilder::new("inspect_meta")
+        .description("Returns the protocolVersion from the per-request meta, if any.")
+        .read_only()
+        .extractor_handler(
+            captured,
+            |State(captured): State<Captured>, ctx: Context, RawArgs(_args): RawArgs| async move {
+                let meta = ctx.per_request_meta().cloned();
+                let answer = meta
+                    .as_ref()
+                    .and_then(|m| m.protocol_version.clone())
+                    .unwrap_or_else(|| "absent".into());
+                *captured.0.lock().unwrap() = meta;
+                Ok(CallToolResult::text(answer))
+            },
+        )
+        .build();
+    McpRouter::new().tool(tool)
+}
+
+async fn call_tool(body: serde_json::Value) -> (serde_json::Value, Captured) {
+    let captured = Captured::default();
+    let app = HttpTransport::new(router(captured.clone()))
+        .disable_origin_validation()
+        .into_router();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    assert!(
+        response.status().is_success(),
+        "expected 2xx, got {}",
+        response.status()
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    (json, captured)
+}
+
+#[tokio::test]
+async fn handler_sees_per_request_meta_from_io_namespace() {
+    // SEP-2575 reverse-DNS keys. Handler should observe protocolVersion +
+    // clientInfo from the per-request meta.
+    let (resp, captured) = call_tool(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "inspect_meta",
+            "arguments": {},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "test-client",
+                    "version": "9.9.9"
+                },
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
+    }))
+    .await;
+
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    assert_eq!(text, "2026-07-28");
+
+    let meta = captured
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("per-request meta must be present on the handler context");
+    assert_eq!(meta.protocol_version.as_deref(), Some("2026-07-28"));
+    let info = meta.client_info.expect("clientInfo carried through");
+    assert_eq!(info.name, "test-client");
+    assert_eq!(info.version, "9.9.9");
+    assert!(meta.client_capabilities.is_some());
+}
+
+#[tokio::test]
+async fn handler_sees_none_when_no_meta_present() {
+    let (resp, captured) = call_tool(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "inspect_meta",
+            "arguments": {}
+        }
+    }))
+    .await;
+
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    assert_eq!(text, "absent");
+    assert!(captured.0.lock().unwrap().is_none());
+}
+
+#[tokio::test]
+async fn legacy_namespace_keys_are_silently_dropped() {
+    // The SEP-1442 draft `modelcontextprotocol.io/...` prefix is no longer
+    // recognized. The meta deserializes, but the legacy keys map to no
+    // field; the handler sees an empty StatelessRequestMeta.
+    let (_resp, captured) = call_tool(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "inspect_meta",
+            "arguments": {},
+            "_meta": {
+                "modelcontextprotocol.io/mcpProtocolVersion": "2025-11-25",
+                "modelcontextprotocol.io/sessionId": "abc"
+            }
+        }
+    }))
+    .await;
+
+    let meta = captured.0.lock().unwrap().clone().unwrap();
+    assert!(meta.protocol_version.is_none(), "legacy key must not match");
+    assert!(meta.client_info.is_none());
+}


### PR DESCRIPTION
## Summary

Chunk 3b of #814. Wires the spec-keyed per-request `_meta` (SEP-2575) from the HTTP transport all the way to tool handlers via `RequestContext`. Handlers can now read `protocolVersion`, `clientInfo`, `clientCapabilities`, `logLevel` per-request via `ctx.per_request_meta()`.

## Plumbing

1. **HTTP transport** (`crates/tower-mcp/src/transport/http.rs`): added `stash_per_request_meta(&request, &mut ext)` helper. Called from both dispatch paths (the stateless-config path and the standard `handle_post` path) right alongside the existing OAuth `TokenClaims` insertion. Both insertions are now collected into a single `Extensions` value, attached to the `JsonRpcService` via `with_extensions(...)` only when non-empty.
2. **Router** (`crates/tower-mcp/src/router.rs`): `RouterRequest.extensions` was silently dropped in `Service::call` -- the field existed but never reached handlers. Plumbed through:
   - `Service::call` passes `req.extensions` to `handle(...)`
   - `handle(...)` propagates to each of the 5 `create_context` call sites
   - New internal `create_context_with_extensions(...)` merges per-request `Extensions` on top of router-level `Extensions` (so per-request data wins on type collision); `create_context(...)` keeps its old signature and delegates with empty per-request extensions
3. **RequestContext**: new typed accessor `pub fn per_request_meta(&self) -> Option<&StatelessRequestMeta>` (under `#[cfg(feature = "stateless")]`). Equivalent to `self.extension::<StatelessRequestMeta>()` but typed so handlers don't have to re-import.

## Tests

New integration test file `crates/tower-mcp/tests/per_request_meta.rs` (3 tests):

- `handler_sees_per_request_meta_from_io_namespace` -- end-to-end via HTTP, asserts the handler observes the SEP-2575 reverse-DNS keys (`io.modelcontextprotocol/protocolVersion`, `clientInfo`, `clientCapabilities`)
- `handler_sees_none_when_no_meta_present` -- request without `_meta` yields `None` at the handler
- `legacy_namespace_keys_are_silently_dropped` -- the SEP-1442 draft `modelcontextprotocol.io/...` prefix is no longer recognized; deserialization succeeds with absent fields rather than erroring

## Backward compatibility

- **Additive only.** No public API removed. `create_context(...)` keeps its 2-arg signature and delegates to the new variant with empty per-request extensions.
- Marked `feat:` (not `feat!:`).

## What's left in chunk 3 / #814

- **Chunk 3c (small)**: server-side enforcement of the REQUIRED spec fields (`protocolVersion`, `clientInfo`, `clientCapabilities`) when negotiated protocol is 2026-07-28+. Tracked as a future commit.
- **Chunk 4**: `messages/listen` RPC.
- **Chunk 5**: stateless-by-default for 2026-07-28.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` -- 711 tower-mcp + 121 types passing
- [x] `cargo test --test '*' --all-features` -- 3 new e2e in `per_request_meta`, all suites green

Refs #814.