### PR TITLE
fix(stateless): realign 2026-07-28 wire constants with the current draft schema

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -153,7 +153,7 @@ jobs:
           echo "$response" | grep -q '"no meta"' || { echo "FAIL: expected 'no meta' text"; exit 1; }
           echo "PASS: absent _meta returns 'no meta'"
 
-      - name: Check messages/listen opens SSE stream with 2026-07-28 (#868)
+      - name: Check subscriptions/listen opens SSE stream with 2026-07-28 (#868)
         run: |
           # Step 1: establish a 2025-11-25 session to get an mcp-session-id.
           # (2026-07-28 initialize is stateless and returns no session ID.)
@@ -178,17 +178,17 @@ jobs:
             -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
             -o /dev/null
 
-          # Step 2: open messages/listen SSE stream in the background, capture output.
+          # Step 2: open subscriptions/listen SSE stream in the background, capture output.
           # Sending MCP-Protocol-Version: 2026-07-28 on the request overrides the
           # session's negotiated version and enables the SSE stream.
           curl -s --max-time 5 \
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
-            -H "Mcp-Method: messages/listen" \
+            -H "Mcp-Method: subscriptions/listen" \
             -H "Accept: text/event-stream" \
             -H "mcp-session-id: $session_id" \
-            -d '{"jsonrpc":"2.0","id":5,"method":"messages/listen","params":{}}' \
+            -d '{"jsonrpc":"2.0","id":5,"method":"subscriptions/listen","params":{}}' \
             -o /tmp/sse-stream.txt &
           SSE_PID=$!
           sleep 1
@@ -199,12 +199,12 @@ jobs:
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
-            -H "Mcp-Method: messages/listen" \
+            -H "Mcp-Method: subscriptions/listen" \
             -H "Accept: text/event-stream" \
-            -d '{"jsonrpc":"2.0","id":6,"method":"messages/listen","params":{}}' || true)
-          echo "messages/listen Content-Type: $content_type"
+            -d '{"jsonrpc":"2.0","id":6,"method":"subscriptions/listen","params":{}}' || true)
+          echo "subscriptions/listen Content-Type: $content_type"
           echo "$content_type" | grep -q "text/event-stream" || { echo "FAIL: expected text/event-stream"; kill $SSE_PID 2>/dev/null; exit 1; }
-          echo "PASS: messages/listen returns SSE stream for 2026-07-28"
+          echo "PASS: subscriptions/listen returns SSE stream for 2026-07-28"
 
           # Step 4: trigger log notifications on the established session.
           # test_tool_with_logging sends three log notifications via ctx.send_log().
@@ -222,27 +222,27 @@ jobs:
           echo "SSE stream output:"
           cat /tmp/sse-stream.txt
           grep -q "^data:" /tmp/sse-stream.txt || { echo "FAIL: no data: lines in SSE stream"; exit 1; }
-          echo "PASS: notification event appeared in messages/listen SSE stream"
+          echo "PASS: notification event appeared in subscriptions/listen SSE stream"
 
