### PR TITLE
chore(rmcp-compat): bump rmcp from 1.7.0 to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2006,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -2053,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-mcp = { path = "../../crates/tower-mcp", features = ["http"] }
-rmcp = { version = "1.7.0", features = [
+rmcp = { version = "2.1.0", features = [
     "server",
     "macros",
     "transport-streamable-http-server",

--- a/tools/rmcp-compat/README.md
+++ b/tools/rmcp-compat/README.md
@@ -24,7 +24,7 @@ It then runs a series of checks across all four operation groups:
 | `prompts/list` | `result.prompts` is array (may be empty) |
 | `resources/read` | Not-found URI returns an error; code is `-32602` per SEP-2164 |
 | `invalid-params` | Missing required tool argument returns error code `-32602` |
-| `initialized-enforcement` | Both reject requests before `notifications/initialized` with `-32600` |
+| `initialized-enforcement` | tower-mcp rejects requests before `notifications/initialized` with `-32600` (per #901); rmcp does not enforce this ordering, so the divergence is a KNOWN-DIFF |
 | `sse-response-mode` | With `.sse_responses(true)`, both return `text/event-stream` with valid JSON-RPC |
 
 ## How to run
@@ -61,7 +61,7 @@ Example output:
 [PASS] method-not-found: error.message is string on both
 [KNOWN-DIFF] method-not-found: error.message phrasing differs (both use -32601): ...
 
-Results: 18/20 checks passed (0 failed, 2 known-diffs, 0 errors)
+Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)
 ```
 
 ## Known diffs
@@ -69,12 +69,31 @@ Results: 18/20 checks passed (0 failed, 2 known-diffs, 0 errors)
 Known diffs are documented divergences that are intentional or explained. They
 appear as `[KNOWN-DIFF]` and do not cause a non-zero exit code.
 
-Current known diffs:
+Current known diffs (against rmcp 2.1.0):
 
 **`error.message` phrasing for method-not-found:**
 rmcp returns just the method name (e.g. `"nonexistent/method"`); tower-mcp
 returns `"Method not found: nonexistent/method"`. Both use error code `-32601`.
 This is an implementation detail, not a spec requirement.
+
+**`resources/read` not-found error code:**
+For a read of a non-existent resource URI, rmcp returns `-32601`
+(MethodNotFound, because it does not advertise the resources capability),
+while tower-mcp returns `-32602` (InvalidParams) per SEP-2164 (#841). Both
+return an error; the codes differ.
+
+**`invalid-params` reporting for a missing required argument:**
+Calling `echo` with no `message` argument is reported by both servers as a
+tool-level error (`result.isError == true`) rather than a JSON-RPC `-32602`
+error. Both agree on the shape.
+
+**`initialized-enforcement` ordering:**
+A `tools/list` sent before `notifications/initialized` is rejected by tower-mcp
+with `-32600` (InvalidRequest) per #901. rmcp does not enforce this ordering and
+returns the tools list. tower-mcp is the stricter, more spec-compliant side, so
+this is a documented divergence rather than a tower-mcp bug. (With rmcp 1.7.0
+this surfaced as a FAIL; rmcp 2.1.0 did not change the behavior, so it is now
+classified as a KNOWN-DIFF.)
 
 **SSE response wrapping (default mode):**
 rmcp always wraps synchronous JSON-RPC responses as SSE (`Content-Type:
@@ -106,7 +125,12 @@ validates that the opt-in SSE mode matches rmcp's behavior exactly.
 Change the version constraint in `tools/rmcp-compat/Cargo.toml`:
 
 ```toml
-rmcp = { version = "1.7.0", features = [...] }
+rmcp = { version = "2.1.0", features = [...] }
 ```
 
 Then run the harness and update any KNOWN-DIFF entries that have changed.
+
+Note the 1.x -> 2.x jump renamed `rmcp::model::Content` to
+`rmcp::model::ContentBlock` (constructed via `ContentBlock::text(...)`); the
+`StreamableHttpService`, `LocalSessionManager`, `ServerHandler`, and the
+`#[tool]`/`#[tool_router]`/`#[tool_handler]` macro surfaces were unchanged.

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -104,7 +104,7 @@ mod rmcp_server {
             &self,
             Parameters(EchoParams { message }): Parameters<EchoParams>,
         ) -> Result<CallToolResult, ErrorData> {
-            Ok(CallToolResult::success(vec![Content::text(message)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(message)]))
         }
     }
 
@@ -450,8 +450,11 @@ async fn check_initialize(
         }
     }
 
-    // MCP spec requires client to send notifications/initialized before other requests.
-    // Both servers now enforce this: rmcp strictly, tower-mcp since #901.
+    // MCP spec requires the client to send notifications/initialized after
+    // initialize and before other requests. Send it to both so subsequent
+    // requests are well-formed. Enforcement of this ordering differs between the
+    // servers (tower-mcp rejects a premature request, rmcp does not); that
+    // divergence is exercised by the initialized-enforcement check below.
     if let Some(ref sid) = rmcp_sid {
         send_initialized(client, &RMCP, Some(sid.as_str())).await;
     }
@@ -1161,8 +1164,10 @@ async fn check_invalid_params(
 
 /// Check 9: notifications/initialized enforcement
 ///
-/// Send tools/list WITHOUT the notifications/initialized step. Both servers
-/// (since #901) should return an error (-32600 InvalidRequest).
+/// Send tools/list WITHOUT the notifications/initialized step. tower-mcp rejects
+/// this with -32600 (InvalidRequest) per #901. rmcp does not enforce the ordering
+/// and returns the tools list, so this is a KNOWN-DIFF (tower-mcp is the stricter,
+/// more spec-compliant side), verified current as of rmcp 2.1.0.
 async fn check_initialized_enforcement(client: &reqwest::Client) -> Vec<CheckResult> {
     // Start fresh sessions without sending notifications/initialized
     let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-enforcement-test","version":"0.1.0"}}}"#;
@@ -1248,13 +1253,28 @@ async fn check_initialized_enforcement(client: &reqwest::Client) -> Vec<CheckRes
             ));
         }
         (None, Some(t)) => {
-            results.push(fail(
-                "initialized-enforcement",
-                format!(
-                    "tower-mcp returned error {t}; rmcp returned result: {}",
-                    rmcp_resp.body
-                ),
-            ));
+            // rmcp does not enforce the notifications/initialized ordering: it
+            // returns the tools/list result instead of an error. tower-mcp
+            // rejects with -32600 (InvalidRequest) per #901, which is the
+            // stricter, more spec-compliant behavior. Documented KNOWN-DIFF,
+            // not a bug. Any other tower-mcp code here would be a regression,
+            // so keep that path a FAIL.
+            if t == -32600 {
+                results.push(known_diff(
+                    "initialized-enforcement",
+                    "tower-mcp rejects tools/list before notifications/initialized with -32600 \
+                     (InvalidRequest, per #901); rmcp does not enforce the ordering and returns \
+                     the tools list. tower-mcp is the stricter, more spec-compliant side.",
+                ));
+            } else {
+                results.push(fail(
+                    "initialized-enforcement",
+                    format!(
+                        "tower-mcp returned error {t} (expected -32600); rmcp returned result: {}",
+                        rmcp_resp.body
+                    ),
+                ));
+            }
         }
         (None, None) => {
             results.push(fail(


### PR DESCRIPTION
## Summary

Bump the rmcp wire-format compatibility harness (`tools/rmcp-compat`) from rmcp 1.7.0 to 2.1.0, the current published release (2026-07-02, two major versions ahead), so the compat checks run against what users actually pin.

## Changes

- Bumped `rmcp` from `1.7.0` to `2.1.0` in `tools/rmcp-compat/Cargo.toml` (feature set unchanged; all used features still exist in 2.1.0) and refreshed `Cargo.lock`.
- Fixed the one API break across the 1.x -> 2.x jump: `rmcp::model::Content` was renamed to `rmcp::model::ContentBlock`. The echo handler now constructs `ContentBlock::text(...)`. `StreamableHttpService`, `LocalSessionManager`, `StreamableHttpServerConfig`, `ServerHandler`, the `#[tool]`/`#[tool_router]`/`#[tool_handler]` macros, `Parameters`, and `ProtocolVersion::V_2025_11_25` were unchanged.
- Reclassified the `initialized-enforcement` check from FAIL to KNOWN-DIFF. rmcp 2.1.0 still does not reject `tools/list` sent before `notifications/initialized` (it returns the tools list), while tower-mcp rejects with `-32600` per #901. tower-mcp is the stricter, more spec-compliant side, so this is a documented divergence, not a bug. A wrong tower-mcp code on that path is still a FAIL.
- Corrected two now-inaccurate code comments that claimed rmcp enforces the ordering.
- Updated the README: check table row, example summary line, the version reference in "How to update the rmcp version", and the known-diffs section (now documents all four runtime known-diffs: method-not-found phrasing, resources/read code, invalid-params shape, and initialized-enforcement).

## Verification

`cargo run -p rmcp-compat` now exits 0:

```
Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)

[KNOWN-DIFF] method-not-found: error.message phrasing differs (both use -32601)
[KNOWN-DIFF] resources/read: not-found error code differs: rmcp=-32601, tower-mcp=-32602 (-32602 InvalidParams per SEP-2164/#841)
[KNOWN-DIFF] invalid-params: missing params reported as tool-level error (isError=true): rmcp=true, tower-mcp=true
[KNOWN-DIFF] initialized-enforcement: tower-mcp rejects tools/list before notifications/initialized with -32600 (per #901); rmcp does not enforce the ordering and returns the tools list
```

`cargo fmt --all -- --check`, `cargo clippy -p rmcp-compat --all-targets -- -D warnings`, and `cargo test -p rmcp-compat` all pass.
