### PR TITLE
test(conformance): enable stateless feature and 2026-07-28 CI run (#862, #865, #868, #870)

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -82,17 +82,28 @@ jobs:
 
       - name: Check server/discover (SEP-2575, #865)
         run: |
-          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+          # Use -D to dump response headers to a temp file, -o for the body.
+          curl -s -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: server/discover" \
-            -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}')
+            -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}' \
+            -D /tmp/discover-headers.txt \
+            -o /tmp/discover-body.json
+          response=$(cat /tmp/discover-body.json)
           echo "server/discover response: $response"
           # DiscoverResult serializes as camelCase: supportedVersions, serverInfo, capabilities
           echo "$response" | grep -q '"supportedVersions"' || { echo "FAIL: supportedVersions missing"; exit 1; }
           echo "$response" | grep -q '"serverInfo"' || { echo "FAIL: serverInfo missing"; exit 1; }
           echo "$response" | grep -q '"capabilities"' || { echo "FAIL: capabilities missing"; exit 1; }
           echo "PASS: server/discover returned well-formed DiscoverResult"
+          # server/discover must NOT set mcp-session-id: stateless responses are sessionless (#865)
+          if grep -qi "mcp-session-id" /tmp/discover-headers.txt; then
+            echo "FAIL: server/discover response must not include mcp-session-id header"
+            cat /tmp/discover-headers.txt
+            exit 1
+          fi
+          echo "PASS: server/discover response does not include mcp-session-id header"
 
       - name: Check stateless tools/call without _meta (#862)
         run: |
@@ -144,36 +155,86 @@ jobs:
 
       - name: Check messages/listen opens SSE stream with 2026-07-28 (#868)
         run: |
-          # Capture just the headers + first bytes; the SSE stream stays open.
+          # Step 1: establish a 2025-11-25 session to get an mcp-session-id.
+          # (2026-07-28 initialize is stateless and returns no session ID.)
+          curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"ci-test","version":"1.0"},"capabilities":{}}}' \
+            -D /tmp/init-headers.txt \
+            -o /tmp/init-body.json
+          session_id=$(grep -i "mcp-session-id" /tmp/init-headers.txt | awk '{print $2}' | tr -d '\r')
+          echo "Session ID: $session_id"
+          if [ -z "$session_id" ]; then
+            echo "FAIL: no mcp-session-id in initialize response"
+            cat /tmp/init-headers.txt
+            exit 1
+          fi
+
+          # Step 2: open messages/listen SSE stream in the background, capture output.
+          # Sending MCP-Protocol-Version: 2026-07-28 on the request overrides the
+          # session's negotiated version and enables the SSE stream.
+          curl -s --max-time 5 \
+            -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: messages/listen" \
+            -H "Accept: text/event-stream" \
+            -H "mcp-session-id: $session_id" \
+            -d '{"jsonrpc":"2.0","id":5,"method":"messages/listen","params":{}}' \
+            -o /tmp/sse-stream.txt &
+          SSE_PID=$!
+          sleep 1
+
+          # Step 3: confirm SSE stream content-type (via a parallel content-type probe).
           content_type=$(curl -s -o /dev/null -w "%{content_type}" \
             --max-time 3 \
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: messages/listen" \
-            -d '{"jsonrpc":"2.0","id":5,"method":"messages/listen","params":{}}' || true)
+            -H "Accept: text/event-stream" \
+            -d '{"jsonrpc":"2.0","id":6,"method":"messages/listen","params":{}}' || true)
           echo "messages/listen Content-Type: $content_type"
-          echo "$content_type" | grep -q "text/event-stream" || { echo "FAIL: expected text/event-stream"; exit 1; }
+          echo "$content_type" | grep -q "text/event-stream" || { echo "FAIL: expected text/event-stream"; kill $SSE_PID 2>/dev/null; exit 1; }
           echo "PASS: messages/listen returns SSE stream for 2026-07-28"
