### PR TITLE
feat(http): add messages/listen SSE streaming endpoint (#814 chunk 4)

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -426,6 +426,13 @@ pub enum McpRequest {
     Complete(CompleteParams),
     /// SEP-2575: discover server capabilities without an initialize handshake
     Discover(DiscoverParams),
+    /// SEP-2575 / SEP-2567: open a server-to-client notification stream
+    /// (`messages/listen`).
+    ///
+    /// The HTTP transport intercepts this before it reaches the router and
+    /// returns an SSE stream. The variant is defined here for client-side
+    /// type-safe construction and for any future transport implementations.
+    MessagesListen(MessagesListenParams),
     /// Unknown method
     Unknown {
         method: String,
@@ -456,6 +463,7 @@ impl McpRequest {
             McpRequest::SetLoggingLevel(_) => "logging/setLevel",
             McpRequest::Complete(_) => "completion/complete",
             McpRequest::Discover(_) => "server/discover",
+            McpRequest::MessagesListen(_) => "messages/listen",
             McpRequest::Unknown { method, .. } => method,
         }
     }
@@ -574,6 +582,13 @@ pub enum McpResponse {
     Pong(EmptyResult),
     /// SEP-2575 `server/discover` response.
     Discover(DiscoverResult),
+    /// SEP-2575 / SEP-2567 `messages/listen` response.
+    ///
+    /// In practice the HTTP transport returns an SSE stream for this method
+    /// and never produces this variant. It is provided for completeness and
+    /// for potential future transport implementations that want a typed
+    /// result.
+    MessagesListen(MessagesListenResult),
     Empty(EmptyResult),
     /// Raw JSON value for experimental/extension methods.
     Raw(Value),
@@ -1582,6 +1597,42 @@ pub struct DiscoverResult {
     /// Optional instructions describing how to use this server.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Optional protocol-level metadata.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+// =============================================================================
+// messages/listen (SEP-2575 / SEP-2567)
+// =============================================================================
+
+/// Parameters for the `messages/listen` RPC (SEP-2575 / SEP-2567).
+///
+/// `messages/listen` is sent by the client over HTTP POST to open a
+/// server-to-client notification stream (SSE). The server responds with
+/// `Content-Type: text/event-stream` and streams zero or more
+/// `notifications/*` events until the client disconnects.
+///
+/// Under SEP-2567 (sessionless), the stream lifetime is scoped to the single
+/// request. Only servers whose negotiated protocol version is >= 2026-07-28
+/// enable this path; older servers return a `Method Not Found` (-32601) error.
+///
+/// The struct takes no parameters today; the empty struct is reserved so
+/// future SEPs can add optional fields without breaking callers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MessagesListenParams {
+    /// Optional protocol-level metadata.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+/// Result of the `messages/listen` RPC.
+///
+/// In practice the HTTP transport opens an SSE stream and never serializes
+/// this type as a JSON-RPC result. It is provided for completeness and for
+/// transports that want a typed acknowledgement shape.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MessagesListenResult {
     /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -4294,6 +4345,12 @@ impl McpRequest {
                 let p: DiscoverParams = serde_json::from_value(params).unwrap_or_default();
                 Ok(McpRequest::Discover(p))
             }
+            "messages/listen" => {
+                // SEP-2575 / SEP-2567: client-initiated streaming.
+                // Empty-or-missing params is valid.
+                let p: MessagesListenParams = serde_json::from_value(params).unwrap_or_default();
+                Ok(McpRequest::MessagesListen(p))
+            }
             method => Ok(McpRequest::Unknown {
                 method: method.to_string(),
                 params: req.params.clone(),
@@ -4407,6 +4464,35 @@ mod tests {
             json.get("instructions").is_none(),
             "instructions must be omitted when None, got: {json}"
         );
+    }
+
+    // =========================================================================
+    // SEP-2575 / SEP-2567 (messages/listen) wire-format tests
+    // =========================================================================
+
+    #[test]
+    fn messages_listen_request_round_trips_with_no_params() {
+        // Per SEP-2575 / SEP-2567, params is empty/optional.
+        let no_params = r#"{"jsonrpc":"2.0","id":1,"method":"messages/listen"}"#;
+        let req: JsonRpcRequest = serde_json::from_str(no_params).unwrap();
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        assert!(matches!(parsed, McpRequest::MessagesListen(_)));
+        assert_eq!(parsed.method_name(), "messages/listen");
+
+        let empty_params = r#"{"jsonrpc":"2.0","id":2,"method":"messages/listen","params":{}}"#;
+        let req: JsonRpcRequest = serde_json::from_str(empty_params).unwrap();
+        let parsed = McpRequest::from_jsonrpc(&req).unwrap();
+        assert!(matches!(parsed, McpRequest::MessagesListen(_)));
+    }
+
+    #[test]
+    fn messages_listen_request_serializes_with_correct_method() {
+        let req = JsonRpcRequest::new(42i64, "messages/listen");
+        let json = serde_json::to_string(&req).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["method"], "messages/listen");
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert_eq!(v["id"], 42);
     }
 
     // =========================================================================

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -187,6 +187,7 @@ use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{
     ClientCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
     LATEST_PROTOCOL_VERSION, McpNotification, RequestId, SUPPORTED_PROTOCOL_VERSIONS,
+    UPCOMING_PROTOCOL_VERSION,
 };
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
@@ -2214,6 +2215,37 @@ async fn handle_post(
         return json_rpc_error_response(None, JsonRpcError::session_required());
     };
 
+    // SEP-2575 / SEP-2567: intercept `messages/listen` before the standard
+    // version validation. `messages/listen` is only available when the
+    // effective protocol version is >= 2026-07-28; otherwise we return a
+    // proper JSON-RPC error rather than silently falling through to the
+    // router (which would return `MethodNotFound` anyway, but without the
+    // protocol-version context).
+    //
+    // We check the Mcp-Protocol-Version header first (per-request override),
+    // falling back to the session-negotiated version. Intercepting here
+    // also prevents the version-validation guard below from rejecting the
+    // 2026-07-28 header before we can inspect it.
+    {
+        let method_str = parsed.get("method").and_then(|m| m.as_str()).unwrap_or("");
+        if method_str == "messages/listen" {
+            let req_id = extract_request_id(&parsed);
+            let effective_version = if let Some(v) = get_protocol_version(&headers) {
+                v
+            } else {
+                session.protocol_version.read().await.clone()
+            };
+            if version_supports_messages_listen(&effective_version) {
+                return handle_messages_listen_sse(session).await;
+            } else {
+                return json_rpc_error_response(
+                    req_id,
+                    JsonRpcError::method_not_found("messages/listen"),
+                );
+            }
+        }
+    }
+
     // Validate protocol version (if present and not init request).
     // Per SEP-2575, unsupported versions get a JSON-RPC error with code
     // -32004 and `{ supported, requested }` data, not a plain-text 400.
@@ -2402,6 +2434,58 @@ async fn handle_post(
     );
 
     resp
+}
+
+/// Returns `true` when the given protocol version string enables `messages/listen`.
+///
+/// `messages/listen` is part of the 2026-07-28 spec (SEP-2575 / SEP-2567).
+/// Version strings are YYYY-MM-DD dates, so lexicographic comparison is correct.
+fn version_supports_messages_listen(version: &str) -> bool {
+    version >= UPCOMING_PROTOCOL_VERSION
+}
+
+/// Serve a `messages/listen` request as an SSE stream.
+///
+/// Subscribes to the session's notification broadcast channel and returns a
+/// streaming `text/event-stream` response. The stream closes naturally when:
+/// - The client disconnects (axum drops the response body).
+/// - The broadcast channel closes (server shutdown / session expiry).
+///
+/// Each notification is assigned a monotonically increasing event ID for
+/// potential stream resumption (SEP-1699).
+async fn handle_messages_listen_sse(session: Arc<Session>) -> Response {
+    let rx = session.notifications_tx.subscribe();
+    let session_clone = session.clone();
+
+    let stream = BroadcastStream::new(rx)
+        .then(move |result: std::result::Result<String, _>| {
+            let session = session_clone.clone();
+            async move {
+                match result {
+                    Ok(msg) => {
+                        let event_id = session.next_event_id();
+                        // Buffer the event for potential replay (SEP-1699)
+                        session.buffer_event(event_id, msg.clone()).await;
+                        Some(Ok::<_, Infallible>(
+                            Event::default()
+                                .id(event_id.to_string())
+                                .event(SSE_MESSAGE_EVENT)
+                                .data(msg),
+                        ))
+                    }
+                    Err(_) => None,
+                }
+            }
+        })
+        .filter_map(|x| x);
+
+    Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(30))
+                .text("ping"),
+        )
+        .into_response()
 }
 
 /// Handle GET requests (SSE stream for server notifications and outgoing requests)

--- a/crates/tower-mcp/tests/messages_listen.rs
+++ b/crates/tower-mcp/tests/messages_listen.rs
@@ -1,0 +1,124 @@
+//! Integration tests for the `messages/listen` RPC (SEP-2575 / SEP-2567).
+//!
+//! `messages/listen` opens a server-to-client notification stream over HTTP
+//! POST. The server responds with `Content-Type: text/event-stream` (SSE)
+//! when the negotiated or requested protocol version is >= 2026-07-28
+//! (the UPCOMING_PROTOCOL_VERSION). Requests that target an older-protocol
+//! server receive a JSON-RPC `Method Not Found` (-32601) error instead.
+
+#![cfg(feature = "http")]
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+fn router() -> McpRouter {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a value")
+        .read_only()
+        .handler(|v: serde_json::Value| async move { Ok(CallToolResult::text(v.to_string())) })
+        .build();
+    McpRouter::new()
+        .server_info("listen-test-server", "1.0.0")
+        .tool(echo)
+}
+
+/// Build a transport with origin/host validation disabled (test convenience).
+fn app() -> axum::Router {
+    HttpTransport::new(router())
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_router()
+}
+
+/// POST a `messages/listen` request with the given `Mcp-Protocol-Version` header.
+async fn post_messages_listen(protocol_version: Option<&str>) -> axum::response::Response {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+
+    if let Some(v) = protocol_version {
+        builder = builder.header("Mcp-Protocol-Version", v);
+    }
+
+    let request = builder
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":1,"method":"messages/listen","params":{}}"#,
+        ))
+        .unwrap();
+
+    app().oneshot(request).await.unwrap()
+}
+
+#[tokio::test]
+async fn messages_listen_returns_sse_when_protocol_is_2026_07_28() {
+    // Clients that request protocol 2026-07-28 get an SSE stream back.
+    let response = post_messages_listen(Some("2026-07-28")).await;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "expected 200 OK for messages/listen with protocol 2026-07-28"
+    );
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    assert!(
+        content_type.contains("text/event-stream"),
+        "expected Content-Type: text/event-stream, got: {content_type}"
+    );
+}
+
+#[tokio::test]
+async fn messages_listen_returns_method_not_found_for_old_protocol() {
+    // Without a 2026-07-28 Mcp-Protocol-Version header, the session falls back
+    // to the 2025-11-25 negotiated version, which does not support
+    // messages/listen. The server must return a JSON-RPC Method Not Found error.
+    let response = post_messages_listen(None).await;
+
+    // JSON-RPC errors ride on 200 OK at the HTTP level.
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "JSON-RPC errors should have HTTP 200"
+    );
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert!(
+        content_type.contains("application/json"),
+        "expected JSON error body, Content-Type was: {content_type}"
+    );
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+    // Must be a JSON-RPC error, not a result.
+    assert!(
+        body.get("error").is_some(),
+        "expected JSON-RPC error object, got: {body}"
+    );
+    assert!(
+        body.get("result").is_none(),
+        "must not have a result field when an error is returned: {body}"
+    );
+
+    // Code -32601 = Method Not Found
+    let code = body["error"]["code"].as_i64().unwrap();
+    assert_eq!(
+        code, -32601,
+        "expected Method Not Found (-32601), got code: {code}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `MessagesListenParams` and `MessagesListenResult` protocol types to `tower-mcp-types`
- Add `McpRequest::MessagesListen` and `McpResponse::MessagesListen` enum variants with `method_name()` and `from_jsonrpc()` support
- Add `version_supports_messages_listen()` helper and `handle_messages_listen_sse()` in the HTTP transport
- Intercept `messages/listen` in `handle_post` before the standard protocol-version validation gate, so clients sending `Mcp-Protocol-Version: 2026-07-28` are not incorrectly rejected
- Strict mode (header or session version >= 2026-07-28): return 200 `text/event-stream` SSE stream of notifications
- Lenient mode (older protocol): return JSON-RPC `Method Not Found` (-32601)
- Wire up the session broadcast channel so server notifications flow to the listener
- Add 2 integration tests in `crates/tower-mcp/tests/messages_listen.rs`
- Add wire-format unit tests in `protocol.rs`

## How it works

SEP-2575 / SEP-2567 replaces the server-initiated GET SSE endpoint with a client-initiated streaming model. The client POSTs:

```json
{"jsonrpc":"2.0","id":1,"method":"messages/listen","params":{}}
```

The server responds with `Content-Type: text/event-stream` and streams `notifications/*` events until the client disconnects (axum detects disconnect via stream drop) or the broadcast channel closes.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` (all pass)
- [x] `messages_listen_returns_sse_when_protocol_is_2026_07_28` -- verifies 200 + `text/event-stream` Content-Type
- [x] `messages_listen_returns_method_not_found_for_old_protocol` -- verifies JSON-RPC error code -32601

Part of #814 (chunk 4 of 5)