### PR TITLE
docs(cargo): correct SEP attribution on stateless feature comment

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -70,7 +70,8 @@ proxy = []
 resilience = ["dep:tower-resilience"]
 # Proc macros for tool/resource/prompt definitions
 macros = ["dep:tower-mcp-macros"]
-# SEP-1442 stateless MCP mode (experimental)
+# Stateless MCP mode (experimental). SEP-1442 is the legacy opt-in path; the
+# finalized 2026-07-28 mechanism is SEP-2575/2567/2243.
 stateless = []
 
 [dependencies.axum]


### PR DESCRIPTION
## Summary

The `stateless` cargo feature comment in `crates/tower-mcp/Cargo.toml` attributed the mode to SEP-1442. The finalized `2026-07-28` stateless mechanism is SEP-2575 (removes the `initialize` / `notifications/initialized` handshake, adds `server/discover`) + SEP-2567 (removes protocol-level sessions), plus SEP-2243 for standardized HTTP headers. SEP-1442 is only the legacy opt-in path.

This aligns the comment with how `crates/tower-mcp/src/stateless.rs` already labels the two paths (SEP-1442 as the legacy opt-in, SEP-2575 for the finalized bits).

## Change

- `crates/tower-mcp/Cargo.toml`: reword the `stateless` feature comment to name SEP-2575/2567/2243 as the finalized mechanism and SEP-1442 as the legacy opt-in path.

Comment-only change; no behavior or API impact.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --all-targets --all-features` (CI configuration)