### PR TITLE
fix: wire client_requester into router for BidirectionalStdioTransport

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -716,7 +716,9 @@ impl BidirectionalStdioTransport {
             Arc::new(ChannelClientRequester::new(request_tx));
 
         let (notif_tx, notification_rx) = notification_channel(256);
-        let router = router.with_notification_sender(notif_tx);
+        let router = router
+            .with_notification_sender(notif_tx)
+            .with_client_requester(client_requester.clone());
 
         let service = JsonRpcService::new(router.clone());
 
@@ -732,7 +734,10 @@ impl BidirectionalStdioTransport {
 
     /// Get the client requester handle
     ///
-    /// Use this to configure the router's request context to enable sampling.
+    /// The requester is already wired into the router's request context by
+    /// [`Self::new`], so handlers can elicit and sample without further setup.
+    /// This getter exposes the same handle for advanced callers that want to
+    /// issue server-to-client requests directly.
     pub fn client_requester(&self) -> ClientRequesterHandle {
         self.client_requester.clone()
     }
@@ -807,7 +812,7 @@ impl BidirectionalStdioTransport {
     /// Handle an incoming message from stdin
     async fn handle_incoming_message<W>(&mut self, line: &str, writer: Arc<Mutex<W>>) -> Result<()>
     where
-        W: tokio::io::AsyncWrite + Unpin + Send,
+        W: tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
         tracing::debug!(input = %line, "Received message");
 
@@ -846,22 +851,32 @@ impl BidirectionalStdioTransport {
                 return self.write_parse_error(&e.to_string(), writer).await;
             }
         };
-        match self.service.call_message(message).await {
-            Ok(response) => {
-                let response_json = serde_json::to_string(&response).map_err(|e| {
-                    Error::Transport(format!("Failed to serialize response: {}", e))
-                })?;
-                tracing::debug!(output = %response_json, "Sending response");
-                self.write_line(&response_json, writer).await?;
+        // Dispatch the request on a spawned task so the run loop stays free to
+        // service outgoing server-to-client requests (elicitation/create,
+        // sampling/createMessage) and the client's responses to them while the
+        // handler is in flight. Handling the request inline here would deadlock
+        // any handler that calls `ctx.elicit_form()` / `ctx.sample()`: the
+        // handler awaits the client's response, but that response can only be
+        // read by this same loop (#923).
+        let mut service = self.service.clone();
+        tokio::spawn(async move {
+            let response_json = match service.call_message(message).await {
+                Ok(response) => serde_json::to_string(&response),
+                Err(e) => {
+                    tracing::error!(error = %e, "Error processing message");
+                    serde_json::to_string(&parse_error_response(e.to_string()))
+                }
+            };
+            match response_json {
+                Ok(json) => {
+                    tracing::debug!(output = %json, "Sending response");
+                    if let Err(e) = write_line_locked(&writer, &json).await {
+                        tracing::error!(error = %e, "Failed to write response to stdout");
+                    }
+                }
+                Err(e) => tracing::error!(error = %e, "Failed to serialize response"),
             }
-            Err(e) => {
-                tracing::error!(error = %e, "Error processing message");
-                let error_response = parse_error_response(e.to_string());
-                let response_json = serde_json::to_string(&error_response)
-                    .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))?;
-                self.write_line(&response_json, writer).await?;
-            }
-        }
+        });
 
         Ok(())
     }
@@ -975,21 +990,33 @@ impl BidirectionalStdioTransport {
     where
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
-        let mut writer = writer.lock().await;
-        writer
-            .write_all(line.as_bytes())
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to write to stdout: {}", e)))?;
-        writer
-            .write_all(b"\n")
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
-        writer
-            .flush()
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to flush stdout: {}", e)))?;
-        Ok(())
+        write_line_locked(&writer, line).await
     }
+}
+
+/// Write a single newline-terminated line to a shared writer and flush it.
+///
+/// Free-standing counterpart to [`BidirectionalStdioTransport::write_line`] so
+/// spawned request-dispatch tasks can write their responses without borrowing
+/// the transport.
+async fn write_line_locked<W>(writer: &Arc<Mutex<W>>, line: &str) -> Result<()>
+where
+    W: tokio::io::AsyncWrite + Unpin + Send,
+{
+    let mut writer = writer.lock().await;
+    writer
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| Error::Transport(format!("Failed to write to stdout: {}", e)))?;
+    writer
+        .write_all(b"\n")
+        .await
+        .map_err(|e| Error::Transport(format!("Failed to write newline: {}", e)))?;
+    writer
+        .flush()
+        .await
+        .map_err(|e| Error::Transport(format!("Failed to flush stdout: {}", e)))?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -10,9 +10,14 @@
 //! Regression coverage for #797 (bidi closed instead of writing a parse-error
 //! response) and follow-up to #812.
 
