### PR TITLE
test: add server/discover versions, per-request meta, router dispatch, and UnsupportedProtocolVersion tests

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -6659,4 +6659,71 @@ mod tests {
         assert_eq!(deserialized.id, RequestId::String("req-2".into()));
         assert!(deserialized.is_error());
     }
+
+    // =========================================================================
+    // Issue #872: McpRequest::Discover unit tests
+    // Unit tests that exercise the router dispatch directly via JsonRpcService,
+    // without going through the HTTP transport layer.
+    // =========================================================================
+
+    #[tokio::test]
+    async fn test_discover_dispatch_via_jsonrpc_service() {
+        // server/discover must work without any prior initialize call.
+        // The router does NOT require session initialization for this RPC.
+        let router = McpRouter::new().server_info("unit-test-server", "4.2.0");
+        let mut service = JsonRpcService::new(router);
+
+        let req = JsonRpcRequest::new(1, "server/discover");
+        let resp = service.call_single(req).await.unwrap();
+
+        match resp {
+            JsonRpcResponse::Result(r) => {
+                // supportedVersions must be a non-empty array.
+                let versions = r
+                    .result
+                    .get("supportedVersions")
+                    .and_then(|v| v.as_array())
+                    .expect("result.supportedVersions must be an array");
+                assert!(!versions.is_empty(), "supportedVersions must not be empty");
+
+                // serverInfo.name must match what we configured.
+                assert_eq!(
+                    r.result["serverInfo"]["name"], "unit-test-server",
+                    "serverInfo.name must match configured value"
+                );
+                assert_eq!(
+                    r.result["serverInfo"]["version"], "4.2.0",
+                    "serverInfo.version must match configured value"
+                );
+
+                // server/discover must NOT include singular protocolVersion
+                // (that field belongs to the initialize response shape).
+                assert!(
+                    r.result.get("protocolVersion").is_none(),
+                    "server/discover must NOT include protocolVersion: {:?}",
+                    r.result
+                );
+            }
+            JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+            _ => panic!("unexpected response variant"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_discover_does_not_require_initialization() {
+        // server/discover works on a freshly created, un-initialized router.
+        // No prior initialize call is made -- the session state is empty.
+        let router = McpRouter::new().server_info("fresh-router", "1.0.0");
+        let mut service = JsonRpcService::new(router);
+
+        let req = JsonRpcRequest::new(2, "server/discover");
+        let resp = service.call_single(req).await.unwrap();
+
+        // Must succeed -- not return an error about missing session/initialization.
+        assert!(
+            !matches!(resp, JsonRpcResponse::Error(_)),
+            "server/discover must not require initialization: {:?}",
+            resp
+        );
+    }
 }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -3155,6 +3155,84 @@ mod tests {
         assert!(supported.contains(&serde_json::json!("2025-11-25")));
         // The request id must be echoed (we have one in the body).
         assert_eq!(json["id"], 99);
+        // Field name must be `supported`, NOT `supportedVersions` (SEP-2575 shape).
+        assert!(
+            json["error"]["data"].get("supportedVersions").is_none(),
+            "error data must use 'supported', not 'supportedVersions': {:?}",
+            json["error"]["data"]
+        );
+        // The supported set must exactly match SUPPORTED_PROTOCOL_VERSIONS --
+        // no extras, none missing.
+        let expected: Vec<serde_json::Value> = SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .map(|v| serde_json::json!(v))
+            .collect();
+        assert_eq!(
+            supported, &expected,
+            "data.supported must exactly match SUPPORTED_PROTOCOL_VERSIONS"
+        );
+    }
+
+    /// When a request (no session) arrives with an invalid `Mcp-Protocol-Version`
+    /// header, the transport must return -32004 with the correct SEP-2575 wire
+    /// shape: `{ supported: [...], requested: "..." }`. This verifies the
+    /// version-validation path fires without requiring a session.
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn stateless_unsupported_protocol_version_returns_spec_shape_error() {
+        let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
+        let app = transport.into_router();
+
+        // "1999-01-01" is below UPCOMING_PROTOCOL_VERSION ("2026-07-28"), so it
+        // does not enter the version-gated stateless block. It is also not in
+        // SUPPORTED_PROTOCOL_VERSIONS, so it triggers the -32004 version check
+        // at lines ~2370-2382. No session header is sent, exercising the
+        // sessionless request path through version validation.
+        let req = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_PROTOCOL_VERSION_HEADER, "1999-01-01")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 42,
+                    "method": "tools/list"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["error"]["code"].as_i64().unwrap(),
+            -32004,
+            "must return UnsupportedProtocolVersion (-32004): {json}"
+        );
+        assert_eq!(
+            json["error"]["data"]["requested"], "1999-01-01",
+            "data.requested must echo the version: {json}"
+        );
+        // Field name must be `supported`, not `supportedVersions`.
+        assert!(
+            json["error"]["data"].get("supportedVersions").is_none(),
+            "error data must use 'supported', not 'supportedVersions': {json}"
+        );
+        let supported = json["error"]["data"]["supported"]
+            .as_array()
+            .expect("data.supported must be an array");
+        let expected: Vec<serde_json::Value> = SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .map(|v| serde_json::json!(v))
+            .collect();
+        assert_eq!(
+            supported, &expected,
+            "data.supported must exactly match SUPPORTED_PROTOCOL_VERSIONS"
+        );
     }
 
     // =========================================================================

