### PR TITLE
fix(transport): size limits, stateless disconnect cancellation, response-id leniency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,6 +2819,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-util",
  "tower",
  "tower-mcp-macros",
  "tower-mcp-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,4 @@ tower-resilience = { version = "0.10.0", default-features = false, features = ["
 # Async
 futures = "0.3"
 async-trait = "0.1"
+tokio-util = { version = "0.7", default-features = false }

--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -449,6 +449,20 @@ pub enum Error {
     #[error("Session expired")]
     SessionExpired,
 
+    /// A single SSE event exceeded the configured maximum size.
+    ///
+    /// Raised by SSE-consuming client transports when a server streams an
+    /// event larger than the configured cap. The stream is terminated
+    /// rather than buffering without bound. `size` is the buffered size at
+    /// the point the limit was detected; `limit` is the configured cap.
+    #[error("SSE event too large: {size} bytes buffered, limit is {limit} bytes")]
+    SseEventTooLarge {
+        /// Bytes buffered for the event when the limit was exceeded.
+        size: usize,
+        /// The configured maximum event size in bytes.
+        limit: usize,
+    },
+
     #[error("Internal error: {0}")]
     Internal(String),
 }

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["network-programming", "asynchronous"]
 tower.workspace = true
 tower-service.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 futures.workspace = true
 pin-project-lite = "0.2"
 tower-mcp-types.workspace = true

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -97,7 +97,19 @@ pub struct HttpClientConfig {
     /// JSON-RPC -32005 errors trigger re-initialization.
     /// Default: `true`.
     pub session_recovery: bool,
+    /// Maximum size in bytes buffered for a single SSE event.
+    ///
+    /// A server that streams an event without ever terminating it would
+    /// otherwise grow the parse buffer without bound. When a single
+    /// event's buffered size exceeds this cap, the stream is terminated
+    /// with [`Error::SseEventTooLarge`].
+    /// Default: 16 MiB (matching rmcp).
+    pub max_sse_event_size: usize,
 }
+
+/// Default maximum buffered size for a single SSE event (16 MiB, matching
+/// rmcp). See [`HttpClientConfig::max_sse_event_size`].
+pub const DEFAULT_MAX_SSE_EVENT_SIZE: usize = 16 * 1024 * 1024;
 
 impl Default for HttpClientConfig {
     fn default() -> Self {
@@ -110,6 +122,7 @@ impl Default for HttpClientConfig {
             sse_reconnect_delay: Duration::from_secs(1),
             max_sse_reconnect_attempts: 5,
             session_recovery: true,
+            max_sse_event_size: DEFAULT_MAX_SSE_EVENT_SIZE,
         }
     }
 }