+use schemars::JsonSchema;
+use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::time::{Duration, timeout};
+use tower_mcp::extract::{Context, Json};
+use tower_mcp::protocol::{ElicitAction, ElicitFormParams, ElicitFormSchema};
 use tower_mcp::transport::stdio::BidirectionalStdioTransport;
-use tower_mcp::{McpRouter, StdioTransport};
+use tower_mcp::{CallToolResult, McpRouter, StdioTransport, ToolBuilder};
 use tower_mcp_types::testing::assert_jsonrpc_error_response;
 
 /// Build a minimal router used for the e2e tests. `ping` works without
@@ -274,4 +279,187 @@ async fn bidi_transport_loop_continues_after_parse_error() {
         "ping must return a successful result frame, got: {}",
         frames[1]
     );
+}
+
+// ============================================================================
+// BidirectionalStdioTransport: elicitation / client_requester (#923)
+// ============================================================================
+//
+// #923: BidirectionalStdioTransport::new built a client_requester but never
+// attached it to the router, so handler contexts had `client_requester: None`
+// and `ctx.can_elicit()` was always false -- elicitation and sampling could
+// never work over bidirectional stdio.
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+/// Read a single non-empty JSON-RPC frame from `reader`. Panics on EOF; callers
+/// wrap this in a timeout so a stalled server surfaces as a test failure rather
+/// than a hang.
+async fn read_frame<R>(reader: &mut BufReader<R>) -> serde_json::Value
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    loop {
+        let mut line = String::new();
+        let n = reader
+            .read_line(&mut line)
+            .await
+            .expect("read from server output");
+        if n == 0 {
+            panic!("EOF before a frame was read");
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        return serde_json::from_str(trimmed)
+            .unwrap_or_else(|e| panic!("invalid JSON on output: {e}: {trimmed}"));
+    }
+}
+
+/// #923 regression: the handler context must carry a client requester over
+/// bidirectional stdio, so `ctx.can_elicit()` is true. A tool reports the value
+/// back so the test can assert it end-to-end through the run loop.
+#[tokio::test]
+async fn bidi_transport_wires_client_requester_into_context() {
+    let check = ToolBuilder::new("check_elicit")
+        .description("Report whether elicitation is available")
+        .extractor_handler((), |ctx: Context, Json(_): Json<NoArgs>| async move {
+            Ok(CallToolResult::text(ctx.can_elicit().to_string()))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("bidi-elicit-test", "0.0.0")
+        .tool(check);
+    let mut transport = BidirectionalStdioTransport::new(router);
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let mut w = server_stdin_writer;
+    w.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{\"elicitation\":{}},\"clientInfo\":{\"name\":\"t\",\"version\":\"0\"}}}\n").await.unwrap();
+    w.write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    w.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"check_elicit\",\"arguments\":{}}}\n").await.unwrap();
+    w.flush().await.unwrap();
+
+    let reader = BufReader::new(server_stdout_reader);
+    let frames = read_n_frames(reader, 2).await;
+    drop(w);
+    let _ = handle.await;
+
+    // Frame 0 = initialize response, frame 1 = tools/call response.
+    let call = &frames[1];
+    assert_eq!(call["id"], 2, "expected tools/call response, got: {call}");
+    let text = call["result"]["content"][0]["text"].as_str().unwrap_or("");
+    assert_eq!(
+        text, "true",
+        "can_elicit() must be true once the requester is wired, got: {call}"
+    );
+}
+
+/// #923 regression: a full `elicitation/create` round-trip must complete over
+/// bidirectional stdio. A tool elicits confirmation; the test acts as the client
+/// and answers the server-initiated request. Bounded by a timeout so a run-loop
+/// that cannot pump the outgoing request concurrently (deadlock) fails fast
+/// instead of hanging.
+#[tokio::test]
+async fn bidi_transport_elicitation_round_trip() {
+    let confirm = ToolBuilder::new("confirm")
+        .description("Confirm an action via elicitation")
+        .extractor_handler((), |ctx: Context, Json(_): Json<NoArgs>| async move {
+            let params = ElicitFormParams {
+                message: "Confirm?".to_string(),
+                requested_schema: ElicitFormSchema::new().boolean_field(
+                    "confirmed",
+                    Some("Confirm"),
+                    true,
+                ),
+                mode: None,
+                meta: None,
+            };
+            match ctx.elicit_form(params).await {
+                Ok(result) => {
+                    let accepted = matches!(result.action, ElicitAction::Accept);
+                    Ok(CallToolResult::text(format!("confirmed={accepted}")))
+                }
+                Err(e) => Ok(CallToolResult::error(format!("elicit failed: {e}"))),
+            }
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("bidi-elicit-test", "0.0.0")
+        .tool(confirm);
+    let mut transport = BidirectionalStdioTransport::new(router);
+
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let driver = async move {
+        let mut w = server_stdin_writer;
+        let mut reader = BufReader::new(server_stdout_reader);
+
+        w.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{\"elicitation\":{}},\"clientInfo\":{\"name\":\"t\",\"version\":\"0\"}}}\n").await.unwrap();
+        w.flush().await.unwrap();
+        let init = read_frame(&mut reader).await;
+        assert_eq!(init["id"], 1, "expected initialize response, got: {init}");
+
+        w.write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+            .await
+            .unwrap();
+        w.write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"confirm\",\"arguments\":{}}}\n").await.unwrap();
+        w.flush().await.unwrap();
+
+        // Expect the server to initiate elicitation/create, answer it, then
+        // receive the tools/call response.
+        loop {
+            let frame = read_frame(&mut reader).await;
+            if frame.get("method").and_then(|m| m.as_str()) == Some("elicitation/create") {
+                let response = serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": frame["id"],
+                    "result": { "action": "accept", "content": { "confirmed": true } }
+                });
+                w.write_all(format!("{response}\n").as_bytes())
+                    .await
+                    .unwrap();
+                w.flush().await.unwrap();
+                continue;
+            }
+            if frame["id"] == serde_json::json!(2) {
+                assert!(
+                    frame.get("result").is_some(),
+                    "tools/call must succeed after elicitation, got: {frame}"
+                );
+                let text = frame["result"]["content"][0]["text"].as_str().unwrap_or("");
+                assert_eq!(
+                    text, "confirmed=true",
+                    "elicitation round-trip should return the client's accept, got: {frame}"
+                );
+                break;
+            }
+        }
+        drop(w);
+    };
+
+    timeout(Duration::from_secs(5), driver)
+        .await
+        .expect("elicitation round-trip over bidirectional stdio timed out (deadlock)");
+    let _ = timeout(Duration::from_secs(2), handle).await;
 }