--- a/crates/tower-mcp/tests/per_request_meta.rs
+++ b/crates/tower-mcp/tests/per_request_meta.rs
@@ -147,3 +147,139 @@ async fn legacy_namespace_keys_are_silently_dropped() {
     assert!(meta.protocol_version.is_none(), "legacy key must not match");
     assert!(meta.client_info.is_none());
 }
+
+/// Verify that `stash_per_request_meta` fires in the session-based (2025-11-25)
+/// path. Initialize to get a session id, then POST tools/call with a session
+/// header AND `_meta` in the body -- assert the handler sees the meta.
+/// This guards against accidental removal of the `stash_per_request_meta` call
+/// at line ~2506 of http.rs.
+#[tokio::test]
+async fn session_path_stashes_per_request_meta() {
+    let captured = Captured::default();
+    let app = HttpTransport::new(router(captured.clone()))
+        .disable_origin_validation()
+        .into_router();
+
+    // Initialize to create a session.
+    let init_req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(Body::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": {},
+                    "clientInfo": { "name": "session-test", "version": "1.0" }
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let init_resp = app.clone().oneshot(init_req).await.unwrap();
+    let session_id = init_resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+        .expect("initialize must return session id");
+
+    // tools/call with session header AND _meta in the body.
+    let tool_req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("Mcp-Session-Id", &session_id)
+        .body(Body::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "inspect_meta",
+                    "arguments": {},
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "session-client",
+                            "version": "0.1"
+                        },
+                        "io.modelcontextprotocol/clientCapabilities": {}
+                    }
+                }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let tool_resp = app.oneshot(tool_req).await.unwrap();
+    assert!(
+        tool_resp.status().is_success(),
+        "expected 2xx, got {}",
+        tool_resp.status()
+    );
+    let bytes = axum::body::to_bytes(tool_resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json.get("error").is_none(), "unexpected error: {json}");
+
+    // The handler must have seen the meta via the session-based path.
+    let meta = captured
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("session-based path must stash per-request meta on the handler context");
+    assert_eq!(
+        meta.protocol_version.as_deref(),
+        Some("2025-11-25"),
+        "handler must see protocol_version from session-based _meta"
+    );
+    let info = meta
+        .client_info
+        .expect("clientInfo must be threaded through");
+    assert_eq!(info.name, "session-client");
+}
+
+/// Verify that the `log_level` field in `_meta` (`io.modelcontextprotocol/logLevel`)
+/// is deserialized and available on the `StatelessRequestMeta` seen by the handler.
+#[tokio::test]
+async fn handler_sees_log_level_from_meta() {
+    let (_, captured) = call_tool(serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "inspect_meta",
+            "arguments": {},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "log-test",
+                    "version": "1.0"
+                },
+                "io.modelcontextprotocol/clientCapabilities": {},
+                "io.modelcontextprotocol/logLevel": "warning"
+            }
+        }
+    }))
+    .await;
+
+    let meta = captured
+        .0
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("meta must be present");
+    use tower_mcp::stateless::LogLevel;
+    assert_eq!(
+        meta.log_level,
+        Some(LogLevel::Warning),
+        "log_level must be threaded through to the handler context"
+    );
+}

