### PR TITLE
feat(examples): add stateless HTTP client example for 2026-07-28 protocol (#881)

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -214,6 +214,11 @@ name = "server_discover"
 path = "../../examples/server_discover.rs"
 required-features = ["http", "stateless"]
 
+[[example]]
+name = "stateless_http_client"
+path = "../../examples/stateless_http_client.rs"
+required-features = ["http", "stateless"]
+
 # --- Sampling and bidirectional ---
 [[example]]
 name = "sampling_server"

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -2587,6 +2587,7 @@ async fn handle_post(
     // Bridge per-request data from HTTP into MCP Extensions: OAuth claims,
     // SEP-2575 `_meta` (clientInfo, clientCapabilities, etc.). Empty ext is
     // skipped to avoid pointless allocation.
+    #[allow(unused_mut)]
     let mut ext = crate::router::Extensions::new();
     #[cfg(feature = "oauth")]
     if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,9 +25,10 @@ cargo run --example axum_embedding --features http
 # WebSocket transport
 cargo run --example websocket_server --features websocket
 
-# Clients (start http_server first)
+# Clients (start http_server first, or run stateless_http_client standalone)
 cargo run --example http_client --features http-client
 cargo run --example http_sse_client --features http
+cargo run --example stateless_http_client --features "http,stateless"
 
 # Dynamic capabilities
 cargo run --example dynamic_capabilities --features dynamic-tools
@@ -81,6 +82,7 @@ cargo run --example tool_macro --features macros
 | [client_cli](client_cli.rs) | Stdio client connecting to subprocess servers |
 | [http_client](http_client.rs) | HTTP client with McpClient API |
 | [http_sse_client](http_sse_client.rs) | SSE stream resumption (Last-Event-ID) |
+| [stateless_http_client](stateless_http_client.rs) | 2026-07-28 stateless protocol: server/discover, tools/list, tools/call, messages/listen -- no session ID |
 
 ### Bidirectional Communication
 

--- a/examples/stateless_http_client.rs
+++ b/examples/stateless_http_client.rs
@@ -1,0 +1,280 @@
+//! Stateless HTTP client example for the 2026-07-28 MCP protocol.
+//!
+//! # What this example demonstrates
+//!
+//! The 2026-07-28 protocol removes the session-based handshake of the 2025-11-25
+//! protocol. There is no `initialize` RPC, no `MCP-Session-Id`, and no per-session
+//! state on the server. Instead:
+//!
+//! - Every request includes `MCP-Protocol-Version: 2026-07-28`.
+//! - Every request includes `Mcp-Method: <method>` (SEP-2243).
+//! - `tools/call` requests include `Mcp-Name: <tool-name>` (SEP-2243).
+//! - `server/discover` replaces `initialize` for capability discovery.
+//! - `messages/listen` replaces per-session SSE for server-push notifications.
+//!
+//! This example spins up an in-process HTTP server on a random port, then makes
+//! the four stateless requests in sequence and prints the results.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo run --example stateless_http_client --features "http,stateless"
+//! ```
+//!
+//! No separate server process is needed -- the server is started in-process.
+//! The `stateless` feature is required for the server to route 2026-07-28
+//! requests without a session.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use reqwest::Client;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+const PROTOCOL_VERSION: &str = "2026-07-28";
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EchoInput {
+    message: String,
+}
+
+fn build_router() -> McpRouter {
+    let add = ToolBuilder::new("add")
+        .description("Add two numbers together")
+        .handler(|input: AddInput| async move {
+            Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+        })
+        .build();
+
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build();
+
+    McpRouter::new()
+        .server_info("stateless-client-example", "1.0.0")
+        .tool(add)
+        .tool(echo)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter("stateless_http_client=debug")
+        .init();
+
+    // Start an in-process HTTP server on a random port.
+    let router = build_router();
+    let transport = HttpTransport::new(router).disable_origin_validation();
+    let app = transport.into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let addr = listener.local_addr()?;
+    let base_url = format!("http://127.0.0.1:{}", addr.port());
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Give the server a moment to start.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let client = Client::new();
+
+    // -----------------------------------------------------------------------
+    // Step 1: server/discover
+    //
+    // Replaces `initialize`. No session is created; no MCP-Session-Id is
+    // returned. The client learns what protocol versions and capabilities
+    // the server supports.
+    // -----------------------------------------------------------------------
+    println!("=== Step 1: server/discover ===");
+    println!("POST {} (no session, no initialize)", base_url);
+
+    let discover_response = client
+        .post(&base_url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        .header("Mcp-Method", "server/discover")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover"
+        }))
+        .send()
+        .await?;
+
+    // Stateless: no MCP-Session-Id must be present.
+    assert!(
+        discover_response.headers().get("mcp-session-id").is_none(),
+        "server returned an unexpected MCP-Session-Id in stateless mode"
+    );
+    println!("Confirmed: no session ID returned (stateless)");
+
+    let discover_body: serde_json::Value = discover_response.json().await?;
+    let result = &discover_body["result"];
+    println!(
+        "Server: {}",
+        result["serverInfo"]["name"].as_str().unwrap_or("(unknown)")
+    );
+    if let Some(versions) = result["supportedVersions"].as_array() {
+        let version_list: Vec<&str> = versions.iter().filter_map(|v| v.as_str()).collect();
+        println!("Supported protocol versions: {}", version_list.join(", "));
+    }
+    println!();
+
+    // -----------------------------------------------------------------------
+    // Step 2: tools/list
+    //
+    // No session ID. The Mcp-Method header is required by SEP-2243 when
+    // using the 2026-07-28 protocol version.
+    // -----------------------------------------------------------------------
+    println!("=== Step 2: tools/list ===");
+
+    let list_response = client
+        .post(&base_url)
+        .header("Content-Type", "application/json")
+        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        .header("Mcp-Method", "tools/list")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list"
+        }))
+        .send()
+        .await?;
+
+    let list_body: serde_json::Value = list_response.json().await?;
+    let tools = list_body["result"]["tools"]
+        .as_array()
+        .map(|a| a.as_slice())
+        .unwrap_or_default();
+
+    println!("Available tools ({}):", tools.len());
+    for tool in tools {
+        println!(
+            "  - {} : {}",
+            tool["name"].as_str().unwrap_or("(unnamed)"),
+            tool["description"].as_str().unwrap_or("(no description)")
+        );
+    }
+    println!();
+
+    // -----------------------------------------------------------------------
+    // Step 3: tools/call
+    //
+    // Calls the "add" tool. The Mcp-Name header is required by SEP-2243 for
+    // tools/call when using the 2026-07-28 protocol version. No session ID.
+    // -----------------------------------------------------------------------
+    println!("=== Step 3: tools/call (add, a=10, b=32) ===");
+
+    let call_response = client
+        .post(&base_url)
+        .header("Content-Type", "application/json")
+        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "add")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/call",
+            "params": {
+                "name": "add",
+                "arguments": { "a": 10, "b": 32 }
+            }
+        }))
+        .send()
+        .await?;
+
+    let call_body: serde_json::Value = call_response.json().await?;
+    if let Some(content) = call_body["result"]["content"].as_array() {
+        for item in content {
+            if item["type"] == "text" {
+                println!("Result: {}", item["text"].as_str().unwrap_or("(empty)"));
+            }
+        }
+    }
+    println!();
+
+    // -----------------------------------------------------------------------
+    // Step 4: messages/listen
+    //
+    // Opens a server-push SSE stream. In the 2026-07-28 protocol this is a
+    // POST (not a GET) with Accept: text/event-stream. The server delivers
+    // notifications for any in-flight requests that carry a progressToken.
+    // We read for a short window and then disconnect.
+    // -----------------------------------------------------------------------
+    println!("=== Step 4: messages/listen (SSE stream, 1-second window) ===");
+
+    let listen_response = client
+        .post(&base_url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "text/event-stream")
+        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+        .header("Mcp-Method", "messages/listen")
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "messages/listen",
+            "params": {}
+        }))
+        .send()
+        .await?;
+
+    let content_type = listen_response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    println!("Response Content-Type: {}", content_type);
+
+    let mut stream = listen_response.bytes_stream();
+    let deadline = tokio::time::sleep(Duration::from_secs(1));
+    tokio::pin!(deadline);
+
+    let mut event_count = 0usize;
+    loop {
+        tokio::select! {
+            chunk = stream.next() => {
+                match chunk {
+                    Some(Ok(bytes)) => {
+                        let text = String::from_utf8_lossy(&bytes);
+                        // Print non-empty, non-comment SSE lines for visibility.
+                        for line in text.lines() {
+                            if !line.is_empty() && !line.starts_with(':') {
+                                println!("  SSE: {}", line);
+                            }
+                        }
+                        event_count += 1;
+                    }
+                    Some(Err(e)) => {
+                        println!("  Stream error: {}", e);
+                        break;
+                    }
+                    None => {
+                        println!("  Stream closed by server");
+                        break;
+                    }
+                }
+            }
+            _ = &mut deadline => {
+                println!("  Disconnecting after 1-second window ({} chunk(s) received)", event_count);
+                break;
+            }
+        }
+    }
+
+    println!();
+    println!("Done. All four stateless 2026-07-28 requests completed.");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Adds `examples/stateless_http_client.rs` demonstrating the 2026-07-28 stateless MCP protocol flow using raw `reqwest` HTTP calls, paired with an in-process server.

The example covers all four stateless protocol operations:
- `server/discover` -- replaces `initialize`, no session created
- `tools/list` with `MCP-Protocol-Version: 2026-07-28` + `Mcp-Method` header
- `tools/call` with `Mcp-Name` header (SEP-2243), no session ID
- `messages/listen` -- POST that returns an SSE stream for server-push notifications

Matches the style of `examples/http_sse_client.rs` (raw reqwest against a live server). Server spins up in-process on a random port.

Also updates `crates/tower-mcp/Cargo.toml` with the `[[example]]` entry and `examples/README.md` with the Clients table row.

Closes #881.

## Test plan

- [ ] `cargo build -p tower-mcp --example stateless_http_client --features http` passes
- [ ] `cargo clippy -p tower-mcp --example stateless_http_client --features http -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo run -p tower-mcp --example stateless_http_client --features http` runs and exits cleanly, printing four sections of output
- [ ] CI passes