+
+          # Step 4: trigger log notifications on the established session.
+          # test_tool_with_logging sends three log notifications via ctx.send_log().
+          curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "Mcp-Method: tools/call" \
+            -H "Mcp-Name: test_tool_with_logging" \
+            -H "mcp-session-id: $session_id" \
+            -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"test_tool_with_logging","arguments":{}}}' \
+            -o /dev/null
+          sleep 1
+
+          # Step 5: verify at least one SSE data line arrived.
+          kill $SSE_PID 2>/dev/null || true
+          echo "SSE stream output:"
+          cat /tmp/sse-stream.txt
+          grep -q "^data:" /tmp/sse-stream.txt || { echo "FAIL: no data: lines in SSE stream"; exit 1; }
+          echo "PASS: notification event appeared in messages/listen SSE stream"
 
       - name: Check messages/listen returns JSON-RPC error without 2026-07-28 (#868)
         run: |
           # Without MCP-Protocol-Version: 2026-07-28, messages/listen must NOT
-          # return an SSE stream. A request with no session ID returns a JSON-RPC
-          # error (SessionRequired, -32006). We assert there is an "error" field and
-          # no "text/event-stream" content -- confirming the endpoint is gated.
+          # return an SSE stream. The 2025-11-25 server returns MethodNotFound
+          # (-32601) because messages/listen is a 2026-07-28-only method.
+          # We assert the error code is exactly -32601 and no SSE stream is returned.
           content_type=$(curl -s -o /tmp/messages-listen-legacy.json \
             -w "%{content_type}" \
             --max-time 3 \
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
-            -d '{"jsonrpc":"2.0","id":6,"method":"messages/listen","params":{}}' || true)
+            -d '{"jsonrpc":"2.0","id":8,"method":"messages/listen","params":{}}' || true)
           response=$(cat /tmp/messages-listen-legacy.json)
           echo "Legacy messages/listen Content-Type: $content_type"
           echo "Legacy messages/listen body: $response"
           echo "$content_type" | grep -vq "text/event-stream" || { echo "FAIL: must not return SSE stream without 2026-07-28"; exit 1; }
           echo "$response" | grep -q '"error"' || { echo "FAIL: expected a JSON-RPC error field"; exit 1; }
-          echo "PASS: messages/listen returns JSON-RPC error without 2026-07-28 version"
+          echo "$response" | grep -q -- '-32601' || { echo "FAIL: expected MethodNotFound error code -32601"; exit 1; }
+          echo "PASS: messages/listen returns MethodNotFound (-32601) without 2026-07-28 version"
 
       - name: Show server logs on failure
         if: failure()

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -50,6 +50,135 @@ jobs:
         if: failure()
         run: cat /tmp/conformance-server.log
 
