### PR TITLE
test(conformance): add TTL, deprecation metadata, and tasks extension coverage (closes #873)

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -183,6 +183,13 @@ struct McpRouterInner {
     min_log_level: Arc<RwLock<LogLevel>>,
     /// Page size for list method pagination (None = return all results)
     page_size: Option<usize>,
+    /// TTL hint for list responses in milliseconds (SEP-2549).
+    /// When set, the value is returned as `ttlMs` in tools/list, resources/list,
+    /// and prompts/list responses so clients can cache the list.
+    list_ttl_ms: Option<u64>,
+    /// Deprecation info for the logging capability (SEP-2577).
+    /// When set, included in the `logging` capability in the initialize result.
+    logging_deprecated: Option<tower_mcp_types::protocol::DeprecationInfo>,
     /// Names of tools that are currently disabled (hidden from list/call).
     disabled_tools: Arc<RwLock<HashSet<String>>>,
     /// URIs of resources that are currently disabled (hidden from list/read).
@@ -315,6 +322,8 @@ impl McpRouter {
                 prompt_filter: None,
                 min_log_level: Arc::new(RwLock::new(LogLevel::Debug)),
                 page_size: None,
+                list_ttl_ms: None,
+                logging_deprecated: None,
                 disabled_tools: Arc::new(RwLock::new(HashSet::new())),
                 disabled_resources: Arc::new(RwLock::new(HashSet::new())),
                 disabled_prompts: Arc::new(RwLock::new(HashSet::new())),
@@ -715,6 +724,26 @@ impl McpRouter {
     /// single response.
     pub fn page_size(mut self, size: usize) -> Self {
         Arc::make_mut(&mut self.inner).page_size = Some(size);
+        self
+    }
+
+    /// Set a TTL hint on list responses (tools/list, resources/list, prompts/list).
+    ///
+    /// When set, the `ttlMs` field is included in list responses so clients can
+    /// cache the list for up to this many milliseconds before re-fetching.
+    /// Implements SEP-2549.
+    pub fn list_ttl(mut self, ms: u64) -> Self {
+        Arc::make_mut(&mut self.inner).list_ttl_ms = Some(ms);
+        self
+    }
+
+    /// Mark the logging capability as deprecated in the server's initialize result.
+    ///
+    /// When set, the `deprecated` object is included in the `logging` capability
+    /// in the `initialize` response, signalling to clients that logging notifications
+    /// are being phased out. Implements SEP-2577.
+    pub fn logging_deprecated(mut self, info: tower_mcp_types::protocol::DeprecationInfo) -> Self {
+        Arc::make_mut(&mut self.inner).logging_deprecated = Some(info);
         self
     }
 
@@ -1614,7 +1643,9 @@ impl McpRouter {
             },
             // Always advertise logging capability when notification channel is configured
             logging: if self.inner.notification_tx.is_some() {
-                Some(LoggingCapability::default())
+                Some(LoggingCapability {
+                    deprecated: self.inner.logging_deprecated.clone(),
+                })
             } else {
                 None
             },
@@ -1804,7 +1835,7 @@ impl McpRouter {
                 Ok(McpResponse::ListTools(ListToolsResult {
                     tools,
                     next_cursor,
-                    ttl_ms: None,
+                    ttl_ms: self.inner.list_ttl_ms,
                     cache_scope: None,
                     meta: None,
                 }))
@@ -2027,7 +2058,7 @@ impl McpRouter {
                 Ok(McpResponse::ListResources(ListResourcesResult {
                     resources,
                     next_cursor,
-                    ttl_ms: None,
+                    ttl_ms: self.inner.list_ttl_ms,
                     cache_scope: None,
                     meta: None,
                 }))
@@ -2067,7 +2098,7 @@ impl McpRouter {
                     ListResourceTemplatesResult {
                         resource_templates,
                         next_cursor,
-                        ttl_ms: None,
+                        ttl_ms: self.inner.list_ttl_ms,
                         cache_scope: None,
                         meta: None,
                     },
@@ -2223,7 +2254,7 @@ impl McpRouter {
                 Ok(McpResponse::ListPrompts(ListPromptsResult {
                     prompts,
                     next_cursor,
-                    ttl_ms: None,
+                    ttl_ms: self.inner.list_ttl_ms,
                     cache_scope: None,
                     meta: None,
                 }))

--- a/examples/conformance-client/src/core_scenarios.rs
+++ b/examples/conformance-client/src/core_scenarios.rs
@@ -107,6 +107,95 @@ pub async fn elicitation_defaults(server_url: &str) -> Result<()> {
     Ok(())
 }
 
+/// `ttl-list` -- Connect and verify tools/list returns a ttlMs hint.
+///
+/// Asserts that the server includes `ttlMs: 60000` in the `tools/list`
+/// response, exercising the SEP-2549 list TTL field end-to-end.
+pub async fn ttl_list(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = McpClient::builder()
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+
+    client.initialize("conformance-client", "0.1.0").await?;
+    let tools = client.list_tools().await?;
+
+    anyhow::ensure!(
+        tools.ttl_ms == Some(60_000),
+        "expected ttlMs=60000 in tools/list response, got {:?}",
+        tools.ttl_ms
+    );
+    tracing::info!("tools/list ttlMs verified: {:?}", tools.ttl_ms);
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// `deprecated-capability` -- Connect and verify the logging capability carries
+/// SEP-2577 deprecation metadata in the initialize result.
+pub async fn deprecated_capability(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = McpClient::builder()
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+
+    let result = client.initialize("conformance-client", "0.1.0").await?;
+
+    let logging = result
+        .capabilities
+        .logging
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("server must advertise logging capability"))?;
+
+    let dep = logging
+        .deprecated
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("logging capability must carry deprecation info"))?;
+
+    anyhow::ensure!(
+        dep.since.as_deref() == Some("2026-07-28"),
+        "expected since=2026-07-28, got {:?}",
+        dep.since
+    );
+    tracing::info!("logging.deprecated.since verified: {:?}", dep.since);
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// `tasks-extension` -- Connect and verify the server advertises the
+/// `io.modelcontextprotocol/tasks` extension (SEP-2663).
+pub async fn tasks_extension(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = McpClient::builder()
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+
+    let result = client.initialize("conformance-client", "0.1.0").await?;
+
+    let extensions = result
+        .capabilities
+        .extensions
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("server must advertise extensions in capabilities"))?;
+
+    anyhow::ensure!(
+        extensions.contains_key(tower_mcp::protocol::TASKS_EXTENSION_ID),
+        "expected io.modelcontextprotocol/tasks in capabilities.extensions, got keys: {:?}",
+        extensions.keys().collect::<Vec<_>>()
+    );
+    tracing::info!("tasks extension advertised in capabilities.extensions");
+
+    // Also verify the task-capable tool is callable
+    let _ = client
+        .call_tool("test_create_task", serde_json::json!({}))
+        .await?;
+    tracing::info!("test_create_task tool called successfully");
+
+    client.shutdown().await?;
+    Ok(())
+}
+
 /// Generate dummy arguments from a tool's input schema.
 pub fn build_tool_arguments(schema: &serde_json::Value) -> serde_json::Value {
     let mut args = serde_json::Map::new();

--- a/examples/conformance-client/src/main.rs
+++ b/examples/conformance-client/src/main.rs
@@ -45,6 +45,15 @@ async fn main() {
             core_scenarios::elicitation_defaults(&server_url).await
         }
 
+        // SEP-2549: TTL on list results
+        "ttl-list" => core_scenarios::ttl_list(&server_url).await,
+
+        // SEP-2577/2596: Deprecation metadata on capabilities
+        "deprecated-capability" => core_scenarios::deprecated_capability(&server_url).await,
+
+        // SEP-2663: Tasks extension advertisement
+        "tasks-extension" => core_scenarios::tasks_extension(&server_url).await,
+
         // Auth scenarios - metadata discovery
         "auth/metadata-default"
         | "auth/metadata-var1"

--- a/examples/conformance-server/src/main.rs
+++ b/examples/conformance-server/src/main.rs
@@ -31,6 +31,7 @@ mod tools;
 
 use clap::Parser;
 use tower_mcp::context::notification_channel;
+use tower_mcp::protocol::DeprecationInfo;
 use tower_mcp::{HttpTransport, McpRouter, StdioTransport};
 
 #[derive(Parser)]
@@ -67,6 +68,18 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
              demonstrates tools, resources, prompts, progress notifications, \
              logging, sampling, and elicitation.",
         )
+        // SEP-2549: advertise a 60-second TTL hint on all list responses
+        .list_ttl(60_000)
+        // SEP-2577: mark the logging capability as deprecated since the 2026-07-28 protocol
+        .logging_deprecated(DeprecationInfo {
+            since: Some("2026-07-28".to_string()),
+            message: Some(
+                "Logging notifications are deprecated; use structured tool output instead."
+                    .to_string(),
+            ),
+            remove_in: None,
+            replacement: None,
+        })
         .with_notification_sender(tx);
 
     for tool in tools::build_tools() {

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -3,7 +3,8 @@ use tower_mcp::protocol::{
     Content, CreateMessageParams, LogLevel, LoggingMessageParams, ResourceContent, SamplingMessage,
 };
 use tower_mcp::{
-    CallToolResult, ElicitFormParams, ElicitFormSchema, ElicitMode, Tool, ToolBuilder,
+    CallToolResult, ElicitFormParams, ElicitFormSchema, ElicitMode, TaskSupportMode, Tool,
+    ToolBuilder,
     extract::{Context, RawArgs},
 };
 
@@ -58,6 +59,8 @@ pub fn build_tools() -> Vec<Tool> {
         build_elicitation_sep1034_defaults(),
         build_elicitation_sep1330_enums(),
         build_per_request_meta(),
+        // SEP-2663: task-capable tool so the server advertises the tasks extension
+        build_create_task(),
     ]
 }
 
@@ -404,6 +407,26 @@ fn build_elicitation_sep1330_enums() -> Tool {
                 ))),
                 Err(e) => Ok(CallToolResult::error(format!("Elicitation failed: {}", e))),
             }
+        })
+        .build()
+}
+
+/// SEP-2663: A tool that opts in to async task support.
+///
+/// Registering at least one tool with `TaskSupportMode::Optional` (or `Required`)
+/// causes the router to advertise `io.modelcontextprotocol/tasks` in the server's
+/// `capabilities.extensions`, giving the conformance client a way to verify the
+/// tasks extension advertisement end-to-end.
+fn build_create_task() -> Tool {
+    ToolBuilder::new("test_create_task")
+        .description(
+            "A tool that supports async task execution (SEP-2663 tasks extension). \
+             Its presence in the tool list causes the server to advertise \
+             io.modelcontextprotocol/tasks in capabilities.extensions.",
+        )
+        .task_support(TaskSupportMode::Optional)
+        .extractor_handler((), |RawArgs(_args): RawArgs| async move {
+            Ok(CallToolResult::text("task support available"))
         })
         .build()
 }


### PR DESCRIPTION
## Summary

Three spec features have type-level and unit-test coverage in `tower-mcp-types` and `tower-mcp` but are completely absent from the conformance server, giving zero end-to-end CI coverage:

- **SEP-2549 TTL on list results**: `ListToolsResult.ttl_ms` / `ListResourcesResult.ttl_ms` / `ListPromptsResult.ttl_ms` are hardcoded to `None` in the router. Added `McpRouter::list_ttl(ms: u64)` builder method and `list_ttl_ms` inner field. The conformance server sets `.list_ttl(60_000)`. A new `ttl-list` scenario asserts `tools.ttl_ms == Some(60_000)`.
- **SEP-2577/2596 deprecation metadata**: `LoggingCapability.deprecated` is always `None`. Added `McpRouter::logging_deprecated(DeprecationInfo)` builder method. The conformance server marks logging as deprecated since `2026-07-28`. A new `deprecated-capability` scenario asserts the field is present.
- **SEP-2663 tasks extension**: No tool in the conformance server has `task_support != Forbidden`, so `capabilities.extensions` never contains `io.modelcontextprotocol/tasks`. Added `test_create_task` tool with `.task_support(TaskSupportMode::Optional)`. A new `tasks-extension` scenario asserts the extension key is advertised and the tool is callable.

## Changes

- `crates/tower-mcp/src/router.rs`: Add `list_ttl_ms` and `logging_deprecated` fields to `McpRouterInner`; add `list_ttl()` and `logging_deprecated()` builder methods; wire `ttl_ms` from inner field in list handlers; use `logging_deprecated` in `capabilities()`
- `examples/conformance-server/src/main.rs`: Call `.list_ttl(60_000)` and `.logging_deprecated(...)`
- `examples/conformance-server/src/tools.rs`: Add `test_create_task` tool with `TaskSupportMode::Optional`
- `examples/conformance-client/src/core_scenarios.rs`: Add `ttl_list`, `deprecated_capability`, `tasks_extension` scenarios
- `examples/conformance-client/src/main.rs`: Dispatch new scenarios

## Test plan

- [ ] `cargo build --manifest-path examples/conformance-server/Cargo.toml` passes
- [ ] `cargo build --manifest-path examples/conformance-client/Cargo.toml` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --lib --all-features` passes
- [ ] Conformance server runs and returns `ttlMs: 60000` in `tools/list` response

Closes #873.