-      - name: Check messages/listen returns JSON-RPC error without 2026-07-28 (#868)
+      - name: Check subscriptions/listen returns JSON-RPC error without 2026-07-28 (#868)
         run: |
-          # Without MCP-Protocol-Version: 2026-07-28, messages/listen must NOT
+          # Without MCP-Protocol-Version: 2026-07-28, subscriptions/listen must NOT
           # return an SSE stream. The 2025-11-25 server returns MethodNotFound
-          # (-32601) because messages/listen is a 2026-07-28-only method.
+          # (-32601) because subscriptions/listen is a 2026-07-28-only method.
           # We assert the error code is exactly -32601 and no SSE stream is returned.
-          content_type=$(curl -s -o /tmp/messages-listen-legacy.json \
+          content_type=$(curl -s -o /tmp/subscriptions-listen-legacy.json \
             -w "%{content_type}" \
             --max-time 3 \
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
-            -d '{"jsonrpc":"2.0","id":8,"method":"messages/listen","params":{}}' || true)
-          response=$(cat /tmp/messages-listen-legacy.json)
-          echo "Legacy messages/listen Content-Type: $content_type"
-          echo "Legacy messages/listen body: $response"
+            -d '{"jsonrpc":"2.0","id":8,"method":"subscriptions/listen","params":{}}' || true)
+          response=$(cat /tmp/subscriptions-listen-legacy.json)
+          echo "Legacy subscriptions/listen Content-Type: $content_type"
+          echo "Legacy subscriptions/listen body: $response"
           echo "$content_type" | grep -vq "text/event-stream" || { echo "FAIL: must not return SSE stream without 2026-07-28"; exit 1; }
           echo "$response" | grep -q '"error"' || { echo "FAIL: expected a JSON-RPC error field"; exit 1; }
           echo "$response" | grep -q -- '-32601' || { echo "FAIL: expected MethodNotFound error code -32601"; exit 1; }
-          echo "PASS: messages/listen returns MethodNotFound (-32601) without 2026-07-28 version"
+          echo "PASS: subscriptions/listen returns MethodNotFound (-32601) without 2026-07-28 version"
 
       - name: Show server logs on failure
         if: failure()

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ use tower_mcp::schemars::JsonSchema;
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
 | `resilience` | Re-export tower-resilience circuit breaker, rate limiter, and bulkhead layers |
-| `stateless` | Experimental 2026-07-28 stateless protocol mode (SEP-2575 final + SEP-2567 accepted) -- version-gated sessionless dispatch, `server/discover` RPC, `messages/listen` SSE endpoint, per-request `_meta` client capabilities. Requires `http`. |
+| `stateless` | Experimental 2026-07-28 stateless protocol mode (SEP-2575 final + SEP-2567 accepted) -- version-gated sessionless dispatch, `server/discover` RPC, `subscriptions/listen` SSE endpoint, per-request `_meta` client capabilities. Requires `http`. |
 
 Example with features:
 
@@ -591,7 +591,7 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 Numbers above are from `@modelcontextprotocol/conformance@0.1.15`, run on every PR. Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot.
 
 The `stateless` feature enables an experimental 2026-07-28 protocol path (version-gated, behind
-`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `messages/listen`, and per-request
+`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, and per-request
 `_meta` capabilities as defined by SEP-2575 (final) and SEP-2567 (accepted). The 2026-07-28
 version is not yet stable and is not included in `SUPPORTED_PROTOCOL_VERSIONS`.
 
@@ -623,7 +623,7 @@ version is not yet stable and is not included in `SUPPORTED_PROTOCOL_VERSIONS`.
 - [x] [`_meta` field on all protocol types](https://modelcontextprotocol.io/specification/2025-11-25)
 - [x] [Strict HTTP headers: `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version` (SEP-2243)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final)
 - [x] [`server/discover` RPC -- stateless capability discovery (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
-- [x] [`messages/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `stateless` feature, 2026-07-28+)
+- [x] [`subscriptions/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `stateless` feature, 2026-07-28+)
 - [x] [Per-request `_meta` client capabilities -- `StatelessRequestMeta` (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
 
 We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](https://github.com/joshrotenberg/tower-mcp/issues?q=label%3Asep). A weekly workflow syncs status from the upstream spec repository.

--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -23,17 +23,24 @@
 //! | Code   | Name                          | Source | Meaning                              |
 //! |--------|-------------------------------|--------|--------------------------------------|
 //! | -32000 | ConnectionClosed              | *impl* | Transport connection was closed      |
-//! | -32001 | HeaderMismatch                | **spec** (SEP-2243) | HTTP headers do not match the request body, or required headers are missing/malformed |
 //! | -32002 | ResourceNotFound              | *deprecated* | **SEP-2164** reassigned to -32602; variant kept for backcompat |
-//! | -32003 | MissingRequiredClientCapability | **spec** (SEP-2575) | Client lacks a capability required by the request |
-//! | -32004 | UnsupportedProtocolVersion    | **spec** (SEP-2575) | Server does not support the request's protocol version |
 //! | -32005 | SessionNotFound               | *impl* | Session not found or expired (legacy; deprecated by SEP-2567) |
 //! | -32006 | SessionRequired               | *impl* | Mcp-Session-Id header required (legacy; deprecated by SEP-2567) |
 //! | -32007 | Forbidden                     | *impl* | Access forbidden (insufficient scope)|
-//! | -32008 | AlreadySubscribed             | *impl* | Resource already subscribed (moved from -32003 to avoid collision with SEP-2575) |
-//! | -32009 | NotSubscribed                 | *impl* | Resource not subscribed (moved from -32004 to avoid collision with SEP-2575) |
-//! | -32010 | RequestTimeout                | *impl* | Request exceeded timeout (moved from -32001 to avoid collision with SEP-2243) |
+//! | -32008 | AlreadySubscribed             | *impl* | Resource already subscribed          |
+//! | -32009 | NotSubscribed                 | *impl* | Resource not subscribed              |
+//! | -32010 | RequestTimeout                | *impl* | Request exceeded timeout             |
+//! | -32020 | HeaderMismatch                | **spec** (SEP-2243) | HTTP headers do not match the request body, or required headers are missing/malformed |
+//! | -32021 | MissingRequiredClientCapability | **spec** (SEP-2575) | Client lacks a capability required by the request |
+//! | -32022 | UnsupportedProtocolVersion    | **spec** (SEP-2575) | Server does not support the request's protocol version |
 //! | -32042 | UrlElicitationRequired        | TS SDK | URL elicitation required             |
+//!
+//! The three **spec** codes were renumbered upstream by the error-code
+//! allocation policy (spec PR modelcontextprotocol#2907, 2026-06): the SEP
+//! documents originally assigned -32001 (HeaderMismatch), -32003
+//! (MissingRequiredClientCapability), and -32004 (UnsupportedProtocolVersion);
+//! the draft schema now assigns -32020/-32021/-32022 and is canonical. Verify
+//! against the published `schema/2026-07-28` at finalization.
 
 use serde::{Deserialize, Serialize};
 
@@ -68,16 +75,18 @@ pub enum ErrorCode {
 /// is permitted by JSON-RPC 2.0 but they are not part of the MCP wire spec.
 ///
 /// Recently-changed assignments:
-/// - `MissingRequiredClientCapability` (-32003) and `UnsupportedProtocolVersion`
-///   (-32004) are spec assignments from SEP-2575.
+/// - `HeaderMismatch` (SEP-2243), `MissingRequiredClientCapability`, and
+///   `UnsupportedProtocolVersion` (both SEP-2575) were originally assigned
+///   -32001/-32003/-32004 by their SEP documents. The upstream error-code
+///   allocation policy (spec PR modelcontextprotocol#2907, 2026-06)
+///   renumbered them to -32020/-32021/-32022 in the draft schema, which is
+///   canonical. **This is a breaking change on the wire** within the
+///   experimental 2026-07-28 surface.
 /// - `AlreadySubscribed` and `NotSubscribed` previously occupied -32003 and
-///   -32004; they moved to -32008 and -32009 to make room. **This is a
-///   breaking change on the wire** for any subscribe/unsubscribe responses
-///   that relied on the old codes.
-/// - `HeaderMismatch` (-32001) is a spec assignment from SEP-2243 (HTTP
-///   header standardization). `RequestTimeout` previously occupied -32001
-///   and moved to -32010 to make room. **This is a breaking change on the
-///   wire** for any consumers matching on the old `RequestTimeout` code.
+///   -32004; they moved to -32008 and -32009 when those slots were believed
+///   to be spec-assigned. They stay at -32008/-32009.
+/// - `RequestTimeout` previously occupied -32001 and moved to -32010 for the
+///   same reason. It stays at -32010.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 #[non_exhaustive]
@@ -88,8 +97,11 @@ pub enum McpErrorCode {
     /// `Mcp-Param-*`) do not match the corresponding values in the request
     /// body, or a required header is missing or malformed.
     ///
+    /// Originally -32001 in the SEP text; renumbered to -32020 by the
+    /// upstream error-code allocation (spec PR modelcontextprotocol#2907).
+    ///
     /// Use [`JsonRpcError::header_mismatch`] to construct.
-    HeaderMismatch = -32001,
+    HeaderMismatch = -32020,
     /// Resource not found.
     ///
     /// **Deprecated**: SEP-2164 (FINAL) moves this to the standard JSON-RPC
@@ -106,11 +118,18 @@ pub enum McpErrorCode {
     ResourceNotFound = -32002,
     /// SEP-2575: client capabilities advertised on the request do not
     /// include a capability required by the called method.
-    MissingRequiredClientCapability = -32003,
+    ///
+    /// Originally -32003 in the SEP text; renumbered to -32021 by the
+    /// upstream error-code allocation (spec PR modelcontextprotocol#2907).
+    MissingRequiredClientCapability = -32021,
     /// SEP-2575: server does not support the protocol version the client
     /// requested (via `MCP-Protocol-Version` header or per-request `_meta`).
+    ///
+    /// Originally -32004 in the SEP text; renumbered to -32022 by the
+    /// upstream error-code allocation (spec PR modelcontextprotocol#2907).
+    ///
     /// Use [`JsonRpcError::unsupported_protocol_version`] to construct.
-    UnsupportedProtocolVersion = -32004,
+    UnsupportedProtocolVersion = -32022,
     /// Session not found or expired -- client should re-initialize.
     ///
     /// SEP-2567 deprecates sessions entirely. This code stays for the
@@ -122,14 +141,14 @@ pub enum McpErrorCode {
     SessionRequired = -32006,
     /// Access forbidden (insufficient scope or authorization).
     Forbidden = -32007,
-    /// Resource already subscribed. Moved from -32003 to avoid the
-    /// SEP-2575 `MissingRequiredClientCapability` collision.
+    /// Resource already subscribed. Moved from -32003 when that slot was
+    /// believed to be spec-assigned; stays at -32008.
     AlreadySubscribed = -32008,
-    /// Resource not subscribed (for unsubscribe). Moved from -32004 to
-    /// avoid the SEP-2575 `UnsupportedProtocolVersion` collision.
+    /// Resource not subscribed (for unsubscribe). Moved from -32004 when
+    /// that slot was believed to be spec-assigned; stays at -32009.
     NotSubscribed = -32009,
-    /// Request exceeded timeout. Moved from -32001 to avoid the SEP-2243
-    /// `HeaderMismatch` collision.
+    /// Request exceeded timeout. Moved from -32001 when that slot was
+    /// believed to be spec-assigned; stays at -32010.
     RequestTimeout = -32010,
     /// URL elicitation is required before processing the request.
     UrlElicitationRequired = -32042,
@@ -325,7 +344,7 @@ impl JsonRpcError {
     }
 }
 
-/// SEP-2575 error data for `UnsupportedProtocolVersion` (-32004).
+/// SEP-2575 error data for `UnsupportedProtocolVersion` (-32022).
 ///
 /// Wire shape per the draft schema:
 /// ```json
@@ -575,19 +594,21 @@ mod tests {
     use super::*;
 
     // =========================================================================
-    // SEP-2575 UnsupportedProtocolVersion (-32004) wire-format tests
+    // SEP-2575 UnsupportedProtocolVersion (-32022) wire-format tests
     // =========================================================================
 
     #[test]
-    fn unsupported_protocol_version_code_is_negative_32004() {
-        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32004);
+    fn unsupported_protocol_version_code_is_negative_32022() {
+        // Renumbered from -32004 by the upstream error-code allocation
+        // (spec PR modelcontextprotocol#2907).
+        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32022);
     }
 
     #[test]
     fn unsupported_protocol_version_constructor_has_spec_shape() {
         let err =
             JsonRpcError::unsupported_protocol_version("2027-01-01", ["2026-07-28", "2025-11-25"]);
-        assert_eq!(err.code, -32004);
+        assert_eq!(err.code, -32022);
         let data = err.data.expect("data must be present");
         assert_eq!(
             data["supported"],
@@ -637,21 +658,25 @@ mod tests {
 
     #[test]
     fn subscribe_codes_moved_off_spec_assignments() {
-        // -32003 and -32004 belong to SEP-2575 spec codes; our subscribe codes
-        // moved to -32008/-32009 to avoid collision.
+        // Our subscribe codes moved to -32008/-32009 when -32003/-32004 were
+        // believed spec-assigned. The SEP-2575 codes have since been
+        // renumbered to -32021/-32022 (spec PR modelcontextprotocol#2907);
+        // the subscribe codes stay put.
         assert_eq!(McpErrorCode::AlreadySubscribed.code(), -32008);
         assert_eq!(McpErrorCode::NotSubscribed.code(), -32009);
-        assert_eq!(McpErrorCode::MissingRequiredClientCapability.code(), -32003);
-        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32004);
+        assert_eq!(McpErrorCode::MissingRequiredClientCapability.code(), -32021);
+        assert_eq!(McpErrorCode::UnsupportedProtocolVersion.code(), -32022);
     }
 
     // =========================================================================
-    // SEP-2243 HeaderMismatch (-32001) wire-format tests
+    // SEP-2243 HeaderMismatch (-32020) wire-format tests
     // =========================================================================
 
     #[test]
-    fn header_mismatch_code_is_negative_32001() {
-        assert_eq!(McpErrorCode::HeaderMismatch.code(), -32001);
+    fn header_mismatch_code_is_negative_32020() {
+        // Renumbered from -32001 by the upstream error-code allocation
+        // (spec PR modelcontextprotocol#2907).
+        assert_eq!(McpErrorCode::HeaderMismatch.code(), -32020);
     }
 
     #[test]
@@ -659,17 +684,17 @@ mod tests {
         let err = JsonRpcError::header_mismatch(
             "Mcp-Name header value 'foo' does not match body value 'bar'",
         );
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
         assert_eq!(err.code, McpErrorCode::HeaderMismatch.code());
         assert!(err.message.contains("Mcp-Name"));
     }
 
     #[test]
     fn request_timeout_moved_off_spec_assignment() {
-        // SEP-2243 took -32001 for HeaderMismatch; our RequestTimeout
-        // moved to -32010 to avoid collision.
+        // RequestTimeout moved to -32010 when -32001 was believed
+        // spec-assigned; HeaderMismatch is now -32020.
         assert_eq!(McpErrorCode::RequestTimeout.code(), -32010);
-        assert_eq!(McpErrorCode::HeaderMismatch.code(), -32001);
+        assert_eq!(McpErrorCode::HeaderMismatch.code(), -32020);
     }
 
     #[test]

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -27,12 +27,13 @@
 //!   protocol versions and capabilities without requiring an `initialize`
 //!   handshake.
 //! - [`error::UnsupportedProtocolVersionData`] -- the structured error data
-//!   attached to a `-32004` (UnsupportedProtocolVersion) response. Contains
+//!   attached to a `-32022` (UnsupportedProtocolVersion) response. Contains
 //!   the `supported` versions list and the `requested` version string.
-//! - [`error::McpErrorCode::HeaderMismatch`] (`-32001`) and
-//!   [`error::McpErrorCode::UnsupportedProtocolVersion`] (`-32004`) -- new
-//!   spec-assigned error codes (SEP-2243 and SEP-2575 respectively). See the
-//!   [`error`] module for the full error code table.
+//! - [`error::McpErrorCode::HeaderMismatch`] (`-32020`) and
+//!   [`error::McpErrorCode::UnsupportedProtocolVersion`] (`-32022`) --
+//!   spec-assigned error codes (SEP-2243 and SEP-2575, renumbered by the
+//!   upstream error-code allocation in spec PR modelcontextprotocol#2907).
+//!   See the [`error`] module for the full error code table.
 //!
 //! # The only standalone Rust MCP types crate
 //!

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -36,7 +36,7 @@ pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-03-26"];
 /// (codegen, conformance harnesses) can reference it explicitly.
 ///
 /// Once the implementation is feature-complete (sessionless transport,
-/// `server/discover`, `messages/listen`, per-request `_meta` capabilities;
+/// `server/discover`, `subscriptions/listen`, per-request `_meta` capabilities;
 /// see [tower-mcp#814]) this value will move into
 /// [`SUPPORTED_PROTOCOL_VERSIONS`] and become the new
 /// [`LATEST_PROTOCOL_VERSION`].
@@ -237,7 +237,7 @@ pub mod notifications {
     /// Log message notification
     pub const MESSAGE: &str = "notifications/message";
     /// Task status changed
-    pub const TASK_STATUS_CHANGED: &str = "notifications/tasks/status";
+    pub const TASK_STATUS_CHANGED: &str = "notifications/tasks";
     /// Elicitation completed (for URL-based elicitation)
     pub const ELICITATION_COMPLETE: &str = "notifications/elicitation/complete";
 }
@@ -396,12 +396,6 @@ pub enum McpRequest {
     ListPrompts(ListPromptsParams),
     /// Get a prompt
     GetPrompt(GetPromptParams),
-    /// List tasks.
-    ///
-    /// Removed from the core protocol by SEP-2663 (the tasks extension drops
-    /// `tasks/list` entirely). Kept here as a legacy parsing target so 2025-11-25
-    /// clients are not broken; new clients should not send this method.
-    ListTasks(ListTasksParams),
     /// Get task info (`tasks/get`).
     GetTaskInfo(GetTaskInfoParams),
     /// Update an in-flight task with `inputResponses` (`tasks/update`).
@@ -410,12 +404,6 @@ pub enum McpRequest {
     /// from the 2025-11-25 experimental spec. The response is an empty ack;
     /// task state is observed via `tasks/get`.
     UpdateTask(UpdateTaskParams),
-    /// Legacy `tasks/result` request from the 2025-11-25 experimental spec.
-    ///
-    /// SEP-2663 removes this method (clients are expected to receive
-    /// `MethodNotFound`), but we keep parsing it so 2025-11-25 servers built
-    /// on this crate continue to handle existing clients.
-    GetTaskResult(GetTaskResultParams),
     /// Cancel a task (`tasks/cancel`).
     CancelTask(CancelTaskParams),
     /// Ping (keepalive)
@@ -427,12 +415,12 @@ pub enum McpRequest {
     /// SEP-2575: discover server capabilities without an initialize handshake
     Discover(DiscoverParams),
     /// SEP-2575 / SEP-2567: open a server-to-client notification stream
-    /// (`messages/listen`).
+    /// (`subscriptions/listen`).
     ///
     /// The HTTP transport intercepts this before it reaches the router and
     /// returns an SSE stream. The variant is defined here for client-side
     /// type-safe construction and for any future transport implementations.
-    MessagesListen(MessagesListenParams),
+    SubscriptionsListen(SubscriptionsListenParams),
     /// Unknown method
     Unknown {
         method: String,
@@ -454,16 +442,14 @@ impl McpRequest {
             McpRequest::UnsubscribeResource(_) => "resources/unsubscribe",
             McpRequest::ListPrompts(_) => "prompts/list",
             McpRequest::GetPrompt(_) => "prompts/get",
-            McpRequest::ListTasks(_) => "tasks/list",
             McpRequest::GetTaskInfo(_) => "tasks/get",
             McpRequest::UpdateTask(_) => "tasks/update",
-            McpRequest::GetTaskResult(_) => "tasks/result",
             McpRequest::CancelTask(_) => "tasks/cancel",
             McpRequest::Ping => "ping",
             McpRequest::SetLoggingLevel(_) => "logging/setLevel",
             McpRequest::Complete(_) => "completion/complete",
             McpRequest::Discover(_) => "server/discover",
-            McpRequest::MessagesListen(_) => "messages/listen",
+            McpRequest::SubscriptionsListen(_) => "subscriptions/listen",
             McpRequest::Unknown { method, .. } => method,
         }
     }
@@ -566,29 +552,26 @@ pub enum McpResponse {
     ListPrompts(ListPromptsResult),
     GetPrompt(GetPromptResult),
     CreateTask(CreateTaskResult),
-    ListTasks(ListTasksResult),
     GetTaskInfo(TaskObject),
     /// Ack-only response for `tasks/update` (SEP-2663).
     UpdateTask(EmptyResult),
-    GetTaskResult(CallToolResult),
-    /// Response to `tasks/cancel`.
+    /// Ack-only response for `tasks/cancel` (SEP-2663).
     ///
-    /// Note: SEP-2663 redefines `tasks/cancel` to return an empty ack, but to
-    /// preserve back-compat for 2025-11-25 clients we still surface the task
-    /// state object here. A future release may migrate to the ack-only shape.
-    CancelTask(TaskObject),
+    /// SEP-2663 (final) requires an empty ack; the observable task status is
+    /// polled via `tasks/get` and may remain non-terminal after the ack.
+    CancelTask(EmptyResult),
     SetLoggingLevel(EmptyResult),
     Complete(CompleteResult),
     Pong(EmptyResult),
     /// SEP-2575 `server/discover` response.
     Discover(DiscoverResult),
-    /// SEP-2575 / SEP-2567 `messages/listen` response.
+    /// SEP-2575 / SEP-2567 `subscriptions/listen` response.
     ///
     /// In practice the HTTP transport returns an SSE stream for this method
     /// and never produces this variant. It is provided for completeness and
     /// for potential future transport implementations that want a typed
     /// result.
-    MessagesListen(MessagesListenResult),
+    SubscriptionsListen(SubscriptionsListenResult),
     Empty(EmptyResult),
     /// Raw JSON value for experimental/extension methods.
     Raw(Value),
@@ -1603,12 +1586,12 @@ pub struct DiscoverResult {
 }
 
 // =============================================================================
-// messages/listen (SEP-2575 / SEP-2567)
+// subscriptions/listen (SEP-2575 / SEP-2567)
 // =============================================================================
 
-/// Parameters for the `messages/listen` RPC (SEP-2575 / SEP-2567).
+/// Parameters for the `subscriptions/listen` RPC (SEP-2575 / SEP-2567).
 ///
-/// `messages/listen` is sent by the client over HTTP POST to open a
+/// `subscriptions/listen` is sent by the client over HTTP POST to open a
 /// server-to-client notification stream (SSE). The server responds with
 /// `Content-Type: text/event-stream` and streams zero or more
 /// `notifications/*` events until the client disconnects.
@@ -1620,19 +1603,19 @@ pub struct DiscoverResult {
 /// The struct takes no parameters today; the empty struct is reserved so
 /// future SEPs can add optional fields without breaking callers.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct MessagesListenParams {
+pub struct SubscriptionsListenParams {
     /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
 }
 
-/// Result of the `messages/listen` RPC.
+/// Result of the `subscriptions/listen` RPC.
 ///
 /// In practice the HTTP transport opens an SSE stream and never serializes
 /// this type as a JSON-RPC result. It is provided for completeness and for
 /// transports that want a typed acknowledgement shape.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct MessagesListenResult {
+pub struct SubscriptionsListenResult {
     /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -4308,13 +4291,8 @@ impl McpRequest {
             // `io.modelcontextprotocol/tasks` identifier is the *extension*
             // label used for capability declarations, not a method prefix.
             // `tasks/list` and `tasks/result` are 2025-11-25 experimental
-            // methods that SEP-2663 removes; we still parse them so legacy
-            // clients receive a structured response instead of a transport
-            // error, but server handlers may reject them at their own discretion.
-            "tasks/list" => {
-                let p: ListTasksParams = serde_json::from_value(params).unwrap_or_default();
-                Ok(McpRequest::ListTasks(p))
-            }
+            // methods that final SEP-2663 removes; they intentionally fall
+            // through to `Unknown` so the router answers `MethodNotFound`.
             "tasks/get" => {
                 let p: GetTaskInfoParams = serde_json::from_value(params)?;
                 Ok(McpRequest::GetTaskInfo(p))
@@ -4322,10 +4300,6 @@ impl McpRequest {
             "tasks/update" => {
                 let p: UpdateTaskParams = serde_json::from_value(params)?;
                 Ok(McpRequest::UpdateTask(p))
-            }
-            "tasks/result" => {
-                let p: GetTaskResultParams = serde_json::from_value(params)?;
-                Ok(McpRequest::GetTaskResult(p))
             }
             "tasks/cancel" => {
                 let p: CancelTaskParams = serde_json::from_value(params)?;
@@ -4345,11 +4319,12 @@ impl McpRequest {
                 let p: DiscoverParams = serde_json::from_value(params).unwrap_or_default();
                 Ok(McpRequest::Discover(p))
             }
-            "messages/listen" => {
+            "subscriptions/listen" => {
                 // SEP-2575 / SEP-2567: client-initiated streaming.
                 // Empty-or-missing params is valid.
-                let p: MessagesListenParams = serde_json::from_value(params).unwrap_or_default();
-                Ok(McpRequest::MessagesListen(p))
+                let p: SubscriptionsListenParams =
+                    serde_json::from_value(params).unwrap_or_default();
+                Ok(McpRequest::SubscriptionsListen(p))
             }
             method => Ok(McpRequest::Unknown {
                 method: method.to_string(),
@@ -4467,30 +4442,31 @@ mod tests {
     }
 
     // =========================================================================
-    // SEP-2575 / SEP-2567 (messages/listen) wire-format tests
+    // SEP-2575 / SEP-2567 (subscriptions/listen) wire-format tests
     // =========================================================================
 
     #[test]
-    fn messages_listen_request_round_trips_with_no_params() {
+    fn subscriptions_listen_request_round_trips_with_no_params() {
         // Per SEP-2575 / SEP-2567, params is empty/optional.
-        let no_params = r#"{"jsonrpc":"2.0","id":1,"method":"messages/listen"}"#;
+        let no_params = r#"{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen"}"#;
         let req: JsonRpcRequest = serde_json::from_str(no_params).unwrap();
         let parsed = McpRequest::from_jsonrpc(&req).unwrap();
-        assert!(matches!(parsed, McpRequest::MessagesListen(_)));
-        assert_eq!(parsed.method_name(), "messages/listen");
+        assert!(matches!(parsed, McpRequest::SubscriptionsListen(_)));
+        assert_eq!(parsed.method_name(), "subscriptions/listen");
 
-        let empty_params = r#"{"jsonrpc":"2.0","id":2,"method":"messages/listen","params":{}}"#;
+        let empty_params =
+            r#"{"jsonrpc":"2.0","id":2,"method":"subscriptions/listen","params":{}}"#;
         let req: JsonRpcRequest = serde_json::from_str(empty_params).unwrap();
         let parsed = McpRequest::from_jsonrpc(&req).unwrap();
-        assert!(matches!(parsed, McpRequest::MessagesListen(_)));
+        assert!(matches!(parsed, McpRequest::SubscriptionsListen(_)));
     }
 
     #[test]
-    fn messages_listen_request_serializes_with_correct_method() {
-        let req = JsonRpcRequest::new(42i64, "messages/listen");
+    fn subscriptions_listen_request_serializes_with_correct_method() {
+        let req = JsonRpcRequest::new(42i64, "subscriptions/listen");
         let json = serde_json::to_string(&req).unwrap();
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
-        assert_eq!(v["method"], "messages/listen");
+        assert_eq!(v["method"], "subscriptions/listen");
         assert_eq!(v["jsonrpc"], "2.0");
         assert_eq!(v["id"], 42);
     }
@@ -5893,9 +5869,9 @@ mod tests {
     }
 
     #[test]
-    fn legacy_tasks_methods_still_parse_for_back_compat() {
-        // 2025-11-25 method strings remain parseable so servers built against
-        // this crate continue to receive structured requests from legacy clients.
+    fn final_tasks_methods_parse() {
+        // The SEP-2663 (final) method set: tasks/get, tasks/update,
+        // tasks/cancel. tasks/list and tasks/result are removed.
         for (method, params, expected_name) in [
             (
                 "tasks/get",
@@ -5907,17 +5883,32 @@ mod tests {
                 serde_json::json!({ "taskId": "x" }),
                 "tasks/cancel",
             ),
-            (
-                "tasks/result",
-                serde_json::json!({ "taskId": "x" }),
-                "tasks/result",
-            ),
-            ("tasks/list", serde_json::json!({}), "tasks/list"),
         ] {
             let req = JsonRpcRequest::new(1, method).with_params(params);
             let parsed = McpRequest::from_jsonrpc(&req)
-                .unwrap_or_else(|e| panic!("failed to parse legacy {method}: {e:?}"));
+                .unwrap_or_else(|e| panic!("failed to parse {method}: {e:?}"));
             assert_eq!(parsed.method_name(), expected_name);
+        }
+    }
+
+    #[test]
+    fn removed_tasks_methods_fall_through_to_unknown() {
+        // Final SEP-2663 removes tasks/list and tasks/result; they must not
+        // parse into typed requests. Falling through to `Unknown` makes the
+        // router answer MethodNotFound (-32601), which is the spec-required
+        // behavior for removed methods.
+        for (method, params) in [
+            ("tasks/list", serde_json::json!({})),
+            ("tasks/result", serde_json::json!({ "taskId": "x" })),
+        ] {
+            let req = JsonRpcRequest::new(1, method).with_params(params);
+            let parsed = McpRequest::from_jsonrpc(&req)
+                .unwrap_or_else(|e| panic!("failed to parse {method}: {e:?}"));
+            assert!(
+                matches!(parsed, McpRequest::Unknown { .. }),
+                "{method} must fall through to Unknown, got {}",
+                parsed.method_name()
+            );
         }
     }
 

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -782,7 +782,7 @@ impl RequestContext {
         Ok(result.action == ElicitAction::Accept)
     }
 
-    /// List tasks tracked by the connected client (SEP-1686).
+    /// List tasks tracked by the connected client (legacy SEP-1686).
     ///
     /// Sends a `tasks/list` request to the client and returns the result.
     /// Pass `Some(status)` to filter to a single status, or `None` for all
@@ -791,6 +791,12 @@ impl RequestContext {
     ///
     /// Returns an error if no client requester is configured or the client
     /// does not advertise task support.
+    #[deprecated(
+        since = "0.13.0",
+        note = "final SEP-2663 removes tasks/list; a conforming peer answers \
+                MethodNotFound (-32601). Only useful against legacy SEP-1686 \
+                clients."
+    )]
     pub async fn list_tasks(&self, status: Option<TaskStatus>) -> Result<ListTasksResult> {
         let params = ListTasksParams {
             status,
@@ -820,13 +826,21 @@ impl RequestContext {
             .map_err(|e| Error::Internal(format!("Failed to deserialize tasks/get: {e}")))
     }
 
-    /// Fetch the terminal result for a task tracked by the client (SEP-1686).
+    /// Fetch the terminal result for a task tracked by the client (legacy
+    /// SEP-1686).
     ///
     /// Sends a `tasks/result` request. The client is expected to block until
     /// the task reaches a terminal state and then return the underlying
     /// `CallToolResult`. For long-running tasks, prefer polling with
     /// [`get_task_info`](Self::get_task_info) and only call this once the
     /// status is terminal.
+    #[deprecated(
+        since = "0.13.0",
+        note = "final SEP-2663 removes tasks/result (results are inlined in \
+                the tasks/get DetailedTask); a conforming peer answers \
+                MethodNotFound (-32601). Only useful against legacy SEP-1686 \
+                clients."
+    )]
     pub async fn get_task_result(&self, task_id: impl Into<String>) -> Result<CallToolResult> {
         let params = GetTaskResultParams {
             task_id: task_id.into(),
@@ -839,25 +853,25 @@ impl RequestContext {
             .map_err(|e| Error::Internal(format!("Failed to deserialize tasks/result: {e}")))
     }
 
-    /// Cancel a task tracked by the client (SEP-1686).
+    /// Cancel a task tracked by the client.
     ///
-    /// Sends a `tasks/cancel` request and returns the resulting task object,
-    /// which will reflect the cancelled status.
+    /// Sends a `tasks/cancel` request. Per final SEP-2663 the acknowledgment
+    /// is an empty result and the observable task status is polled via
+    /// [`get_task_info`](Self::get_task_info); the ack body is discarded, so
+    /// this also tolerates legacy SEP-1686 peers that return the task object.
     pub async fn cancel_task(
         &self,
         task_id: impl Into<String>,
         reason: Option<String>,
-    ) -> Result<TaskObject> {
+    ) -> Result<()> {
         let params = CancelTaskParams {
             task_id: task_id.into(),
             reason,
             meta: None,
         };
-        let value = self
-            .request_raw("tasks/cancel", serde_json::to_value(&params)?)
+        self.request_raw("tasks/cancel", serde_json::to_value(&params)?)
             .await?;
-        serde_json::from_value(value)
-            .map_err(|e| Error::Internal(format!("Failed to deserialize tasks/cancel: {e}")))
+        Ok(())
     }
 
     /// Send an arbitrary JSON-RPC request to the client.
@@ -1280,6 +1294,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(deprecated)] // exercises the legacy SEP-1686 helper
     async fn test_list_tasks_round_trips() {
         let (tx, rx) = outgoing_request_channel(10);
         spawn_mock_client(rx, |method, params| {
@@ -1307,18 +1322,32 @@ mod tests {
         spawn_mock_client(rx, |method, params| {
             assert_eq!(method, "tasks/cancel");
             assert_eq!(params["reason"], serde_json::json!("user requested"));
-            let task_id = params["taskId"].as_str().unwrap().to_string();
-            make_task_object(&task_id, TaskStatus::Cancelled)
+            // SEP-2663 (final): the cancel acknowledgment is an empty result.
+            serde_json::json!({})
         });
         let requester: ClientRequesterHandle = Arc::new(ChannelClientRequester::new(tx));
         let ctx = RequestContext::new(RequestId::Number(1)).with_client_requester(requester);
 
-        let task = ctx
-            .cancel_task("task-99", Some("user requested".into()))
+        ctx.cancel_task("task-99", Some("user requested".into()))
             .await
-            .unwrap();
-        assert_eq!(task.task_id, "task-99");
-        assert!(matches!(task.status, TaskStatus::Cancelled));
+            .expect("empty ack should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_cancel_task_tolerates_legacy_task_object_ack() {
+        // Legacy SEP-1686 peers return the task object from tasks/cancel;
+        // the helper discards the body either way.
+        let (tx, rx) = outgoing_request_channel(10);
+        spawn_mock_client(rx, |method, _params| {
+            assert_eq!(method, "tasks/cancel");
+            make_task_object("task-99", TaskStatus::Cancelled)
+        });
+        let requester: ClientRequesterHandle = Arc::new(ChannelClientRequester::new(tx));
+        let ctx = RequestContext::new(RequestId::Number(1)).with_client_requester(requester);
+
+        ctx.cancel_task("task-99", None)
+            .await
+            .expect("legacy task-object ack should also succeed");
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -158,7 +158,7 @@
 //! - `macros` - Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`)
 //! - `stateless` - Experimental 2026-07-28 stateless protocol mode (SEP-2575 + SEP-2567). Enables
 //!   version-gated sessionless dispatch, `server/discover` RPC, per-request `_meta` via
-//!   [`stateless::StatelessRequestMeta`], and `messages/listen` SSE endpoint. Requires `http`.
+//!   [`stateless::StatelessRequestMeta`], and `subscriptions/listen` SSE endpoint. Requires `http`.
 //!
 //! ## Middleware Placement Guide
 //!
@@ -341,9 +341,10 @@
 //! - **`server/discover`** -- stateless capability discovery. Clients that send requests with
 //!   `MCP-Protocol-Version: 2026-07-28` (SEP-2243 header) can call `server/discover` instead
 //!   of `initialize` to learn what the server supports without establishing a session.
-//! - **`messages/listen`** -- client-initiated SSE subscription. A GET to `/mcp` with
-//!   `MCP-Protocol-Version: 2026-07-28` opens a server-push stream that is not tied to any
-//!   session, allowing stateless clients to receive notifications.
+//! - **`subscriptions/listen`** -- client-initiated SSE subscription. A POST of a
+//!   `subscriptions/listen` request with `MCP-Protocol-Version: 2026-07-28` opens a
+//!   server-push stream that is not tied to any session, allowing stateless clients to
+//!   receive notifications.
 //!
 //! Per-request client identity and capabilities ride in each request's `_meta` object via
 //! [`stateless::StatelessRequestMeta`] rather than being negotiated once at session open.
@@ -432,7 +433,7 @@
 //!
 //! The `stateless` feature additionally tracks the upcoming 2026-07-28 protocol defined by:
 //! - [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (accepted) --
-//!   `messages/listen` SSE endpoint
+//!   `subscriptions/listen` SSE endpoint
 //! - [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (final) --
 //!   stateless session model, `server/discover`, per-request `_meta`
 //! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final) --

--- a/crates/tower-mcp/src/middleware/tracing.rs
+++ b/crates/tower-mcp/src/middleware/tracing.rs
@@ -205,9 +205,7 @@ pub(crate) fn extract_operation_details(
         McpRequest::ListPrompts(_) => (Some("list"), Some("prompts".to_string())),
         McpRequest::SubscribeResource(params) => (Some("subscribe"), Some(params.uri.clone())),
         McpRequest::UnsubscribeResource(params) => (Some("unsubscribe"), Some(params.uri.clone())),
-        McpRequest::ListTasks(_) => (Some("list"), Some("tasks".to_string())),
         McpRequest::GetTaskInfo(params) => (Some("task"), Some(params.task_id.clone())),
-        McpRequest::GetTaskResult(params) => (Some("task_result"), Some(params.task_id.clone())),
         McpRequest::CancelTask(params) => (Some("cancel"), Some(params.task_id.clone())),
         McpRequest::Complete(params) => {
             let ref_type = match &params.reference {

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1662,7 +1662,10 @@ impl McpRouter {
                     .any(|t| !matches!(t.task_support, TaskSupportMode::Forbidden));
                 if has_task_support {
                     Some(TasksCapability {
-                        list: Some(TasksListCapability {}),
+                        // `list` is intentionally not advertised: final
+                        // SEP-2663 removes `tasks/list` and this router
+                        // answers MethodNotFound for it.
+                        list: None,
                         cancel: Some(TasksCancelCapability {}),
                         requests: Some(TasksRequestsCapability {
                             tools: Some(TasksToolsRequestsCapability {
@@ -2307,18 +2310,6 @@ impl McpRouter {
 
             McpRequest::Ping => Ok(McpResponse::Pong(EmptyResult {})),
 
-            McpRequest::ListTasks(params) => {
-                let tasks = self.inner.task_store.list_tasks(params.status);
-
-                let (tasks, next_cursor) =
-                    paginate(tasks, params.cursor.as_deref(), self.inner.page_size)?;
-
-                Ok(McpResponse::ListTasks(ListTasksResult {
-                    tasks,
-                    next_cursor,
-                }))
-            }
-
             McpRequest::GetTaskInfo(params) => {
                 let task = self
                     .inner
@@ -2332,44 +2323,6 @@ impl McpRouter {
                     })?;
 
                 Ok(McpResponse::GetTaskInfo(task))
-            }
-
-            McpRequest::GetTaskResult(params) => {
-                // Wait for task to reach terminal state (blocks if still running)
-                let (task_obj, result, error) = self
-                    .inner
-                    .task_store
-                    .wait_for_completion(&params.task_id)
-                    .await
-                    .ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Task not found: {}",
-                            params.task_id
-                        )))
-                    })?;
-
-                // Build _meta with related-task reference
-                let meta = serde_json::json!({
-                    "io.modelcontextprotocol/related-task": task_obj
-                });
-
-                match task_obj.status {
-                    TaskStatus::Cancelled => Err(Error::JsonRpc(JsonRpcError::invalid_params(
-                        format!("Task {} was cancelled", params.task_id),
-                    ))),
-                    TaskStatus::Failed => {
-                        let mut call_result = CallToolResult::error(
-                            error.unwrap_or_else(|| "Task failed".to_string()),
-                        );
-                        call_result.meta = Some(meta);
-                        Ok(McpResponse::GetTaskResult(call_result))
-                    }
-                    _ => {
-                        let mut call_result = result.unwrap_or_else(|| CallToolResult::text(""));
-                        call_result.meta = Some(meta);
-                        Ok(McpResponse::GetTaskResult(call_result))
-                    }
-                }
             }
 
             McpRequest::UpdateTask(params) => {
@@ -2413,8 +2366,7 @@ impl McpRouter {
                     ))));
                 }
 
-                let task_obj = self
-                    .inner
+                self.inner
                     .task_store
                     .cancel_task(&params.task_id, params.reason.as_deref())
                     .ok_or_else(|| {
@@ -2424,7 +2376,10 @@ impl McpRouter {
                         )))
                     })?;
 
-                Ok(McpResponse::CancelTask(task_obj))
+                // SEP-2663 (final): the cancel acknowledgment MUST be an empty
+                // result. The observable status is polled via `tasks/get` and
+                // may remain non-terminal after this ack.
+                Ok(McpResponse::CancelTask(EmptyResult {}))
             }
 
             McpRequest::SetLoggingLevel(params) => {
@@ -3624,23 +3579,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_list_tasks_empty() {
+    async fn test_removed_tasks_methods_get_method_not_found() {
+        // Final SEP-2663 removes tasks/list and tasks/result. They no longer
+        // parse into typed requests, so the router sees Unknown and must
+        // answer MethodNotFound (-32601).
         let mut router = McpRouter::new();
         init_router(&mut router).await;
 
-        let req = RouterRequest {
-            id: RequestId::Number(1),
-            inner: McpRequest::ListTasks(ListTasksParams::default()),
-            extensions: Extensions::new(),
-        };
+        for method in ["tasks/list", "tasks/result"] {
+            let req = RouterRequest {
+                id: RequestId::Number(1),
+                inner: McpRequest::Unknown {
+                    method: method.to_string(),
+                    params: None,
+                },
+                extensions: Extensions::new(),
+            };
 
-        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+            let resp = router.ready().await.unwrap().call(req).await.unwrap();
 
-        match resp.inner {
-            Ok(McpResponse::ListTasks(result)) => {
-                assert!(result.tasks.is_empty());
+            match resp.inner {
+                Err(err) => {
+                    assert_eq!(err.code, -32601, "{method} must be MethodNotFound");
+                }
+                other => panic!("Expected MethodNotFound error for {method}, got {other:?}"),
             }
-            _ => panic!("Expected ListTasks response"),
         }
     }
 
@@ -3678,10 +3641,12 @@ mod tests {
         // Wait for task to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-        // Get task result
+        // Poll task state via tasks/get (final SEP-2663 removed the blocking
+        // tasks/result; the terminal result payload on tasks/get is the
+        // phase 4 DetailedTask work, #951).
         let req = RouterRequest {
             id: RequestId::Number(2),
-            inner: McpRequest::GetTaskResult(GetTaskResultParams {
+            inner: McpRequest::GetTaskInfo(GetTaskInfoParams {
                 task_id: task_id.clone(),
                 meta: None,
             }),
@@ -3691,16 +3656,11 @@ mod tests {
         let resp = router.ready().await.unwrap().call(req).await.unwrap();
 
         match resp.inner {
-            Ok(McpResponse::GetTaskResult(result)) => {
-                // Result should have _meta with related-task
-                assert!(result.meta.is_some());
-                // Check the result content
-                match &result.content[0] {
-                    Content::Text { text, .. } => assert_eq!(text, "15"),
-                    _ => panic!("Expected text content"),
-                }
+            Ok(McpResponse::GetTaskInfo(info)) => {
+                assert_eq!(info.task_id, task_id);
+                assert_eq!(info.status, TaskStatus::Completed);
             }
-            _ => panic!("Expected GetTaskResult response"),
+            _ => panic!("Expected GetTaskInfo response"),
         }
     }
 
@@ -3750,11 +3710,27 @@ mod tests {
 
         let resp = router.ready().await.unwrap().call(req).await.unwrap();
 
+        // SEP-2663 (final): cancel acknowledges with an empty result.
         match resp.inner {
-            Ok(McpResponse::CancelTask(task_obj)) => {
-                assert_eq!(task_obj.status, TaskStatus::Cancelled);
+            Ok(McpResponse::CancelTask(EmptyResult {})) => {}
+            other => panic!("Expected empty CancelTask ack, got {other:?}"),
+        }
+
+        // Observable status is polled via tasks/get.
+        let req = RouterRequest {
+            id: RequestId::Number(3),
+            inner: McpRequest::GetTaskInfo(GetTaskInfoParams {
+                task_id: task_id.clone(),
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        match resp.inner {
+            Ok(McpResponse::GetTaskInfo(info)) => {
+                assert_eq!(info.status, TaskStatus::Cancelled);
             }
-            _ => panic!("Expected CancelTask response"),
+            _ => panic!("Expected GetTaskInfo response"),
         }
     }
 

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -156,19 +156,21 @@ pub use crate::error::UnsupportedProtocolVersionData;
 ///
 /// These were wrong: SEP-1442 (draft) placed `UNSUPPORTED_VERSION` at -32000,
 /// which collides with the established `ConnectionClosed` assignment.
-/// SEP-2575 (FINAL) moved it to -32004. Use
+/// SEP-2575 assigned -32004, which the upstream error-code allocation
+/// (spec PR modelcontextprotocol#2907, 2026-06) renumbered to -32022. Use
 /// [`crate::error::McpErrorCode::UnsupportedProtocolVersion`] or
 /// [`crate::error::JsonRpcError::unsupported_protocol_version`] instead.
 pub mod error_codes {
-    /// Spec-correct unsupported protocol version code (SEP-2575).
-    pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32004;
+    /// Spec-correct unsupported protocol version code (SEP-2575, renumbered
+    /// from -32004 to -32022 by spec PR modelcontextprotocol#2907).
+    pub const UNSUPPORTED_PROTOCOL_VERSION: i32 = -32022;
 
     /// Wrong assignment from SEP-1442 draft. Kept temporarily for
     /// back-compat; new code should use [`UNSUPPORTED_PROTOCOL_VERSION`].
     #[deprecated(
         since = "0.12.0",
-        note = "SEP-1442 draft assignment was wrong; SEP-2575 FINAL uses -32004. \
-                Use `UNSUPPORTED_PROTOCOL_VERSION` or \
+        note = "SEP-1442 draft assignment was wrong; the current draft schema \
+                uses -32022. Use `UNSUPPORTED_PROTOCOL_VERSION` or \
                 `crate::error::McpErrorCode::UnsupportedProtocolVersion`."
     )]
     pub const UNSUPPORTED_VERSION: i32 = -32000;
@@ -176,20 +178,17 @@ pub mod error_codes {
     /// Invalid or missing required session ID (-32001) per the SEP-1442
     /// draft.
     ///
-    /// **Deprecated**: SEP-2243 (FINAL 2026-04-15) reassigns -32001 to
-    /// `HeaderMismatch`. SEP-2567 (FINAL) also removes sessions
-    /// entirely. New code should use one of:
+    /// **Deprecated**: SEP-2567 (FINAL) removes sessions entirely, and
+    /// -32001 is no longer assigned by any current SEP (SEP-2243 briefly
+    /// claimed it for `HeaderMismatch` before the upstream renumbering moved
+    /// that code to -32020). New code should use one of:
     /// - [`crate::error::McpErrorCode::SessionRequired`] (-32006) for a
     ///   missing session ID, or
     /// - [`crate::error::McpErrorCode::SessionNotFound`] (-32005) for an
     ///   unknown or expired session.
-    ///
-    /// The numeric value of this constant is unchanged so any existing
-    /// match arms keep compiling, but emitting -32001 from new code will
-    /// confuse SEP-2243-aware clients.
     #[deprecated(
         since = "0.11.0",
-        note = "SEP-2243 reclaims -32001 for HeaderMismatch. Use \
+        note = "Sessions are removed by SEP-2567. Use \
                 McpErrorCode::SessionRequired (-32006) or SessionNotFound (-32005)."
     )]
     pub const INVALID_SESSION: i32 = -32001;
@@ -268,7 +267,8 @@ impl StatelessConfig {
 /// Validate a protocol version string against supported versions.
 ///
 /// Returns `Ok(())` if valid, or a JSON-RPC `UnsupportedProtocolVersion`
-/// error (-32004 per SEP-2575) with the spec-shape data:
+/// error (-32022 per SEP-2575 after the upstream renumbering) with the
+/// spec-shape data:
 ///
 /// ```json
 /// { "supported": ["..."], "requested": "..." }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -44,21 +44,21 @@
 //! Stateful clients (those sending an `mcp-session-id`) continue to work
 //! normally on the same transport alongside both stateless paths.
 //!
-//! ## `messages/listen` SSE stream
+//! ## `subscriptions/listen` SSE stream
 //!
 //! Clients using the 2026-07-28 protocol open a server-to-client notification
-//! stream by POSTing a `messages/listen` JSON-RPC request. The server responds
+//! stream by POSTing a `subscriptions/listen` JSON-RPC request. The server responds
 //! with `Content-Type: text/event-stream` and streams zero or more
 //! `notifications/*` events until the client disconnects.
 //!
 //! This replaces the `GET /` SSE endpoint used by the 2025-11-25 protocol. The
-//! `GET /` endpoint is still supported for 2025-11-25 sessions; `messages/listen`
+//! `GET /` endpoint is still supported for 2025-11-25 sessions; `subscriptions/listen`
 //! is only available for 2026-07-28+ clients.
 //!
 //! ```text
 //! Client (2026-07-28)                          Server
 //!   |                                            |
-//!   |-- POST / {method: "messages/listen",       |
+//!   |-- POST / {method: "subscriptions/listen",  |
 //!   |           MCP-Protocol-Version: 2026-07-28} -->|
 //!   |<-- 200 Content-Type: text/event-stream ----|
 //!   |<-- event: message (notification) ----------|
@@ -81,7 +81,7 @@
 //! request are validated for consistency with the body, but missing headers are
 //! not an error. Validation is **strict** for 2026-07-28+ clients: `Mcp-Method`
 //! must be present on every POST and `Mcp-Name` must be present for the three
-//! named methods. Violations return `-32001` (HeaderMismatch).
+//! named methods. Violations return `-32020` (HeaderMismatch).
 //!
 //! The public constants [`MCP_METHOD_HEADER`], [`MCP_NAME_HEADER`], and
 //! [`MCP_PARAM_HEADER_PREFIX`] hold the canonical lowercase header names.
@@ -150,8 +150,8 @@
 //!
 //! | Code    | Name                      | Description                                        |
 //! |---------|---------------------------|----------------------------------------------------|
-//! | -32001  | HeaderMismatch            | Required HTTP header missing or inconsistent with body (SEP-2243, strict mode) |
-//! | -32004  | UnsupportedProtocolVersion| Server does not support the requested protocol version (SEP-2575) |
+//! | -32020  | HeaderMismatch            | Required HTTP header missing or inconsistent with body (SEP-2243, strict mode) |
+//! | -32022  | UnsupportedProtocolVersion| Server does not support the requested protocol version (SEP-2575) |
 //! | -32005  | SessionNotFound           | Session expired or server restarted                |
 //! | -32006  | SessionRequired           | MCP-Session-Id header missing                      |
 //!
@@ -1582,7 +1582,7 @@ impl HttpTransport {
     /// `.sse_responses(true)` to match rmcp's behavior when targeting clients
     /// written against rmcp.
     ///
-    /// The existing SSE notification stream (GET `/`) and `messages/listen` stream
+    /// The existing SSE notification stream (GET `/`) and `subscriptions/listen` stream
     /// (2026-07-28+) are unaffected by this flag.
     ///
     /// Default: `false` (bare JSON, `Content-Type: application/json`).
@@ -2296,9 +2296,9 @@ async fn handle_post(
         if let Some(ref version) = version_in_play
             && is_stateless_protocol_version(version)
             && get_session_id(&headers).is_none()
-            // `messages/listen` opens an SSE stream; let it fall through to the
+            // `subscriptions/listen` opens an SSE stream; let it fall through to the
             // dedicated intercept below rather than handling it as a plain RPC call.
-            && parsed.get("method").and_then(|m| m.as_str()) != Some("messages/listen")
+            && parsed.get("method").and_then(|m| m.as_str()) != Some("subscriptions/listen")
         {
             // Notifications and responses are fire-and-forget; no dispatch needed.
             if !is_init && (parsed.get("id").is_none() || is_response(&parsed)) {
@@ -2536,8 +2536,8 @@ async fn handle_post(
         return json_rpc_error_response(None, JsonRpcError::session_required());
     };
 
-    // SEP-2575 / SEP-2567: intercept `messages/listen` before the standard
-    // version validation. `messages/listen` is only available when the
+    // SEP-2575 / SEP-2567: intercept `subscriptions/listen` before the standard
+    // version validation. `subscriptions/listen` is only available when the
     // effective protocol version is >= 2026-07-28; otherwise we return a
     // proper JSON-RPC error rather than silently falling through to the
     // router (which would return `MethodNotFound` anyway, but without the
@@ -2549,19 +2549,19 @@ async fn handle_post(
     // 2026-07-28 header before we can inspect it.
     {
         let method_str = parsed.get("method").and_then(|m| m.as_str()).unwrap_or("");
-        if method_str == "messages/listen" {
+        if method_str == "subscriptions/listen" {
             let req_id = extract_request_id(&parsed);
             let effective_version = if let Some(v) = get_protocol_version(&headers) {
                 v
             } else {
                 session.protocol_version.read().await.clone()
             };
-            if version_supports_messages_listen(&effective_version) {
-                return handle_messages_listen_sse(session).await;
+            if version_supports_subscriptions_listen(&effective_version) {
+                return handle_subscriptions_listen_sse(session).await;
             } else {
                 return json_rpc_error_response(
                     req_id,
-                    JsonRpcError::method_not_found("messages/listen"),
+                    JsonRpcError::method_not_found("subscriptions/listen"),
                 );
             }
         }
@@ -2569,7 +2569,7 @@ async fn handle_post(
 
     // Validate protocol version (if present and not init request).
     // Per SEP-2575, unsupported versions get a JSON-RPC error with code
-    // -32004 and `{ supported, requested }` data, not a plain-text 400.
+    // -32022 and `{ supported, requested }` data, not a plain-text 400.
     if !is_init
         && let Some(version) = get_protocol_version(&headers)
         && !SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
@@ -2795,11 +2795,11 @@ async fn handle_post(
     resp
 }
 
-/// Returns `true` when the given protocol version string enables `messages/listen`.
+/// Returns `true` when the given protocol version string enables `subscriptions/listen`.
 ///
-/// `messages/listen` is part of the 2026-07-28 spec (SEP-2575 / SEP-2567).
+/// `subscriptions/listen` is part of the 2026-07-28 spec (SEP-2575 / SEP-2567).
 /// Version strings are YYYY-MM-DD dates, so lexicographic comparison is correct.
-fn version_supports_messages_listen(version: &str) -> bool {
+fn version_supports_subscriptions_listen(version: &str) -> bool {
     version >= UPCOMING_PROTOCOL_VERSION
 }
 
@@ -2814,7 +2814,7 @@ fn is_stateless_protocol_version(version: &str) -> bool {
     version >= UPCOMING_PROTOCOL_VERSION
 }
 
-/// Serve a `messages/listen` request as an SSE stream.
+/// Serve a `subscriptions/listen` request as an SSE stream.
 ///
 /// Subscribes to the session's notification broadcast channel and returns a
 /// streaming `text/event-stream` response. The stream closes naturally when:
@@ -2823,7 +2823,7 @@ fn is_stateless_protocol_version(version: &str) -> bool {
 ///
 /// Each notification is assigned a monotonically increasing event ID for
 /// potential stream resumption (SEP-1699).
-async fn handle_messages_listen_sse(session: Arc<Session>) -> Response {
+async fn handle_subscriptions_listen_sse(session: Arc<Session>) -> Response {
     let rx = session.notifications_tx.subscribe();
     let session_clone = session.clone();
 
@@ -3362,7 +3362,7 @@ mod tests {
     #[tokio::test]
     async fn unsupported_protocol_version_returns_spec_shape_error() {
         // SEP-2575: requests carrying an unrecognized MCP-Protocol-Version
-        // header (post-initialize) get a JSON-RPC error with code -32004 and
+        // header (post-initialize) get a JSON-RPC error with code -32022 and
         // data `{ supported: [...], requested: "..." }`.
         let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
         let app = transport.into_router();
@@ -3418,7 +3418,7 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32004);
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32022);
         assert_eq!(json["error"]["data"]["requested"], "1999-01-01");
         let supported = json["error"]["data"]["supported"]
             .as_array()
@@ -3445,7 +3445,7 @@ mod tests {
     }
 
     /// When a request (no session) arrives with an invalid `Mcp-Protocol-Version`
-    /// header, the transport must return -32004 with the correct SEP-2575 wire
+    /// header, the transport must return -32022 with the correct SEP-2575 wire
     /// shape: `{ supported: [...], requested: "..." }`. This verifies the
     /// version-validation path fires without requiring a session.
     #[cfg(feature = "stateless")]
@@ -3456,7 +3456,7 @@ mod tests {
 
         // "1999-01-01" is below UPCOMING_PROTOCOL_VERSION ("2026-07-28"), so it
         // does not enter the version-gated stateless block. It is also not in
-        // SUPPORTED_PROTOCOL_VERSIONS, so it triggers the -32004 version check
+        // SUPPORTED_PROTOCOL_VERSIONS, so it triggers the -32022 version check
         // at lines ~2370-2382. No session header is sent, exercising the
         // sessionless request path through version validation.
         let req = Request::builder()
@@ -3481,8 +3481,8 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(
             json["error"]["code"].as_i64().unwrap(),
-            -32004,
-            "must return UnsupportedProtocolVersion (-32004): {json}"
+            -32022,
+            "must return UnsupportedProtocolVersion (-32022): {json}"
         );
         assert_eq!(
             json["error"]["data"]["requested"], "1999-01-01",
@@ -3570,7 +3570,7 @@ mod tests {
 
     /// In lenient mode, if the client opts in by sending Mcp-Method,
     /// the server still validates against the body and rejects a
-    /// mismatch with -32001.
+    /// mismatch with -32020.
     #[tokio::test]
     async fn sep_2243_lenient_mode_validates_present_headers() {
         let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
@@ -3629,7 +3629,7 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32001);
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32020);
         assert!(
             json["error"]["message"]
                 .as_str()
@@ -3736,7 +3736,7 @@ mod tests {
     }
 
     /// tools/call with mismatched Mcp-Name vs body params.name MUST be
-    /// rejected with -32001 and HTTP 400 even in lenient mode.
+    /// rejected with -32020 and HTTP 400 even in lenient mode.
     #[tokio::test]
     async fn sep_2243_tools_call_mcp_name_mismatch_rejected() {
         use crate::{CallToolResult, ToolBuilder};
@@ -3807,7 +3807,7 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32001);
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32020);
         let msg = json["error"]["message"].as_str().unwrap();
         assert!(msg.contains("Mcp-Name"), "got: {msg}");
         assert_eq!(json["id"], 7);
@@ -6013,7 +6013,7 @@ mod tests {
         );
     }
 
-    /// 2026-07-28 stateless request missing Mcp-Method returns -32001 + HTTP 400 (#859).
+    /// 2026-07-28 stateless request missing Mcp-Method returns -32020 + HTTP 400 (#859).
     #[tokio::test]
     #[cfg(feature = "stateless")]
     async fn stateless_v2026_missing_mcp_method_returns_400() {
@@ -6048,8 +6048,8 @@ mod tests {
         assert!(json.get("error").is_some(), "expected error, got: {json}");
         assert_eq!(
             json["error"]["code"].as_i64().unwrap(),
-            -32001,
-            "expected InvalidRequest (-32001)"
+            -32020,
+            "expected HeaderMismatch (-32020)"
         );
         assert!(
             json["error"]["message"]

--- a/crates/tower-mcp/src/transport/http_headers.rs
+++ b/crates/tower-mcp/src/transport/http_headers.rs
@@ -33,7 +33,7 @@
 //!
 //! All validation failures return a JSON-RPC error with code
 //! [`McpErrorCode::HeaderMismatch`](crate::error::McpErrorCode::HeaderMismatch)
-//! (-32001) and HTTP status `400 Bad Request`.
+//! (-32020) and HTTP status `400 Bad Request`.
 //!
 //! ## Version gating
 //!
@@ -386,7 +386,7 @@ mod tests {
     fn strict_missing_mcp_method_is_error() {
         let body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"});
         let err = validate(&hm(&[]), &body, Sep2243Mode::Strict).unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
         assert!(err.message.contains("Mcp-Method"));
     }
 
@@ -401,7 +401,7 @@ mod tests {
         let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
         for mode in [Sep2243Mode::Strict, Sep2243Mode::Lenient] {
             let err = validate(&hm(&[("mcp-method", "ping")]), &body, mode).unwrap_err();
-            assert_eq!(err.code, -32001, "mode={mode:?}");
+            assert_eq!(err.code, -32020, "mode={mode:?}");
             assert!(err.message.contains("Mcp-Method"));
         }
     }
@@ -419,7 +419,7 @@ mod tests {
             Sep2243Mode::Strict,
         )
         .unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
     }
 
     #[test]
@@ -432,7 +432,7 @@ mod tests {
             Sep2243Mode::Strict,
         )
         .unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
         assert!(err.message.contains("Mcp-Name"));
     }
 
@@ -470,7 +470,7 @@ mod tests {
             Sep2243Mode::Lenient,
         )
         .unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
     }
 
     #[test]
@@ -569,7 +569,7 @@ mod tests {
             Sep2243Mode::Strict,
         )
         .unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
         assert!(err.message.contains("Base64"));
     }
 
@@ -609,7 +609,7 @@ mod tests {
             Sep2243Mode::Strict,
         )
         .unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
         assert!(err.message.contains("Mcp-Param-region"));
     }
 
@@ -689,7 +689,7 @@ mod tests {
         let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
                           "params": {"name": "x", "arguments": {"region": "c"}}});
         let err = validate(&h, &body, Sep2243Mode::Strict).unwrap_err();
-        assert_eq!(err.code, -32001);
+        assert_eq!(err.code, -32020);
     }
 
     #[test]
@@ -707,7 +707,7 @@ mod tests {
             h.insert(name, axum::http::HeaderValue::from_static("x"));
             let body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"});
             let err = validate(&h, &body, Sep2243Mode::Strict).unwrap_err();
-            assert_eq!(err.code, -32001);
+            assert_eq!(err.code, -32020);
             assert!(err.message.contains("empty suffix"));
         }
     }

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -1159,7 +1159,7 @@ mod tests {
         let json = serialize_notification(&notification).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed["method"], "notifications/tasks/status");
+        assert_eq!(parsed["method"], "notifications/tasks");
         assert_eq!(parsed["params"]["taskId"], "task-42");
         assert_eq!(parsed["params"]["status"], "working");
     }

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2349,7 +2349,7 @@ mod stateless_tests {
         );
     }
 
-    /// Unsupported protocol version returns SEP-2575 error code -32004
+    /// Unsupported protocol version returns SEP-2575 error code -32022
     /// with the spec-shape data: `{ supported: [...], requested: "..." }`.
     /// (SEP-1442 draft used -32000 / `supportedVersions`; both were wrong.)
     #[tokio::test]
@@ -2377,7 +2377,7 @@ mod stateless_tests {
 
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
-        assert_eq!(body["error"]["code"].as_i64().unwrap(), -32004);
+        assert_eq!(body["error"]["code"].as_i64().unwrap(), -32022);
         assert!(
             body["error"]["data"]["supported"].is_array(),
             "spec data field is 'supported': {body}"

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -1682,18 +1682,29 @@ async fn test_task_list_after_creation() {
         _ => panic!("unexpected response variant"),
     };
 
-    // List tasks
+    // tasks/list is removed by final SEP-2663: expect MethodNotFound. The
+    // created task remains observable via tasks/get.
     let list_req = JsonRpcRequest::new(3, "tasks/list");
     let resp = service.call_single(list_req).await.unwrap();
 
     match resp {
+        JsonRpcResponse::Error(e) => {
+            assert_eq!(e.error.code, -32601, "tasks/list must be MethodNotFound");
+        }
         JsonRpcResponse::Result(r) => {
-            let tasks = r.result.get("tasks").unwrap().as_array().unwrap();
-            assert!(!tasks.is_empty(), "tasks list should not be empty");
-            let found = tasks
-                .iter()
-                .any(|t| t.get("taskId").unwrap().as_str().unwrap() == task_id);
-            assert!(found, "created task should be in the list");
+            panic!("tasks/list is removed by SEP-2663, got result: {:?}", r)
+        }
+        _ => panic!("unexpected response variant"),
+    }
+
+    // The task itself is still tracked.
+    let get_req = JsonRpcRequest::new(4, "tasks/get").with_params(serde_json::json!({
+        "taskId": task_id
+    }));
+    let resp = service.call_single(get_req).await.unwrap();
+    match resp {
+        JsonRpcResponse::Result(r) => {
+            assert_eq!(r.result["taskId"].as_str().unwrap(), task_id);
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
         _ => panic!("unexpected response variant"),
@@ -1772,24 +1783,32 @@ async fn test_task_lifecycle_get_result() {
     // Wait briefly for the spawned task to complete
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
-    // Get task result
+    // tasks/result is removed by final SEP-2663: expect MethodNotFound.
     let result_req = JsonRpcRequest::new(3, "tasks/result").with_params(serde_json::json!({
         "taskId": task_id
     }));
     let resp = service.call_single(result_req).await.unwrap();
 
     match resp {
+        JsonRpcResponse::Error(e) => {
+            assert_eq!(e.error.code, -32601, "tasks/result must be MethodNotFound");
+        }
         JsonRpcResponse::Result(r) => {
-            let content = r.result.get("content").unwrap().as_array().unwrap();
-            let text = content[0].get("text").unwrap().as_str().unwrap();
-            assert_eq!(text, "task result");
+            panic!("tasks/result is removed by SEP-2663, got result: {:?}", r)
+        }
+        _ => panic!("unexpected response variant"),
+    }
 
-            // Check _meta contains related-task
-            let meta = r.result.get("_meta").expect("result should have '_meta'");
-            let related_task = meta
-                .get("io.modelcontextprotocol/related-task")
-                .expect("_meta should have related-task");
-            assert_eq!(related_task["taskId"].as_str().unwrap(), task_id);
+    // Completion is observed by polling tasks/get. (Returning the terminal
+    // result payload on tasks/get is the phase 4 DetailedTask work, #951.)
+    let get_req = JsonRpcRequest::new(4, "tasks/get").with_params(serde_json::json!({
+        "taskId": task_id
+    }));
+    let resp = service.call_single(get_req).await.unwrap();
+    match resp {
+        JsonRpcResponse::Result(r) => {
+            assert_eq!(r.result["taskId"].as_str().unwrap(), task_id);
+            assert_eq!(r.result["status"].as_str().unwrap(), "completed");
         }
         JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
         _ => panic!("unexpected response variant"),
@@ -1816,13 +1835,30 @@ async fn test_task_cancel() {
         _ => panic!("unexpected response variant"),
     };
 
-    // Cancel the task
+    // Cancel the task. SEP-2663 (final): the ack is an empty result; the
+    // observable status is polled via tasks/get.
     let cancel_req = JsonRpcRequest::new(3, "tasks/cancel").with_params(serde_json::json!({
         "taskId": task_id,
         "reason": "Testing cancellation"
     }));
     let resp = service.call_single(cancel_req).await.unwrap();
 
+    match resp {
+        JsonRpcResponse::Result(r) => {
+            assert!(
+                r.result.as_object().is_some_and(|o| o.is_empty()),
+                "cancel ack must be an empty result, got: {:?}",
+                r.result
+            );
+        }
+        JsonRpcResponse::Error(e) => panic!("Expected success, got error: {:?}", e),
+        _ => panic!("unexpected response variant"),
+    }
+
+    let get_req = JsonRpcRequest::new(4, "tasks/get").with_params(serde_json::json!({
+        "taskId": task_id
+    }));
+    let resp = service.call_single(get_req).await.unwrap();
     match resp {
         JsonRpcResponse::Result(r) => {
             assert_eq!(r.result["status"].as_str().unwrap(), "cancelled");
@@ -1947,7 +1983,10 @@ async fn test_task_capabilities_advertised() {
             let tasks = caps
                 .get("tasks")
                 .expect("capabilities should include 'tasks' (back-compat)");
-            assert!(tasks.get("list").is_some(), "tasks should have 'list'");
+            assert!(
+                tasks.get("list").is_none(),
+                "tasks must not advertise 'list': final SEP-2663 removes tasks/list"
+            );
             assert!(tasks.get("cancel").is_some(), "tasks should have 'cancel'");
             let requests = tasks.get("requests").expect("tasks should have 'requests'");
             assert!(

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -1,6 +1,6 @@
-//! Integration tests for the `messages/listen` RPC (SEP-2575 / SEP-2567).
+//! Integration tests for the `subscriptions/listen` RPC (SEP-2575 / SEP-2567).
 //!
-//! `messages/listen` opens a server-to-client notification stream over HTTP
+//! `subscriptions/listen` opens a server-to-client notification stream over HTTP
 //! POST. The server responds with `Content-Type: text/event-stream` (SSE)
 //! when the negotiated or requested protocol version is >= 2026-07-28
 //! (the UPCOMING_PROTOCOL_VERSION). Requests that target an older-protocol
@@ -32,8 +32,8 @@ fn app() -> axum::Router {
         .into_router()
 }
 
-/// POST a `messages/listen` request with the given `Mcp-Protocol-Version` header.
-async fn post_messages_listen(protocol_version: Option<&str>) -> axum::response::Response {
+/// POST a `subscriptions/listen` request with the given `Mcp-Protocol-Version` header.
+async fn post_subscriptions_listen(protocol_version: Option<&str>) -> axum::response::Response {
     let mut builder = Request::builder()
         .method("POST")
         .uri("/")
@@ -46,7 +46,7 @@ async fn post_messages_listen(protocol_version: Option<&str>) -> axum::response:
 
     let request = builder
         .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":1,"method":"messages/listen","params":{}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen","params":{}}"#,
         ))
         .unwrap();
 
@@ -54,14 +54,14 @@ async fn post_messages_listen(protocol_version: Option<&str>) -> axum::response:
 }
 
 #[tokio::test]
-async fn messages_listen_returns_sse_when_protocol_is_2026_07_28() {
+async fn subscriptions_listen_returns_sse_when_protocol_is_2026_07_28() {
     // Clients that request protocol 2026-07-28 get an SSE stream back.
-    let response = post_messages_listen(Some("2026-07-28")).await;
+    let response = post_subscriptions_listen(Some("2026-07-28")).await;
 
     assert_eq!(
         response.status(),
         StatusCode::OK,
-        "expected 200 OK for messages/listen with protocol 2026-07-28"
+        "expected 200 OK for subscriptions/listen with protocol 2026-07-28"
     );
 
     let content_type = response
@@ -77,11 +77,11 @@ async fn messages_listen_returns_sse_when_protocol_is_2026_07_28() {
 }
 
 #[tokio::test]
-async fn messages_listen_returns_method_not_found_for_old_protocol() {
+async fn subscriptions_listen_returns_method_not_found_for_old_protocol() {
     // Without a 2026-07-28 Mcp-Protocol-Version header, the session falls back
     // to the 2025-11-25 negotiated version, which does not support
-    // messages/listen. The server must return a JSON-RPC Method Not Found error.
-    let response = post_messages_listen(None).await;
+    // subscriptions/listen. The server must return a JSON-RPC Method Not Found error.
+    let response = post_subscriptions_listen(None).await;
 
     // JSON-RPC errors ride on 200 OK at the HTTP level.
     assert_eq!(
@@ -131,7 +131,7 @@ async fn messages_listen_returns_method_not_found_for_old_protocol() {
     );
 }
 
-/// Initialize with 2025-11-25 (creates a session), then POST `messages/listen`
+/// Initialize with 2025-11-25 (creates a session), then POST `subscriptions/listen`
 /// with a per-request `Mcp-Protocol-Version: 2026-07-28` header.
 ///
 /// This exercises the header-override branch in `handle_post`: the session was
@@ -139,7 +139,7 @@ async fn messages_listen_returns_method_not_found_for_old_protocol() {
 /// version to 2026-07-28, which enables the SSE path.
 #[cfg(feature = "stateless")]
 #[tokio::test]
-async fn messages_listen_via_session_with_header_override() {
+async fn subscriptions_listen_via_session_with_header_override() {
     let a = app();
 
     // Step 1: initialize with 2025-11-25 to create a session.
@@ -167,7 +167,7 @@ async fn messages_listen_via_session_with_header_override() {
         .map(|s| s.to_string())
         .expect("initialize response must include mcp-session-id header");
 
-    // Step 2: POST messages/listen with session ID + Mcp-Protocol-Version: 2026-07-28.
+    // Step 2: POST subscriptions/listen with session ID + Mcp-Protocol-Version: 2026-07-28.
     // The session is at 2025-11-25 but the per-request header overrides the
     // effective version to 2026-07-28, so the server should return SSE.
     let listen_request = Request::builder()
@@ -178,7 +178,7 @@ async fn messages_listen_via_session_with_header_override() {
         .header("mcp-session-id", &session_id)
         .header("Mcp-Protocol-Version", "2026-07-28")
         .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":2,"method":"messages/listen","params":{}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"subscriptions/listen","params":{}}"#,
         ))
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn messages_listen_via_session_with_header_override() {
     assert_eq!(
         listen_resp.status(),
         StatusCode::OK,
-        "messages/listen with header override must return 200"
+        "subscriptions/listen with header override must return 200"
     );
 
     let content_type = listen_resp
@@ -210,24 +210,24 @@ async fn messages_listen_via_session_with_header_override() {
 /// `initialize` handshake, so the pure headerless fallback path cannot be
 /// exercised through the HTTP API without the per-request header override.
 ///
-/// The header-override test (`messages_listen_via_session_with_header_override`)
+/// The header-override test (`subscriptions_listen_via_session_with_header_override`)
 /// covers the adjacent code path; this placeholder documents the gap.
 ///
 /// If 2026-07-28 is promoted to `SUPPORTED_PROTOCOL_VERSIONS`, this test can
 /// be filled in: initialize without the stateless feature, capture the session
-/// ID, and POST `messages/listen` with only the session ID header (no
+/// ID, and POST `subscriptions/listen` with only the session ID header (no
 /// `Mcp-Protocol-Version`).
 #[cfg(not(feature = "stateless"))]
 #[tokio::test]
-async fn messages_listen_session_fallback_placeholder() {
+async fn subscriptions_listen_session_fallback_placeholder() {
     // When 2026-07-28 is in SUPPORTED_PROTOCOL_VERSIONS, initialize with that
     // version (no stateless feature), capture the session ID, then POST
-    // messages/listen with no Mcp-Protocol-Version header. The session record
+    // subscriptions/listen with no Mcp-Protocol-Version header. The session record
     // will carry 2026-07-28 and the server should return SSE.
     //
     // For now: just verify the existing 2025-11-25 path (no header = MethodNotFound)
     // still works correctly, confirming the test runs in CI.
-    let response = post_messages_listen(None).await;
+    let response = post_subscriptions_listen(None).await;
     assert_eq!(response.status(), StatusCode::OK);
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
         .await

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,7 +82,7 @@ cargo run --example tool_macro --features macros
 | [client_cli](client_cli.rs) | Stdio client connecting to subprocess servers |
 | [http_client](http_client.rs) | HTTP client with McpClient API |
 | [http_sse_client](http_sse_client.rs) | SSE stream resumption (Last-Event-ID) |
-| [stateless_http_client](stateless_http_client.rs) | 2026-07-28 stateless protocol: server/discover, tools/list, tools/call, messages/listen -- no session ID |
+| [stateless_http_client](stateless_http_client.rs) | 2026-07-28 stateless protocol: server/discover, tools/list, tools/call, subscriptions/listen -- no session ID |
 
 ### Bidirectional Communication
 

--- a/examples/http_server.rs
+++ b/examples/http_server.rs
@@ -8,7 +8,7 @@
 //! - **2026-07-28** (stateless): no `initialize` handshake and no
 //!   `MCP-Session-Id`. Every request carries `MCP-Protocol-Version: 2026-07-28`
 //!   and the SEP-2243 `Mcp-Method` header. Use `server/discover` for capability
-//!   discovery and `messages/listen` for server-push notifications.
+//!   discovery and `subscriptions/listen` for server-push notifications.
 //!
 //! Run with: cargo run --example http_server --features http
 //!
@@ -114,8 +114,8 @@
 //!   -H "Content-Type: application/json" \
 //!   -H "Accept: text/event-stream" \
 //!   -H "MCP-Protocol-Version: 2026-07-28" \
-//!   -H "Mcp-Method: messages/listen" \
-//!   -d '{"jsonrpc":"2.0","id":4,"method":"messages/listen","params":{}}'
+//!   -H "Mcp-Method: subscriptions/listen" \
+//!   -d '{"jsonrpc":"2.0","id":4,"method":"subscriptions/listen","params":{}}'
 //! ```
 
 use std::time::Duration;

--- a/examples/http_sse_client.rs
+++ b/examples/http_sse_client.rs
@@ -4,8 +4,8 @@
 //! initializes a session, receives an `MCP-Session-Id`, and opens a
 //! per-session SSE stream via `GET`. Under the 2026-07-28 stateless protocol
 //! there is no session ID; SSE notifications are instead delivered via
-//! `messages/listen` (a `POST` with `Accept: text/event-stream`,
-//! `MCP-Protocol-Version: 2026-07-28`, and `Mcp-Method: messages/listen`).
+//! `subscriptions/listen` (a `POST` with `Accept: text/event-stream`,
+//! `MCP-Protocol-Version: 2026-07-28`, and `Mcp-Method: subscriptions/listen`).
 //! If you are running a 2026-07-28 server, the `GET` stream used here will
 //! not work as expected.
 //!

--- a/examples/stateless_http_client.rs
+++ b/examples/stateless_http_client.rs
@@ -10,7 +10,7 @@
 //! - Every request includes `Mcp-Method: <method>` (SEP-2243).
 //! - `tools/call` requests include `Mcp-Name: <tool-name>` (SEP-2243).
 //! - `server/discover` replaces `initialize` for capability discovery.
-//! - `messages/listen` replaces per-session SSE for server-push notifications.
+//! - `subscriptions/listen` replaces per-session SSE for server-push notifications.
 //!
 //! This example spins up an in-process HTTP server on a random port, then makes
 //! the four stateless requests in sequence and prints the results.
@@ -206,25 +206,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     // -----------------------------------------------------------------------
-    // Step 4: messages/listen
+    // Step 4: subscriptions/listen
     //
     // Opens a server-push SSE stream. In the 2026-07-28 protocol this is a
     // POST (not a GET) with Accept: text/event-stream. The server delivers
     // notifications for any in-flight requests that carry a progressToken.
     // We read for a short window and then disconnect.
     // -----------------------------------------------------------------------
-    println!("=== Step 4: messages/listen (SSE stream, 1-second window) ===");
+    println!("=== Step 4: subscriptions/listen (SSE stream, 1-second window) ===");
 
     let listen_response = client
         .post(&base_url)
         .header("Content-Type", "application/json")
         .header("Accept", "text/event-stream")
         .header("MCP-Protocol-Version", PROTOCOL_VERSION)
-        .header("Mcp-Method", "messages/listen")
+        .header("Mcp-Method", "subscriptions/listen")
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 4,
-            "method": "messages/listen",
+            "method": "subscriptions/listen",
             "params": {}
         }))
         .send()


### PR DESCRIPTION
Closes #947. Part of the parity roadmap in #929 (phase 0).

## Problem

The 2026-07-28 draft schema changed after the stateless preview shipped. tower-mcp carried wire constants from pre-renumbering SEP text.

## Changes

| Was | Now | Why |
|---|---|---|
| `HeaderMismatch = -32001` | `-32020` | error-code allocation, spec PR modelcontextprotocol#2907 |
| `MissingRequiredClientCapability = -32003` | `-32021` | same renumbering |
| `UnsupportedProtocolVersion = -32004` | `-32022` | same renumbering |
| `messages/listen` | `subscriptions/listen` | renamed in the draft schema |
| `notifications/tasks/status` | `notifications/tasks` | final SEP-2663 |
| `tasks/list`, `tasks/result` dispatched | fall through to `Unknown`, router answers MethodNotFound | removed by final SEP-2663 |
| `tasks/cancel` returns `TaskObject` | empty ack; status polled via `tasks/get` | final SEP-2663 |
| legacy `tasks` capability advertises `list` | `list: None` | do not advertise a method the router 404s |

Also:

- `RequestContext::cancel_task` returns `Ok(())` and tolerates both the SEP-2663 empty ack and legacy SEP-1686 task-object acks (it previously failed on a conforming peer's empty ack).
- `RequestContext::list_tasks` / `get_task_result` deprecated (methods removed by final SEP-2663; only useful against legacy SEP-1686 peers).
- Doc comments and error-code tables corrected; they asserted the pre-renumbering values were final.
- `subscriptions/listen` rename carried through types, transport, tests (file renamed), examples, README, and the stateless conformance CI job.
- Regression tests: removed methods fall through at parse level and get -32601 at router level; cancel ack shape asserted empty; cancelled status observed via `tasks/get`.
- The `capabilities.extensions["io.modelcontextprotocol/tasks"]` declaration was already present and is unchanged.

The listen rename is name and plumbing only; `SubscriptionFilter`/acknowledgment/subscriptionId semantics are #952.

## Out of scope, noted for follow-up

- `oauth/middleware.rs` and `examples/http_auth.rs` emit `-32001` for auth failures on the stable 2025-11-25 path. Pre-existing and legal (impl-defined range), but worth migrating to `Forbidden` (-32007) for consistency with `auth.rs`.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features` (22 suites green, incl. rewritten task/listen tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo build -p tower-mcp --examples --all-features`; conformance-server and codegen-mcp workspace builds
- Two-lens adversarial review of the diff (spec fidelity + sed-collateral); all findings addressed
- Every value re-verified against the published `schema/2026-07-28` at finalization before release (checklist in #929)