--- a/crates/tower-mcp/tests/server_discover.rs
+++ b/crates/tower-mcp/tests/server_discover.rs
@@ -77,6 +77,17 @@ async fn discover_returns_supported_versions_and_server_info() {
         result.get("protocolVersion").is_none(),
         "server/discover must NOT include singular protocolVersion -- that's the initialize shape: {result}"
     );
+    // LATEST_PROTOCOL_VERSION must be present in the advertised list so clients
+    // can always negotiate the current stable version. This assertion catches
+    // regressions where a version is accidentally removed from SUPPORTED_PROTOCOL_VERSIONS.
+    assert!(
+        versions
+            .iter()
+            .any(|v| v.as_str() == Some(tower_mcp::protocol::LATEST_PROTOCOL_VERSION)),
+        "supportedVersions must include LATEST_PROTOCOL_VERSION ({}) but got: {:?}",
+        tower_mcp::protocol::LATEST_PROTOCOL_VERSION,
+        versions
+    );
 }
 
 #[tokio::test]
@@ -97,4 +108,48 @@ async fn discover_is_idempotent() {
     let a = post_discover().await;
     let b = post_discover().await;
     assert_eq!(a["result"], b["result"]);
+}
+
+/// server/discover via the 2026-07-28 stateless dispatch path succeeds without
+/// a session and does not create one. The request carries `Mcp-Protocol-Version:
+/// 2026-07-28` and `Mcp-Method: server/discover` (required by strict SEP-2243 mode).
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stateless_v2026_discover_returns_supported_versions_no_session() {
+    let (app, handle) = HttpTransport::new(router())
+        .disable_origin_validation()
+        .into_router_with_handle();
+
+    let req = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("Mcp-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "server/discover")
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":1,"method":"server/discover"}"#,
+        ))
+        .unwrap();
+    let response = app.oneshot(req).await.unwrap();
+    assert!(
+        response.status().is_success(),
+        "expected 2xx, got {}",
+        response.status()
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let resp: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(resp.get("error").is_none(), "expected no error: {resp}");
+    assert!(
+        resp["result"]["supportedVersions"].is_array(),
+        "supportedVersions must be an array: {resp}"
+    );
+    // No session must be created for a stateless discover call.
+    assert_eq!(
+        handle.session_count().await,
+        0,
+        "stateless discover must not create a session"
+    );
 }


### PR DESCRIPTION
## Summary

- #866: extend `discover_returns_supported_versions_and_server_info` to assert `LATEST_PROTOCOL_VERSION` is present; add stateless `server/discover` test with `Mcp-Protocol-Version: 2026-07-28`
- #869: add session-path `stash_per_request_meta` coverage (initialize then tools/call with `_meta`); add `log_level` field threading test
- #872: add router unit tests for `McpRequest::Discover` dispatch via `JsonRpcService` directly (no HTTP/transport layer)
- #875: extend `unsupported_protocol_version_returns_spec_shape_error` to assert exact `data.supported` set and `supported` field name; add stateless-path `-32004` test

Closes #866, closes #869, closes #872, closes #875.