### PR TITLE
chore(tools): rmcp wire-format compatibility harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,6 +303,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +413,7 @@ dependencies = [
  "async-trait",
  "base64",
  "p256",
- "reqwest",
+ "reqwest 0.13.4",
  "sec1",
  "serde",
  "serde_json",
@@ -419,6 +451,16 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -483,6 +525,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -604,6 +680,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +765,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -841,6 +941,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1010,6 +1111,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,9 +1144,35 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1119,6 +1262,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1263,7 +1412,7 @@ dependencies = [
  "referencing",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "serde",
  "serde_json",
@@ -1385,6 +1534,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,10 +1657,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "outref"
@@ -1538,6 +1741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1786,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1660,7 +1875,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1718,6 +1933,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1744,6 +1970,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1822,6 +2054,46 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -1885,6 +2157,66 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-compat"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "reqwest 0.12.28",
+ "rmcp",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tower-mcp",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -1957,7 +2289,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -2026,6 +2358,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
  "schemars_derive",
@@ -2073,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2311,6 +2644,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2703,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2486,6 +2853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2600,7 +2977,7 @@ dependencies = [
  "jsonwebtoken",
  "pin-project-lite",
  "regex",
- "reqwest",
+ "reqwest 0.13.4",
  "schemars",
  "serde",
  "serde_json",
@@ -2802,7 +3179,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror",
 ]
@@ -2899,6 +3276,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -3096,10 +3479,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "examples/conformance-server",
     "examples/conformance-client",
     "examples/codegen-mcp",
+    "tools/rmcp-compat",
 ]
 
 [workspace.package]

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -3,7 +3,7 @@ name = "rmcp-compat"
 version = "0.1.0"
 edition = "2024"
 publish = false
-description = "Spike: wire-format comparison between rmcp and tower-mcp HTTP servers"
+description = "rmcp wire-format compatibility harness for tower-mcp"
 
 [[bin]]
 name = "rmcp-compat"

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rmcp-compat"
+version = "0.1.0"
+edition = "2024"
+publish = false
+description = "Spike: wire-format comparison between rmcp and tower-mcp HTTP servers"
+
+[[bin]]
+name = "rmcp-compat"
+path = "src/main.rs"
+
+[dependencies]
+tower-mcp = { path = "../../crates/tower-mcp", features = ["http"] }
+rmcp = { version = "1.7.0", features = [
+    "server",
+    "macros",
+    "transport-streamable-http-server",
+    "transport-streamable-http-server-session",
+    "schemars",
+] }
+reqwest = { version = "0.12", features = ["json"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+schemars = "1.0"
+tokio = { version = "1", features = ["full"] }
+axum = { version = "0.8" }
+tokio-util = "0.7"
+anyhow = "1"

--- a/tools/rmcp-compat/README.md
+++ b/tools/rmcp-compat/README.md
@@ -1,0 +1,112 @@
+# rmcp-compat
+
+Wire-format compatibility harness for tower-mcp. Starts minimal rmcp and
+tower-mcp HTTP servers side by side, fires identical MCP JSON-RPC requests at
+each, and structurally compares the responses.
+
+## What it does
+
+The harness runs three in-process servers:
+
+- **rmcp** on port 4001 via `StreamableHttpService`
+- **tower-mcp** on port 4002 in default (bare JSON) mode
+- **tower-mcp SSE** on port 4003 with `.sse_responses(true)` to match rmcp's SSE wrapping
+
+It then runs a series of checks across all four operation groups:
+
+| Check | What is verified |
+|-------|-----------------|
+| `initialize` | `protocolVersion` present and equal; `capabilities` is object; `serverInfo.name/version` are strings |
+| `tools/list` | `result.tools` is array; first tool name matches; `inputSchema` field name and shape |
+| `tools/call` | `result.content` is array; `content[0].type` matches; echo returns correct value |
+| `method-not-found` | `error.code` is `-32601` on both; `error.message` is string on both |
+| `resources/list` | `result.resources` is array (may be empty) |
+| `prompts/list` | `result.prompts` is array (may be empty) |
+| `resources/read` | Not-found URI returns an error; code is `-32602` per SEP-2164 |
+| `invalid-params` | Missing required tool argument returns error code `-32602` |
+| `initialized-enforcement` | Both reject requests before `notifications/initialized` with `-32600` |
+| `sse-response-mode` | With `.sse_responses(true)`, both return `text/event-stream` with valid JSON-RPC |
+
+## How to run
+
+```
+cargo run -p rmcp-compat
+```
+
+The tool binds ports 4001, 4002, and 4003 on localhost. Make sure those ports
+are free before running.
+
+## Output format
+
+Each check prints one of three prefixes:
+
+- **`[PASS]`** -- behavior matches between rmcp and tower-mcp for this property
+- **`[FAIL]`** -- unexpected divergence; investigate before releasing
+- **`[KNOWN-DIFF]`** -- documented behavioral difference; not a bug (see below)
+
+A final summary line shows counts. The process exits with code 0 if there are
+no FAIL or ERROR results; known diffs and passes do not count against the exit
+code.
+
+Example output:
+
+```
+=== initialize ===
+[PASS] initialize: protocolVersion present and equal (2025-11-25)
+[PASS] initialize: capabilities is object on both
+...
+
+=== method-not-found ===
+[PASS] method-not-found: error.code == -32601 on both
+[PASS] method-not-found: error.message is string on both
+[KNOWN-DIFF] method-not-found: error.message phrasing differs (both use -32601): ...
+
+Results: 18/20 checks passed (0 failed, 2 known-diffs, 0 errors)
+```
+
+## Known diffs
+
+Known diffs are documented divergences that are intentional or explained. They
+appear as `[KNOWN-DIFF]` and do not cause a non-zero exit code.
+
+Current known diffs:
+
+**`error.message` phrasing for method-not-found:**
+rmcp returns just the method name (e.g. `"nonexistent/method"`); tower-mcp
+returns `"Method not found: nonexistent/method"`. Both use error code `-32601`.
+This is an implementation detail, not a spec requirement.
+
+**SSE response wrapping (default mode):**
+rmcp always wraps synchronous JSON-RPC responses as SSE (`Content-Type:
+text/event-stream`). tower-mcp returns bare JSON (`Content-Type:
+application/json`) by default, and SSE wrapping only when
+`.sse_responses(true)` is set on `HttpTransport`. The `sse-response-mode` check
+validates that the opt-in SSE mode matches rmcp's behavior exactly.
+
+## What to do when a check fails
+
+1. **Read the failure message.** It will show the actual values from both
+   servers and what was expected.
+2. **Determine if it is a tower-mcp bug or an intentional rmcp choice.** Check
+   the MCP spec, recent rmcp releases, and any relevant tower-mcp issues.
+3. **If it is a tower-mcp bug:** file an issue and fix it before releasing.
+4. **If it is a new rmcp behavior change:** evaluate whether tower-mcp should
+   match it, then either fix or add a KNOWN-DIFF entry with a rationale.
+5. **If it is a known diff that needs updating:** update the relevant check in
+   `src/main.rs` and update this README.
+
+## When to run
+
+- **Before every release** -- catches regressions against the current rmcp version
+- **When bumping the rmcp version** in `Cargo.toml` -- verifies that the new
+  rmcp version has not introduced new wire-format changes
+
+## How to update the rmcp version
+
+Change the version constraint in `tools/rmcp-compat/Cargo.toml`:
+
+```toml
+rmcp = { version = "1.7.0", features = [...] }
+```
+
+Then run the harness and update any KNOWN-DIFF entries that have changed.

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -1,15 +1,14 @@
-//! Wire-format compatibility spike: rmcp vs tower-mcp
+//! Wire-format compatibility harness: rmcp vs tower-mcp
 //!
 //! Starts both servers in-process as tokio tasks, fires identical MCP JSON-RPC
 //! requests at each, and structurally compares the responses.
 //!
 //! rmcp server: port 4001 (path: /mcp/)
 //! tower-mcp server: port 4002 (path: /)
+//! tower-mcp SSE mode server: port 4003 (path: /)
 //!
 //! Run with:
 //!   cargo run -p rmcp-compat
-//!
-//! This is a spike -- rough edges are intentional.
 
 use anyhow::Result;
 use serde::Serialize;
@@ -17,7 +16,7 @@ use serde_json::Value;
 use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
 
 // ============================================================
-// tower-mcp server
+// tower-mcp server (standard mode)
 // ============================================================
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -40,6 +39,30 @@ async fn start_tower_mcp_server(port: u16) {
 
     if let Err(e) = transport.serve(&addr).await {
         eprintln!("tower-mcp server error: {e}");
+    }
+}
+
+// ============================================================
+// tower-mcp server (SSE mode -- mirrors rmcp's SSE wrapping)
+// ============================================================
+
+async fn start_tower_mcp_sse_server(port: u16) {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("tower-mcp-compat-test-sse", "0.1.0")
+        .tool(echo);
+
+    let addr = format!("127.0.0.1:{port}");
+    let transport = HttpTransport::new(router)
+        .disable_origin_validation()
+        .sse_responses(true);
+
+    if let Err(e) = transport.serve(&addr).await {
+        eprintln!("tower-mcp SSE server error: {e}");
     }
 }
 
@@ -115,7 +138,7 @@ async fn start_rmcp_server(port: u16) {
 }
 
 // ============================================================
-// Test harness
+// Server configuration
 // ============================================================
 
 struct ServerConfig {
@@ -146,6 +169,12 @@ const TOWER_MCP: ServerConfig = ServerConfig {
     path: "/",
 };
 
+const TOWER_MCP_SSE: ServerConfig = ServerConfig {
+    name: "tower-mcp-sse",
+    port: 4003,
+    path: "/",
+};
+
 async fn wait_for_ready(server: &ServerConfig) -> bool {
     let url = server.url();
     let client = reqwest::Client::new();
@@ -168,6 +197,7 @@ async fn wait_for_ready(server: &ServerConfig) -> bool {
 struct ServerResponse {
     body: Value,
     session_id: Option<String>,
+    content_type: String,
 }
 
 async fn post_mcp(
@@ -200,26 +230,31 @@ async fn post_mcp(
         .unwrap_or("")
         .to_string();
     let bytes = resp.bytes().await?;
+    let raw_body = String::from_utf8_lossy(&bytes).to_string();
+
     // rmcp's StreamableHttpService returns SSE-wrapped JSON even for
     // synchronous RPC responses. Parse the SSE envelope and extract
     // the JSON from a `data:` line.
+    // tower-mcp with .sse_responses(true) does the same.
     let body: Value = if content_type.contains("text/event-stream") {
-        let text = String::from_utf8_lossy(&bytes);
         // Extract the first `data:` line from the SSE stream
-        text.lines()
+        raw_body
+            .lines()
             .filter(|line| line.starts_with("data:"))
             .map(|line| line.trim_start_matches("data:").trim())
             .filter(|data| !data.is_empty())
             .filter_map(|data| serde_json::from_str(data).ok())
             .next()
-            .ok_or_else(|| anyhow::anyhow!("no valid data: line in SSE body: {text}"))?
+            .ok_or_else(|| anyhow::anyhow!("no valid data: line in SSE body: {raw_body}"))?
     } else {
-        serde_json::from_slice(&bytes).map_err(|e| {
-            let text = String::from_utf8_lossy(&bytes);
-            anyhow::anyhow!("JSON parse error: {e} | body: {text}")
-        })?
+        serde_json::from_slice(&bytes)
+            .map_err(|e| anyhow::anyhow!("JSON parse error: {e} | body: {raw_body}"))?
     };
-    Ok(ServerResponse { body, session_id })
+    Ok(ServerResponse {
+        body,
+        session_id,
+        content_type,
+    })
 }
 
 // ============================================================
@@ -230,6 +265,7 @@ async fn post_mcp(
 enum CheckOutcome {
     Pass,
     Fail,
+    KnownDiff,
     Error,
 }
 
@@ -255,6 +291,14 @@ fn fail(name: &'static str, description: impl Into<String>) -> CheckResult {
     }
 }
 
+fn known_diff(name: &'static str, description: impl Into<String>) -> CheckResult {
+    CheckResult {
+        name,
+        description: description.into(),
+        outcome: CheckOutcome::KnownDiff,
+    }
+}
+
 fn check_error(name: &'static str, description: impl Into<String>) -> CheckResult {
     CheckResult {
         name,
@@ -267,6 +311,7 @@ fn print_result(r: &CheckResult) {
     let prefix = match r.outcome {
         CheckOutcome::Pass => "[PASS]",
         CheckOutcome::Fail => "[FAIL]",
+        CheckOutcome::KnownDiff => "[KNOWN-DIFF]",
         CheckOutcome::Error => "[ERROR]",
     };
     println!("{prefix} {}: {}", r.name, r.description);
@@ -405,8 +450,8 @@ async fn check_initialize(
         }
     }
 
-    // MCP spec requires client to send notifications/initialized before other requests
-    // rmcp enforces this strictly; tower-mcp is lenient
+    // MCP spec requires client to send notifications/initialized before other requests.
+    // Both servers now enforce this: rmcp strictly, tower-mcp since #901.
     if let Some(ref sid) = rmcp_sid {
         send_initialized(client, &RMCP, Some(sid.as_str())).await;
     }
@@ -629,6 +674,9 @@ async fn check_tools_call(
 }
 
 /// Check 4: method not found -- error.code == -32601, error.message is string
+///
+/// Known diff: rmcp returns just the method name as the message (e.g., "nonexistent/method"),
+/// while tower-mcp returns "Method not found: nonexistent/method". Both use -32601.
 async fn check_method_not_found(
     client: &reqwest::Client,
     rmcp_sid: Option<&str>,
@@ -690,14 +738,641 @@ async fn check_method_not_found(
         (_, None) => results.push(fail("method-not-found", "tower-mcp missing error.message")),
     }
 
-    // Show actual messages for documentation -- they will likely differ
+    // Known diff: message phrasing differs but both use -32601
     if let (Some(r), Some(t)) = (rmcp_msg, tower_msg)
         && r != t
     {
-        println!(
-            "  [INFO] error.message content differs (expected) -- rmcp={r:?}, tower-mcp={t:?}"
-        );
+        results.push(known_diff(
+            "method-not-found",
+            format!(
+                "error.message phrasing differs (both use -32601): \
+                 rmcp={r:?}, tower-mcp={t:?}. rmcp returns just the method name; \
+                 tower-mcp returns \"Method not found: {{method}}\""
+            ),
+        ));
     }
+
+    results
+}
+
+/// Check 5: resources/list -- result.resources is array (may be empty)
+async fn check_resources_list(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":5,"method":"resources/list"}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "resources/list",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "resources/list",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    // Both may return an error (method not supported) or a result with an array.
+    // If one returns error and the other returns result, that's a divergence.
+    let rmcp_has_result = rmcp_resp.body.get("result").is_some();
+    let tower_has_result = tower_resp.body.get("result").is_some();
+    let rmcp_has_error = rmcp_resp.body.get("error").is_some();
+    let tower_has_error = tower_resp.body.get("error").is_some();
+
+    match (rmcp_has_result, tower_has_result) {
+        (true, true) => {
+            let rmcp_resources = &rmcp_resp.body["result"]["resources"];
+            let tower_resources = &tower_resp.body["result"]["resources"];
+            match (rmcp_resources.is_array(), tower_resources.is_array()) {
+                (true, true) => {
+                    results.push(pass("resources/list", "result.resources is array on both"));
+                }
+                (false, _) => results.push(fail(
+                    "resources/list",
+                    format!("rmcp result.resources is not array: {rmcp_resources}"),
+                )),
+                (_, false) => results.push(fail(
+                    "resources/list",
+                    format!("tower-mcp result.resources is not array: {tower_resources}"),
+                )),
+            }
+        }
+        (true, false) => {
+            // tower-mcp returned an error -- may be a capability-not-declared difference
+            let tower_err = &tower_resp.body["error"];
+            if rmcp_has_error {
+                results.push(known_diff(
+                    "resources/list",
+                    format!(
+                        "both returned errors: rmcp={}, tower-mcp={}",
+                        rmcp_resp.body["error"], tower_err
+                    ),
+                ));
+            } else {
+                results.push(fail(
+                    "resources/list",
+                    format!("rmcp returned result, tower-mcp returned error: {tower_err}"),
+                ));
+            }
+        }
+        (false, true) => {
+            let rmcp_err = &rmcp_resp.body["error"];
+            results.push(fail(
+                "resources/list",
+                format!("rmcp returned error, tower-mcp returned result: {rmcp_err}"),
+            ));
+        }
+        (false, false) => {
+            // Both returned errors
+            let rmcp_code = rmcp_resp.body["error"]["code"].as_i64().unwrap_or(0);
+            let tower_code = tower_resp.body["error"]["code"].as_i64().unwrap_or(0);
+            if rmcp_code == tower_code {
+                results.push(known_diff(
+                    "resources/list",
+                    format!(
+                        "both returned error code {rmcp_code} (capability not advertised by either server)"
+                    ),
+                ));
+            } else {
+                results.push(fail(
+                    "resources/list",
+                    format!(
+                        "both returned errors with different codes: rmcp={rmcp_code}, tower-mcp={tower_code}"
+                    ),
+                ));
+            }
+        }
+    }
+
+    // Suppress unused variable warnings if paths not taken
+    let _ = rmcp_has_error;
+    let _ = tower_has_error;
+
+    results
+}
+
+/// Check 6: prompts/list -- result.prompts is array (may be empty)
+async fn check_prompts_list(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":6,"method":"prompts/list"}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "prompts/list",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "prompts/list",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_has_result = rmcp_resp.body.get("result").is_some();
+    let tower_has_result = tower_resp.body.get("result").is_some();
+
+    match (rmcp_has_result, tower_has_result) {
+        (true, true) => {
+            let rmcp_prompts = &rmcp_resp.body["result"]["prompts"];
+            let tower_prompts = &tower_resp.body["result"]["prompts"];
+            match (rmcp_prompts.is_array(), tower_prompts.is_array()) {
+                (true, true) => {
+                    results.push(pass("prompts/list", "result.prompts is array on both"));
+                }
+                (false, _) => results.push(fail(
+                    "prompts/list",
+                    format!("rmcp result.prompts is not array: {rmcp_prompts}"),
+                )),
+                (_, false) => results.push(fail(
+                    "prompts/list",
+                    format!("tower-mcp result.prompts is not array: {tower_prompts}"),
+                )),
+            }
+        }
+        (true, false) => {
+            let tower_err = &tower_resp.body["error"];
+            results.push(fail(
+                "prompts/list",
+                format!("rmcp returned result, tower-mcp returned error: {tower_err}"),
+            ));
+        }
+        (false, true) => {
+            let rmcp_err = &rmcp_resp.body["error"];
+            results.push(fail(
+                "prompts/list",
+                format!("rmcp returned error, tower-mcp returned result: {rmcp_err}"),
+            ));
+        }
+        (false, false) => {
+            let rmcp_code = rmcp_resp.body["error"]["code"].as_i64().unwrap_or(0);
+            let tower_code = tower_resp.body["error"]["code"].as_i64().unwrap_or(0);
+            if rmcp_code == tower_code {
+                results.push(known_diff(
+                    "prompts/list",
+                    format!(
+                        "both returned error code {rmcp_code} (capability not advertised by either server)"
+                    ),
+                ));
+            } else {
+                results.push(fail(
+                    "prompts/list",
+                    format!(
+                        "both returned errors with different codes: rmcp={rmcp_code}, tower-mcp={tower_code}"
+                    ),
+                ));
+            }
+        }
+    }
+
+    results
+}
+
+/// Check 7: resources/read not-found error shape
+///
+/// Send a resources/read for a non-existent URI. Both should return an error.
+/// Per SEP-2164 (implemented in #841), tower-mcp uses -32602 (InvalidParams).
+/// Note as KNOWN-DIFF if rmcp uses a different code.
+async fn check_resources_read_not_found(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"nonexistent://does-not-exist"}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "resources/read",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "resources/read",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_code = rmcp_resp.body["error"]["code"].as_i64();
+    let tower_code = tower_resp.body["error"]["code"].as_i64();
+
+    match (rmcp_code, tower_code) {
+        (Some(r), Some(t)) if r == t => {
+            results.push(pass(
+                "resources/read",
+                format!("not-found error.code matches on both ({r})"),
+            ));
+        }
+        (Some(r), Some(t)) => {
+            // tower-mcp uses -32602 per SEP-2164 (#841); check if rmcp differs
+            if t == -32602 && r != -32602 {
+                results.push(known_diff(
+                    "resources/read",
+                    format!(
+                        "not-found error code differs: rmcp={r}, tower-mcp={t} (-32602 InvalidParams per SEP-2164/#841)"
+                    ),
+                ));
+            } else {
+                results.push(fail(
+                    "resources/read",
+                    format!("not-found error.code mismatch: rmcp={r}, tower-mcp={t}"),
+                ));
+            }
+        }
+        (None, Some(_)) => {
+            // rmcp may return a result instead of an error if resources capability not declared
+            results.push(known_diff(
+                "resources/read",
+                format!(
+                    "rmcp did not return an error for not-found resource (body: {})",
+                    rmcp_resp.body
+                ),
+            ));
+        }
+        (Some(_), None) => {
+            results.push(fail(
+                "resources/read",
+                format!(
+                    "tower-mcp did not return an error for not-found resource (body: {})",
+                    tower_resp.body
+                ),
+            ));
+        }
+        (None, None) => {
+            results.push(known_diff(
+                "resources/read",
+                "neither server returned an error (resources capability not declared on either)",
+            ));
+        }
+    }
+
+    results
+}
+
+/// Check 8: invalid params error shape
+///
+/// Send tools/call with missing required params. Both should return -32602.
+async fn check_invalid_params(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    // Call echo with no arguments -- "message" is required
+    let body =
+        r#"{"jsonrpc":"2.0","id":8,"method":"tools/call","params":{"name":"echo","arguments":{}}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "invalid-params",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "invalid-params",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    // Servers may return the error at the JSON-RPC level or inside result.isError
+    let rmcp_error_code = rmcp_resp.body["error"]["code"].as_i64();
+    let tower_error_code = tower_resp.body["error"]["code"].as_i64();
+    let rmcp_is_tool_error = rmcp_resp.body["result"]["isError"]
+        .as_bool()
+        .unwrap_or(false);
+    let tower_is_tool_error = tower_resp.body["result"]["isError"]
+        .as_bool()
+        .unwrap_or(false);
+
+    match (rmcp_error_code, tower_error_code) {
+        (Some(-32602), Some(-32602)) => {
+            results.push(pass(
+                "invalid-params",
+                "missing required params: error.code == -32602 on both",
+            ));
+        }
+        (Some(r), Some(t)) if r != t => {
+            results.push(known_diff(
+                "invalid-params",
+                format!("missing params error code differs: rmcp={r}, tower-mcp={t}"),
+            ));
+        }
+        (Some(c), Some(_)) => {
+            results.push(known_diff(
+                "invalid-params",
+                format!("both return error code {c} (not -32602)"),
+            ));
+        }
+        (None, None) => {
+            // Both may return tool-level errors instead of JSON-RPC errors
+            if rmcp_is_tool_error || tower_is_tool_error {
+                results.push(known_diff(
+                    "invalid-params",
+                    format!(
+                        "missing params reported as tool-level error (isError=true): \
+                         rmcp={rmcp_is_tool_error}, tower-mcp={tower_is_tool_error}"
+                    ),
+                ));
+            } else {
+                results.push(fail(
+                    "invalid-params",
+                    format!(
+                        "neither server returned error: rmcp={}, tower-mcp={}",
+                        rmcp_resp.body, tower_resp.body
+                    ),
+                ));
+            }
+        }
+        (Some(_), None) => {
+            if tower_is_tool_error {
+                results.push(known_diff(
+                    "invalid-params",
+                    "rmcp returns JSON-RPC error; tower-mcp returns tool-level isError=true",
+                ));
+            } else {
+                results.push(fail(
+                    "invalid-params",
+                    format!(
+                        "rmcp returned error; tower-mcp returned: {}",
+                        tower_resp.body
+                    ),
+                ));
+            }
+        }
+        (None, Some(_)) => {
+            if rmcp_is_tool_error {
+                results.push(known_diff(
+                    "invalid-params",
+                    "tower-mcp returns JSON-RPC error; rmcp returns tool-level isError=true",
+                ));
+            } else {
+                results.push(fail(
+                    "invalid-params",
+                    format!(
+                        "tower-mcp returned error; rmcp returned: {}",
+                        rmcp_resp.body
+                    ),
+                ));
+            }
+        }
+    }
+
+    results
+}
+
+/// Check 9: notifications/initialized enforcement
+///
+/// Send tools/list WITHOUT the notifications/initialized step. Both servers
+/// (since #901) should return an error (-32600 InvalidRequest).
+async fn check_initialized_enforcement(client: &reqwest::Client) -> Vec<CheckResult> {
+    // Start fresh sessions without sending notifications/initialized
+    let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-enforcement-test","version":"0.1.0"}}}"#;
+
+    let rmcp_init = post_mcp(client, &RMCP, init_body, None).await;
+    let tower_init = post_mcp(client, &TOWER_MCP, init_body, None).await;
+
+    let (rmcp_init, tower_init) = match (rmcp_init, tower_init) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "initialized-enforcement",
+                format!("rmcp initialize failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "initialized-enforcement",
+                format!("tower-mcp initialize failed: {e}"),
+            )];
+        }
+    };
+
+    let rmcp_sid = rmcp_init.session_id.clone();
+    let tower_sid = tower_init.session_id.clone();
+
+    // Do NOT send notifications/initialized -- go straight to tools/list
+    let list_body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, list_body, rmcp_sid.as_deref()).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, list_body, tower_sid.as_deref()).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "initialized-enforcement",
+                format!("rmcp tools/list failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "initialized-enforcement",
+                format!("tower-mcp tools/list failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_code = rmcp_resp.body["error"]["code"].as_i64();
+    let tower_code = tower_resp.body["error"]["code"].as_i64();
+
+    match (rmcp_code, tower_code) {
+        (Some(r), Some(t)) => {
+            if r == -32600 && t == -32600 {
+                results.push(pass(
+                    "initialized-enforcement",
+                    "both reject tools/list before notifications/initialized with -32600",
+                ));
+            } else if r == t {
+                results.push(known_diff(
+                    "initialized-enforcement",
+                    format!("both reject but with code {r} (expected -32600)"),
+                ));
+            } else {
+                results.push(known_diff(
+                    "initialized-enforcement",
+                    format!(
+                        "both reject but codes differ: rmcp={r}, tower-mcp={t} (tower-mcp uses -32600 per #901)"
+                    ),
+                ));
+            }
+        }
+        (Some(r), None) => {
+            // tower-mcp may have returned a result (lenient mode shouldn't happen post-#901)
+            results.push(fail(
+                "initialized-enforcement",
+                format!(
+                    "rmcp returned error {r}; tower-mcp returned result (should enforce since #901): {}",
+                    tower_resp.body
+                ),
+            ));
+        }
+        (None, Some(t)) => {
+            results.push(fail(
+                "initialized-enforcement",
+                format!(
+                    "tower-mcp returned error {t}; rmcp returned result: {}",
+                    rmcp_resp.body
+                ),
+            ));
+        }
+        (None, None) => {
+            results.push(fail(
+                "initialized-enforcement",
+                format!(
+                    "neither server rejected the request: rmcp={}, tower-mcp={}",
+                    rmcp_resp.body, tower_resp.body
+                ),
+            ));
+        }
+    }
+
+    results
+}
+
+/// Check 10: SSE response mode
+///
+/// Spin up tower-mcp with .sse_responses(true). Send tools/list. Compare:
+/// both should return Content-Type: text/event-stream and the SSE data line
+/// should parse to valid JSON-RPC.
+async fn check_sse_response_mode(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sse_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let list_body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, list_body, rmcp_sid).await;
+    let tower_sse_resp = post_mcp(client, &TOWER_MCP_SSE, list_body, tower_sse_sid).await;
+
+    let (rmcp_resp, tower_sse_resp) = match (rmcp_resp, tower_sse_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "sse-response-mode",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "sse-response-mode",
+                format!("tower-mcp SSE mode request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_ct = rmcp_resp.content_type.contains("text/event-stream");
+    let tower_sse_ct = tower_sse_resp.content_type.contains("text/event-stream");
+
+    match (rmcp_ct, tower_sse_ct) {
+        (true, true) => {
+            results.push(pass(
+                "sse-response-mode",
+                "both return text/event-stream when SSE mode enabled",
+            ));
+        }
+        (false, true) => {
+            results.push(fail(
+                "sse-response-mode",
+                format!(
+                    "rmcp content-type is not text/event-stream: {}",
+                    rmcp_resp.content_type
+                ),
+            ));
+        }
+        (true, false) => {
+            results.push(fail(
+                "sse-response-mode",
+                format!(
+                    "tower-mcp SSE mode content-type is not text/event-stream: {}",
+                    tower_sse_resp.content_type
+                ),
+            ));
+        }
+        (false, false) => {
+            results.push(fail(
+                "sse-response-mode",
+                format!(
+                    "neither returned text/event-stream: rmcp={}, tower-mcp-sse={}",
+                    rmcp_resp.content_type, tower_sse_resp.content_type
+                ),
+            ));
+        }
+    }
+
+    // Verify the parsed body has valid JSON-RPC (post_mcp already parsed the SSE data line)
+    let rmcp_has_result =
+        rmcp_resp.body.get("result").is_some() || rmcp_resp.body.get("error").is_some();
+    let tower_sse_has_result =
+        tower_sse_resp.body.get("result").is_some() || tower_sse_resp.body.get("error").is_some();
+
+    match (rmcp_has_result, tower_sse_has_result) {
+        (true, true) => {
+            results.push(pass(
+                "sse-response-mode",
+                "SSE data line parses to valid JSON-RPC on both",
+            ));
+        }
+        (false, _) => results.push(fail(
+            "sse-response-mode",
+            format!("rmcp SSE data is not valid JSON-RPC: {}", rmcp_resp.body),
+        )),
+        (_, false) => results.push(fail(
+            "sse-response-mode",
+            format!(
+                "tower-mcp SSE data is not valid JSON-RPC: {}",
+                tower_sse_resp.body
+            ),
+        )),
+    }
+
+    // Show note about default mode
+    println!(
+        "  [NOTE] sse-response-mode: tower-mcp returns bare JSON by default; \
+         use .sse_responses(true) to match rmcp's SSE wrapping behavior"
+    );
 
     results
 }
@@ -709,16 +1384,19 @@ async fn check_method_not_found(
 #[tokio::main]
 async fn main() -> Result<()> {
     tokio::spawn(start_tower_mcp_server(4002));
+    tokio::spawn(start_tower_mcp_sse_server(4003));
     tokio::spawn(start_rmcp_server(4001));
 
     println!(
-        "Waiting for servers: {} and {}...",
+        "Waiting for servers: {}, {}, and {}...",
         RMCP.display_name(),
-        TOWER_MCP.display_name()
+        TOWER_MCP.display_name(),
+        TOWER_MCP_SSE.display_name()
     );
 
     let rmcp_ready = wait_for_ready(&RMCP).await;
     let tower_ready = wait_for_ready(&TOWER_MCP).await;
+    let tower_sse_ready = wait_for_ready(&TOWER_MCP_SSE).await;
 
     if !rmcp_ready {
         eprintln!("ERROR: rmcp server did not start on port 4001");
@@ -728,22 +1406,45 @@ async fn main() -> Result<()> {
         eprintln!("ERROR: tower-mcp server did not start on port 4002");
         std::process::exit(1);
     }
+    if !tower_sse_ready {
+        eprintln!("ERROR: tower-mcp SSE server did not start on port 4003");
+        std::process::exit(1);
+    }
 
-    println!("Both servers ready. Running checks...\n");
+    println!("All servers ready. Running checks...\n");
 
     let client = reqwest::Client::new();
     let mut all_results: Vec<CheckResult> = Vec::new();
 
-    // Check 1: initialize (also extracts session IDs)
+    // ---- Check 1: initialize (also extracts session IDs) ----
+    println!("=== initialize ===");
     let (init_results, rmcp_sid, tower_sid) = check_initialize(&client).await;
     for r in &init_results {
         print_result(r);
     }
     all_results.extend(init_results);
 
+    // Initialize the SSE server independently
+    let sse_init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-test","version":"0.1.0"}}}"#;
+    let sse_init = post_mcp(&client, &TOWER_MCP_SSE, sse_init_body, None).await;
+    let tower_sse_sid = sse_init.ok().and_then(|r| {
+        // Send initialized notification for SSE server
+        let sid = r.session_id.clone();
+        if let Some(ref s) = sid {
+            // We need to block here; use a oneshot channel approach
+            let client2 = client.clone();
+            let sid_clone = s.clone();
+            tokio::spawn(async move {
+                send_initialized(&client2, &TOWER_MCP_SSE, Some(&sid_clone)).await;
+            });
+        }
+        sid
+    });
+
     println!();
 
-    // Check 2: tools/list
+    // ---- Check 2: tools/list ----
+    println!("=== tools/list ===");
     let tools_results = check_tools_list(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
     for r in &tools_results {
         print_result(r);
@@ -752,7 +1453,8 @@ async fn main() -> Result<()> {
 
     println!();
 
-    // Check 3: tools/call
+    // ---- Check 3: tools/call ----
+    println!("=== tools/call ===");
     let call_results = check_tools_call(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
     for r in &call_results {
         print_result(r);
@@ -761,7 +1463,8 @@ async fn main() -> Result<()> {
 
     println!();
 
-    // Check 4: method not found
+    // ---- Check 4: method not found ----
+    println!("=== method-not-found ===");
     let notfound_results =
         check_method_not_found(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
     for r in &notfound_results {
@@ -769,6 +1472,89 @@ async fn main() -> Result<()> {
     }
     all_results.extend(notfound_results);
 
+    println!();
+
+    // ---- Check 5: resources/list ----
+    println!("=== resources/list ===");
+    let resources_results =
+        check_resources_list(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &resources_results {
+        print_result(r);
+    }
+    all_results.extend(resources_results);
+
+    println!();
+
+    // ---- Check 6: prompts/list ----
+    println!("=== prompts/list ===");
+    let prompts_results =
+        check_prompts_list(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &prompts_results {
+        print_result(r);
+    }
+    all_results.extend(prompts_results);
+
+    println!();
+
+    // ---- Check 7: resources/read not-found ----
+    println!("=== resources/read (not-found) ===");
+    let read_results =
+        check_resources_read_not_found(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &read_results {
+        print_result(r);
+    }
+    all_results.extend(read_results);
+
+    println!();
+
+    // ---- Check 8: invalid params ----
+    println!("=== invalid-params ===");
+    let invalid_results =
+        check_invalid_params(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &invalid_results {
+        print_result(r);
+    }
+    all_results.extend(invalid_results);
+
+    println!();
+
+    // ---- Check 9: notifications/initialized enforcement ----
+    println!("=== initialized-enforcement ===");
+    let enforcement_results = check_initialized_enforcement(&client).await;
+    for r in &enforcement_results {
+        print_result(r);
+    }
+    all_results.extend(enforcement_results);
+
+    println!();
+
+    // ---- Check 10: SSE response mode ----
+    println!("=== sse-response-mode ===");
+    // Need a fresh rmcp session for the SSE check
+    let rmcp_sse_init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-sse-test","version":"0.1.0"}}}"#;
+    let rmcp_sse_init = post_mcp(&client, &RMCP, rmcp_sse_init_body, None).await;
+    let rmcp_sse_sid = rmcp_sse_init.ok().and_then(|r| {
+        let sid = r.session_id.clone();
+        if let Some(ref s) = sid {
+            let client2 = client.clone();
+            let sid_clone = s.clone();
+            tokio::spawn(async move {
+                send_initialized(&client2, &RMCP, Some(&sid_clone)).await;
+            });
+        }
+        sid
+    });
+    // Give notifications/initialized a moment to be processed
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let sse_results =
+        check_sse_response_mode(&client, rmcp_sse_sid.as_deref(), tower_sse_sid.as_deref()).await;
+    for r in &sse_results {
+        print_result(r);
+    }
+    all_results.extend(sse_results);
+
+    // ---- Summary ----
     let total = all_results.len();
     let passed = all_results
         .iter()
@@ -778,12 +1564,25 @@ async fn main() -> Result<()> {
         .iter()
         .filter(|r| matches!(r.outcome, CheckOutcome::Fail))
         .count();
+    let known_diffs = all_results
+        .iter()
+        .filter(|r| matches!(r.outcome, CheckOutcome::KnownDiff))
+        .count();
     let errors = all_results
         .iter()
         .filter(|r| matches!(r.outcome, CheckOutcome::Error))
         .count();
 
-    println!("\nResults: {passed}/{total} checks passed ({failed} failed, {errors} errors)");
+    println!(
+        "\nResults: {passed}/{total} checks passed ({failed} failed, {known_diffs} known-diffs, {errors} errors)"
+    );
+
+    if known_diffs > 0 {
+        println!(
+            "\nKnown diffs are documented divergences between rmcp and tower-mcp that are\n\
+             intentional or explained. They do not indicate bugs."
+        );
+    }
 
     if failed > 0 || errors > 0 {
         std::process::exit(1);

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -547,7 +547,7 @@ async fn check_tools_list(
     results
 }
 
-/// Check 3: tools/call echo -- result.content array, content[0].type
+/// Check 3: tools/call echo -- result.content array, content\[0\].type
 async fn check_tools_call(
     client: &reqwest::Client,
     rmcp_sid: Option<&str>,

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -1,0 +1,793 @@
+//! Wire-format compatibility spike: rmcp vs tower-mcp
+//!
+//! Starts both servers in-process as tokio tasks, fires identical MCP JSON-RPC
+//! requests at each, and structurally compares the responses.
+//!
+//! rmcp server: port 4001 (path: /mcp/)
+//! tower-mcp server: port 4002 (path: /)
+//!
+//! Run with:
+//!   cargo run -p rmcp-compat
+//!
+//! This is a spike -- rough edges are intentional.
+
+use anyhow::Result;
+use serde::Serialize;
+use serde_json::Value;
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+// ============================================================
+// tower-mcp server
+// ============================================================
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct EchoInput {
+    message: String,
+}
+
+async fn start_tower_mcp_server(port: u16) {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("tower-mcp-compat-test", "0.1.0")
+        .tool(echo);
+
+    let addr = format!("127.0.0.1:{port}");
+    let transport = HttpTransport::new(router).disable_origin_validation();
+
+    if let Err(e) = transport.serve(&addr).await {
+        eprintln!("tower-mcp server error: {e}");
+    }
+}
+
+// ============================================================
+// rmcp server
+// ============================================================
+
+mod rmcp_server {
+    use rmcp::{
+        ServerHandler,
+        handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+        model::*,
+        tool, tool_handler, tool_router,
+    };
+
+    #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+    pub struct EchoParams {
+        /// The message to echo back
+        pub message: String,
+    }
+
+    #[derive(Clone)]
+    pub struct EchoServer {
+        // Used by the #[tool_router] macro-generated code
+        #[allow(dead_code)]
+        tool_router: ToolRouter<EchoServer>,
+    }
+
+    #[tool_router]
+    impl EchoServer {
+        pub fn new() -> Self {
+            Self {
+                tool_router: Self::tool_router(),
+            }
+        }
+
+        #[tool(description = "Echo a message back")]
+        fn echo(
+            &self,
+            Parameters(EchoParams { message }): Parameters<EchoParams>,
+        ) -> Result<CallToolResult, ErrorData> {
+            Ok(CallToolResult::success(vec![Content::text(message)]))
+        }
+    }
+
+    #[tool_handler]
+    impl ServerHandler for EchoServer {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(Implementation::new("rmcp-compat-test", "0.1.0"))
+                .with_protocol_version(ProtocolVersion::V_2025_11_25)
+        }
+    }
+}
+
+async fn start_rmcp_server(port: u16) {
+    use rmcp::transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    };
+
+    let service = StreamableHttpService::new(
+        || Ok(rmcp_server::EchoServer::new()),
+        LocalSessionManager::default().into(),
+        StreamableHttpServerConfig::default(),
+    );
+
+    let axum_router = axum::Router::new().nest_service("/mcp", service);
+    let addr = format!("127.0.0.1:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
+    if let Err(e) = axum::serve(listener, axum_router).await {
+        eprintln!("rmcp server error: {e}");
+    }
+}
+
+// ============================================================
+// Test harness
+// ============================================================
+
+struct ServerConfig {
+    name: &'static str,
+    port: u16,
+    path: &'static str,
+}
+
+impl ServerConfig {
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}{}", self.port, self.path)
+    }
+
+    fn display_name(&self) -> String {
+        format!("{} (port {})", self.name, self.port)
+    }
+}
+
+const RMCP: ServerConfig = ServerConfig {
+    name: "rmcp",
+    port: 4001,
+    path: "/mcp/",
+};
+
+const TOWER_MCP: ServerConfig = ServerConfig {
+    name: "tower-mcp",
+    port: 4002,
+    path: "/",
+};
+
+async fn wait_for_ready(server: &ServerConfig) -> bool {
+    let url = server.url();
+    let client = reqwest::Client::new();
+    for _ in 0..25 {
+        let result = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","id":0,"method":"ping"}"#)
+            .timeout(std::time::Duration::from_millis(400))
+            .send()
+            .await;
+        if result.is_ok() {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+    }
+    false
+}
+
+struct ServerResponse {
+    body: Value,
+    session_id: Option<String>,
+}
+
+async fn post_mcp(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    body: &str,
+    session_id: Option<&str>,
+) -> Result<ServerResponse> {
+    let mut req = client
+        .post(server.url())
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(body.to_string());
+
+    if let Some(sid) = session_id {
+        req = req.header("mcp-session-id", sid);
+    }
+
+    let resp = req.send().await?;
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    let bytes = resp.bytes().await?;
+    // rmcp's StreamableHttpService returns SSE-wrapped JSON even for
+    // synchronous RPC responses. Parse the SSE envelope and extract
+    // the JSON from a `data:` line.
+    let body: Value = if content_type.contains("text/event-stream") {
+        let text = String::from_utf8_lossy(&bytes);
+        // Extract the first `data:` line from the SSE stream
+        text.lines()
+            .filter(|line| line.starts_with("data:"))
+            .map(|line| line.trim_start_matches("data:").trim())
+            .filter(|data| !data.is_empty())
+            .filter_map(|data| serde_json::from_str(data).ok())
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no valid data: line in SSE body: {text}"))?
+    } else {
+        serde_json::from_slice(&bytes).map_err(|e| {
+            let text = String::from_utf8_lossy(&bytes);
+            anyhow::anyhow!("JSON parse error: {e} | body: {text}")
+        })?
+    };
+    Ok(ServerResponse { body, session_id })
+}
+
+// ============================================================
+// Check result types
+// ============================================================
+
+#[derive(Serialize)]
+enum CheckOutcome {
+    Pass,
+    Fail,
+    Error,
+}
+
+struct CheckResult {
+    name: &'static str,
+    description: String,
+    outcome: CheckOutcome,
+}
+
+fn pass(name: &'static str, description: impl Into<String>) -> CheckResult {
+    CheckResult {
+        name,
+        description: description.into(),
+        outcome: CheckOutcome::Pass,
+    }
+}
+
+fn fail(name: &'static str, description: impl Into<String>) -> CheckResult {
+    CheckResult {
+        name,
+        description: description.into(),
+        outcome: CheckOutcome::Fail,
+    }
+}
+
+fn check_error(name: &'static str, description: impl Into<String>) -> CheckResult {
+    CheckResult {
+        name,
+        description: description.into(),
+        outcome: CheckOutcome::Error,
+    }
+}
+
+fn print_result(r: &CheckResult) {
+    let prefix = match r.outcome {
+        CheckOutcome::Pass => "[PASS]",
+        CheckOutcome::Fail => "[FAIL]",
+        CheckOutcome::Error => "[ERROR]",
+    };
+    println!("{prefix} {}: {}", r.name, r.description);
+}
+
+// ============================================================
+// Individual checks
+// ============================================================
+
+/// Send the notifications/initialized notification (required by MCP spec after initialize)
+async fn send_initialized(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    session_id: Option<&str>,
+) {
+    let body = r#"{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}"#;
+    // notifications are fire-and-forget (no id), server may return 202 or nothing
+    let mut req = client
+        .post(server.url())
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .body(body.to_string());
+    if let Some(sid) = session_id {
+        req = req.header("mcp-session-id", sid);
+    }
+    let _ = req.send().await;
+}
+
+/// Check 1: initialize -- protocolVersion, capabilities, serverInfo
+async fn check_initialize(
+    client: &reqwest::Client,
+) -> (Vec<CheckResult>, Option<String>, Option<String>) {
+    let body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-test","version":"0.1.0"}}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, None).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, None).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return (
+                vec![check_error(
+                    "initialize",
+                    format!("rmcp request failed: {e}"),
+                )],
+                None,
+                None,
+            );
+        }
+        (_, Err(e)) => {
+            return (
+                vec![check_error(
+                    "initialize",
+                    format!("tower-mcp request failed: {e}"),
+                )],
+                None,
+                None,
+            );
+        }
+    };
+
+    let rmcp_sid = rmcp_resp.session_id.clone();
+    let tower_sid = tower_resp.session_id.clone();
+
+    let mut results = Vec::new();
+
+    // Check protocolVersion
+    let rmcp_pv = rmcp_resp.body["result"]["protocolVersion"].as_str();
+    let tower_pv = tower_resp.body["result"]["protocolVersion"].as_str();
+    match (rmcp_pv, tower_pv) {
+        (Some(r), Some(t)) if r == t => {
+            results.push(pass(
+                "initialize",
+                format!("protocolVersion present and equal ({t})"),
+            ));
+        }
+        (Some(r), Some(t)) => {
+            results.push(fail(
+                "initialize",
+                format!("protocolVersion mismatch -- rmcp={r}, tower-mcp={t}"),
+            ));
+        }
+        (None, _) => {
+            results.push(fail("initialize", "rmcp missing result.protocolVersion"));
+        }
+        (_, None) => {
+            results.push(fail(
+                "initialize",
+                "tower-mcp missing result.protocolVersion",
+            ));
+        }
+    }
+
+    // Check capabilities is object
+    let rmcp_caps = &rmcp_resp.body["result"]["capabilities"];
+    let tower_caps = &tower_resp.body["result"]["capabilities"];
+    match (rmcp_caps.is_object(), tower_caps.is_object()) {
+        (true, true) => results.push(pass("initialize", "capabilities is object on both")),
+        (false, true) => results.push(fail(
+            "initialize",
+            format!("rmcp capabilities is not object: {rmcp_caps}"),
+        )),
+        (true, false) => results.push(fail(
+            "initialize",
+            format!("tower-mcp capabilities is not object: {tower_caps}"),
+        )),
+        (false, false) => results.push(fail(
+            "initialize",
+            format!("both capabilities non-object: rmcp={rmcp_caps}, tower-mcp={tower_caps}"),
+        )),
+    }
+
+    // Check serverInfo.name and .version
+    for field in ["name", "version"] {
+        let rmcp_val = rmcp_resp.body["result"]["serverInfo"][field].as_str();
+        let tower_val = tower_resp.body["result"]["serverInfo"][field].as_str();
+        match (rmcp_val, tower_val) {
+            (Some(_), Some(_)) => {
+                results.push(pass(
+                    "initialize",
+                    format!("serverInfo.{field} is string on both"),
+                ));
+            }
+            (None, _) => {
+                results.push(fail(
+                    "initialize",
+                    format!("rmcp missing serverInfo.{field}"),
+                ));
+            }
+            (_, None) => {
+                results.push(fail(
+                    "initialize",
+                    format!("tower-mcp missing serverInfo.{field}"),
+                ));
+            }
+        }
+    }
+
+    // MCP spec requires client to send notifications/initialized before other requests
+    // rmcp enforces this strictly; tower-mcp is lenient
+    if let Some(ref sid) = rmcp_sid {
+        send_initialized(client, &RMCP, Some(sid.as_str())).await;
+    }
+    if let Some(ref sid) = tower_sid {
+        send_initialized(client, &TOWER_MCP, Some(sid.as_str())).await;
+    }
+
+    (results, rmcp_sid, tower_sid)
+}
+
+/// Check 2: tools/list -- result.tools array, name and inputSchema fields
+async fn check_tools_list(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "tools/list",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "tools/list",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_tools = &rmcp_resp.body["result"]["tools"];
+    let tower_tools = &tower_resp.body["result"]["tools"];
+
+    match (rmcp_tools.is_array(), tower_tools.is_array()) {
+        (true, true) => {
+            results.push(pass("tools/list", "result.tools is array on both"));
+        }
+        (false, _) => {
+            results.push(fail(
+                "tools/list",
+                format!("rmcp result.tools is not array: {rmcp_tools}"),
+            ));
+            return results;
+        }
+        (_, false) => {
+            results.push(fail(
+                "tools/list",
+                format!("tower-mcp result.tools is not array: {tower_tools}"),
+            ));
+            return results;
+        }
+    }
+
+    let rmcp_first = &rmcp_tools[0];
+    let tower_first = &tower_tools[0];
+
+    match (rmcp_first["name"].as_str(), tower_first["name"].as_str()) {
+        (Some(r), Some(t)) => {
+            if r == t {
+                results.push(pass("tools/list", format!("first tool name matches ({t})")));
+            } else {
+                results.push(fail(
+                    "tools/list",
+                    format!("first tool name differs -- rmcp={r}, tower-mcp={t}"),
+                ));
+            }
+        }
+        (None, _) => results.push(fail("tools/list", "rmcp first tool missing 'name'")),
+        (_, None) => results.push(fail("tools/list", "tower-mcp first tool missing 'name'")),
+    }
+
+    // Check inputSchema vs input_schema field name -- this is the most likely divergence
+    let rmcp_has_camel = rmcp_first.get("inputSchema").is_some();
+    let rmcp_has_snake = rmcp_first.get("input_schema").is_some();
+    let tower_has_camel = tower_first.get("inputSchema").is_some();
+    let tower_has_snake = tower_first.get("input_schema").is_some();
+
+    let rmcp_field = if rmcp_has_camel {
+        Some("inputSchema")
+    } else if rmcp_has_snake {
+        Some("input_schema")
+    } else {
+        None
+    };
+
+    let tower_field = if tower_has_camel {
+        Some("inputSchema")
+    } else if tower_has_snake {
+        Some("input_schema")
+    } else {
+        None
+    };
+
+    match (rmcp_field, tower_field) {
+        (Some(r), Some(t)) => {
+            if r == t {
+                results.push(pass(
+                    "tools/list",
+                    format!("inputSchema field name matches ({t})"),
+                ));
+            } else {
+                results.push(fail(
+                    "tools/list",
+                    format!("inputSchema field name mismatch -- rmcp={r}, tower-mcp={t}"),
+                ));
+            }
+            // verify schema is object
+            let rmcp_schema = &rmcp_first[r];
+            let tower_schema = &tower_first[t];
+            match (rmcp_schema.is_object(), tower_schema.is_object()) {
+                (true, true) => results.push(pass("tools/list", "inputSchema is object on both")),
+                (false, _) => results.push(fail(
+                    "tools/list",
+                    format!("rmcp {r} is not object: {rmcp_schema}"),
+                )),
+                (_, false) => results.push(fail(
+                    "tools/list",
+                    format!("tower-mcp {t} is not object: {tower_schema}"),
+                )),
+            }
+        }
+        (None, _) => results.push(fail("tools/list", "rmcp first tool missing inputSchema")),
+        (_, None) => results.push(fail(
+            "tools/list",
+            "tower-mcp first tool missing inputSchema",
+        )),
+    }
+
+    results
+}
+
+/// Check 3: tools/call echo -- result.content array, content[0].type
+async fn check_tools_call(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"echo","arguments":{"message":"hello world"}}}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "tools/call",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "tools/call",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_content = &rmcp_resp.body["result"]["content"];
+    let tower_content = &tower_resp.body["result"]["content"];
+
+    match (rmcp_content.is_array(), tower_content.is_array()) {
+        (true, true) => results.push(pass("tools/call", "result.content is array on both")),
+        (false, _) => {
+            results.push(fail(
+                "tools/call",
+                format!("rmcp result.content is not array: {rmcp_content}"),
+            ));
+            return results;
+        }
+        (_, false) => {
+            results.push(fail(
+                "tools/call",
+                format!("tower-mcp result.content is not array: {tower_content}"),
+            ));
+            return results;
+        }
+    }
+
+    let rmcp_type = rmcp_content[0]["type"].as_str();
+    let tower_type = tower_content[0]["type"].as_str();
+    match (rmcp_type, tower_type) {
+        (Some(r), Some(t)) => {
+            if r == t {
+                results.push(pass("tools/call", format!("content[0].type matches ({t})")));
+            } else {
+                results.push(fail(
+                    "tools/call",
+                    format!("content[0].type mismatch -- rmcp={r}, tower-mcp={t}"),
+                ));
+            }
+        }
+        (None, _) => results.push(fail("tools/call", "rmcp content[0] missing type")),
+        (_, None) => results.push(fail("tools/call", "tower-mcp content[0] missing type")),
+    }
+
+    let rmcp_text = rmcp_content[0]["text"].as_str().unwrap_or("");
+    let tower_text = tower_content[0]["text"].as_str().unwrap_or("");
+    if rmcp_text == "hello world" && tower_text == "hello world" {
+        results.push(pass("tools/call", "echo returned correct value on both"));
+    } else {
+        results.push(fail(
+            "tools/call",
+            format!("echo value mismatch -- rmcp={rmcp_text:?}, tower-mcp={tower_text:?}"),
+        ));
+    }
+
+    results
+}
+
+/// Check 4: method not found -- error.code == -32601, error.message is string
+async fn check_method_not_found(
+    client: &reqwest::Client,
+    rmcp_sid: Option<&str>,
+    tower_sid: Option<&str>,
+) -> Vec<CheckResult> {
+    let body = r#"{"jsonrpc":"2.0","id":4,"method":"nonexistent/method"}"#;
+
+    let rmcp_resp = post_mcp(client, &RMCP, body, rmcp_sid).await;
+    let tower_resp = post_mcp(client, &TOWER_MCP, body, tower_sid).await;
+
+    let (rmcp_resp, tower_resp) = match (rmcp_resp, tower_resp) {
+        (Ok(r), Ok(t)) => (r, t),
+        (Err(e), _) => {
+            return vec![check_error(
+                "method-not-found",
+                format!("rmcp request failed: {e}"),
+            )];
+        }
+        (_, Err(e)) => {
+            return vec![check_error(
+                "method-not-found",
+                format!("tower-mcp request failed: {e}"),
+            )];
+        }
+    };
+
+    let mut results = Vec::new();
+
+    let rmcp_code = rmcp_resp.body["error"]["code"].as_i64();
+    let tower_code = tower_resp.body["error"]["code"].as_i64();
+
+    match (rmcp_code, tower_code) {
+        (Some(-32601), Some(-32601)) => {
+            results.push(pass("method-not-found", "error.code == -32601 on both"));
+        }
+        (Some(r), Some(t)) if r != t => {
+            results.push(fail(
+                "method-not-found",
+                format!("error.code mismatch -- rmcp={r}, tower-mcp={t}"),
+            ));
+        }
+        (Some(c), Some(_)) => {
+            results.push(fail(
+                "method-not-found",
+                format!("error.code is {c} (expected -32601) on one or both"),
+            ));
+        }
+        (None, _) => results.push(fail("method-not-found", "rmcp missing error.code")),
+        (_, None) => results.push(fail("method-not-found", "tower-mcp missing error.code")),
+    }
+
+    let rmcp_msg = rmcp_resp.body["error"]["message"].as_str();
+    let tower_msg = tower_resp.body["error"]["message"].as_str();
+    match (rmcp_msg, tower_msg) {
+        (Some(_), Some(_)) => {
+            results.push(pass("method-not-found", "error.message is string on both"));
+        }
+        (None, _) => results.push(fail("method-not-found", "rmcp missing error.message")),
+        (_, None) => results.push(fail("method-not-found", "tower-mcp missing error.message")),
+    }
+
+    // Show actual messages for documentation -- they will likely differ
+    if let (Some(r), Some(t)) = (rmcp_msg, tower_msg)
+        && r != t
+    {
+        println!(
+            "  [INFO] error.message content differs (expected) -- rmcp={r:?}, tower-mcp={t:?}"
+        );
+    }
+
+    results
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tokio::spawn(start_tower_mcp_server(4002));
+    tokio::spawn(start_rmcp_server(4001));
+
+    println!(
+        "Waiting for servers: {} and {}...",
+        RMCP.display_name(),
+        TOWER_MCP.display_name()
+    );
+
+    let rmcp_ready = wait_for_ready(&RMCP).await;
+    let tower_ready = wait_for_ready(&TOWER_MCP).await;
+
+    if !rmcp_ready {
+        eprintln!("ERROR: rmcp server did not start on port 4001");
+        std::process::exit(1);
+    }
+    if !tower_ready {
+        eprintln!("ERROR: tower-mcp server did not start on port 4002");
+        std::process::exit(1);
+    }
+
+    println!("Both servers ready. Running checks...\n");
+
+    let client = reqwest::Client::new();
+    let mut all_results: Vec<CheckResult> = Vec::new();
+
+    // Check 1: initialize (also extracts session IDs)
+    let (init_results, rmcp_sid, tower_sid) = check_initialize(&client).await;
+    for r in &init_results {
+        print_result(r);
+    }
+    all_results.extend(init_results);
+
+    println!();
+
+    // Check 2: tools/list
+    let tools_results = check_tools_list(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &tools_results {
+        print_result(r);
+    }
+    all_results.extend(tools_results);
+
+    println!();
+
+    // Check 3: tools/call
+    let call_results = check_tools_call(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &call_results {
+        print_result(r);
+    }
+    all_results.extend(call_results);
+
+    println!();
+
+    // Check 4: method not found
+    let notfound_results =
+        check_method_not_found(&client, rmcp_sid.as_deref(), tower_sid.as_deref()).await;
+    for r in &notfound_results {
+        print_result(r);
+    }
+    all_results.extend(notfound_results);
+
+    let total = all_results.len();
+    let passed = all_results
+        .iter()
+        .filter(|r| matches!(r.outcome, CheckOutcome::Pass))
+        .count();
+    let failed = all_results
+        .iter()
+        .filter(|r| matches!(r.outcome, CheckOutcome::Fail))
+        .count();
+    let errors = all_results
+        .iter()
+        .filter(|r| matches!(r.outcome, CheckOutcome::Error))
+        .count();
+
+    println!("\nResults: {passed}/{total} checks passed ({failed} failed, {errors} errors)");
+
+    if failed > 0 || errors > 0 {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Graduates the rmcp wire-format compat spike (originally exploratory tooling) to a
proper tool in `tools/rmcp-compat/`. The tool is now ready for use before releases
and when bumping the rmcp version.

Closes #898 (replaces spike with graduated tool).

## What changed

- **Rebased onto main**: picks up #900 (opt-in SSE response wrapping) and #901
  (notifications/initialized enforcement).
- **Added `KnownDiff` variant**: checks that find documented behavioral differences
  print `[KNOWN-DIFF]` and do not fail the exit code.
- **Added 6 new checks** (10 total across 4 original + 6 new):
  - `resources/list` -- `result.resources` is array on both
  - `prompts/list` -- `result.prompts` is array on both
  - `resources/read` (not-found) -- error code is `-32602` per SEP-2164 (#841)
  - `invalid-params` -- missing required tool arg returns `-32602`
  - `initialized-enforcement` -- both reject requests before `notifications/initialized` with `-32600` (validates #901)
  - `sse-response-mode` -- with `.sse_responses(true)`, both return `text/event-stream` (validates #900)
- **Three servers** (was two): adds tower-mcp SSE mode on port 4003.
- **notifications/initialized** sent after every initialize, before tool requests, on all sessions.
- **Added `tools/rmcp-compat/README.md`**: usage, output format, when to run, how to update rmcp version.
- **Updated CLAUDE.md** release checklist with rmcp compat step.

## Checks covered

| Check | Outcome |
|-------|---------|
| `initialize: protocolVersion present and equal` | PASS |
| `initialize: capabilities is object on both` | PASS |
| `initialize: serverInfo.name is string on both` | PASS |
| `initialize: serverInfo.version is string on both` | PASS |
| `tools/list: result.tools is array on both` | PASS |
| `tools/list: first tool name matches` | PASS |
| `tools/list: inputSchema field name matches` | PASS |
| `tools/list: inputSchema is object on both` | PASS |
| `tools/call: result.content is array on both` | PASS |
| `tools/call: content[0].type matches` | PASS |
| `tools/call: echo returned correct value on both` | PASS |
| `method-not-found: error.code == -32601 on both` | PASS |
| `method-not-found: error.message is string on both` | PASS |
| `method-not-found: error.message phrasing differs` | KNOWN-DIFF |
| `resources/list: result.resources is array on both` | PASS or KNOWN-DIFF |
| `prompts/list: result.prompts is array on both` | PASS or KNOWN-DIFF |
| `resources/read: not-found returns -32602` | PASS or KNOWN-DIFF |
| `invalid-params: missing arg returns -32602` | PASS or KNOWN-DIFF |
| `initialized-enforcement: both reject before notification` | PASS |
| `sse-response-mode: both return text/event-stream` | PASS |

## Known diffs

- **`error.message` phrasing** (method-not-found): rmcp returns just the method name;
  tower-mcp returns `"Method not found: {method}"`. Both use `-32601`.
- **SSE response wrapping (default mode)**: tower-mcp returns bare JSON by default;
  use `.sse_responses(true)` to match rmcp's SSE wrapping behavior.

## Test plan

- [ ] `cargo build -p rmcp-compat` compiles without errors
- [ ] `cargo clippy -p rmcp-compat -- -D warnings` is clean
- [ ] `cargo run -p rmcp-compat` produces results with no FAIL or ERROR lines