### PR TITLE
docs: module-level docs for stateless transport, context, and types (#860, #864, #867, #874)

### DIFF
--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -13,6 +13,27 @@
 //!   format without running a full server
 //! - Testing libraries that want MCP types without pulling in a server stack
 //!
+//! # Stateless protocol support (2026-07-28)
+//!
+//! This crate also tracks the next protocol version (`2026-07-28`) that adds
+//! stateless operation, per-request `_meta`, and the `server/discover` RPC.
+//! Key items:
+//!
+//! - [`protocol::UPCOMING_PROTOCOL_VERSION`] -- the `"2026-07-28"` version
+//!   string, not yet in `SUPPORTED_PROTOCOL_VERSIONS`. Useful for codegen
+//!   tools and conformance harnesses that need to reference it explicitly.
+//! - [`protocol::DiscoverResult`] / [`protocol::DiscoverParams`] -- types for
+//!   the `server/discover` RPC (SEP-2575), which returns the server's supported
+//!   protocol versions and capabilities without requiring an `initialize`
+//!   handshake.
+//! - [`error::UnsupportedProtocolVersionData`] -- the structured error data
+//!   attached to a `-32004` (UnsupportedProtocolVersion) response. Contains
+//!   the `supported` versions list and the `requested` version string.
+//! - [`error::McpErrorCode::HeaderMismatch`] (`-32001`) and
+//!   [`error::McpErrorCode::UnsupportedProtocolVersion`] (`-32004`) -- new
+//!   spec-assigned error codes (SEP-2243 and SEP-2575 respectively). See the
+//!   [`error`] module for the full error code table.
+//!
 //! # The only standalone Rust MCP types crate
 //!
 //! Most Rust MCP libraries bundle their protocol types with their runtime.

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -68,6 +68,50 @@
 //!     }
 //! }
 //! ```
+//!
+//! # Stateless mode: per-request metadata (`stateless` feature)
+//!
+//! With the 2026-07-28 protocol, clients do not run an initialize handshake.
+//! Instead, every request carries the client's protocol version, identity, and
+//! capabilities in a `_meta` object. The HTTP transport extracts these fields
+//! and stashes them as a [`StatelessRequestMeta`](crate::stateless::StatelessRequestMeta)
+//! extension on the [`RequestContext`], accessible via
+//! [`ctx.per_request_meta()`](RequestContext::per_request_meta).
+//!
+//! `per_request_meta()` returns `Some` when:
+//! - The `stateless` feature is compiled in, AND
+//! - The request was dispatched by the HTTP transport, AND
+//! - The request's `_meta` contained at least one recognized field.
+//!
+//! It returns `None` for stdio/WebSocket transports, for 2025-11-25 session-based
+//! requests, and when the request carried no `_meta`.
+//!
+//! The [`StatelessRequestMeta`](crate::stateless::StatelessRequestMeta) struct
+//! provides:
+//!
+//! - `protocol_version` -- the `io.modelcontextprotocol/protocolVersion` field
+//! - `client_info` -- the `io.modelcontextprotocol/clientInfo` field (name, version)
+//! - `client_capabilities` -- the `io.modelcontextprotocol/clientCapabilities` field
+//! - `log_level` -- optional per-request log level override
+//! - `progress_token` -- optional progress token for progress notifications
+//!
+//! ```rust,ignore
+//! // Requires feature = ["stateless"]
+//! use tower_mcp::context::RequestContext;
+//!
+//! async fn my_tool(ctx: RequestContext, input: MyInput) -> Result<CallToolResult> {
+//!     if let Some(meta) = ctx.per_request_meta() {
+//!         // Available for 2026-07-28+ clients on the HTTP transport
+//!         if let Some(ref info) = meta.client_info {
+//!             tracing::info!(client = %info.name, version = %info.version, "request from");
+//!         }
+//!         if let Some(ref version) = meta.protocol_version {
+//!             tracing::debug!(protocol_version = %version);
+//!         }
+//!     }
+//!     Ok(CallToolResult::text("ok"))
+//! }
+//! ```
 
 use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -436,14 +480,30 @@ impl RequestContext {
     /// SEP-2575 per-request `_meta` (protocol version, client info, client
     /// capabilities, log level) if the transport extracted it.
     ///
-    /// Returns `None` when:
+    /// Returns `Some` for 2026-07-28+ clients on the HTTP transport when the
+    /// request carried a `_meta` object with recognized fields. Returns `None`
+    /// when:
     /// - The request had no `_meta` field, or
     /// - The transport does not stash per-request metadata (only the HTTP
-    ///   transport currently does), or
-    /// - The `stateless` feature is not enabled.
+    ///   transport currently does this), or
+    /// - The `stateless` feature is not compiled in.
     ///
-    /// Equivalent to `self.extension::<StatelessRequestMeta>()` but typed
-    /// so handlers don't have to repeat the import.
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// async fn my_tool(ctx: RequestContext, input: MyInput) -> Result<CallToolResult> {
+    ///     if let Some(meta) = ctx.per_request_meta() {
+    ///         // protocol_version, client_info, client_capabilities are all Option<_>
+    ///         if let Some(ref version) = meta.protocol_version {
+    ///             tracing::debug!(protocol_version = %version);
+    ///         }
+    ///         if let Some(ref info) = meta.client_info {
+    ///             tracing::info!(client = %info.name, version = %info.version);
+    ///         }
+    ///     }
+    ///     Ok(CallToolResult::text("ok"))
+    /// }
+    /// ```
     #[cfg(feature = "stateless")]
     pub fn per_request_meta(&self) -> Option<&crate::stateless::StatelessRequestMeta> {
         self.extension::<crate::stateless::StatelessRequestMeta>()

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -1,26 +1,46 @@
-//! SEP-1442 Stateless MCP support (experimental)
+//! Stateless MCP support: SEP-1442 opt-in and automatic 2026-07-28 dispatch
 //!
-//! This module provides experimental support for stateless MCP as defined in
-//! [SEP-1442](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1442).
+//! This module contains types and helpers for stateless MCP operation. There are
+//! two distinct paths; understanding which one applies to your deployment is
+//! important.
 //!
-//! ## Feature Flag
+//! ## Two stateless paths
+//!
+//! ### Automatic version-gated path (2026-07-28+)
+//!
+//! When the `stateless` feature is compiled in, the HTTP transport automatically
+//! dispatches any request carrying `MCP-Protocol-Version: 2026-07-28` (or later)
+//! statelessly -- no session is created or looked up, and no initialize handshake
+//! is required. Client identity and capabilities flow through per-request `_meta`
+//! (see [`StatelessRequestMeta`]).
+//!
+//! **This path is always active when the feature is compiled in, regardless of
+//! whether [`StatelessConfig`] was provided to the transport.** Adding
+//! `features = ["stateless"]` to your `Cargo.toml` is sufficient; you do not
+//! need to call `HttpTransport::stateless()`.
+//!
+//! ### Legacy SEP-1442 opt-in path
+//!
+//! [`StatelessConfig`] and `HttpTransport::stateless()` activate the older
+//! SEP-1442-style opt-in stateless behavior for clients that do not use the
+//! 2026-07-28 protocol. This path controls whether sessions are optional,
+//! whether the protocol version must be present in every request, and whether
+//! `server/discover` is enabled.
+//!
+//! ## Feature flag
 //!
 //! This module is gated behind the `stateless` feature flag:
 //!
 //! ```toml
-//! tower-mcp = { version = "0.9", features = ["stateless"] }
+//! tower-mcp = { version = "0.10", features = ["stateless"] }
 //! ```
 //!
-//! ## Key Changes from Standard MCP
+//! ## Key properties of stateless mode
 //!
-//! 1. **Per-request protocol version**: Every request includes the protocol version
-//! 2. **Optional discovery**: `server/discover` RPC for capability discovery
-//! 3. **Optional sessions**: Sessions are no longer mandatory
-//! 4. **Per-request client capabilities**: Clients can specify capabilities per-request
-//!
-//! ## Warning
-//!
-//! SEP-1442 is still in-review. The API may change as the specification evolves.
+//! 1. **Per-request protocol version**: Every request carries the protocol version
+//! 2. **Optional discovery**: `server/discover` RPC for capability discovery (SEP-2575)
+//! 3. **No sessions required**: Sessions are optional (2026-07-28) or configurable (SEP-1442)
+//! 4. **Per-request client capabilities**: Client info and capabilities ride on each request
 
 use serde::{Deserialize, Serialize};
 
@@ -179,9 +199,18 @@ pub mod error_codes {
 // Stateless mode configuration
 // =============================================================================
 
-/// Configuration for stateless MCP mode.
+/// Configuration for the legacy SEP-1442 stateless opt-in path.
 ///
-/// Controls which SEP-1442 features are enabled and their strictness.
+/// **This configuration applies only to the legacy SEP-1442 opt-in path.**
+/// It does NOT control the automatic version-gated path for 2026-07-28+
+/// clients: when the `stateless` feature is compiled in, any request with
+/// `MCP-Protocol-Version: 2026-07-28` and no `mcp-session-id` is dispatched
+/// statelessly regardless of whether this config is set on the transport.
+///
+/// Use [`HttpTransport::stateless()`](crate::transport::http::HttpTransport::stateless)
+/// to attach this configuration to a transport. Omitting it does not disable
+/// stateless support for 2026-07-28+ clients; it only disables the
+/// additional SEP-1442 opt-in behaviors below.
 #[derive(Debug, Clone)]
 pub struct StatelessConfig {
     /// Whether to require protocol version in every request.

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1,6 +1,8 @@
 //! Streamable HTTP transport for MCP
 //!
-//! Implements the Streamable HTTP transport from MCP specification 2025-11-25.
+//! Implements the Streamable HTTP transport from MCP specification 2025-11-25,
+//! with version-gated support for the 2026-07-28 stateless protocol (SEP-2575 /
+//! SEP-2567) when the `stateless` feature is compiled in.
 //!
 //! ## Features
 //!
@@ -10,6 +12,79 @@
 //! - SSE event IDs and stream resumption via `Last-Event-ID` header (SEP-1699)
 //! - Configurable session TTL and cleanup
 //! - **Sampling support**: Server-to-client LLM requests via SSE + POST
+//! - **Stateless mode** (`stateless` feature): version-gated dispatch for
+//!   2026-07-28+ clients with per-request `_meta` and no session handshake
+//!
+//! ## Stateless mode (2026-07-28 protocol)
+//!
+//! When the `stateless` feature is compiled in, the transport handles two
+//! distinct stateless paths:
+//!
+//! ### Automatic version-gated path (2026-07-28+)
+//!
+//! Any request that arrives with `MCP-Protocol-Version: 2026-07-28` (or
+//! later) and no `mcp-session-id` header is dispatched statelessly, regardless
+//! of whether [`HttpTransport::stateless()`] was called. The client is fully
+//! self-identifying: every request carries its protocol version, client info,
+//! and client capabilities in the `_meta` object; no initialize handshake is
+//! needed. Handlers access this data via
+//! [`RequestContext::per_request_meta()`](crate::context::RequestContext::per_request_meta).
+//!
+//! This path runs before the legacy SEP-1442 opt-in path, so 2026-07-28
+//! clients are always handled correctly even on transports that never call
+//! `HttpTransport::stateless()`.
+//!
+//! ### Legacy SEP-1442 opt-in path
+//!
+//! Calling [`HttpTransport::stateless()`] with a [`crate::stateless::StatelessConfig`]
+//! activates the older SEP-1442-style opt-in stateless behavior for clients that
+//! do not carry `MCP-Protocol-Version: 2026-07-28`. See
+//! [`crate::stateless::StatelessConfig`] for details on what this path controls.
+//!
+//! Stateful clients (those sending an `mcp-session-id`) continue to work
+//! normally on the same transport alongside both stateless paths.
+//!
+//! ## `messages/listen` SSE stream
+//!
+//! Clients using the 2026-07-28 protocol open a server-to-client notification
+//! stream by POSTing a `messages/listen` JSON-RPC request. The server responds
+//! with `Content-Type: text/event-stream` and streams zero or more
+//! `notifications/*` events until the client disconnects.
+//!
+//! This replaces the `GET /` SSE endpoint used by the 2025-11-25 protocol. The
+//! `GET /` endpoint is still supported for 2025-11-25 sessions; `messages/listen`
+//! is only available for 2026-07-28+ clients.
+//!
+//! ```text
+//! Client (2026-07-28)                          Server
+//!   |                                            |
+//!   |-- POST / {method: "messages/listen",       |
+//!   |           MCP-Protocol-Version: 2026-07-28} -->|
+//!   |<-- 200 Content-Type: text/event-stream ----|
+//!   |<-- event: message (notification) ----------|
+//!   |<-- event: message (notification) ----------|
+//!   |   (client disconnects)                     |
+//! ```
+//!
+//! ## SEP-2243 HTTP headers
+//!
+//! SEP-2243 defines HTTP headers that let load balancers, proxies, and
+//! observability tools inspect MCP traffic without parsing the JSON-RPC body:
+//!
+//! | Header | Required when | Description |
+//! |--------|---------------|-------------|
+//! | `Mcp-Method` | All POST requests (strict mode) | Mirrors the JSON-RPC `method` field |
+//! | `Mcp-Name` | `tools/call`, `prompts/get`, `resources/read` (strict mode) | Mirrors `params.name` or `params.uri` |
+//! | `MCP-Protocol-Version` | All requests (strict mode) | The protocol version in use |
+//!
+//! Validation is **lenient** for 2025-11-25 clients: headers present in the
+//! request are validated for consistency with the body, but missing headers are
+//! not an error. Validation is **strict** for 2026-07-28+ clients: `Mcp-Method`
+//! must be present on every POST and `Mcp-Name` must be present for the three
+//! named methods. Violations return `-32001` (HeaderMismatch).
+//!
+//! The public constants [`MCP_METHOD_HEADER`], [`MCP_NAME_HEADER`], and
+//! [`MCP_PARAM_HEADER_PREFIX`] hold the canonical lowercase header names.
 //!
 //! ## Sampling (Server-to-Client Requests)
 //!
@@ -73,10 +148,12 @@
 //!
 //! ## Error Codes
 //!
-//! | Code    | Name           | Description                              |
-//! |---------|----------------|------------------------------------------|
-//! | -32005  | SessionNotFound| Session expired or server restarted      |
-//! | -32006  | SessionRequired| MCP-Session-Id header missing            |
+//! | Code    | Name                      | Description                                        |
+//! |---------|---------------------------|----------------------------------------------------|
+//! | -32001  | HeaderMismatch            | Required HTTP header missing or inconsistent with body (SEP-2243, strict mode) |
+//! | -32004  | UnsupportedProtocolVersion| Server does not support the requested protocol version (SEP-2575) |
+//! | -32005  | SessionNotFound           | Session expired or server restarted                |
+//! | -32006  | SessionRequired           | MCP-Session-Id header missing                      |
 //!
 //! ## Session Handling
 //!
@@ -1417,18 +1494,29 @@ impl HttpTransport {
         self
     }
 
-    /// Enable SEP-1442 stateless mode (experimental).
+    /// Enable the legacy SEP-1442 stateless opt-in path.
     ///
-    /// When enabled, requests with an `MCP-Protocol-Version` header (or
-    /// `_meta.protocolVersion` in the body) are processed without requiring a
-    /// session. Each stateless request gets an ephemeral, pre-initialized
-    /// router that is discarded after the response is sent.
+    /// This activates the SEP-1442-style stateless behavior for clients that
+    /// do NOT send `MCP-Protocol-Version: 2026-07-28`. Specifically, when a
+    /// [`crate::stateless::StatelessConfig`] is set:
     ///
-    /// This enables horizontal scaling and serverless deployments where
-    /// sessions cannot be maintained across instances.
+    /// - Requests without a session ID can be served without an initialize
+    ///   handshake (if [`crate::stateless::StatelessConfig::optional_sessions`]
+    ///   is `true`).
+    /// - The `server/discover` RPC is enabled (if
+    ///   [`crate::stateless::StatelessConfig::enable_discover`] is `true`).
+    /// - Protocol version may be required in every request body (if
+    ///   [`crate::stateless::StatelessConfig::require_protocol_version`] is `true`).
+    ///
+    /// **Note:** this method does NOT control the automatic version-gated
+    /// stateless path for 2026-07-28+ clients. When the `stateless` feature
+    /// is compiled in, any request with `MCP-Protocol-Version: 2026-07-28`
+    /// and no `mcp-session-id` is dispatched statelessly regardless of
+    /// whether this method is called. See the [`crate::stateless`] module
+    /// documentation for the full two-path explanation.
     ///
     /// Stateful clients (those that send `mcp-session-id`) continue to work
-    /// normally alongside stateless clients.
+    /// normally on the same transport.
     ///
     /// # Example
     ///
@@ -1440,6 +1528,8 @@ impl HttpTransport {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
+    ///     // Enables the SEP-1442 opt-in path. 2026-07-28 clients are
+    ///     // handled statelessly regardless of this call.
     ///     let transport = HttpTransport::new(router)
     ///         .stateless(StatelessConfig::new());
     ///     transport.serve("127.0.0.1:3000").await?;


### PR DESCRIPTION
## Summary

Four doc-gap issues resolved in one pass:

- **#860** -- `transport/http.rs` module doc: add stateless dispatch, `messages/listen`, and SEP-2243 header validation sections; extend error code table
- **#864** -- `StatelessConfig` and `HttpTransport::stateless()`: explain version-gated automatic path vs. legacy SEP-1442 opt-in
- **#867** -- `context.rs` module doc: add stateless per-request `_meta` section with flow explanation and example
- **#874** -- `tower-mcp-types` crate doc: mention `UPCOMING_PROTOCOL_VERSION`, `DiscoverResult`, `UnsupportedProtocolVersionData`, and new error codes

## Test plan

- [ ] `cargo doc --no-deps --all-features` produces no new warnings
- [ ] All doc examples compile (`cargo test --doc --all-features`)
- [ ] CI passes (fmt, clippy, test)

Closes #860, closes #864, closes #867, closes #874.