### PR TITLE
chore(rmcp-compat): bump rmcp to 3.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -701,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1480,7 +1480,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2004,9 +2004,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "ff9e21bad592f6657fe8dc58bb92019ef8870e63eda751a419bfddfe9adf78ef"
 dependencies = [
  "async-trait",
  "base64",
@@ -2051,9 +2051,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "966af4779cdbaee14fc3011db558dbb66d3e6b64d6c4e2bc2fe45e09477cacdb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2087,7 +2087,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2144,7 +2144,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2473,7 +2473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2488,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2579,7 +2579,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3253,7 +3253,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-mcp = { path = "../../crates/tower-mcp", features = ["http"] }
-rmcp = { version = "2.1.0", features = [
+rmcp = { version = "3.0.0-beta.1", features = [
     "server",
     "macros",
     "transport-streamable-http-server",

--- a/tools/rmcp-compat/README.md
+++ b/tools/rmcp-compat/README.md
@@ -69,7 +69,7 @@ Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)
 Known diffs are documented divergences that are intentional or explained. They
 appear as `[KNOWN-DIFF]` and do not cause a non-zero exit code.
 
-Current known diffs (against rmcp 2.1.0):
+Current known diffs (against rmcp 3.0.0-beta.1):
 
 **`error.message` phrasing for method-not-found:**
 rmcp returns just the method name (e.g. `"nonexistent/method"`); tower-mcp
@@ -92,8 +92,8 @@ A `tools/list` sent before `notifications/initialized` is rejected by tower-mcp
 with `-32600` (InvalidRequest) per #901. rmcp does not enforce this ordering and
 returns the tools list. tower-mcp is the stricter, more spec-compliant side, so
 this is a documented divergence rather than a tower-mcp bug. (With rmcp 1.7.0
-this surfaced as a FAIL; rmcp 2.1.0 did not change the behavior, so it is now
-classified as a KNOWN-DIFF.)
+this surfaced as a FAIL; rmcp 2.1.0 and 3.0.0-beta.1 did not change the
+behavior, so it is classified as a KNOWN-DIFF.)
 
 **SSE response wrapping (default mode):**
 rmcp always wraps synchronous JSON-RPC responses as SSE (`Content-Type:
@@ -125,7 +125,7 @@ validates that the opt-in SSE mode matches rmcp's behavior exactly.
 Change the version constraint in `tools/rmcp-compat/Cargo.toml`:
 
 ```toml
-rmcp = { version = "2.1.0", features = [...] }
+rmcp = { version = "3.0.0-beta.1", features = [...] }
 ```
 
 Then run the harness and update any KNOWN-DIFF entries that have changed.
@@ -134,3 +134,14 @@ Note the 1.x -> 2.x jump renamed `rmcp::model::Content` to
 `rmcp::model::ContentBlock` (constructed via `ContentBlock::text(...)`); the
 `StreamableHttpService`, `LocalSessionManager`, `ServerHandler`, and the
 `#[tool]`/`#[tool_router]`/`#[tool_handler]` macro surfaces were unchanged.
+
+The 2.x -> 3.x jump (3.0.0-beta.1 implements the 2026-07-28 SEP batch)
+required no harness code changes: the harness does not use the surfaces that
+broke (Meta type split, `CallToolResult.structured_content` widening,
+`Annotations.last_modified`, the removed experimental tasks API). The
+`StreamableHttpServerConfig.stateful_mode` field was renamed
+`legacy_session_mode`; the harness uses `StreamableHttpServerConfig::default()`
+and the default remains `legacy_session_mode: true`, so rmcp still serves the
+2025-11-25 session-based flow that the harness exercises. rmcp 3.x dispatches
+the 2026-07-28 stateless protocol per-request, so requests negotiating
+`2025-11-25` behave as before.

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -1167,7 +1167,7 @@ async fn check_invalid_params(
 /// Send tools/list WITHOUT the notifications/initialized step. tower-mcp rejects
 /// this with -32600 (InvalidRequest) per #901. rmcp does not enforce the ordering
 /// and returns the tools list, so this is a KNOWN-DIFF (tower-mcp is the stricter,
-/// more spec-compliant side), verified current as of rmcp 2.1.0.
+/// more spec-compliant side), verified current as of rmcp 3.0.0-beta.1.
 async fn check_initialized_enforcement(client: &reqwest::Client) -> Vec<CheckResult> {
     // Start fresh sessions without sending notifications/initialized
     let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-enforcement-test","version":"0.1.0"}}}"#;


### PR DESCRIPTION
## Summary

Bumps the rmcp interop-compat harness (`tools/rmcp-compat/`) from rmcp 2.1.0 (2.2.0 in the lockfile) to 3.0.0-beta.1, released 2026-07-23, the first rmcp release implementing the 2026-07-28 SEP batch. This is the harness re-run called for by the parity roadmap #929.

## API porting required

None. The harness compiled and ran against 3.0.0-beta.1 without source changes:

- The known 3.x breaks (Meta split into MetaObject/RequestMetaObject/NotificationMetaObject, `CallToolResult.structured_content` widened to `serde_json::Value`, `Annotations.last_modified` now `Option<String>`, non-exhaustive protocol enums, `IntoCallToolResult` producing `CallToolResponse`, removed experimental tasks API) do not touch the surface the harness uses (`ServerHandler`, `#[tool]`/`#[tool_router]`/`#[tool_handler]`, `CallToolResult::success`, `ContentBlock::text`, `StreamableHttpService`, `LocalSessionManager`, `ProtocolVersion::V_2025_11_25`).
- The `StreamableHttpServerConfig.stateful_mode` to `legacy_session_mode` rename is invisible to the harness because it uses `StreamableHttpServerConfig::default()`. Verified in the 3.0.0-beta.1 source that the default remains `legacy_session_mode: true`, and that rmcp 3.x dispatches the 2026-07-28 stateless protocol per-request, so the 2025-11-25 session-based flow the harness exercises behaves exactly as before.

## Harness results

```
Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)
```

Identical to the rmcp 2.1.0 baseline. Exit code 0.

## KNOWN-DIFF changes

No new known diffs and none removed. All four existing entries reproduce unchanged against 3.0.0-beta.1 and were re-verified in this run:

1. `method-not-found` message phrasing (both use -32601)
2. `resources/read` not-found code: rmcp -32601 vs tower-mcp -32602 (SEP-2164, #841)
3. `invalid-params` missing required argument reported as tool-level `isError` on both
4. `initialized-enforcement`: tower-mcp rejects pre-`notifications/initialized` requests with -32600 (#901); rmcp 3.0.0-beta.1 still does not enforce the ordering

README updates: known-diff section now references 3.0.0-beta.1, and a 2.x to 3.x porting note documents why no code changes were needed and the `legacy_session_mode` default.

## Suspected bugs

- tower-mcp: none found.
- rmcp 3.0.0-beta.1: none observed on the legacy 2025-11-25 path exercised here. Note the harness only covers the session-based flow; it does not yet exercise rmcp's new 2026-07-28 stateless path against tower-mcp's `stateless` feature. That would be a follow-up under #929.

## Lockfile

`Cargo.lock` updated per repo policy: rmcp and rmcp-macros to 3.0.0-beta.1, sse-stream 0.2.3 to 0.2.5, plus a windows-sys unification to 0.61.2 pulled in by the new rmcp dependency graph.

## Validation

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` all passing
- `cargo run -p rmcp-compat` final run clean (exit 0)

Refs #929.