+  stateless-conformance:
+    name: Stateless 2026-07-28 Conformance
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build conformance server (with stateless feature)
+        run: cargo build --manifest-path examples/conformance-server/Cargo.toml
+
+      - name: Start server
+        run: |
+          cargo run --manifest-path examples/conformance-server/Cargo.toml \
+            > /tmp/conformance-server-stateless.log 2>&1 &
+          echo $! > /tmp/conformance-server-stateless.pid
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 3001 2>/dev/null; then
+              echo "Server is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start. Logs:"
+          cat /tmp/conformance-server-stateless.log
+          exit 1
+
+      - name: Check server/discover (SEP-2575, #865)
+        run: |
+          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: server/discover" \
+            -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}')
+          echo "server/discover response: $response"
+          # DiscoverResult serializes as camelCase: supportedVersions, serverInfo, capabilities
+          echo "$response" | grep -q '"supportedVersions"' || { echo "FAIL: supportedVersions missing"; exit 1; }
+          echo "$response" | grep -q '"serverInfo"' || { echo "FAIL: serverInfo missing"; exit 1; }
+          echo "$response" | grep -q '"capabilities"' || { echo "FAIL: capabilities missing"; exit 1; }
+          echo "PASS: server/discover returned well-formed DiscoverResult"
+
+      - name: Check stateless tools/call without _meta (#862)
+        run: |
+          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: tools/call" \
+            -H "Mcp-Name: test_simple_text" \
+            -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_simple_text","arguments":{}}}')
+          echo "stateless tools/call response: $response"
+          echo "$response" | grep -q '"result"' || { echo "FAIL: no result field"; exit 1; }
+          echo "PASS: stateless tools/call succeeded"
+
+      - name: Check test_per_request_meta with _meta block (#870)
+        run: |
+          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: tools/call" \
+            -H "Mcp-Name: test_per_request_meta" \
+            -d '{
+              "jsonrpc":"2.0","id":3,"method":"tools/call",
+              "params":{
+                "_meta":{
+                  "io.modelcontextprotocol/protocolVersion":"2026-07-28",
+                  "io.modelcontextprotocol/clientInfo":{"name":"test-client","version":"1.0"},
+                  "io.modelcontextprotocol/clientCapabilities":{}
+                },
+                "name":"test_per_request_meta",
+                "arguments":{}
+              }
+            }')
+          echo "per_request_meta response: $response"
+          echo "$response" | grep -q '2026-07-28' || { echo "FAIL: protocol_version not reflected"; exit 1; }
+          echo "$response" | grep -q 'test-client' || { echo "FAIL: client_name not reflected"; exit 1; }
+          echo "PASS: per-request _meta threaded to handler"
+
+      - name: Check test_per_request_meta without _meta returns no meta (#870)
+        run: |
+          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: tools/call" \
+            -H "Mcp-Name: test_per_request_meta" \
+            -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test_per_request_meta","arguments":{}}}')
+          echo "no-meta response: $response"
+          echo "$response" | grep -q '"no meta"' || { echo "FAIL: expected 'no meta' text"; exit 1; }
+          echo "PASS: absent _meta returns 'no meta'"
+
+      - name: Check messages/listen opens SSE stream with 2026-07-28 (#868)
+        run: |
+          # Capture just the headers + first bytes; the SSE stream stays open.
+          content_type=$(curl -s -o /dev/null -w "%{content_type}" \
+            --max-time 3 \
+            -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -H "MCP-Protocol-Version: 2026-07-28" \
+            -H "Mcp-Method: messages/listen" \
+            -d '{"jsonrpc":"2.0","id":5,"method":"messages/listen","params":{}}' || true)
+          echo "messages/listen Content-Type: $content_type"
+          echo "$content_type" | grep -q "text/event-stream" || { echo "FAIL: expected text/event-stream"; exit 1; }
+          echo "PASS: messages/listen returns SSE stream for 2026-07-28"
+
+      - name: Check messages/listen returns JSON-RPC error without 2026-07-28 (#868)
+        run: |
+          # Without MCP-Protocol-Version: 2026-07-28, messages/listen must NOT
+          # return an SSE stream. A request with no session ID returns a JSON-RPC
+          # error (SessionRequired, -32006). We assert there is an "error" field and
+          # no "text/event-stream" content -- confirming the endpoint is gated.
+          content_type=$(curl -s -o /tmp/messages-listen-legacy.json \
+            -w "%{content_type}" \
+            --max-time 3 \
+            -X POST http://127.0.0.1:3001/mcp \
+            -H "Content-Type: application/json" \
+            -d '{"jsonrpc":"2.0","id":6,"method":"messages/listen","params":{}}' || true)
+          response=$(cat /tmp/messages-listen-legacy.json)
+          echo "Legacy messages/listen Content-Type: $content_type"
+          echo "Legacy messages/listen body: $response"
+          echo "$content_type" | grep -vq "text/event-stream" || { echo "FAIL: must not return SSE stream without 2026-07-28"; exit 1; }
+          echo "$response" | grep -q '"error"' || { echo "FAIL: expected a JSON-RPC error field"; exit 1; }
+          echo "PASS: messages/listen returns JSON-RPC error without 2026-07-28 version"
+
+      - name: Show server logs on failure
+        if: failure()
+        run: cat /tmp/conformance-server-stateless.log
+
   client-conformance:
     name: Client Conformance Suite
     runs-on: ubuntu-latest

--- a/examples/conformance-server/Cargo.toml
+++ b/examples/conformance-server/Cargo.toml
@@ -12,7 +12,7 @@ name = "conformance-server"
 path = "src/main.rs"
 
 [dependencies]
-tower-mcp = { workspace = true, features = ["http", "oauth"] }
+tower-mcp = { workspace = true, features = ["http", "oauth", "stateless"] }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -57,6 +57,7 @@ pub fn build_tools() -> Vec<Tool> {
         build_elicitation(),
         build_elicitation_sep1034_defaults(),
         build_elicitation_sep1330_enums(),
+        build_per_request_meta(),
     ]
 }
 
@@ -290,9 +291,41 @@ fn build_elicitation_sep1034_defaults() -> Tool {
         .build()
 }
 
+fn build_per_request_meta() -> Tool {
+    ToolBuilder::new("test_per_request_meta")
+        .description(
+            "Reflects per-request _meta from the request context. \
+             Returns protocol_version and client_info.name when a 2026-07-28 \
+             _meta block is present, or \"no meta\" when absent. \
+             Exercises SEP-2575 per-request metadata threading (#870).",
+        )
+        .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
+            match ctx.per_request_meta() {
+                Some(meta) => {
+                    let version = meta
+                        .protocol_version
+                        .as_deref()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let client_name = meta
+                        .client_info
+                        .as_ref()
+                        .map(|i| i.name.as_str())
+                        .unwrap_or("unknown")
+                        .to_string();
+                    Ok(CallToolResult::text(format!(
+                        "protocol_version={version} client_name={client_name}"
+                    )))
+                }
+                None => Ok(CallToolResult::text("no meta")),
+            }
+        })
+        .build()
+}
+
 fn build_elicitation_sep1330_enums() -> Tool {
     ToolBuilder::new("test_elicitation_sep1330_enums")
-        .description("Requests elicitation with enum schemas")
+        .description("Requests elicitation with enum schemas -- all 5 SEP-1330 variants")
         .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
             if !ctx.can_elicit() {
                 return Ok(CallToolResult::error("Elicitation not available"));


### PR DESCRIPTION
## Summary

Closes #862, closes #865, closes #868, closes #870

Wire the existing stateless implementation into the conformance gate. All four
issues share the same root cause: the conformance server was built without the
`stateless` feature, so none of the 2026-07-28 protocol paths were exercised in
CI.

## Changes

1. **`examples/conformance-server/Cargo.toml`**: Add `"stateless"` to the
   tower-mcp feature list. This single change enables the `#[cfg(feature =
   "stateless")]` blocks in the HTTP transport, allowing the server to handle
   `MCP-Protocol-Version: 2026-07-28` requests, `server/discover` RPCs, and
   `messages/listen` SSE streams.

2. **`examples/conformance-server/src/tools.rs`**: Add `test_per_request_meta`
   tool that reads `ctx.per_request_meta()` and reflects `protocol_version` and
   `client_info.name` back to the caller (or `"no meta"` if absent). Exercises
   #870.

3. **`.github/workflows/conformance.yml`**: Add a `stateless-conformance` job
   that starts the conformance server with the `stateless` feature and runs a
   suite of curl-based checks against the 2026-07-28 protocol path. Covers:
   - `server/discover` (#865)
   - `tools/call` in stateless mode (#862)
   - `messages/listen` SSE stream presence (#868)
   - `test_per_request_meta` with populated `_meta` block (#870)
   - Negative check: `messages/listen` with 2025-11-25 returns MethodNotFound

## Notes

The upstream `@modelcontextprotocol/conformance@0.1.15` does not yet have
2026-07-28 scenarios, so the second CI job uses curl assertions rather than the
conformance runner. The `--spec-version 2026-07-28` flag is plumbed but no
scenarios exist at that filter yet; this will auto-expand when the conformance
tool adds 2026-07-28 coverage.