### PR TITLE
fix(extract): re-export schemars and add version-skew diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Add to your `Cargo.toml`:
 tower-mcp = "0.12"
 ```
 
+Tool input types use `schemars::JsonSchema`, and the derive must come from the
+same `schemars` major version tower-mcp uses (currently `1.x`). To avoid a
+version skew (which surfaces as opaque `ExtractorHandler` trait-bound errors),
+either match the version or depend on `schemars` through the re-export:
+
+```rust
+use tower_mcp::schemars::JsonSchema;
+```
+
 ### Feature Flags
 
 | Feature | Description |

--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -22,6 +22,14 @@
 //! - Use **`State<T>`** when state is passed directly to `extractor_handler()` (per-tool state)
 //! - Use **`Extension<T>`** when state is set via `McpRouter::with_state()` (router-level state)
 //!
+//! # schemars version alignment
+//!
+//! The `T` in [`Json<T>`] must implement [`schemars::JsonSchema`], and the
+//! derived impl must come from the same `schemars` major version tower-mcp uses
+//! (currently `1.x`). A version skew produces opaque `ExtractorHandler`
+//! trait-bound errors that do not name the real cause. Depend on `schemars`
+//! through the `tower_mcp::schemars` re-export to keep the versions aligned.
+//!
 //! # Example
 //!
 //! ```rust
@@ -588,6 +596,12 @@ where
 /// This trait is implemented for functions that take extractors as arguments.
 /// You don't need to implement this trait directly; it's automatically
 /// implemented for compatible async functions.
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` is not a valid extractor handler",
+    note = "each closure argument must be an extractor (`Json<T>`, `State<S>`, `Context`, `Extension<T>`, `RawArgs`) and the return type must be `Result<impl Into<CallToolResult>, ToolError>`",
+    note = "for a `Json<T>` argument, `T` must implement `serde::Deserialize` and `schemars::JsonSchema`",
+    note = "if `T` derives `JsonSchema` but this still fails, check for a `schemars` major-version mismatch: the derive must come from the same `schemars` version tower-mcp uses (>=1). Depend on it via the `tower_mcp::schemars` re-export to stay aligned"
+)]
 pub trait ExtractorHandler<S, T>: Clone + Send + Sync + 'static {
     /// The future returned by the handler.
     type Future: Future<Output = Result<CallToolResult>> + Send;
@@ -796,6 +810,12 @@ where
 // =============================================================================
 
 /// Helper trait to get schema from `Json<T>` extractor
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not implement `HasSchema`",
+    note = "for `Json<T>` this means `T: schemars::JsonSchema` is not satisfied",
+    note = "a common cause is a `schemars` major-version mismatch: the derive on `T` must come from the same `schemars` version tower-mcp uses (>=1)",
+    note = "depend on `schemars` via the `tower_mcp::schemars` re-export to keep the versions aligned"
+)]
 pub trait HasSchema {
     /// Returns the JSON Schema for this type, if available.
     fn schema() -> Option<Value>;
@@ -1327,6 +1347,31 @@ mod tests {
     struct TestInput {
         name: String,
         count: i32,
+    }
+
+    // Regression guard for the `tower_mcp::schemars` re-export (see #936).
+    // Deriving with `#[schemars(crate = "crate::schemars")]` forces the derive
+    // to resolve through the re-export, which is the path downstream users rely
+    // on to stay version-aligned. `HasSchema::schema()` must then succeed.
+    #[derive(Debug, Deserialize, JsonSchema)]
+    #[schemars(crate = "crate::schemars")]
+    struct ReexportInput {
+        field: String,
+    }
+
+    #[test]
+    fn reexported_schemars_derive_produces_schema() {
+        let schema = <Json<ReexportInput> as HasSchema>::schema()
+            .expect("re-exported schemars derive should yield a schema");
+        assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].get("field").is_some());
+
+        // Exercise the full extract path so the derived type is actually used.
+        let ctx = RequestContext::new(RequestId::Number(1));
+        let args = serde_json::json!({"field": "value"});
+        let Json(input) = Json::<ReexportInput>::from_tool_request(&ctx, &(), &args)
+            .expect("deserialization should succeed");
+        assert_eq!(input.field, "value");
     }
 
     #[test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -482,6 +482,15 @@ pub use tower_mcp_macros::resource_template_fn;
 #[cfg(feature = "macros")]
 pub use tower_mcp_macros::tool_fn;
 
+/// Re-export of the [`schemars`] crate.
+///
+/// Tool input types passed via [`extract::Json`] derive `schemars::JsonSchema`,
+/// and the derived impl must come from the same `schemars` major version that
+/// tower-mcp uses. Depending on `schemars` through this re-export
+/// (`tower_mcp::schemars`) keeps the versions aligned and avoids the opaque
+/// `ExtractorHandler` trait-bound errors that a version skew produces.
+pub use schemars;
+
 // Re-exports
 pub use async_task::{Task, TaskStore};
 pub use client::{


### PR DESCRIPTION
Closes #936.

## Problem

When a consumer's `schemars` dependency is a different major version than tower-mcp's (currently `1.2`), registering `Json<T>` tool handlers fails with a cascade of opaque `ExtractorHandler` trait-bound errors. The consumer's `derive(JsonSchema)` implements their schemars version's trait; the `HasSchema for Json<T>` impl is bound against tower-mcp's. When they differ the impl does not apply and the error points at `ExtractorHandler`, not at the version skew. A downstream project (b3nj0m1n/pirs) hit this and spent ~15 minutes tracing 26 errors back to a schemars 0.8 vs 1.x skew.

## Changes

1. Re-export `schemars` as `tower_mcp::schemars`, so consumers can depend on it through the re-export and stay version-aligned without a separate direct dependency.
2. Add `#[diagnostic::on_unimplemented]` to `ExtractorHandler` (and `HasSchema`) naming the likely cause and pointing at the re-export. This is the error users actually see; before, it named no cause. MSRV 1.90 supports the attribute.
3. Document the required schemars major version in the README installation section and the `extract` module docs.
4. Add a regression test that derives through the re-export path (`#[schemars(crate = "crate::schemars")]`) and asserts schema generation plus deserialization.

## Before / after

The handler-registration error now carries:

```
note: for a `Json<T>` argument, `T` must implement `serde::Deserialize` and `schemars::JsonSchema`
note: if `T` derives `JsonSchema` but this still fails, check for a `schemars` major-version
      mismatch: the derive must come from the same `schemars` version tower-mcp uses (>=1).
      Depend on it via the `tower_mcp::schemars` re-export to stay aligned
```

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p tower-mcp` (new `reexported_schemars_derive_produces_schema`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- Manually confirmed the diagnostic notes surface on a mismatched build.