@@ -534,6 +547,7 @@ impl ClientTransport for HttpClientTransport {
             let last_event_id = self.last_event_id.clone();
             let sse_retry_delay = self.sse_retry_delay.clone();
             let sse_reconnect_signal = self.sse_reconnect_signal.clone();
+            let max_sse_event_size = self.config.max_sse_event_size;
             tokio::spawn(async move {
                 let response = match request.send().await {
                     Ok(r) => r,
@@ -581,7 +595,7 @@ impl ClientTransport for HttpClientTransport {
                 if is_sse {
                     // Stream SSE response to extract id/retry fields
                     let mut stream = response.bytes_stream();
-                    let mut parser = SseParser::new();
+                    let mut parser = SseParser::with_limit(max_sse_event_size);
                     let mut had_retry = false;
                     let mut had_data = false;
 
@@ -590,7 +604,20 @@ impl ClientTransport for HttpClientTransport {
                         match result {
                             Ok(bytes) => {
                                 let text = String::from_utf8_lossy(&bytes);
-                                for event in parser.feed(&text) {
+                                let events = match parser.feed(&text) {
+                                    Ok(events) => events,
+                                    Err(e) => {
+                                        // A single event exceeded the cap;
+                                        // terminate the stream instead of
+                                        // buffering without bound. The
+                                        // response for this request is lost,
+                                        // so the transport is unusable.
+                                        tracing::error!(error = %e, "POST SSE stream terminated");
+                                        connected.store(false, Ordering::Release);
+                                        return;
+                                    }
+                                };
+                                for event in events {
                                     if let Some(ref id) = event.id {
                                         *last_event_id.write().await = Some(id.clone());
                                     }
@@ -889,7 +916,7 @@ async fn sse_stream_loop(params: SseLoopParams) {
 
         // Parse SSE stream, also listening for reconnect signals from POST handlers
         let mut stream = response.bytes_stream();
-        let mut parser = SseParser::new();
+        let mut parser = SseParser::with_limit(config.max_sse_event_size);
 
         use futures::StreamExt;
         loop {
@@ -898,7 +925,19 @@ async fn sse_stream_loop(params: SseLoopParams) {
                     match chunk {
                         Some(Ok(bytes)) => {
                             let text = String::from_utf8_lossy(&bytes);
-                            for event in parser.feed(&text) {
+                            let events = match parser.feed(&text) {
+                                Ok(events) => events,
+                                Err(e) => {
+                                    // A single event exceeded the cap;
+                                    // terminate the stream (no reconnect,
+                                    // the server would just repeat it)
+                                    // instead of buffering without bound.
+                                    tracing::error!(error = %e, "SSE stream terminated");
+                                    connected.store(false, Ordering::Release);
+                                    return;
+                                }
+                            };
+                            for event in events {
                                 if let Some(ref id) = event.id {
                                     *last_event_id.write().await = Some(id.clone());
                                 }
@@ -970,8 +1009,10 @@ fn extract_json_messages(body: &str) -> Vec<String> {
         || trimmed.starts_with(':');
 
     if looks_like_sse {
+        // The body is already fully in memory here, so no event-size cap
+        // applies: an unlimited parser never returns an error.
         let mut parser = SseParser::new();
-        let events = parser.feed(body);
+        let events = parser.feed(body).unwrap_or_default();
         events.into_iter().map(|e| e.data).collect()
     } else {
         vec![trimmed.to_string()]
@@ -992,7 +1033,11 @@ struct SseEvent {
 /// Incremental SSE parser.
 ///
 /// Handles partial chunks from the byte stream, buffering incomplete
-/// lines across `feed()` calls.
+/// lines across `feed()` calls. When constructed with
+/// [`with_limit`](Self::with_limit), a single event whose buffered size
+/// exceeds the limit terminates parsing with
+/// [`Error::SseEventTooLarge`] instead of growing without bound
+/// (rmcp #970 analog).
 struct SseParser {
     /// Partial line buffer (when a chunk ends mid-line).
     buffer: String,
@@ -1000,20 +1045,37 @@ struct SseParser {
     current_id: Option<String>,
     current_data: Vec<String>,
     current_retry: Option<u64>,
+    /// Total bytes across `current_data` lines, tracked incrementally.
+    data_len: usize,
+    /// Maximum buffered size for a single event.
+    max_event_size: usize,
 }
 
 impl SseParser {
+    /// Create a parser with no event-size limit.
     fn new() -> Self {
+        Self::with_limit(usize::MAX)
+    }
+
+    /// Create a parser that rejects events buffering more than
+    /// `max_event_size` bytes.
+    fn with_limit(max_event_size: usize) -> Self {
         Self {
             buffer: String::new(),
             current_id: None,
             current_data: Vec::new(),
             current_retry: None,
+            data_len: 0,
+            max_event_size,
         }
     }
 
     /// Feed a chunk of text and return any complete events.
-    fn feed(&mut self, text: &str) -> Vec<SseEvent> {
+    ///
+    /// Returns [`Error::SseEventTooLarge`] when the bytes buffered for a
+    /// single in-progress event exceed the configured limit. The parser
+    /// should not be fed further after an error.
+    fn feed(&mut self, text: &str) -> Result<Vec<SseEvent>> {
         self.buffer.push_str(text);
         let mut events = Vec::new();
 
@@ -1033,6 +1095,7 @@ impl SseParser {
                         retry: self.current_retry.take(),
                     });
                     self.current_data.clear();
+                    self.data_len = 0;
                 }
                 self.current_id = None;
                 self.current_retry = None;
@@ -1042,7 +1105,9 @@ impl SseParser {
                     self.current_id = Some(trimmed.to_string());
                 }
             } else if let Some(value) = line.strip_prefix("data:") {
-                self.current_data.push(value.trim().to_string());
+                let data = value.trim().to_string();
+                self.data_len += data.len();
+                self.current_data.push(data);
             } else if let Some(value) = line.strip_prefix("retry:") {
                 self.current_retry = value.trim().parse().ok();
             }
@@ -1050,7 +1115,18 @@ impl SseParser {
             // Lines starting with 'event:' are event types -- ignored (we only care about data)
         }
 
-        events
+        // Everything still buffered belongs to a single unfinished event
+        // (or an unfinished line of one). Cap it so a server that never
+        // terminates an event can't grow the buffers without bound.
+        let buffered = self.buffer.len() + self.data_len;
+        if buffered > self.max_event_size {
+            return Err(Error::SseEventTooLarge {
+                size: buffered,
+                limit: self.max_event_size,
+            });
+        }
+
+        Ok(events)
     }
 }
 
@@ -1065,7 +1141,9 @@ mod tests {
     #[test]
     fn test_parse_complete_event() {
         let mut parser = SseParser::new();
-        let events = parser.feed("id: 1\nevent: message\ndata: {\"hello\":\"world\"}\n\n");
+        let events = parser
+            .feed("id: 1\nevent: message\ndata: {\"hello\":\"world\"}\n\n")
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, Some("1".to_string()));
@@ -1075,8 +1153,9 @@ mod tests {
     #[test]
     fn test_parse_multiple_events() {
         let mut parser = SseParser::new();
-        let events =
-            parser.feed("id: 1\ndata: first\n\nid: 2\ndata: second\n\nid: 3\ndata: third\n\n");
+        let events = parser
+            .feed("id: 1\ndata: first\n\nid: 2\ndata: second\n\nid: 3\ndata: third\n\n")
+            .unwrap();
 
         assert_eq!(events.len(), 3);
         assert_eq!(events[0].data, "first");
@@ -1092,11 +1171,11 @@ mod tests {
         let mut parser = SseParser::new();
 
         // First chunk: partial event
-        let events = parser.feed("id: 1\nda");
+        let events = parser.feed("id: 1\nda").unwrap();
         assert!(events.is_empty());
 
         // Second chunk: completes the event
-        let events = parser.feed("ta: hello\n\n");
+        let events = parser.feed("ta: hello\n\n").unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, Some("1".to_string()));
         assert_eq!(events[0].data, "hello");
@@ -1105,7 +1184,9 @@ mod tests {
     #[test]
     fn test_parse_multiline_data() {
         let mut parser = SseParser::new();
-        let events = parser.feed("id: 1\ndata: line1\ndata: line2\ndata: line3\n\n");
+        let events = parser
+            .feed("id: 1\ndata: line1\ndata: line2\ndata: line3\n\n")
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "line1\nline2\nline3");
@@ -1114,7 +1195,7 @@ mod tests {
     #[test]
     fn test_parse_comment_lines() {
         let mut parser = SseParser::new();
-        let events = parser.feed(": keep-alive\nid: 1\ndata: hello\n\n");
+        let events = parser.feed(": keep-alive\nid: 1\ndata: hello\n\n").unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "hello");
@@ -1123,7 +1204,7 @@ mod tests {
     #[test]
     fn test_parse_event_without_id() {
         let mut parser = SseParser::new();
-        let events = parser.feed("data: no-id-event\n\n");
+        let events = parser.feed("data: no-id-event\n\n").unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, None);
@@ -1133,7 +1214,7 @@ mod tests {
     #[test]
     fn test_empty_data_no_event() {
         let mut parser = SseParser::new();
-        let events = parser.feed("id: 1\n\n");
+        let events = parser.feed("id: 1\n\n").unwrap();
 
         // No data lines = no event produced
         assert!(events.is_empty());
@@ -1142,7 +1223,7 @@ mod tests {
     #[test]
     fn test_parse_crlf_line_endings() {
         let mut parser = SseParser::new();
-        let events = parser.feed("id: 1\r\ndata: crlf\r\n\r\n");
+        let events = parser.feed("id: 1\r\ndata: crlf\r\n\r\n").unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "crlf");
@@ -1153,7 +1234,7 @@ mod tests {
         let mut parser = SseParser::new();
         let json = r#"{"jsonrpc":"2.0","method":"notifications/progress","params":{"token":"t1","progress":50}}"#;
         let input = format!("id: 42\nevent: message\ndata: {}\n\n", json);
-        let events = parser.feed(&input);
+        let events = parser.feed(&input).unwrap();
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, Some("42".to_string()));
@@ -1161,6 +1242,44 @@ mod tests {
         // Verify it's valid JSON
         let parsed: serde_json::Value = serde_json::from_str(&events[0].data).unwrap();
         assert_eq!(parsed["method"], "notifications/progress");
+    }
+
+    #[test]
+    fn test_event_exceeding_limit_is_rejected() {
+        let mut parser = SseParser::with_limit(64);
+
+        // An unterminated data line larger than the limit trips the cap.
+        let big = "data: ".to_string() + &"x".repeat(128);
+        let err = parser.feed(&big).unwrap_err();
+        match err {
+            Error::SseEventTooLarge { size, limit } => {
+                assert!(size > 64, "size {} should exceed limit", size);
+                assert_eq!(limit, 64);
+            }
+            other => panic!("expected SseEventTooLarge, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_accumulated_data_lines_count_toward_limit() {
+        let mut parser = SseParser::with_limit(64);
+
+        // Many complete data lines belonging to one unterminated event.
+        let mut result = Ok(Vec::new());
+        for _ in 0..10 {
+            result = parser.feed("data: 0123456789\n");
+            if result.is_err() {
+                break;
+            }
+        }
+        assert!(matches!(result, Err(Error::SseEventTooLarge { .. })));
+    }
+
+    #[test]
+    fn test_events_within_limit_pass() {
+        let mut parser = SseParser::with_limit(64);
+        let events = parser.feed("data: hello\n\ndata: world\n\n").unwrap();
+        assert_eq!(events.len(), 2);
     }
 
     // =========================================================================

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -1043,11 +1043,27 @@ fn handle_response(
         }
     };
 
+    // Exact match first; genuine string IDs always take precedence. As a
+    // fallback, accept a response whose id is the string form of a numeric
+    // request id ("42" matching 42) -- some servers stringify numeric ids
+    // when echoing them (rmcp #1021 analog).
     let pending = match pending_requests.remove(&id) {
         Some(p) => p,
         None => {
-            tracing::warn!(id = ?id, "Response for unknown request");
-            return;
+            let numeric_fallback = match &id {
+                RequestId::String(s) => s
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|n| pending_requests.remove(&RequestId::Number(n))),
+                _ => None,
+            };
+            match numeric_fallback {
+                Some(p) => p,
+                None => {
+                    tracing::warn!(id = ?id, "Response for unknown request");
+                    return;
+                }
+            }
         }
     };
 
@@ -1854,5 +1870,80 @@ mod tests {
             }
             _ => panic!("Expected Unknown"),
         }
+    }
+
+    // =========================================================================
+    // handle_response ID correlation
+    // =========================================================================
+
+    fn pending_with(
+        ids: &[RequestId],
+    ) -> (
+        HashMap<RequestId, PendingRequest>,
+        Vec<oneshot::Receiver<Result<serde_json::Value>>>,
+    ) {
+        let mut map = HashMap::new();
+        let mut rxs = Vec::new();
+        for id in ids {
+            let (tx, rx) = oneshot::channel();
+            map.insert(id.clone(), PendingRequest { response_tx: tx });
+            rxs.push(rx);
+        }
+        (map, rxs)
+    }
+
+    #[tokio::test]
+    async fn test_stringified_numeric_response_id_correlates() {
+        // rmcp #1021 analog: a numeric request id 42 answered with a
+        // stringified id "42" still correlates.
+        let (mut pending, mut rxs) = pending_with(&[RequestId::Number(42)]);
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "42",
+            "result": {"ok": true}
+        });
+        handle_response(&response, &mut pending);
+
+        assert!(pending.is_empty(), "pending request should be resolved");
+        let result = rxs.remove(0).await.unwrap().unwrap();
+        assert_eq!(result, serde_json::json!({"ok": true}));
+    }
+
+    #[tokio::test]
+    async fn test_exact_string_id_takes_precedence() {
+        // A genuine string id "42" must match exactly and win over the
+        // numeric interpretation when both are pending.
+        let (mut pending, mut rxs) =
+            pending_with(&[RequestId::String("42".to_string()), RequestId::Number(42)]);
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "42",
+            "result": {"which": "string"}
+        });
+        handle_response(&response, &mut pending);
+
+        // The string entry resolved; the numeric entry is still pending.
+        assert_eq!(pending.len(), 1);
+        assert!(pending.contains_key(&RequestId::Number(42)));
+        let result = rxs.remove(0).await.unwrap().unwrap();
+        assert_eq!(result, serde_json::json!({"which": "string"}));
+    }
+
+    #[tokio::test]
+    async fn test_non_numeric_string_id_does_not_correlate() {
+        // A string id that is not the string form of the pending numeric
+        // id must not resolve it.
+        let (mut pending, _rxs) = pending_with(&[RequestId::Number(42)]);
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "not-a-number",
+            "result": {}
+        });
+        handle_response(&response, &mut pending);
+
+        assert_eq!(pending.len(), 1, "numeric request should stay pending");
     }
 }

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -113,7 +113,7 @@
 //! }
 //! ```
 
-use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -310,8 +310,8 @@ pub struct RequestContext {
     request_id: RequestId,
     /// Progress token (if provided by client)
     progress_token: Option<ProgressToken>,
-    /// Cancellation flag
-    cancelled: Arc<AtomicBool>,
+    /// Cancellation signal for this request
+    cancellation: tokio_util::sync::CancellationToken,
     /// Channel for sending notifications
     notification_tx: Option<NotificationSender>,
     /// Handle for sending requests to the client (for sampling, etc.)
@@ -391,7 +391,7 @@ impl std::fmt::Debug for RequestContext {
         f.debug_struct("RequestContext")
             .field("request_id", &self.request_id)
             .field("progress_token", &self.progress_token)
-            .field("cancelled", &self.cancelled.load(Ordering::Relaxed))
+            .field("cancelled", &self.cancellation.is_cancelled())
             .finish()
     }
 }
@@ -402,7 +402,7 @@ impl RequestContext {
         Self {
             request_id,
             progress_token: None,
-            cancelled: Arc::new(AtomicBool::new(false)),
+            cancellation: tokio_util::sync::CancellationToken::new(),
             notification_tx: None,
             client_requester: None,
             extensions: Arc::new(Extensions::new()),
@@ -521,19 +521,48 @@ impl RequestContext {
 
     /// Check if the request has been cancelled
     pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Relaxed)
+        self.cancellation.is_cancelled()
     }
 
     /// Mark the request as cancelled
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
+        self.cancellation.cancel();
+    }
+
+    /// Wait until the request is cancelled.
+    ///
+    /// Completes when [`cancel`](Self::cancel) is called -- by a
+    /// `notifications/cancelled` message, or by the transport when the
+    /// client disconnects before the response is delivered (HTTP
+    /// stateless mode). Useful in `tokio::select!` to abandon work early:
+    ///
+    /// ```rust,ignore
+    /// tokio::select! {
+    ///     result = do_work() => { /* ... */ }
+    ///     _ = ctx.cancelled() => return Err(Error::tool("cancelled")),
+    /// }
+    /// ```
+    pub async fn cancelled(&self) {
+        self.cancellation.cancelled().await
     }
 
     /// Get a cancellation token that can be shared
     pub fn cancellation_token(&self) -> CancellationToken {
         CancellationToken {
-            cancelled: self.cancelled.clone(),
+            inner: self.cancellation.clone(),
         }
+    }
+
+    /// Replace this context's cancellation source with an existing token.
+    ///
+    /// Used by transports to link a request's lifetime to an external
+    /// signal (e.g. client disconnect on the HTTP stateless path). After
+    /// this call, `is_cancelled()`, `cancelled()`, and tokens returned by
+    /// [`cancellation_token`](Self::cancellation_token) all observe the
+    /// given token.
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation = token.inner;
+        self
     }
 
     /// Report progress to the client
@@ -893,21 +922,37 @@ impl RequestContext {
     }
 }
 
-/// A token that can be used to check for cancellation
-#[derive(Clone, Debug)]
+/// A token that can be used to check for, wait on, or request cancellation
+///
+/// Cloned tokens share the same underlying signal: cancelling any clone
+/// cancels them all. Backed by [`tokio_util::sync::CancellationToken`],
+/// so cancellation can also be awaited via [`cancelled`](Self::cancelled).
+#[derive(Clone, Debug, Default)]
 pub struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
+    inner: tokio_util::sync::CancellationToken,
 }
 
 impl CancellationToken {
+    /// Create a new, un-cancelled token
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     /// Check if cancellation has been requested
     pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Relaxed)
+        self.inner.is_cancelled()
     }
 
     /// Request cancellation
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
+        self.inner.cancel();
+    }
+
+    /// Wait until cancellation is requested
+    ///
+    /// Completes immediately if the token is already cancelled.
+    pub async fn cancelled(&self) {
+        self.inner.cancelled().await
     }
 }
 

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -724,6 +724,16 @@ impl McpRouter {
         // visible; per-request meta (SEP-2575) is now reachable too.
         let mut merged = (*self.inner.extensions).clone();
         merged.merge(per_request);
+
+        // Adopt a transport-provided cancellation token (e.g. HTTP stateless
+        // client disconnect) so `ctx.is_cancelled()` / `ctx.cancelled()` and
+        // in-flight tracking observe the transport's signal.
+        let ctx = if let Some(token) = merged.get::<CancellationToken>() {
+            ctx.with_cancellation_token(token.clone())
+        } else {
+            ctx
+        };
+
         let ctx = ctx.with_extensions(Arc::new(merged));
 
         // Set up log level filtering

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -314,6 +314,11 @@ pub const MCP_PARAM_HEADER_PREFIX: &str = "mcp-param-";
 /// error.
 pub(super) const SEP_2243_MIN_PROTOCOL_VERSION: &str = "2026-07-28";
 
+/// Default maximum POST body size in bytes (4 MiB, matching rmcp).
+///
+/// See [`HttpTransport::max_body_size`].
+pub const DEFAULT_MAX_BODY_SIZE: usize = 4 * 1024 * 1024;
+
 /// SSE event type for JSON-RPC messages
 const SSE_MESSAGE_EVENT: &str = "message";
 
@@ -1288,6 +1293,8 @@ struct AppState {
     stateless_config: Option<crate::stateless::StatelessConfig>,
     /// Whether to wrap synchronous responses in SSE format (rmcp compat)
     sse_responses: bool,
+    /// Maximum accepted POST body size in bytes
+    max_body_size: usize,
 }
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
@@ -1342,6 +1349,10 @@ pub struct HttpTransport {
     ///
     /// See [`HttpTransport::sse_responses()`] for details.
     sse_responses: bool,
+    /// Maximum accepted POST body size in bytes.
+    ///
+    /// See [`HttpTransport::max_body_size()`] for details.
+    max_body_size: usize,
 }
 
 impl HttpTransport {
@@ -1370,6 +1381,7 @@ impl HttpTransport {
             #[cfg(feature = "oauth")]
             oauth_config: None,
             sse_responses: false,
+            max_body_size: DEFAULT_MAX_BODY_SIZE,
         }
     }
 
@@ -1426,6 +1438,7 @@ impl HttpTransport {
             #[cfg(feature = "oauth")]
             oauth_config: None,
             sse_responses: false,
+            max_body_size: DEFAULT_MAX_BODY_SIZE,
         }
     }
 
@@ -1594,6 +1607,42 @@ impl HttpTransport {
     /// ```
     pub fn sse_responses(mut self, enabled: bool) -> Self {
         self.sse_responses = enabled;
+        self
+    }
+
+    /// Set the maximum accepted POST body size in bytes.
+    ///
+    /// Requests whose body exceeds the limit are rejected with HTTP 413
+    /// (Payload Too Large) before any JSON parsing or dispatch happens.
+    /// A `Content-Length` header above the limit short-circuits without
+    /// reading the body; chunked bodies are capped while streaming.
+    ///
+    /// Default: 4 MiB ([`DEFAULT_MAX_BODY_SIZE`]), matching rmcp.
+    ///
+    /// # Interplay with axum's `DefaultBodyLimit`
+    ///
+    /// axum's built-in [`DefaultBodyLimit`](axum::extract::DefaultBodyLimit)
+    /// (2 MB by default) only applies to body-consuming extractors such as
+    /// `Bytes`, `String`, and `Json`. The MCP endpoint consumes the raw
+    /// [`Request`](axum::extract::Request) and reads the body itself, so
+    /// `DefaultBodyLimit` never applies to it; this transport-level limit
+    /// is the only bound on the MCP POST body. Layering
+    /// `DefaultBodyLimit` onto the router returned by
+    /// [`into_router`](Self::into_router) does not change the MCP
+    /// endpoint's behavior.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::McpRouter;
+    /// use tower_mcp::transport::http::HttpTransport;
+    ///
+    /// let router = McpRouter::new().server_info("my-server", "1.0.0");
+    /// // Accept request bodies up to 1 MiB.
+    /// let transport = HttpTransport::new(router).max_body_size(1024 * 1024);
+    /// ```
+    pub fn max_body_size(mut self, bytes: usize) -> Self {
+        self.max_body_size = bytes;
         self
     }
 
@@ -1886,6 +1935,7 @@ impl HttpTransport {
             #[cfg(feature = "stateless")]
             stateless_config: self.stateless_config.clone(),
             sse_responses: self.sse_responses,
+            max_body_size: self.max_body_size,
         })
     }
 
@@ -2227,7 +2277,21 @@ async fn handle_post(
         return resp;
     }
 
-    let body = match axum::body::to_bytes(body_bytes, usize::MAX).await {
+    // Bound the body size (rmcp #970 analog). axum's `DefaultBodyLimit`
+    // doesn't apply here because this handler consumes the raw `Request`
+    // instead of a body-consuming extractor, so this is the only limit on
+    // the MCP POST body. A declared Content-Length above the limit is
+    // rejected without reading; chunked bodies are capped while streaming.
+    if let Some(declared) = headers
+        .get(header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<usize>().ok())
+        && declared > state.max_body_size
+    {
+        return body_too_large_response(state.max_body_size);
+    }
+
+    let body = match axum::body::to_bytes(body_bytes, state.max_body_size).await {
         Ok(bytes) => match String::from_utf8(bytes.to_vec()) {
             Ok(s) => s,
             Err(e) => {
@@ -2237,6 +2301,9 @@ async fn handle_post(
                 );
             }
         },
+        Err(e) if is_length_limit_error(&e) => {
+            return body_too_large_response(state.max_body_size);
+        }
         Err(e) => {
             return json_rpc_error_response(
                 None,
@@ -2359,9 +2426,21 @@ async fn handle_post(
                 ext.insert(claims.clone());
             }
             stash_per_request_meta(&request, &mut ext);
-            if !ext.is_empty() {
-                service = service.with_extensions(ext);
-            }
+
+            // rmcp #967 analog: give the request a cancellation token that
+            // fires if the client disconnects before the response is
+            // delivered. The router adopts the token as the
+            // `RequestContext`'s cancellation source, so handlers observe
+            // the disconnect via `ctx.is_cancelled()` / `ctx.cancelled()`,
+            // and spawned work holding a token clone is signalled even
+            // after the request future itself is dropped. Session-based
+            // requests are exempt: with stream resumption, a disconnect is
+            // not a cancellation.
+            let cancel_token = crate::context::CancellationToken::new();
+            let mut cancel_guard = CancelOnDisconnect::arm(cancel_token.clone());
+            ext.insert(cancel_token);
+
+            service = service.with_extensions(ext);
 
             let mut call: std::pin::Pin<
                 Box<dyn std::future::Future<Output = crate::error::Result<JsonRpcResponse>> + Send>,
@@ -2388,6 +2467,10 @@ async fn handle_post(
 
             match first {
                 FirstOutbound::Response(result) => {
+                    // Handler finished; the response is about to be
+                    // produced, so dropping the connection from here on is
+                    // no longer a cancellation.
+                    cancel_guard.disarm();
                     let mut response = match result {
                         Ok(resp) => resp,
                         Err(e) => {
@@ -2430,6 +2513,7 @@ async fn handle_post(
                         notif_rx,
                         is_init,
                         version.clone(),
+                        cancel_guard,
                     );
                     resp.headers_mut().insert(
                         MCP_PROTOCOL_VERSION_HEADER,
@@ -2869,6 +2953,37 @@ fn is_stateless_protocol_version(version: &str) -> bool {
     version >= UPCOMING_PROTOCOL_VERSION
 }
 
+/// Drop guard that cancels a per-request [`CancellationToken`] when the
+/// request is abandoned before its response is produced.
+///
+/// On the sessionless POST path the response future (plain JSON) or the SSE
+/// response stream is dropped when the client disconnects; holding this
+/// guard in that future/stream turns the drop into a cancellation signal.
+/// [`disarm`](Self::disarm) once the handler's terminal response resolves
+/// so normal completion doesn't signal cancellation.
+#[cfg(feature = "stateless")]
+struct CancelOnDisconnect(Option<crate::context::CancellationToken>);
+
+#[cfg(feature = "stateless")]
+impl CancelOnDisconnect {
+    fn arm(token: crate::context::CancellationToken) -> Self {
+        Self(Some(token))
+    }
+
+    fn disarm(&mut self) {
+        self.0 = None;
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl Drop for CancelOnDisconnect {
+    fn drop(&mut self) {
+        if let Some(token) = self.0.take() {
+            token.cancel();
+        }
+    }
+}
+
 /// Stream a sessionless POST response as SSE: the notifications the handler
 /// emitted, in order, followed by the terminal JSON-RPC response.
 ///
@@ -2887,6 +3002,7 @@ fn stateless_sse_with_notifications(
     rx: crate::context::NotificationReceiver,
     is_init: bool,
     version: String,
+    cancel_guard: CancelOnDisconnect,
 ) -> Response {
     struct Ctx {
         call: Option<
@@ -2900,6 +3016,10 @@ fn stateless_sse_with_notifications(
         terminal: Option<String>,
         is_init: bool,
         version: String,
+        /// Cancels the per-request token if the client disconnects (the
+        /// stream, and with it this state, is dropped) while the handler
+        /// is still in flight. Disarmed once the handler resolves.
+        cancel_guard: CancelOnDisconnect,
     }
 
     let mut queue = std::collections::VecDeque::new();
@@ -2914,6 +3034,7 @@ fn stateless_sse_with_notifications(
         terminal: None,
         is_init,
         version,
+        cancel_guard,
     };
 
     let stream = futures::stream::unfold(ctx, |mut ctx| async move {
@@ -2935,6 +3056,9 @@ fn stateless_sse_with_notifications(
             let mut call = ctx.call.take()?;
             tokio::select! {
                 result = &mut call => {
+                    // Handler finished; a later disconnect is no longer a
+                    // cancellation.
+                    ctx.cancel_guard.disarm();
                     // Drain notifications that were queued before the handler
                     // finished so they precede the terminal response.
                     while let Ok(n) = ctx.rx.try_recv() {
@@ -3390,6 +3514,32 @@ fn json_rpc_error_response(
     axum::Json(response).into_response()
 }
 
+/// HTTP 413 response for a POST body exceeding [`HttpTransport::max_body_size`].
+fn body_too_large_response(limit: usize) -> Response {
+    let mut resp = json_rpc_error_response(
+        None,
+        JsonRpcError::invalid_request(format!(
+            "Request body exceeds the maximum size of {} bytes",
+            limit
+        )),
+    );
+    *resp.status_mut() = StatusCode::PAYLOAD_TOO_LARGE;
+    resp
+}
+
+/// Returns `true` when the body-read error was caused by exceeding the
+/// configured length limit (as opposed to a transport-level I/O failure).
+fn is_length_limit_error(err: &axum::Error) -> bool {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = source {
+        if e.is::<http_body_util::LengthLimitError>() {
+            return true;
+        }
+        source = e.source();
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3399,6 +3549,72 @@ mod tests {
 
     fn create_test_router() -> McpRouter {
         McpRouter::new().server_info("test-server", "1.0.0")
+    }
+
+    #[tokio::test]
+    async fn test_oversized_body_rejected_with_413() {
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .max_body_size(1024);
+        let app = transport.into_router();
+
+        // 2 KiB of body against a 1 KiB limit.
+        let padding = "x".repeat(2048);
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"method":"ping","params":{{"pad":"{}"}}}}"#,
+            padding
+        );
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_content_length_rejected_without_reading() {
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .max_body_size(1024);
+        let app = transport.into_router();
+
+        // Declared Content-Length above the limit short-circuits even
+        // though the actual body is tiny.
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Content-Length", "10485760")
+            .body(Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test]
+    async fn test_body_within_limit_accepted() {
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .max_body_size(1024);
+        let app = transport.into_router();
+
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(r#"{"jsonrpc":"2.0","id":1,"method":"ping"}"#))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/stateless_disconnect.rs
+++ b/crates/tower-mcp/tests/stateless_disconnect.rs
@@ -1,0 +1,209 @@
+//! rmcp #967 analog: on the 2026-07-28 sessionless POST path, a client
+//! disconnect cancels the in-flight request's `CancellationToken`, so
+//! handler-spawned work observes the disconnect instead of running to
+//! completion for a client that is gone.
+
+#![cfg(all(feature = "http", feature = "stateless"))]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
+use tower_mcp::extract::{Context, RawArgs, State};
+use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+/// Shared flags the handler reports through.
+#[derive(Clone, Default)]
+struct Flags {
+    /// Set by the handler as soon as it starts running.
+    started: Arc<AtomicBool>,
+    /// Set by a handler-spawned watcher when the request token cancels.
+    cancelled: Arc<AtomicBool>,
+}
+
+fn router(flags: Flags) -> McpRouter {
+    let tool = ToolBuilder::new("slow")
+        .description("Sleeps forever; reports cancellation via shared flags.")
+        .extractor_handler(
+            flags,
+            |State(flags): State<Flags>, ctx: Context, RawArgs(_): RawArgs| async move {
+                flags.started.store(true, Ordering::SeqCst);
+
+                // Spawned work holding a token clone observes the
+                // disconnect even after the request future is dropped.
+                let token = ctx.cancellation_token();
+                let cancelled = flags.cancelled.clone();
+                tokio::spawn(async move {
+                    token.cancelled().await;
+                    cancelled.store(true, Ordering::SeqCst);
+                });
+
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                Ok(CallToolResult::text("done"))
+            },
+        )
+        .build();
+    McpRouter::new()
+        .server_info("disconnect-test", "1.0.0")
+        .tool(tool)
+}
+
+async fn wait_for(flag: &AtomicBool, timeout: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while tokio::time::Instant::now() < deadline {
+        if flag.load(Ordering::SeqCst) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    flag.load(Ordering::SeqCst)
+}
+
+/// A raw HTTP/1.1 POST for a stateless (2026-07-28) tools/call, written
+/// over a plain TCP stream so the test controls the connection lifetime.
+fn stateless_call_request(body: &str) -> String {
+    format!(
+        "POST / HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Content-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n\
+         MCP-Protocol-Version: 2026-07-28\r\n\
+         Mcp-Method: tools/call\r\n\
+         Mcp-Name: slow\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {}",
+        body.len(),
+        body
+    )
+}
+
+#[tokio::test]
+async fn stateless_client_disconnect_cancels_in_flight_handler() {
+    let flags = Flags::default();
+    let app = HttpTransport::new(router(flags.clone()))
+        .disable_origin_validation()
+        .into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "slow", "arguments": {}}
+    })
+    .to_string();
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream
+        .write_all(stateless_call_request(&body).as_bytes())
+        .await
+        .unwrap();
+    stream.flush().await.unwrap();
+
+    // The handler must be running before the disconnect for the test to
+    // prove in-flight cancellation.
+    assert!(
+        wait_for(&flags.started, Duration::from_secs(5)).await,
+        "handler never started"
+    );
+    assert!(
+        !flags.cancelled.load(Ordering::SeqCst),
+        "token must not be cancelled while the client is connected"
+    );
+
+    // Disconnect mid-call.
+    drop(stream);
+
+    assert!(
+        wait_for(&flags.cancelled, Duration::from_secs(5)).await,
+        "handler did not observe cancellation after client disconnect"
+    );
+}
+
+#[tokio::test]
+async fn stateless_normal_completion_does_not_cancel() {
+    let flags = Flags::default();
+    let fast = {
+        let flags = flags.clone();
+        ToolBuilder::new("fast")
+            .description("Returns immediately; watcher records cancellation.")
+            .extractor_handler(
+                flags,
+                |State(flags): State<Flags>, ctx: Context, RawArgs(_): RawArgs| async move {
+                    let token = ctx.cancellation_token();
+                    let cancelled = flags.cancelled.clone();
+                    tokio::spawn(async move {
+                        token.cancelled().await;
+                        cancelled.store(true, Ordering::SeqCst);
+                    });
+                    Ok(CallToolResult::text("done"))
+                },
+            )
+            .build()
+    };
+    let router = McpRouter::new()
+        .server_info("disconnect-test", "1.0.0")
+        .tool(fast);
+    let app = HttpTransport::new(router)
+        .disable_origin_validation()
+        .into_router();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "fast", "arguments": {}}
+    })
+    .to_string();
+
+    let request = format!(
+        "POST / HTTP/1.1\r\n\
+         Host: 127.0.0.1\r\n\
+         Content-Type: application/json\r\n\
+         Accept: application/json, text/event-stream\r\n\
+         MCP-Protocol-Version: 2026-07-28\r\n\
+         Mcp-Method: tools/call\r\n\
+         Mcp-Name: fast\r\n\
+         Content-Length: {}\r\n\
+         \r\n\
+         {}",
+        body.len(),
+        body
+    );
+
+    let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.flush().await.unwrap();
+
+    // Read the response so the request completes while connected.
+    let mut buf = vec![0u8; 4096];
+    use tokio::io::AsyncReadExt;
+    let n = tokio::time::timeout(Duration::from_secs(5), stream.read(&mut buf))
+        .await
+        .expect("timed out reading response")
+        .unwrap();
+    let response = String::from_utf8_lossy(&buf[..n]);
+    assert!(response.starts_with("HTTP/1.1 200"), "got: {}", response);
+
+    // The guard was disarmed on response production; closing the
+    // connection afterwards must not signal cancellation.
+    drop(stream);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(
+        !flags.cancelled.load(Ordering::SeqCst),
+        "normal completion must not cancel the request token"
+    );
+}


### PR DESCRIPTION
Part of #952 (parity roadmap #929). Three spec-independent robustness fixes mirroring recent rmcp changes (rust-sdk #970, #967, #1021).

## 1. Request/stream size limits (rmcp #970 analog)

**Server.** `handle_post` extracts the raw `axum::extract::Request` and read the body with `to_bytes(body, usize::MAX)`. axum's `DefaultBodyLimit` (2 MB default) only applies to body-consuming extractors (`Bytes`, `String`, `Json`), so it never applied to the MCP endpoint: the POST body was unbounded. Now:

- New `HttpTransport::max_body_size(bytes)` builder method, default 4 MiB (`DEFAULT_MAX_BODY_SIZE`, rmcp parity).
- A declared `Content-Length` above the limit is rejected without reading the body; chunked bodies are capped while streaming (`to_bytes` with the limit, with `http_body_util::LengthLimitError` detected via the error source chain).
- Oversized bodies get HTTP 413 with a JSON-RPC invalid-request body.
- The `DefaultBodyLimit` interplay is documented on the builder method: layering `DefaultBodyLimit` onto the returned router does not affect the MCP endpoint; this transport-level limit is the only bound.

**Client.** The HTTP client's incremental `SseParser` buffered a single SSE event without bound (`buffer: String` and `current_data: Vec<String>` grow until a blank line arrives; a server that never terminates an event grows them forever). Now:

- `HttpClientConfig.max_sse_event_size`, default 16 MiB (`DEFAULT_MAX_SSE_EVENT_SIZE`, rmcp parity).
- `SseParser::feed` returns the new typed `Error::SseEventTooLarge { size, limit }` (added to the `#[non_exhaustive]` error enum in tower-mcp-types) when a single event's buffered size exceeds the cap.
- Both streaming consumers (the POST response SSE stream and the background GET notification stream) terminate the stream and mark the transport disconnected on that error instead of buffering without bound. The GET stream does not reconnect in that case (the server would repeat the oversized event).
- `extract_json_messages` (fully-in-memory POST bodies) keeps an unlimited parser, since the body is already read at that point.

## 2. Cancel in-flight stateless handlers on client disconnect (rmcp #967 analog)

`RequestContext` already had a cancellation surface (`is_cancelled`/`cancel`/`cancellation_token`) backed by an `Arc<AtomicBool>`, but nothing wired transport-level disconnect into it and the token was not awaitable.

- `context::CancellationToken` is now backed by `tokio_util::sync::CancellationToken` (new `tokio-util` dependency, default-features off). The existing API is preserved; `cancelled()` (awaitable) and `new()` are added. `RequestContext` gains `cancelled()` and `with_cancellation_token()`.
- On the 2026-07-28 sessionless POST path each request gets a fresh token, stashed in the per-request `Extensions` (same pattern as `stash_per_request_meta`); `McpRouter::create_context_with_extensions` adopts it as the `RequestContext`'s cancellation source, so it is also the token registered for `notifications/cancelled` in-flight tracking.
- A `CancelOnDisconnect` drop guard cancels the token when the connection drops: the plain JSON path disarms it once the handler resolves; the SSE fallback path carries the guard in the stream state (so a mid-stream disconnect drops it) and disarms it when the handler's terminal response resolves. The `stateless_sse_with_notifications` notification-race behavior is unchanged.
- Session-based (2025-11-25) behavior unchanged: with stream resumption, disconnect is not cancellation.
- Integration tests (`tests/stateless_disconnect.rs`) run a real server and a raw-TCP client: a slow handler's spawned watcher observes cancellation when the client disconnects mid-call, and a normally-completed request does not signal cancellation.

**Deferred:** cancelling in-flight handlers on server shutdown. `HttpTransport::serve` uses `axum::serve` with no graceful-shutdown signal today, so there is nothing to hook; adding a shutdown signal is a separate feature.

## 3. Stringified numeric response ID leniency (rmcp #1021 analog)

Client-side correlation lives in one place: `handle_response` in `client/mod.rs` (all `ClientTransport` implementations funnel raw messages through the `McpClient` loop; `TestClient` uses in-process `call_single` and does no ID matching).

- Exact match runs first; as a fallback, a response whose id is the string form of a numeric request id ("42" matching 42) correlates.
- Genuine string IDs take precedence: when both `String("42")` and `Number(42)` are pending, the string entry wins and the numeric entry stays pending (unit-tested).
- Server-side ID echo untouched.

## Validation

- `cargo fmt --all -- --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace --all-features` green (includes new unit and integration tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- `cargo build -p tower-mcp --examples --all-features` and both workspace example crates build
- Conformance against the rebuilt conformance-server: 2026-07-28 draft suite (`@0.2.0-alpha.9`, `--suite all`) baseline check passed; 2025-11-25 suite (`@0.1.16`) 39/39 passed