### PR TITLE
refactor(tasks): promote TaskStore to a pluggable trait

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -4,29 +4,31 @@
 //! longer than a typical request/response cycle. Tasks can be created via
 //! task-augmented `tools/call` requests, tracked, polled for status, and cancelled.
 //!
+//! Task state lives behind the pluggable [`TaskStore`] trait, mirroring the
+//! shape of [`crate::session_store`] and [`crate::event_store`]: a trait, an
+//! error enum, and an in-memory default. By default routers use
+//! [`MemoryTaskStore`], which keeps tasks in an in-process map (behavior
+//! identical to earlier versions). External stores (Redis, Postgres, etc.) can
+//! be plugged in so `tasks/get` works on any instance behind a load balancer
+//! in the sessionless 2026-07-28 flows (SEP-2663).
+//!
 //! # Example
 //!
-//! ```rust,ignore
-//! use tower_mcp::async_task::{TaskStore, Task};
-//! use tower_mcp::protocol::TaskStatus;
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+//! use tower_mcp::McpRouter;
 //!
-//! // Create a task store
-//! let store = TaskStore::new();
-//!
-//! // Create a task
-//! let task = store.create_task("my-tool", serde_json::json!({"key": "value"}), None);
-//!
-//! // Get task status
-//! let info = store.get_task(&task.id);
-//!
-//! // Mark task as complete
-//! store.complete_task(&task.id, Ok(result));
+//! let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+//! let router = McpRouter::new().task_store(store);
 //! ```
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
 
 use crate::protocol::{CallToolResult, TaskObject, TaskStatus};
 
@@ -142,20 +144,122 @@ impl CancellationToken {
     }
 }
 
-/// Thread-safe task storage
+/// Errors returned by [`TaskStore`] implementations.
+///
+/// Mirrors the three-variant shape of
+/// [`SessionStoreError`](crate::session_store::SessionStoreError): encode and
+/// decode errors from (de)serializing task state, and catch-all backend errors
+/// from the storage layer. [`MemoryTaskStore`] never returns errors; the
+/// variants exist for external implementations.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum TaskStoreError {
+    /// Failed to encode task state (e.g. serde serialization error).
+    #[error("encode error: {0}")]
+    Encode(String),
+    /// Failed to decode task state (e.g. corrupt data in the backend).
+    #[error("decode error: {0}")]
+    Decode(String),
+    /// Backend error (e.g. connection failure, transient storage error).
+    #[error("backend error: {0}")]
+    Backend(String),
+}
+
+/// Result alias for task store operations.
+pub type Result<T> = std::result::Result<T, TaskStoreError>;
+
+/// A task's current snapshot: the task object plus any result or error
+/// captured so far.
+pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<String>);
+
+/// Storage backend for async task state.
+///
+/// Implementations persist task lifecycle state keyed by task ID. The default
+/// implementation is [`MemoryTaskStore`]; external stores (Redis, Postgres,
+/// etc.) typically live in separate crates.
+///
+/// # Semantics
+///
+/// - Terminal states ([`TaskStatus::is_terminal`]) are immutable: once a task
+///   is completed, failed, or cancelled, further transitions must be rejected
+///   (`Ok(false)` from the transition methods).
+/// - [`cancel_task`](Self::cancel_task) must signal the task's
+///   [`CancellationToken`] even if the task is already terminal.
+/// - [`wait_for_completion`](Self::wait_for_completion) blocks until the task
+///   reaches a terminal state; how an implementation waits (notification,
+///   polling, pub/sub) is an implementation detail and must not leak into the
+///   trait.
+#[async_trait]
+pub trait TaskStore: Send + Sync + 'static {
+    /// Create and store a new task.
+    ///
+    /// Returns the task ID and a cancellation token for the spawned work.
+    async fn create_task(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        ttl: Option<u64>,
+    ) -> Result<(String, CancellationToken)>;
+
+    /// Get task object by ID. Returns `None` if unknown.
+    async fn get_task(&self, task_id: &str) -> Result<Option<TaskObject>>;
+
+    /// Get a task's full snapshot (task object, result, error) by ID.
+    async fn get_task_result(&self, task_id: &str) -> Result<Option<TaskSnapshot>>;
+
+    /// Wait for a task to reach a terminal state, then return its snapshot.
+    ///
+    /// If the task is already terminal, returns immediately. Otherwise blocks
+    /// until the task completes, fails, or is cancelled. Returns `None` if
+    /// the task is unknown.
+    async fn wait_for_completion(&self, task_id: &str) -> Result<Option<TaskSnapshot>>;
+
+    /// List all tasks, optionally filtered by status.
+    async fn list_tasks(&self, status_filter: Option<TaskStatus>) -> Result<Vec<TaskObject>>;
+
+    /// Mark a task as requiring input.
+    ///
+    /// Returns `Ok(false)` if the task is unknown or already terminal.
+    async fn require_input(&self, task_id: &str, message: &str) -> Result<bool>;
+
+    /// Mark a task as completed with a result.
+    ///
+    /// Returns `Ok(false)` if the task is unknown or already terminal.
+    async fn complete_task(&self, task_id: &str, result: CallToolResult) -> Result<bool>;
+
+    /// Mark a task as failed with an error.
+    ///
+    /// Returns `Ok(false)` if the task is unknown or already terminal.
+    async fn fail_task(&self, task_id: &str, error: &str) -> Result<bool>;
+
+    /// Cancel a task.
+    ///
+    /// Signals the task's [`CancellationToken`] and, if the task is not
+    /// already terminal, marks it cancelled. Returns the updated task object,
+    /// or `None` if the task is unknown.
+    async fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Result<Option<TaskObject>>;
+}
+
+/// In-memory [`TaskStore`] backed by a `HashMap`.
+///
+/// This is the default store. Suitable for single-instance deployments. For
+/// horizontal scaling, use an external store that shares state across
+/// instances. Completion wakeups for
+/// [`wait_for_completion`](TaskStore::wait_for_completion) use a per-task
+/// [`tokio::sync::Notify`], which is an implementation detail of this store.
 #[derive(Debug, Clone)]