### PR DESCRIPTION
Closes #923

## Problem

`BidirectionalStdioTransport::new` builds a `client_requester`, stores it as a struct field, and wires `.with_notification_sender(notif_tx)` onto the router, but never calls `.with_client_requester(...)` before building the `JsonRpcService`. The router only attaches a requester to per-request contexts when `self.inner.client_requester` is `Some`, so over bidirectional stdio every handler context gets `client_requester: None`: `ctx.can_elicit()` is always `false` and `ctx.elicit_form(...)` / `ctx.sample(...)` fail.

The sibling `WebSocketTransport` already wires `.with_client_requester(...)` correctly, so this is a stdio-specific oversight.

## Second bug found while fixing this: a run-loop deadlock

Wiring the requester makes `can_elicit()` return `true`, but a real `elicit_form()` / `sample()` round-trip then **deadlocks**. The bidi run loop awaits each incoming request inline in its `select!`:

```rust
result = reader.read_line(&mut line) => {
    ...
    self.handle_incoming_message(trimmed, writer.clone()).await?;  // parks here
}
Some(outgoing) = self.request_rx.recv() => { self.send_outgoing_request(...).await? }
```

While a handler is parked inside `elicit_form().await` (awaiting the client's response via a oneshot), the loop cannot reach the `request_rx` branch to actually send `elicitation/create`, nor read the client's response to it. The handler waits forever. `WebSocketTransport` avoids this by processing messages on a spawned task; bidi stdio did not.

## Fix

1. Attach the requester to the router before building the service (the reported one-liner):

```rust
let router = router
    .with_notification_sender(notif_tx)
    .with_client_requester(client_requester.clone());
```

2. Dispatch each incoming request on a spawned task so the run loop stays free to pump outgoing server-to-client requests and read their responses concurrently. Parse errors, notifications, and responses to our pending requests are still handled inline on the loop (the response path must stay on the loop to unblock spawned handlers).

## Tests

`crates/tower-mcp/tests/stdio_loop.rs`:

- `bidi_transport_wires_client_requester_into_context`: a tool reports `ctx.can_elicit()` back through the run loop; asserts `true`. Guards the wiring fix.
- `bidi_transport_elicitation_round_trip`: drives a full `elicitation/create` round-trip (the test plays the client), bounded by a 5s timeout so the pre-fix deadlock fails fast instead of hanging.

Before this PR the round-trip test times out; after, it passes. The existing `#797` parse-error ordering tests still pass unchanged.

## Validation

- `cargo fmt --all -- --check`: clean
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p tower-mcp`: 400 lib + 7 stdio integration + 84 doctests, 0 failures