### PR TITLE
docs(examples): fix session ID casing, add stateless pointers, clarify protocol scope (#879, #880, #882, #883)

### DIFF
--- a/examples/axum_embedding.rs
+++ b/examples/axum_embedding.rs
@@ -28,6 +28,11 @@
 //!   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"curl","version":"1.0"}}}'
 //! ```
 //!
+//! The curl examples above use the 2025-11-25 session-based flow. The 2026-07-28
+//! stateless protocol is also supported when embedding -- `HttpTransport::into_router()`
+//! honours `MCP-Protocol-Version` on every request. See `http_server.rs` for the
+//! stateless curl walkthrough.
+//!
 //! # Why this example exists
 //!
 //! `HttpTransport::into_router()` returns a plain [`axum::Router`]. That means

--- a/examples/capability_filtering.rs
+++ b/examples/capability_filtering.rs
@@ -30,27 +30,31 @@
 //! # List tools (admin_ tools are hidden)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -H "Mcp-Session-Id: <session-id-from-init>" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
 //!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 //!
 //! # Try to call hidden admin tool (returns "method not found")
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -H "Mcp-Session-Id: <session-id-from-init>" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
 //!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"admin_delete_user","arguments":{"user_id":"123"}}}'
 //!
 //! # List resources (admin config is hidden)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -H "Mcp-Session-Id: <session-id-from-init>" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
 //!   -d '{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}'
 //!
 //! # List prompts (admin/internal prompts are hidden)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
-//!   -H "Mcp-Session-Id: <session-id-from-init>" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
 //!   -d '{"jsonrpc":"2.0","id":5,"method":"prompts/list","params":{}}'
 //! ```
+//!
+//! The curl examples above use the 2025-11-25 session-based flow. The 2026-07-28
+//! stateless protocol is also supported: `DenialBehavior` filtering applies equally
+//! to stateless requests. See `http_server.rs` for the stateless curl walkthrough.
 
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/examples/dynamic_capabilities.rs
+++ b/examples/dynamic_capabilities.rs
@@ -7,6 +7,15 @@
 //! - Meta-tools (`create_tool`, `remove_tool`) that manage other tools
 //! - List-changed notifications when capabilities change
 //!
+//! This example drives the service in-process via `JsonRpcService::call_single`
+//! rather than starting a real transport. `JsonRpcService` is the JSON-RPC 2.0
+//! framing layer that sits directly below all transports (HTTP, stdio, WebSocket),
+//! making it useful for in-process testing, scripting, and protocol-level
+//! inspection without a network round-trip. In a production server you would
+//! attach the same `DynamicToolRegistry` to an `HttpTransport` or
+//! `StdioTransport` and external clients would connect normally -- see
+//! `http_server.rs` or `getting_started.rs` for that pattern.
+//!
 //! Run with: `cargo run --example dynamic_capabilities --features dynamic-tools`
 
 use schemars::JsonSchema;

--- a/examples/http_auth.rs
+++ b/examples/http_auth.rs
@@ -40,6 +40,23 @@
 //! #   Payload: {"sub":"demo-user","scope":"mcp:read mcp:write"}
 //! #   Secret:  demo-secret-do-not-use-in-production
 //! ```
+//!
+//! The examples above use the 2025-11-25 session-based flow. Both auth strategies
+//! also work with the 2026-07-28 stateless protocol -- the `Authorization` header
+//! is validated on every request regardless of protocol version. No `initialize`
+//! call or `MCP-Session-Id` is required in stateless mode:
+//!
+//! ```bash
+//! # Stateless request with API key auth (2026-07-28)
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "Authorization: Bearer sk-test-key-123" \
+//!   -H "MCP-Protocol-Version: 2026-07-28" \
+//!   -H "Mcp-Method: tools/list" \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+//! ```
+//!
+//! See `http_server.rs` for the full 2026-07-28 stateless walkthrough.
 
 use axum::Router;
 use schemars::JsonSchema;

--- a/examples/http_sse_client.rs
+++ b/examples/http_sse_client.rs
@@ -1,5 +1,14 @@
 //! HTTP SSE client example demonstrating stream resumption
 //!
+//! This example targets the **2025-11-25 session-based protocol** only. It
+//! initializes a session, receives an `MCP-Session-Id`, and opens a
+//! per-session SSE stream via `GET`. Under the 2026-07-28 stateless protocol
+//! there is no session ID; SSE notifications are instead delivered via
+//! `messages/listen` (a `POST` with `Accept: text/event-stream`,
+//! `MCP-Protocol-Version: 2026-07-28`, and `Mcp-Method: messages/listen`).
+//! If you are running a 2026-07-28 server, the `GET` stream used here will
+//! not work as expected.
+//!
 //! This example shows how to connect to an MCP server's SSE stream and use
 //! the Last-Event-ID header for stream resumption (SEP-1699).
 //!

--- a/examples/unix_socket_server.rs
+++ b/examples/unix_socket_server.rs
@@ -27,6 +27,10 @@
 //!   -H "MCP-Session-Id: <session-id>" \
 //!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"add","arguments":{"a":10,"b":32}}}'
 //! ```
+//!
+//! The curl examples above use the 2025-11-25 session-based flow. The Unix socket
+//! transport also supports the 2026-07-28 stateless protocol when the server is
+//! configured for it. See `http_server.rs` for the stateless curl walkthrough.
 
 #[cfg(unix)]
 mod app {


### PR DESCRIPTION
## Summary

Doc-comment-only fixes across four example files:

- **#879**: Fix `Mcp-Session-Id` -> `MCP-Session-Id` header casing in `capability_filtering.rs` curl snippets (matches all other HTTP examples)
- **#880**: Add a brief stateless pointer note to `http_auth.rs`, `axum_embedding.rs`, `capability_filtering.rs`, and `unix_socket_server.rs`; add a stateless + auth curl snippet to `http_auth.rs`
- **#882**: Add a note to `http_sse_client.rs` doc comment stating this targets 2025-11-25 only and directing 2026-07-28 users to `messages/listen`
- **#883**: Add a sentence to `dynamic_capabilities.rs` doc comment explaining why `JsonRpcService` is used directly (in-process/testing) vs a transport

## Changes

- `examples/capability_filtering.rs` -- header casing fix + stateless note
- `examples/http_auth.rs` -- stateless note + stateless+auth curl snippet
- `examples/axum_embedding.rs` -- stateless note
- `examples/unix_socket_server.rs` -- stateless note
- `examples/http_sse_client.rs` -- protocol version scope note
- `examples/dynamic_capabilities.rs` -- JsonRpcService direct-use explanation

No runtime behavior changes. Doc comments only.

Closes #879, closes #880, closes #882, closes #883.