### PR TITLE
ci(conformance): run the official 2026-07-28 draft conformance suite

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,7 +44,7 @@ jobs:
           exit 1
 
       - name: Run conformance suite
-        run: npx @modelcontextprotocol/conformance@0.1.15 server --url http://127.0.0.1:3001/mcp --expected-failures ./conformance-baseline.yml
+        run: npx @modelcontextprotocol/conformance@0.1.16 server --url http://127.0.0.1:3001/mcp --expected-failures ./conformance-baseline.yml
 
       - name: Show server logs on failure
         if: failure()
@@ -264,10 +264,63 @@ jobs:
 
       - name: Run client conformance suite
         run: |
-          npx @modelcontextprotocol/conformance@0.1.15 client \
+          # Known gaps (new 0.1.16 offline-access scenarios, SHOULD-level
+          # warnings) are inventoried in conformance-baseline-client.yml and
+          # tracked in #953. The baseline makes the tool's exit code
+          # reliable: it fails on unexpected failures or stale entries.
+          npx @modelcontextprotocol/conformance@0.1.16 client \
             --suite all \
             --command "cargo run --manifest-path examples/conformance-client/Cargo.toml --" \
-            2>&1 | tee /tmp/client-conformance.log
-          # The conformance tool exits non-zero on SHOULD-level warnings.
-          # Check for actual failures (0 failed) to determine pass/fail.
-          grep -q "0 failed" /tmp/client-conformance.log
+            --expected-failures ./conformance-baseline-client.yml
+
+  draft-conformance:
+    name: Official 2026-07-28 Draft Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Build conformance server
+        run: cargo build --manifest-path examples/conformance-server/Cargo.toml
+
+      - name: Start server
+        run: |
+          cargo run --manifest-path examples/conformance-server/Cargo.toml \
+            > /tmp/conformance-server-draft.log 2>&1 &
+          echo $! > /tmp/conformance-server-draft.pid
+
+      - name: Wait for server
+        run: |
+          for i in $(seq 1 30); do
+            if nc -z 127.0.0.1 3001 2>/dev/null; then
+              echo "Server is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to start. Logs:"
+          cat /tmp/conformance-server-draft.log
+          exit 1
+
+      - name: Run official 2026-07-28 draft suite
+        run: |
+          # The 0.2.0-alpha.x line carries the 2026-07-28 draft scenarios.
+          # --suite all includes draft/pending-status scenarios
+          # (server-stateless, caching, header validation, the 14 MRTR
+          # input-required-result scenarios). Known gaps are inventoried in
+          # conformance-baseline-draft.yml, one entry per parity-roadmap
+          # phase issue (#929); the job fails on unexpected failures OR on
+          # stale baseline entries that started passing.
+          npx @modelcontextprotocol/conformance@0.2.0-alpha.9 server \
+            --url http://127.0.0.1:3001/mcp \
+            --spec-version 2026-07-28 \
+            --suite all \
+            --expected-failures ./conformance-baseline-draft.yml
+
+      - name: Show server logs on failure
+        if: failure()
+        run: cat /tmp/conformance-server-draft.log

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/crates/l/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp#license)
 [![MSRV](https://img.shields.io/crates/msrv/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp)
 [![MCP](https://img.shields.io/badge/MCP-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
-[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_265%2F265_client-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
+[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_264%2F266_client-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
 
 Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
 
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks (30 scenarios) and 265/265 client checks (24 scenarios) from the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance) pass in CI on every PR. The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 draft suite (58/101 checks at 0.2.0-alpha.9, gaps baselined per [#929](https://github.com/joshrotenberg/tower-mcp/issues/929)) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -585,10 +585,11 @@ let router = McpRouter::new()
 
 tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
-- **Server:** 39/39 checks across 30 scenarios
-- **Client:** 265/265 checks across 24 scenarios (3 SHOULD-level warnings)
+- **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
+- **Client (2025-11-25):** 264/266 checks (`conformance@0.1.16`; the two gaps are new offline-access scenarios, baselined in `conformance-baseline-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953))
+- **Server (2026-07-28 draft):** 58/101 checks (`conformance@0.2.0-alpha.9`, `--suite all`); remaining gaps are baselined in `conformance-baseline-draft.yml`, one entry per phase of the parity roadmap in [#929](https://github.com/joshrotenberg/tower-mcp/issues/929)
 
-Numbers above are from `@modelcontextprotocol/conformance@0.1.15`, run on every PR. Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot.
+Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. CI fails when a baselined scenario regresses further or starts passing (stale baseline), so the baselines cannot silently rot.
 
 The `stateless` feature enables an experimental 2026-07-28 protocol path (version-gated, behind
 `MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, and per-request

--- a/conformance-baseline-client.yml
+++ b/conformance-baseline-client.yml
@@ -1,0 +1,22 @@
+# MCP Conformance Suite -- Expected Failures Baseline (client, 2025-11-25)
+#
+# Applies to `@modelcontextprotocol/conformance@0.1.16 client --suite all`.
+# The baseline checker counts SHOULD-level warnings the same as failures,
+# so warning-carrying scenarios are listed too. CI fails when a baselined
+# scenario starts passing cleanly (stale entry) or a non-baselined scenario
+# fails.
+#
+# Status at 0.1.16 (2026-07-23): 264/266 checks pass, 4 warnings.
+
+client:
+  # New scenarios in 0.1.16 that the conformance-client harness does not
+  # implement yet ("Unknown scenario"): offline_access scope handling.
+  # Client-side work tracked in #953 (phase 6).
+  - auth/offline-access-scope
+  - auth/offline-access-not-supported
+
+  # SHOULD-level warnings (passing checks, warning flags). Inventoried for
+  # #953; each needs a look at whether the SHOULD is worth implementing.
+  - auth/basic-cimd
+  - auth/scope-from-scopes-supported
+  - auth/scope-step-up

--- a/conformance-baseline-draft.yml
+++ b/conformance-baseline-draft.yml
@@ -1,0 +1,59 @@
+# MCP Conformance Suite -- Expected Failures Baseline (2026-07-28 draft)
+#
+# Applies to the 0.2.0-alpha.x draft suite run with
+# `--spec-version 2026-07-28 --suite all`. Each entry is a scenario expected
+# to fail (or carry SHOULD-level warnings, which the baseline checker counts
+# the same) while the corresponding parity-roadmap issue (#929) is open.
+# Remove entries as the phases land; CI fails when a baselined scenario
+# starts passing (stale entry) or a non-baselined scenario fails.
+#
+# Status at 0.2.0-alpha.9 (2026-07-23): 58/101 checks pass;
+# 26/40 scenarios fully green.
+#
+# Format (0.2.x suite): plain scenario-name strings under `server:` /
+# `client:` keys; reasons live in these comments.
+
+server:
+  # SEP-2575/2567 stateless core gaps (4/28 checks pass): required
+  # per-request _meta validation (-32602 + HTTP 400), HTTP status mapping
+  # (400/404 for version/header/capability/method errors), per-request
+  # capability gating (-32021), subscriptions/listen
+  # acknowledgment/subscriptionId/filter semantics.
+  # Types work in #949; transport and listen semantics in #952.
+  - server-stateless
+
+  # Progress notifications are not delivered when the draft-path response is
+  # a plain JSON body; needs JSON-vs-SSE content negotiation (#952).
+  - tools-call-with-progress
+
+  # SHOULD-level warning: resource-not-found error data omits `uri`.
+  # Small fix, batched into #952.
+  - sep-2164-resource-not-found
+
+  # SEP-2549 (1/7 checks pass): list results emit ttlMs but cacheScope is
+  # always absent; the draft spec requires both on the six cacheable
+  # results (#949).
+  - caching
+
+  # SEP-2243 (7/9 checks pass): the two failures need schema-aware rejection
+  # when an x-mcp-header-annotated argument is present in the body but its
+  # Mcp-Param-* header is missing; the transport does not yet consult tool
+  # schemas during header validation (#952).
+  - http-custom-header-server-validation
+
+  # SEP-2322 MRTR is not implemented (#950). Scenarios that fully pass do so
+  # because correct non-MRTR behavior (rejecting unsupported methods)
+  # coincides with the spec; the two warning-only entries below also need
+  # the MRTR fixture tools.
+  - input-required-result-basic-elicitation
+  - input-required-result-basic-sampling
+  - input-required-result-basic-list-roots
+  - input-required-result-request-state
+  - input-required-result-multiple-input-requests
+  - input-required-result-multi-round
+  - input-required-result-missing-input-response
+  - input-required-result-non-tool-request
+  - input-required-result-result-type
+  - input-required-result-tampered-state
+  - input-required-result-capability-check
+  - input-required-result-ignore-extra-params

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -61,7 +61,79 @@ pub fn build_tools() -> Vec<Tool> {
         build_per_request_meta(),
         // SEP-2663: task-capable tool so the server advertises the tasks extension
         build_create_task(),
+        // Fixtures for the official 2026-07-28 conformance suite (#948)
+        build_json_schema_2020_12(),
+        build_custom_header(),
     ]
+}
+
+/// Fixture for the `json-schema-2020-12` conformance scenario: a tool whose
+/// input schema exercises the 2020-12 keyword families (`$defs`/`$anchor`,
+/// `allOf`/`anyOf`, `if`/`then`/`else`). The suite verifies the schema
+/// round-trips through the server unmodified.
+fn build_json_schema_2020_12() -> Tool {
+    ToolBuilder::new("json_schema_2020_12_tool")
+        .description("Tool with JSON Schema 2020-12 features")
+        .input_schema(serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "$defs": {
+                "address": {
+                    "$anchor": "address",
+                    "type": "object",
+                    "properties": {
+                        "street": { "type": "string" },
+                        "city": { "type": "string" }
+                    }
+                }
+            },
+            "properties": {
+                "name": { "type": "string" },
+                "address": { "$ref": "#/$defs/address" }
+            },
+            "allOf": [{
+                "anyOf": [
+                    { "required": ["name"] },
+                    { "required": ["address"] }
+                ]
+            }],
+            "if": { "required": ["address"] },
+            "then": {
+                "properties": {
+                    "address": { "required": ["street"] }
+                }
+            },
+            "else": { "required": ["name"] },
+            "additionalProperties": false
+        }))
+        .extractor_handler((), |RawArgs(args): RawArgs| async move {
+            let name = args.get("name").and_then(|v| v.as_str()).unwrap_or("world");
+            Ok(CallToolResult::text(format!("Hello, {name}!")))
+        })
+        .build()
+}
+
+/// Fixture for the `http-custom-header-server-validation` conformance
+/// scenario (SEP-2243): the `x-mcp-header` annotation promotes the `value`
+/// argument to an `Mcp-Param-Value` HTTP header, which the transport
+/// validates against the body.
+fn build_custom_header() -> Tool {
+    ToolBuilder::new("test_custom_header")
+        .description("Validates SEP-2243 custom parameter headers")
+        .input_schema(serde_json::json!({
+            "type": "object",
+            "properties": {
+                "value": { "type": "string", "x-mcp-header": "Value" }
+            },
+            "required": ["value"]
+        }))
+        .extractor_handler((), |RawArgs(args): RawArgs| async move {
+            match args.get("value").and_then(|v| v.as_str()) {
+                Some(value) => Ok(CallToolResult::text(value.to_string())),
+                None => Ok(CallToolResult::error("value must be a string")),
+            }
+        })
+        .build()
 }
 
 fn build_simple_text() -> Tool {


### PR DESCRIPTION
Closes #948. Part of the parity roadmap in #929 (phase 1).

## What this does

Adopts the official MCP conformance suite as the parity measuring stick, including the 2026-07-28 draft suite tower-mcp had never been run against.

### Version bumps (2025-11-25 suites)

- Server and client jobs: `conformance@0.1.15` to `0.1.16`.
- Server: 39/39 unchanged.
- Client: 264/266. The two failures are new offline-access scenarios (`auth/offline-access-scope`, `auth/offline-access-not-supported`) the conformance-client harness does not implement yet; baselined in `conformance-baseline-client.yml`, tracked in #953. The job now relies on the tool's exit code via `--expected-failures` instead of grepping the log for `0 failed` (the old grep matched any per-scenario line and could not fail on real regressions).

### New job: Official 2026-07-28 Draft Suite

`conformance@0.2.0-alpha.9 server --spec-version 2026-07-28 --suite all`. First-ever official measurement, after adding two fixture tools:

| Scenario group | Standing |
|---|---|
| Overall | 58/101 checks, 26/40 scenarios fully green |
| http-header-validation | 13/13 (passes because of #954's -32020 renumbering) |
| json-schema-2020-12 | 7/7 (new fixture tool) |
| http-custom-header-server-validation | 7/9 (new fixture tool; base64 sentinel validation already worked) |
| sep-2164, dns-rebinding, sse-multiple-streams | pass |
| server-stateless | 4/28 (gaps in #949/#952) |
| caching | 1/7 (#949) |
| input-required-result-* (MRTR) | not implemented (#950) |

Gaps are inventoried in `conformance-baseline-draft.yml`, one entry per phase issue. The baseline checker fails CI on unexpected failures or stale entries (a baselined scenario that starts passing must be removed), so the baseline cannot rot silently.

### Fixture tools added to conformance-server

- `json_schema_2020_12_tool`: input schema exercising `$defs`/`$anchor`, `allOf`/`anyOf`, `if`/`then`/`else`; verifies 2020-12 keyword round-trip.
- `test_custom_header`: `x-mcp-header: "Value"` annotation promoting the `value` argument to an `Mcp-Param-Value` header (SEP-2243).

### Kept

The homegrown stateless curl job stays: it covers session-header interplay (mcp-session-id suppression, header-override behavior) that the official `server-stateless` scenario does not exercise.

### README

Conformance claims updated to the official numbers with links to the baselines and #929.

## Verification

- All three suites run locally against the built conformance-server: 2025-11-25 server 39/39, client 264/266 with baseline check passed, draft 58/101 with baseline check passed
- `cargo fmt --all -- --check`; clippy clean on conformance-server