### PR TITLE
docs(examples): update http_server and horizontal_scaling for 2026-07-28 stateless protocol

### DIFF
--- a/examples/horizontal_scaling.rs
+++ b/examples/horizontal_scaling.rs
@@ -1,5 +1,7 @@
 //! Horizontal scaling example: two HTTP transports, one shared store.
 //!
+//! ## 2025-11-25 session-based path
+//!
 //! Spawns two independent [`HttpTransport`] instances on different ports
 //! that share the same [`SessionStore`] and [`EventStore`]. A small
 //! in-process client:
@@ -9,10 +11,22 @@
 //! 2. Drops the connection and reconnects to instance B (port 3001) with
 //!    the same `mcp-session-id`. Instance B has never seen the session
 //!    locally, but finds it in the shared store and restores it
-//!    transparently. The follow-up `tools/list` call succeeds.
+//!    transparently. The follow-up `tools/call` succeeds.
 //!
 //! This simulates what happens behind a load balancer without session
-//! affinity, or after an instance restarts.
+//! affinity, or after an instance restarts. In production the shared
+//! stores would be backed by Redis or a similar external store so that
+//! session state survives instance restarts.
+//!
+//! ## 2026-07-28 stateless path
+//!
+//! Under the 2026-07-28 protocol, requests carry no `MCP-Session-Id` and
+//! the server creates no session state. Every request is self-contained --
+//! any instance can handle any request without consulting a shared store.
+//! Session affinity at the load balancer is not required, and no shared
+//! [`SessionStore`] or [`EventStore`] is needed. The demo below uses the
+//! session-based flow only; for the stateless flow see
+//! `examples/http_server.rs`.
 //!
 //! Run with: `cargo run --example horizontal_scaling --features http`
 

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -1,8 +1,19 @@
 //! HTTP server example for tower-mcp
 //!
+//! This transport supports two MCP protocol versions:
+//!
+//! - **2025-11-25** (session-based): clients initialize once, receive a
+//!   `MCP-Session-Id`, and attach it to subsequent requests. SSE notifications
+//!   are delivered on a per-session stream opened via a GET request.
+//! - **2026-07-28** (stateless): no `initialize` handshake and no
+//!   `MCP-Session-Id`. Every request carries `MCP-Protocol-Version: 2026-07-28`
+//!   and the SEP-2243 `Mcp-Method` header. Use `server/discover` for capability
+//!   discovery and `messages/listen` for server-push notifications.
+//!
 //! Run with: cargo run --example http_server --features http
 //!
-//! Test with curl:
+//! ## 2025-11-25 session-based flow
+//!
 //! ```bash
 //! # Initialize session (client sends protocolVersion)
 //! curl -X POST http://localhost:3000/ \
@@ -47,6 +58,64 @@
 //!   -H "Accept: text/event-stream" \
 //!   -H "MCP-Session-Id: <session-id>" \
 //!   -H "Last-Event-ID: 5"
+//! ```
+//!
+//! ## 2026-07-28 stateless flow
+//!
+//! The 2026-07-28 protocol removes the `initialize` handshake and `MCP-Session-Id`.
+//! Every request is self-contained: include `MCP-Protocol-Version: 2026-07-28`
+//! and the SEP-2243 `Mcp-Method` header (required in strict mode for this
+//! protocol version). No session ID is sent or returned by the server.
+//!
+//! ```bash
+//! # (Optional) Discover server capabilities -- replaces initialize
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "Accept: application/json" \
+//!   -H "MCP-Protocol-Version: 2026-07-28" \
+//!   -H "Mcp-Method: server/discover" \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}'
+//!
+//! # Server responds with its capabilities (no session created):
+//! # {
+//! #   "jsonrpc": "2.0",
+//! #   "id": 1,
+//! #   "result": {
+//! #     "protocolVersion": "2026-07-28",
+//! #     "serverInfo": { "name": "http-example", "version": "1.0.0" },
+//! #     "capabilities": { "tools": {}, "resources": {}, "prompts": {} }
+//! #   }
+//! # }
+//!
+//! # List tools -- no MCP-Session-Id, just the protocol version header
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Protocol-Version: 2026-07-28" \
+//!   -H "Mcp-Method: tools/list" \
+//!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+//!
+//! # Call a tool -- Mcp-Name is required when calling tools (SEP-2243)
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Protocol-Version: 2026-07-28" \
+//!   -H "Mcp-Method: tools/call" \
+//!   -H "Mcp-Name: add" \
+//!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":10,"b":32}}}'
+//!
+//! # Open a server-push notification stream -- replaces per-session SSE.
+//! # The server delivers notifications (progress, logs, etc.) for requests
+//! # whose progressToken matches a subscription. Each SSE event carries an
+//! # ID for potential resumption (SEP-1699).
+//! #
+//! #   id: 0
+//! #   event: message
+//! #   data: {"jsonrpc":"2.0","method":"notifications/progress",...}
+//! curl -N -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "Accept: text/event-stream" \
+//!   -H "MCP-Protocol-Version: 2026-07-28" \
+//!   -H "Mcp-Method: messages/listen" \
+//!   -d '{"jsonrpc":"2.0","id":4,"method":"messages/listen","params":{}}'
 //! ```
 
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Update `examples/http_server.rs` and `examples/horizontal_scaling.rs` doc comments to demonstrate the 2026-07-28 stateless MCP protocol path (SEP-2575 / SEP-2567). Both files currently only document the 2025-11-25 session-based flow.

## Changes

### `examples/http_server.rs`

- Add a "2026-07-28 stateless flow" section to the doc comment with working curl examples
- Show: no `initialize` handshake, `MCP-Protocol-Version: 2026-07-28` header, `Mcp-Method` header (SEP-2243 strict mode), `server/discover`, `tools/list` and `tools/call` without `MCP-Session-Id`, `messages/listen` for server-push
- Update the header paragraph to note both protocol versions are supported
- Keep the existing 2025-11-25 curl examples intact

### `examples/horizontal_scaling.rs`

- Add a note explaining that under 2026-07-28, stateless requests carry no session ID and require no session store
- Clarify the existing session-store demo is for the 2025-11-25 path only

## Acceptance

- [x] `http_server.rs` doc comment shows working curl commands for both `2025-11-25` and `2026-07-28`
- [x] `horizontal_scaling.rs` updated to reflect stateless-mode implications
- [x] `cargo build -p tower-mcp --examples --features http` passes
- [x] No TODO/FIXME left in changed files

Closes #854