### PR TITLE
docs(deployment): gate Unix socket doctest on the unix feature

### DIFF
--- a/crates/tower-mcp/src/deployment.rs
+++ b/crates/tower-mcp/src/deployment.rs
@@ -294,7 +294,7 @@
 //! avoids TCP overhead and removes the need to pick a port:
 //!
 //! ```rust,no_run
-//! # #[cfg(unix)]
+//! # #[cfg(all(unix, feature = "unix"))]
 //! # async fn run() -> Result<(), tower_mcp::BoxError> {
 //! # use tower_mcp::{McpRouter, UnixSocketTransport};
 //! let router = McpRouter::new().server_info("sidecar", "1.0.0");


### PR DESCRIPTION
## Problem

The "Containerized and Sidecar Patterns" module doctest in `crates/tower-mcp/src/deployment.rs` imports `tower_mcp::UnixSocketTransport`, which is exported only under `#[cfg(all(unix, feature = "unix"))]` (`crates/tower-mcp/src/lib.rs:572`). The example's hidden guard was `#[cfg(unix)]`, which covers the OS but not the `unix` cargo feature, so the doctest fails to compile whenever the `deployment` module is built (it is gated on `http`/`websocket`) with `unix` off:

```
error[E0432]: unresolved import `tower_mcp::UnixSocketTransport`
   --> crates/tower-mcp/src/deployment.rs:300:28
```

CI did not catch this because it runs `cargo test --all-targets --all-features`: `--all-features` resolves the import and `--all-targets` skips doctests entirely.

## Fix

Extend the hidden guard from `#[cfg(unix)]` to `#[cfg(all(unix, feature = "unix"))]`. rustdoc propagates the crate's active feature cfgs into the doctest crate, so:

- Under `--features unix` the example body is compiled and type-checked (real coverage where `UnixSocketTransport` exists).
- Otherwise the body is cleanly stripped, so the doctest no longer references a symbol that is not exported.

The change is on a hidden `#` line, so the rendered docs are unchanged. Verified the body is genuinely compiled (not silently stripped) by temporarily injecting a type error into the guarded body and confirming it failed under `--features unix` and passed under `--features http`.

## Verification

| Command | Result |
| --- | --- |
| `cargo test --doc -p tower-mcp` (default) | ok, 0 failed |
| `cargo test --doc -p tower-mcp --features http` (repro) | ok, `line 296 - compile ... ok` |
| `cargo test --doc -p tower-mcp --features unix` | ok, `line 296 - compile ... ok` |
| `cargo test --doc -p tower-mcp --all-features` | ok, 148 passed |
| `cargo test --all-targets --all-features` (CI) | exit 0 |
| `cargo fmt --all -- --check` | ok |
| `cargo clippy -p tower-mcp --all-features --all-targets -- -D warnings` | ok |

Unrelated to #927.