### PR TITLE
docs: update lib.rs and README for 2026-07-28 stateless protocol (#858, #871)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ tower-mcp = "0.9"
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
 | `resilience` | Re-export tower-resilience circuit breaker, rate limiter, and bulkhead layers |
-| `stateless` | SEP-1442 stateless MCP mode (experimental) -- serve requests without sessions |
+| `stateless` | Experimental 2026-07-28 stateless protocol mode (SEP-2575 final + SEP-2567 accepted) -- version-gated sessionless dispatch, `server/discover` RPC, `messages/listen` SSE endpoint, per-request `_meta` client capabilities. Requires `http`. |
 
 Example with features:
 
@@ -581,6 +581,11 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 Numbers above are from `@modelcontextprotocol/conformance@0.1.15`, run on every PR. Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot.
 
+The `stateless` feature enables an experimental 2026-07-28 protocol path (version-gated, behind
+`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `messages/listen`, and per-request
+`_meta` capabilities as defined by SEP-2575 (final) and SEP-2567 (accepted). The 2026-07-28
+version is not yet stable and is not included in `SUPPORTED_PROTOCOL_VERSIONS`.
+
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
 
 - [x] [JSON-RPC 2.0 message format](https://modelcontextprotocol.io/specification/2025-11-25/basic#messages)
@@ -607,6 +612,10 @@ Numbers above are from `@modelcontextprotocol/conformance@0.1.15`, run on every 
 - [x] [Async tasks](https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/async) (task ID, status tracking, TTL cleanup, per-tool task support mode)
 - [x] [SSE event IDs and stream resumption](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery) (SEP-1699)
 - [x] [`_meta` field on all protocol types](https://modelcontextprotocol.io/specification/2025-11-25)
+- [x] [Strict HTTP headers: `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version` (SEP-2243)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final)
+- [x] [`server/discover` RPC -- stateless capability discovery (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
+- [x] [`messages/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `stateless` feature, 2026-07-28+)
+- [x] [Per-request `_meta` client capabilities -- `StatelessRequestMeta` (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
 
 We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](https://github.com/joshrotenberg/tower-mcp/issues?q=label%3Asep). A weekly workflow syncs status from the upstream spec repository.
 

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -136,6 +136,10 @@
 //! - [`GetPromptResult`] - Prompt expansion result
 //! - [`Content`] - Text, image, audio, or resource content
 //!
+//! ### Stateless (2026-07-28, requires `stateless` feature)
+//! - [`stateless::StatelessRequestMeta`] - Per-request `_meta` carrying protocol version,
+//!   client identity, and client capabilities for sessionless 2026-07-28 requests
+//!
 //! ## Feature Flags
 //!
 //! - `full` - Enable all optional features
@@ -152,6 +156,9 @@
 //! - `http-client` - HTTP client transport for connecting to remote MCP servers
 //! - `oauth-client` - OAuth 2.0 client-side token acquisition via client credentials grant (requires `http-client`)
 //! - `macros` - Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`)
+//! - `stateless` - Experimental 2026-07-28 stateless protocol mode (SEP-2575 + SEP-2567). Enables
+//!   version-gated sessionless dispatch, `server/discover` RPC, per-request `_meta` via
+//!   [`stateless::StatelessRequestMeta`], and `messages/listen` SSE endpoint. Requires `http`.
 //!
 //! ## Middleware Placement Guide
 //!
@@ -325,6 +332,40 @@
 //!     .build();
 //! ```
 //!
+//! ### Stateless Mode (2026-07-28, requires `stateless` + `http` features)
+//!
+//! The `stateless` feature enables experimental support for the 2026-07-28 MCP protocol
+//! (SEP-2575 final + SEP-2567 accepted). In this mode the initialize/initialized handshake
+//! is replaced by two new RPCs:
+//!
+//! - **`server/discover`** -- stateless capability discovery. Clients that send requests with
+//!   `MCP-Protocol-Version: 2026-07-28` (SEP-2243 header) can call `server/discover` instead
+//!   of `initialize` to learn what the server supports without establishing a session.
+//! - **`messages/listen`** -- client-initiated SSE subscription. A GET to `/mcp` with
+//!   `MCP-Protocol-Version: 2026-07-28` opens a server-push stream that is not tied to any
+//!   session, allowing stateless clients to receive notifications.
+//!
+//! Per-request client identity and capabilities ride in each request's `_meta` object via
+//! [`stateless::StatelessRequestMeta`] rather than being negotiated once at session open.
+//! The `MCP-Protocol-Version` header value is the version gate: requests carrying `2026-07-28`
+//! or later route through the stateless path; older requests continue through the
+//! session-based path unchanged.
+//!
+//! ```rust,ignore
+//! use tower_mcp::{McpRouter, HttpTransport};
+//! use tower_mcp::stateless::StatelessConfig;
+//!
+//! let router = McpRouter::new().server_info("my-server", "1.0.0");
+//!
+//! // Enable stateless mode alongside the session-based path.
+//! let transport = HttpTransport::new(router)
+//!     .stateless(StatelessConfig::new());
+//! ```
+//!
+//! The 2026-07-28 protocol is experimental. The `UPCOMING_PROTOCOL_VERSION` constant in
+//! `tower_mcp::protocol` tracks the target version string and will not appear in
+//! `SUPPORTED_PROTOCOL_VERSIONS` until the spec is stable.
+//!
 //! ### Router Composition
 //!
 //! Combine multiple routers using [`McpRouter::merge()`] or [`McpRouter::nest()`]:
@@ -388,6 +429,14 @@
 //!
 //! This crate implements the MCP specification (2025-11-25):
 //! <https://modelcontextprotocol.io/specification/2025-11-25>
+//!
+//! The `stateless` feature additionally tracks the upcoming 2026-07-28 protocol defined by:
+//! - [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (accepted) --
+//!   `messages/listen` SSE endpoint
+//! - [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (final) --
+//!   stateless session model, `server/discover`, per-request `_meta`
+//! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final) --
+//!   strict HTTP headers (`Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`)
 
 pub mod async_task;
 pub mod auth;


### PR DESCRIPTION
## Summary

Update `lib.rs` crate-level doc and `README.md` to reflect the stateless HTTP
support that landed in #814. Both files are silent on the 2026-07-28 protocol
path, `server/discover`, `messages/listen`, `StatelessRequestMeta`, and the
corrected SEP attribution (SEP-2575/SEP-2567, not the draft SEP-1442).

Closes #858, closes #871.

## Changes

### `crates/tower-mcp/src/lib.rs`

- Add `stateless` to the Feature Flags section
- Add a "Stateless Mode (2026-07-28)" subsection under "Advanced Features"
- Add `StatelessRequestMeta` to the Key Types section
- Extend the MCP Specification footnote to mention the upcoming 2026-07-28 path

### `README.md`

- Update `stateless` feature row in the Feature Flags table
- Add `server/discover`, `messages/listen`, SEP-2243 strict headers, and
  per-request `_meta` to the Protocol Compliance checklist
- Add a sentence in the Protocol Compliance section about the experimental
  2026-07-28 path