-pub struct TaskStore {
+pub struct MemoryTaskStore {
     tasks: Arc<RwLock<HashMap<String, Task>>>,
     next_id: Arc<AtomicU64>,
 }
 
-impl Default for TaskStore {
+impl Default for MemoryTaskStore {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl TaskStore {
+impl MemoryTaskStore {
     /// Create a new task store
     pub fn new() -> Self {
         Self {
@@ -170,172 +274,10 @@ impl TaskStore {
         format!("task-{}", id)
     }
 
-    /// Create and store a new task
+    /// Remove expired tasks (call periodically for cleanup).
     ///
-    /// Returns the task ID and a cancellation token for the spawned work.
-    pub fn create_task(
-        &self,
-        tool_name: &str,
-        arguments: serde_json::Value,
-        ttl: Option<u64>,
-    ) -> (String, CancellationToken) {
-        let id = self.generate_id();
-        let task = Task::new(id.clone(), tool_name.to_string(), arguments, ttl);
-        let token = task.cancellation_token.clone();
-
-        if let Ok(mut tasks) = self.tasks.write() {
-            tasks.insert(id.clone(), task);
-        }
-
-        (id, token)
-    }
-
-    /// Get task object by ID
-    pub fn get_task(&self, task_id: &str) -> Option<TaskObject> {
-        if let Ok(tasks) = self.tasks.read() {
-            tasks.get(task_id).map(|t| t.to_task_object())
-        } else {
-            None
-        }
-    }
-
-    /// Get full task result by ID (task object, result, error)
-    pub fn get_task_result(
-        &self,
-        task_id: &str,
-    ) -> Option<(TaskObject, Option<CallToolResult>, Option<String>)> {
-        if let Ok(tasks) = self.tasks.read() {
-            tasks
-                .get(task_id)
-                .map(|t| (t.to_task_object(), t.result.clone(), t.error.clone()))
-        } else {
-            None
-        }
-    }
-
-    /// Wait for a task to reach a terminal state, then return its result.
-    ///
-    /// If the task is already terminal, returns immediately. Otherwise blocks
-    /// until the task completes, fails, or is cancelled.
-    pub async fn wait_for_completion(
-        &self,
-        task_id: &str,
-    ) -> Option<(TaskObject, Option<CallToolResult>, Option<String>)> {
-        // First check if already terminal and get the notify handle
-        let notify = {
-            let tasks = self.tasks.read().ok()?;
-            let task = tasks.get(task_id)?;
-            if task.status.is_terminal() {
-                return Some((
-                    task.to_task_object(),
-                    task.result.clone(),
-                    task.error.clone(),
-                ));
-            }
-            task.completion_notify.clone()
-        };
-
-        // Wait for completion notification
-        notify.notified().await;
-
-        // Read the result
-        self.get_task_result(task_id)
-    }
-
-    /// List all tasks, optionally filtered by status
-    pub fn list_tasks(&self, status_filter: Option<TaskStatus>) -> Vec<TaskObject> {
-        if let Ok(tasks) = self.tasks.read() {
-            tasks
-                .values()
-                .filter(|t| status_filter.is_none() || status_filter == Some(t.status))
-                .map(|t| t.to_task_object())
-                .collect()
-        } else {
-            vec![]
-        }
-    }
-
-    /// Mark a task as requiring input
-    pub fn require_input(&self, task_id: &str, message: &str) -> bool {
-        let Ok(mut tasks) = self.tasks.write() else {
-            return false;
-        };
-        let Some(task) = tasks.get_mut(task_id) else {
-            return false;
-        };
-        if task.status.is_terminal() {
-            return false;
-        }
-        task.status = TaskStatus::InputRequired;
-        task.status_message = Some(message.to_string());
-        task.last_updated_at_str = chrono_now_iso8601();
-        true
-    }
-
-    /// Mark a task as completed with a result
-    pub fn complete_task(&self, task_id: &str, result: CallToolResult) -> bool {
-        let Ok(mut tasks) = self.tasks.write() else {
-            return false;
-        };
-        let Some(task) = tasks.get_mut(task_id) else {
-            return false;
-        };
-        if task.status.is_terminal() {
-            return false;
-        }
-        task.status = TaskStatus::Completed;
-        task.status_message = Some("Task completed".to_string());
-        task.result = Some(result);
-        task.completed_at = Some(Instant::now());
-        task.last_updated_at_str = chrono_now_iso8601();
-        task.completion_notify.notify_waiters();
-        true
-    }
-
-    /// Mark a task as failed with an error
-    pub fn fail_task(&self, task_id: &str, error: &str) -> bool {
-        let Ok(mut tasks) = self.tasks.write() else {
-            return false;
-        };
-        let Some(task) = tasks.get_mut(task_id) else {
-            return false;
-        };
-        if task.status.is_terminal() {
-            return false;
-        }
-        task.status = TaskStatus::Failed;
-        task.status_message = Some(format!("Task failed: {}", error));
-        task.error = Some(error.to_string());
-        task.completed_at = Some(Instant::now());
-        task.last_updated_at_str = chrono_now_iso8601();
-        task.completion_notify.notify_waiters();
-        true
-    }
-
-    /// Cancel a task
-    pub fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Option<TaskObject> {
-        let mut tasks = self.tasks.write().ok()?;
-        let task = tasks.get_mut(task_id)?;
-
-        // Signal cancellation
-        task.cancellation_token.cancel();
-
-        // If not already terminal, mark as cancelled
-        if !task.status.is_terminal() {
-            task.status = TaskStatus::Cancelled;
-            task.status_message = Some(
-                reason
-                    .map(|r| format!("Cancelled: {}", r))
-                    .unwrap_or_else(|| "Task cancelled".to_string()),
-            );
-            task.completed_at = Some(Instant::now());
-            task.last_updated_at_str = chrono_now_iso8601();
-            task.completion_notify.notify_waiters();
-        }
-        Some(task.to_task_object())
-    }
-
-    /// Remove expired tasks (call periodically for cleanup)
+    /// Returns the number removed. Not part of the [`TaskStore`] trait;
+    /// external backends typically expire entries natively (e.g. Redis TTL).
     pub fn cleanup_expired(&self) -> usize {
         if let Ok(mut tasks) = self.tasks.write() {
             let before = tasks.len();
@@ -360,6 +302,162 @@ impl TaskStore {
     #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+#[async_trait]
+impl TaskStore for MemoryTaskStore {
+    async fn create_task(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        ttl: Option<u64>,
+    ) -> Result<(String, CancellationToken)> {
+        let id = self.generate_id();
+        let task = Task::new(id.clone(), tool_name.to_string(), arguments, ttl);
+        let token = task.cancellation_token.clone();
+
+        if let Ok(mut tasks) = self.tasks.write() {
+            tasks.insert(id.clone(), task);
+        }
+
+        Ok((id, token))
+    }
+
+    async fn get_task(&self, task_id: &str) -> Result<Option<TaskObject>> {
+        Ok(if let Ok(tasks) = self.tasks.read() {
+            tasks.get(task_id).map(|t| t.to_task_object())
+        } else {
+            None
+        })
+    }
+
+    async fn get_task_result(&self, task_id: &str) -> Result<Option<TaskSnapshot>> {
+        Ok(if let Ok(tasks) = self.tasks.read() {
+            tasks
+                .get(task_id)
+                .map(|t| (t.to_task_object(), t.result.clone(), t.error.clone()))
+        } else {
+            None
+        })
+    }
+
+    async fn wait_for_completion(&self, task_id: &str) -> Result<Option<TaskSnapshot>> {
+        // First check if already terminal and get the notify handle
+        let notify = {
+            let Ok(tasks) = self.tasks.read() else {
+                return Ok(None);
+            };
+            let Some(task) = tasks.get(task_id) else {
+                return Ok(None);
+            };
+            if task.status.is_terminal() {
+                return Ok(Some((
+                    task.to_task_object(),
+                    task.result.clone(),
+                    task.error.clone(),
+                )));
+            }
+            task.completion_notify.clone()
+        };
+
+        // Wait for completion notification
+        notify.notified().await;
+
+        // Read the result
+        self.get_task_result(task_id).await
+    }
+
+    async fn list_tasks(&self, status_filter: Option<TaskStatus>) -> Result<Vec<TaskObject>> {
+        Ok(if let Ok(tasks) = self.tasks.read() {
+            tasks
+                .values()
+                .filter(|t| status_filter.is_none() || status_filter == Some(t.status))
+                .map(|t| t.to_task_object())
+                .collect()
+        } else {
+            vec![]
+        })
+    }
+
+    async fn require_input(&self, task_id: &str, message: &str) -> Result<bool> {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(false);
+        };
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(false);
+        };
+        if task.status.is_terminal() {
+            return Ok(false);
+        }
+        task.status = TaskStatus::InputRequired;
+        task.status_message = Some(message.to_string());
+        task.last_updated_at_str = chrono_now_iso8601();
+        Ok(true)
+    }
+
+    async fn complete_task(&self, task_id: &str, result: CallToolResult) -> Result<bool> {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(false);
+        };
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(false);
+        };
+        if task.status.is_terminal() {
+            return Ok(false);
+        }
+        task.status = TaskStatus::Completed;
+        task.status_message = Some("Task completed".to_string());
+        task.result = Some(result);
+        task.completed_at = Some(Instant::now());
+        task.last_updated_at_str = chrono_now_iso8601();
+        task.completion_notify.notify_waiters();
+        Ok(true)
+    }
+
+    async fn fail_task(&self, task_id: &str, error: &str) -> Result<bool> {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(false);
+        };
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(false);
+        };
+        if task.status.is_terminal() {
+            return Ok(false);
+        }
+        task.status = TaskStatus::Failed;
+        task.status_message = Some(format!("Task failed: {}", error));
+        task.error = Some(error.to_string());
+        task.completed_at = Some(Instant::now());
+        task.last_updated_at_str = chrono_now_iso8601();
+        task.completion_notify.notify_waiters();
+        Ok(true)
+    }
+
+    async fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Result<Option<TaskObject>> {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(None);
+        };
+        let Some(task) = tasks.get_mut(task_id) else {
+            return Ok(None);
+        };
+
+        // Signal cancellation
+        task.cancellation_token.cancel();
+
+        // If not already terminal, mark as cancelled
+        if !task.status.is_terminal() {
+            task.status = TaskStatus::Cancelled;
+            task.status_message = Some(
+                reason
+                    .map(|r| format!("Cancelled: {}", r))
+                    .unwrap_or_else(|| "Task cancelled".to_string()),
+            );
+            task.completed_at = Some(Instant::now());
+            task.last_updated_at_str = chrono_now_iso8601();
+            task.completion_notify.notify_waiters();
+        }
+        Ok(Some(task.to_task_object()))
     }
 }
 
@@ -429,123 +527,214 @@ fn is_leap_year(year: i32) -> bool {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_create_task() {
-        let store = TaskStore::new();
-        let (id, token) = store.create_task("test-tool", serde_json::json!({"a": 1}), None);
+    #[tokio::test]
+    async fn test_create_task() {
+        let store = MemoryTaskStore::new();
+        let (id, token) = store
+            .create_task("test-tool", serde_json::json!({"a": 1}), None)
+            .await
+            .unwrap();
 
         assert!(id.starts_with("task-"));
         assert!(!token.is_cancelled());
 
-        let info = store.get_task(&id).expect("task should exist");
+        let info = store
+            .get_task(&id)
+            .await
+            .unwrap()
+            .expect("task should exist");
         assert_eq!(info.task_id, id);
         assert_eq!(info.status, TaskStatus::Working);
     }
 
-    #[test]
-    fn test_task_lifecycle() {
-        let store = TaskStore::new();
-        let (id, _) = store.create_task("test-tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_task_lifecycle() {
+        let store = MemoryTaskStore::new();
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         // Complete task
-        assert!(store.complete_task(&id, CallToolResult::text("Done")));
+        assert!(
+            store
+                .complete_task(&id, CallToolResult::text("Done"))
+                .await
+                .unwrap()
+        );
 
-        let info = store.get_task(&id).unwrap();
+        let info = store.get_task(&id).await.unwrap().unwrap();
         assert_eq!(info.status, TaskStatus::Completed);
     }
 
-    #[test]
-    fn test_task_cancellation() {
-        let store = TaskStore::new();
-        let (id, token) = store.create_task("test-tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_task_cancellation() {
+        let store = MemoryTaskStore::new();
+        let (id, token) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         assert!(!token.is_cancelled());
 
-        let task_obj = store.cancel_task(&id, Some("User requested"));
+        let task_obj = store
+            .cancel_task(&id, Some("User requested"))
+            .await
+            .unwrap();
         assert!(task_obj.is_some());
         assert_eq!(task_obj.unwrap().status, TaskStatus::Cancelled);
         assert!(token.is_cancelled());
 
-        let info = store.get_task(&id).unwrap();
+        let info = store.get_task(&id).await.unwrap().unwrap();
         assert_eq!(info.status, TaskStatus::Cancelled);
     }
 
-    #[test]
-    fn test_task_failure() {
-        let store = TaskStore::new();
-        let (id, _) = store.create_task("test-tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_task_failure() {
+        let store = MemoryTaskStore::new();
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
-        assert!(store.fail_task(&id, "Something went wrong"));
+        assert!(store.fail_task(&id, "Something went wrong").await.unwrap());
 
-        let info = store.get_task(&id).unwrap();
+        let info = store.get_task(&id).await.unwrap().unwrap();
         assert_eq!(info.status, TaskStatus::Failed);
         assert!(info.status_message.as_ref().unwrap().contains("failed"));
     }
 
-    #[test]
-    fn test_list_tasks() {
-        let store = TaskStore::new();
-        store.create_task("tool1", serde_json::json!({}), None);
-        store.create_task("tool2", serde_json::json!({}), None);
-        let (id3, _) = store.create_task("tool3", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_list_tasks() {
+        let store = MemoryTaskStore::new();
+        store
+            .create_task("tool1", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        store
+            .create_task("tool2", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        let (id3, _) = store
+            .create_task("tool3", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         // Complete one task
-        store.complete_task(&id3, CallToolResult::text("Done"));
+        store
+            .complete_task(&id3, CallToolResult::text("Done"))
+            .await
+            .unwrap();
 
         // List all tasks
-        let all = store.list_tasks(None);
+        let all = store.list_tasks(None).await.unwrap();
         assert_eq!(all.len(), 3);
 
         // List only working tasks
-        let working = store.list_tasks(Some(TaskStatus::Working));
+        let working = store.list_tasks(Some(TaskStatus::Working)).await.unwrap();
         assert_eq!(working.len(), 2);
 
         // List only completed tasks
-        let completed = store.list_tasks(Some(TaskStatus::Completed));
+        let completed = store.list_tasks(Some(TaskStatus::Completed)).await.unwrap();
         assert_eq!(completed.len(), 1);
     }
 
-    #[test]
-    fn test_terminal_state_immutable() {
-        let store = TaskStore::new();
-        let (id, _) = store.create_task("test-tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_terminal_state_immutable() {
+        let store = MemoryTaskStore::new();
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         // Complete the task
-        store.complete_task(&id, CallToolResult::text("Done"));
+        store
+            .complete_task(&id, CallToolResult::text("Done"))
+            .await
+            .unwrap();
 
         // Try to fail - should fail
-        assert!(!store.fail_task(&id, "Error"));
+        assert!(!store.fail_task(&id, "Error").await.unwrap());
 
         // Status should still be completed
-        let info = store.get_task(&id).unwrap();
+        let info = store.get_task(&id).await.unwrap().unwrap();
         assert_eq!(info.status, TaskStatus::Completed);
     }
 
-    #[test]
-    fn test_task_ids_unique() {
-        let store = TaskStore::new();
-        let (id1, _) = store.create_task("tool", serde_json::json!({}), None);
-        let (id2, _) = store.create_task("tool", serde_json::json!({}), None);
-        let (id3, _) = store.create_task("tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_task_ids_unique() {
+        let store = MemoryTaskStore::new();
+        let (id1, _) = store
+            .create_task("tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        let (id2, _) = store
+            .create_task("tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        let (id3, _) = store
+            .create_task("tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         assert_ne!(id1, id2);
         assert_ne!(id2, id3);
         assert_ne!(id1, id3);
     }
 
-    #[test]
-    fn test_get_task_result() {
-        let store = TaskStore::new();
-        let (id, _) = store.create_task("test-tool", serde_json::json!({}), None);
+    #[tokio::test]
+    async fn test_get_task_result() {
+        let store = MemoryTaskStore::new();
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
 
         // Complete with result
         let result = CallToolResult::text("The result");
-        store.complete_task(&id, result);
+        store.complete_task(&id, result).await.unwrap();
 
-        let (task_obj, result, error) = store.get_task_result(&id).unwrap();
+        let (task_obj, result, error) = store.get_task_result(&id).await.unwrap().unwrap();
         assert_eq!(task_obj.status, TaskStatus::Completed);
         assert!(result.is_some());
         assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_wait_for_completion_returns_terminal_snapshot() {
+        let store = MemoryTaskStore::new();
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
+
+        // Complete the task from another task while a waiter is blocked.
+        let waiter_store = store.clone();
+        let waiter_id = id.clone();
+        let waiter =
+            tokio::spawn(async move { waiter_store.wait_for_completion(&waiter_id).await });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        store
+            .complete_task(&id, CallToolResult::text("Done"))
+            .await
+            .unwrap();
+
+        let (task_obj, result, error) = waiter.await.unwrap().unwrap().unwrap();
+        assert_eq!(task_obj.status, TaskStatus::Completed);
+        assert!(result.is_some());
+        assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn dyn_task_store_object_safe() {
+        // Compile-time check that TaskStore is object-safe.
+        let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+        let (id, _) = store
+            .create_task("tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        assert!(store.get_task(&id).await.unwrap().is_some());
     }
 
     #[test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -493,7 +493,7 @@ pub use tower_mcp_macros::tool_fn;
 pub use schemars;
 
 // Re-exports
-pub use async_task::{Task, TaskStore};
+pub use async_task::{MemoryTaskStore, Task, TaskStore};
 pub use client::{
     ChannelTransport, ClientHandler, ClientTransport, McpClient, McpClientBuilder,
     NotificationHandler, StdioClientTransport,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -13,7 +13,7 @@ use tower_service::Service;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 
-use crate::async_task::TaskStore;
+use crate::async_task::{MemoryTaskStore, TaskStore, TaskStoreError};
 use crate::context::{
     CancellationToken, ClientRequesterHandle, NotificationSender, RequestContext,
     ServerNotification,
@@ -55,6 +55,14 @@ fn decode_cursor(cursor: &str) -> Result<usize> {
 /// Encode an offset into an opaque pagination cursor.
 fn encode_cursor(offset: usize) -> String {
     BASE64.encode(offset.to_string())
+}
+
+/// Map a [`TaskStoreError`] to a JSON-RPC internal error.
+fn task_store_error(e: TaskStoreError) -> Error {
+    Error::JsonRpc(JsonRpcError::internal_error(format!(
+        "Task store error: {}",
+        e
+    )))
 }
 
 /// Apply pagination to a collected list of items.
@@ -166,7 +174,7 @@ struct McpRouterInner {
     /// Handle for sending requests to the client (for sampling, etc.)
     client_requester: Option<ClientRequesterHandle>,
     /// Task store for async operations
-    task_store: TaskStore,
+    task_store: Arc<dyn TaskStore>,
     /// Subscribed resource URIs
     subscriptions: Arc<RwLock<HashSet<String>>>,
     /// Handler for completion requests
@@ -313,7 +321,7 @@ impl McpRouter {
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 notification_tx: None,
                 client_requester: None,
-                task_store: TaskStore::new(),
+                task_store: Arc::new(MemoryTaskStore::new()),
                 subscriptions: Arc::new(RwLock::new(HashSet::new())),
                 extensions: Arc::new(crate::context::Extensions::new()),
                 completion_handler: None,
@@ -391,9 +399,26 @@ impl McpRouter {
         ToolAnnotationsMap { map: Arc::new(map) }
     }
 
-    /// Get access to the task store for async operations
-    pub fn task_store(&self) -> &TaskStore {
-        &self.inner.task_store
+    /// Configure a pluggable [`TaskStore`] for async task state.
+    ///
+    /// The default is an in-process [`MemoryTaskStore`]. Supply an external
+    /// store (Redis, Postgres, etc.) to share task state across server
+    /// instances behind a load balancer, so `tasks/get` works regardless of
+    /// which instance created the task (SEP-2663).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use std::sync::Arc;
+    /// use tower_mcp::McpRouter;
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    ///
+    /// let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+    /// let router = McpRouter::new().task_store(store);
+    /// ```
+    pub fn task_store(mut self, store: Arc<dyn TaskStore>) -> Self {
+        Arc::make_mut(&mut self.inner).task_store = store;
+        self
     }
 
     /// Enable dynamic tool registration and return a registry handle.
@@ -1908,11 +1933,12 @@ impl McpRouter {
                     }
 
                     // Create the task
-                    let (task_id, cancellation_token) = self.inner.task_store.create_task(
-                        &params.name,
-                        params.arguments.clone(),
-                        task_params.ttl,
-                    );
+                    let (task_id, cancellation_token) = self
+                        .inner
+                        .task_store
+                        .create_task(&params.name, params.arguments.clone(), task_params.ttl)
+                        .await
+                        .map_err(task_store_error)?;
 
                     tracing::info!(task_id = %task_id, tool = %params.name, "Created async task");
 
@@ -1948,7 +1974,9 @@ impl McpRouter {
                         } else if result.is_error {
                             // Tool returned an error result
                             let error_msg = result.first_text().unwrap_or("Tool execution failed");
-                            task_store.fail_task(&task_id_clone, error_msg);
+                            if let Err(e) = task_store.fail_task(&task_id_clone, error_msg).await {
+                                tracing::warn!(task_id = %task_id_clone, error = %e, "failed to record task failure");
+                            }
                             tracing::info!(
                                 target: "mcp::tools",
                                 tool = %tool_name,
@@ -1959,7 +1987,9 @@ impl McpRouter {
                                 "tool call completed"
                             );
                         } else {
-                            task_store.complete_task(&task_id_clone, result);
+                            if let Err(e) = task_store.complete_task(&task_id_clone, result).await {
+                                tracing::warn!(task_id = %task_id_clone, error = %e, "failed to record task completion");
+                            }
                             tracing::info!(
                                 target: "mcp::tools",
                                 tool = %tool_name,
@@ -1971,11 +2001,17 @@ impl McpRouter {
                         }
                     });
 
-                    let task = self.inner.task_store.get_task(&task_id).ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::internal_error(
-                            "Failed to retrieve created task",
-                        ))
-                    })?;
+                    let task = self
+                        .inner
+                        .task_store
+                        .get_task(&task_id)
+                        .await
+                        .map_err(task_store_error)?
+                        .ok_or_else(|| {
+                            Error::JsonRpc(JsonRpcError::internal_error(
+                                "Failed to retrieve created task",
+                            ))
+                        })?;
 
                     Ok(McpResponse::CreateTask(CreateTaskResult::new(task)))
                 } else {
@@ -2315,6 +2351,8 @@ impl McpRouter {
                     .inner
                     .task_store
                     .get_task(&params.task_id)
+                    .await
+                    .map_err(task_store_error)?
                     .ok_or_else(|| {
                         Error::JsonRpc(JsonRpcError::invalid_params(format!(
                             "Task not found: {}",
@@ -2337,6 +2375,8 @@ impl McpRouter {
                     .inner
                     .task_store
                     .get_task(&params.task_id)
+                    .await
+                    .map_err(task_store_error)?
                     .ok_or_else(|| {
                         Error::JsonRpc(JsonRpcError::invalid_params(format!(
                             "Task not found: {}",
@@ -2352,6 +2392,8 @@ impl McpRouter {
                     .inner
                     .task_store
                     .get_task(&params.task_id)
+                    .await
+                    .map_err(task_store_error)?
                     .ok_or_else(|| {
                         Error::JsonRpc(JsonRpcError::invalid_params(format!(
                             "Task not found: {}",
@@ -2369,6 +2411,8 @@ impl McpRouter {
                 self.inner
                     .task_store
                     .cancel_task(&params.task_id, params.reason.as_deref())
+                    .await
+                    .map_err(task_store_error)?
                     .ok_or_else(|| {
                         Error::JsonRpc(JsonRpcError::invalid_params(format!(
                             "Task not found: {}",
@@ -3576,6 +3620,168 @@ mod tests {
             }
             _ => panic!("Expected CreateTask response"),
         }
+    }
+
+    /// [`TaskStore`] wrapper that counts calls, for proving dispatch goes
+    /// through an injected store.
+    struct CountingTaskStore {
+        inner: MemoryTaskStore,
+        creates: std::sync::atomic::AtomicUsize,
+        gets: std::sync::atomic::AtomicUsize,
+        completes: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingTaskStore {
+        fn new() -> Self {
+            Self {
+                inner: MemoryTaskStore::new(),
+                creates: std::sync::atomic::AtomicUsize::new(0),
+                gets: std::sync::atomic::AtomicUsize::new(0),
+                completes: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TaskStore for CountingTaskStore {
+        async fn create_task(
+            &self,
+            tool_name: &str,
+            arguments: serde_json::Value,
+            ttl: Option<u64>,
+        ) -> crate::async_task::Result<(String, crate::async_task::CancellationToken)> {
+            self.creates
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.inner.create_task(tool_name, arguments, ttl).await
+        }
+
+        async fn get_task(&self, task_id: &str) -> crate::async_task::Result<Option<TaskObject>> {
+            self.gets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.inner.get_task(task_id).await
+        }
+
+        async fn get_task_result(
+            &self,
+            task_id: &str,
+        ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+            self.inner.get_task_result(task_id).await
+        }
+
+        async fn wait_for_completion(
+            &self,
+            task_id: &str,
+        ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+            self.inner.wait_for_completion(task_id).await
+        }
+
+        async fn list_tasks(
+            &self,
+            status_filter: Option<TaskStatus>,
+        ) -> crate::async_task::Result<Vec<TaskObject>> {
+            self.inner.list_tasks(status_filter).await
+        }
+
+        async fn require_input(
+            &self,
+            task_id: &str,
+            message: &str,
+        ) -> crate::async_task::Result<bool> {
+            self.inner.require_input(task_id, message).await
+        }
+
+        async fn complete_task(
+            &self,
+            task_id: &str,
+            result: CallToolResult,
+        ) -> crate::async_task::Result<bool> {
+            self.completes
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.inner.complete_task(task_id, result).await
+        }
+
+        async fn fail_task(&self, task_id: &str, error: &str) -> crate::async_task::Result<bool> {
+            self.inner.fail_task(task_id, error).await
+        }
+
+        async fn cancel_task(
+            &self,
+            task_id: &str,
+            reason: Option<&str>,
+        ) -> crate::async_task::Result<Option<TaskObject>> {
+            self.inner.cancel_task(task_id, reason).await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_injected_task_store_used_by_dispatch() {
+        let store = Arc::new(CountingTaskStore::new());
+
+        let add_tool = ToolBuilder::new("add")
+            .description("Add two numbers")
+            .task_support(TaskSupportMode::Optional)
+            .handler(|input: AddInput| async move {
+                Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+            })
+            .build();
+
+        let mut router = McpRouter::new()
+            .tool(add_tool)
+            .task_store(store.clone() as Arc<dyn TaskStore>);
+        init_router(&mut router).await;
+
+        // Task-augmented tools/call must create the task in the injected store.
+        let req = RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                name: "add".to_string(),
+                arguments: serde_json::json!({"a": 2, "b": 3}),
+                meta: None,
+                task: Some(TaskRequestParams { ttl: None }),
+            }),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        let task_id = match resp.inner {
+            Ok(McpResponse::CreateTask(result)) => result.task.task_id,
+            other => panic!("Expected CreateTask response, got {other:?}"),
+        };
+
+        assert_eq!(
+            store.creates.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "create_task must go through the injected store"
+        );
+
+        // Wait for the background execution to record completion.
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            store.completes.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "complete_task must go through the injected store"
+        );
+
+        // tasks/get must read from the injected store.
+        let gets_before = store.gets.load(std::sync::atomic::Ordering::Relaxed);
+        let req = RouterRequest {
+            id: RequestId::Number(2),
+            inner: McpRequest::GetTaskInfo(GetTaskInfoParams {
+                task_id: task_id.clone(),
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let resp = router.ready().await.unwrap().call(req).await.unwrap();
+        match resp.inner {
+            Ok(McpResponse::GetTaskInfo(info)) => {
+                assert_eq!(info.task_id, task_id);
+                assert_eq!(info.status, TaskStatus::Completed);
+            }
+            other => panic!("Expected GetTaskInfo response, got {other:?}"),
+        }
+        assert!(
+            store.gets.load(std::sync::atomic::Ordering::Relaxed) > gets_before,
+            "tasks/get must go through the injected store"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Part of #951 (SEP-2663 task parity) and the parity roadmap #929.

`TaskStore` in `crates/tower-mcp/src/async_task.rs` was a concrete struct owned by `McpRouterInner`. The repo's other stores are pluggable traits with in-memory defaults: `SessionStore` / `MemorySessionStore` and `EventStore` / `MemoryEventStore`. In the sessionless 2026-07-28 world, `tasks/get` can hit any instance behind a load balancer, so task state needs a pluggable backend too.

This PR is the trait extraction only. No new protocol behavior, notifications, or wire changes.

## What changed

- Renamed the concrete struct to `MemoryTaskStore`, keeping its behavior identical (std `RwLock` map, per-task tokio `Notify` for completion wakeups; both remain implementation details of the memory store and do not appear in the trait).
- Defined `trait TaskStore` mirroring the `SessionStore` / `EventStore` conventions: `#[async_trait]`, `Send + Sync + 'static`, object safe, with a `TaskStoreError` enum (`Encode` / `Decode` / `Backend`) and `Result<T>` alias in the same three-variant shape as `SessionStoreError`. `MemoryTaskStore` never errors; the variants exist for external backends.
- Trait methods: `create_task`, `get_task`, `get_task_result`, `wait_for_completion`, `list_tasks`, `require_input`, `complete_task`, `fail_task`, `cancel_task`. A `TaskSnapshot` type alias names the `(TaskObject, Option<CallToolResult>, Option<String>)` tuple used by `get_task_result` and `wait_for_completion`. `cleanup_expired` stays an inherent method on `MemoryTaskStore` (mirroring `MemorySessionStore::cleanup_expired`); external backends typically expire entries natively.
- `McpRouterInner.task_store` is now `Arc<dyn TaskStore>`, defaulting to `MemoryTaskStore`. New builder method `McpRouter::task_store(Arc<dyn TaskStore>)` injects a custom store, mirroring `HttpTransport::session_store` / `event_store`.
- Router dispatch call sites (task-augmented `tools/call`, `tasks/get`, `tasks/update`, `tasks/cancel`) await the store and map `TaskStoreError` to JSON-RPC internal errors. The spawned task execution logs (rather than drops) store errors from `complete_task` / `fail_task`.
- Re-exported `MemoryTaskStore` from the crate root alongside `Task` and `TaskStore`.
- Tests: existing `async_task` unit tests converted to `#[tokio::test]` against the trait; added a `wait_for_completion` blocking-waiter test and a `dyn TaskStore` object-safety test (matching the session/event store test suites); added `router::tests::test_injected_task_store_used_by_dispatch`, which injects a call-counting `TaskStore` wrapper and asserts `create_task`, `complete_task`, and `get_task` all go through the injected store.

## Breaking changes

Tasks are an experimental surface, so the following renames are acceptable and noted here:

- `TaskStore` (struct) is now `MemoryTaskStore`; the name `TaskStore` now refers to the trait.
- Store methods are now async and return `Result<_, TaskStoreError>`.
- The `McpRouter::task_store()` accessor (returning `&TaskStore`) is replaced by a builder-style setter of the same name. Nothing in-repo used the accessor; callers who need direct store access can keep a clone of the `Arc` they inject.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- `cargo build -p tower-mcp --examples --all-features`