### PR TITLE
fix(examples): correct subprocess example names in client_cli and proxy

### DIFF
--- a/examples/client_cli.rs
+++ b/examples/client_cli.rs
@@ -2,7 +2,7 @@
 //!
 //! Demonstrates using McpClient to connect to an MCP server and interact with it.
 //!
-//! This example spawns the stdio_server example as a subprocess and:
+//! This example spawns the getting_started example as a subprocess and:
 //! 1. Initializes the connection
 //! 2. Lists available tools
 //! 3. Calls each tool with sample inputs
@@ -21,10 +21,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .with_env_filter("tower_mcp=info,client_cli=debug")
         .init();
 
-    // Get server command from args, or default to our stdio_server example
+    // Get server command from args, or default to our getting_started example
     let args: Vec<String> = std::env::args().skip(1).collect();
     let (cmd, cmd_args): (&str, Vec<&str>) = if args.is_empty() {
-        ("cargo", vec!["run", "--example", "stdio_server"])
+        ("cargo", vec!["run", "--example", "getting_started"])
     } else {
         (
             args[0].as_str(),

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -8,7 +8,7 @@
 //! - Health checks (ping all backends)
 //!
 //! This example spawns two backend servers as subprocesses:
-//! - `basic` server (provides echo and add tools)
+//! - `getting_started` server (provides echo and add tools)
 //! - `sampling_server` (provides summarize, confirm_delete, slow_task tools)
 //!
 //! Run with: cargo run --example proxy --features proxy
@@ -34,7 +34,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Spawn backend servers as subprocesses
     let basic_transport =
-        StdioClientTransport::spawn("cargo", &["run", "--example", "basic"]).await?;
+        StdioClientTransport::spawn("cargo", &["run", "--example", "getting_started"]).await?;
     let sampling_transport =
         StdioClientTransport::spawn("cargo", &["run", "--example", "sampling_server"]).await?;
 


### PR DESCRIPTION
## Summary

Two examples reference `--example` names that no longer exist in the codebase:

- `examples/client_cli.rs` defaulted to spawning `--example stdio_server` (file does not exist)
- `examples/proxy.rs` spawned `--example basic` (file does not exist)

Both are updated to use `--example getting_started`, which is the simple stdio server example that provides the `echo` and `add` tools both examples exercise.

## Changes

- `examples/client_cli.rs`: update default subprocess from `stdio_server` to `getting_started`; fix doc comment to match
- `examples/proxy.rs`: update spawn call from `basic` to `getting_started`; fix doc comment to match

Fixes #878.