### PR TITLE
feat(transport): ChannelTransport notification delivery and concurrent requests

### DIFF
--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -1,8 +1,18 @@
 //! In-process channel transport for connecting an [`McpClient`] to an [`McpRouter`].
 //!
 //! This transport bridges client and server in the same process without
-//! any network or subprocess overhead. It is primarily useful for testing
-//! (e.g., proxy tests) but can also be used for in-process composition.
+//! any network or subprocess overhead. It is useful for testing (e.g.,
+//! proxy tests) and for in-process composition, where a co-located client
+//! (a REPL, an editor integration, an orchestrator) drives a router living
+//! in the same process.
+//!
+//! Server notifications emitted through the router's notification sender
+//! (progress, log messages, list-changed) are serialized into JSON-RPC
+//! notification frames and interleaved into [`recv`](ClientTransport::recv),
+//! so a [`NotificationHandler`](crate::client::NotificationHandler) works
+//! identically to the network transports. Requests are processed
+//! concurrently: a slow tool call does not block other requests on the
+//! transport (the client correlates responses by request id).
 //!
 //! # Example
 //!
@@ -18,11 +28,39 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Host-pushed notifications
+//!
+//! When the host process wants to push notifications from its own tasks
+//! (mirroring [`HttpTransport::with_notifications`]), it keeps the sender
+//! and hands the receiver to the transport:
+//!
+//! ```rust,no_run
+//! use tower_mcp::client::{McpClient, ChannelTransport};
+//! use tower_mcp::context::notification_channel;
+//! use tower_mcp::McpRouter;
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let (notif_tx, notif_rx) = notification_channel(64);
+//! let router = McpRouter::new()
+//!     .server_info("backend", "1.0.0")
+//!     .with_notification_sender(notif_tx.clone());
+//!
+//! let transport = ChannelTransport::with_notifications(router, notif_rx);
+//! let client = McpClient::connect(transport).await?;
+//!
+//! // Elsewhere in the host process:
+//! // notif_tx.send(ServerNotification::ToolsListChanged).await.ok();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`HttpTransport::with_notifications`]: crate::transport::HttpTransport::with_notifications
 
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
-use crate::context::notification_channel;
+use crate::context::{NotificationReceiver, notification_channel};
 use crate::error::Result;
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse, McpNotification};
@@ -32,13 +70,14 @@ use super::transport::ClientTransport;
 
 /// An in-process [`ClientTransport`] that connects directly to an [`McpRouter`].
 ///
-/// Messages are passed through tokio channels — the transport spawns a
-/// background task that feeds incoming JSON-RPC requests to a
-/// [`JsonRpcService<McpRouter>`] and returns responses.
+/// Messages are passed through tokio channels: background tasks feed
+/// incoming JSON-RPC requests to a [`JsonRpcService<McpRouter>`] (one spawned
+/// task per request, so calls run concurrently) and pump server
+/// notifications into the response stream.
 pub struct ChannelTransport {
     /// Send raw JSON messages to the server task.
     request_tx: mpsc::Sender<String>,
-    /// Receive raw JSON responses from the server task.
+    /// Receive raw JSON responses and notification frames from the server tasks.
     response_rx: mpsc::Receiver<String>,
     connected: bool,
 }
@@ -46,14 +85,56 @@ pub struct ChannelTransport {
 impl ChannelTransport {
     /// Create a new channel transport backed by the given router.
     ///
-    /// Spawns a background tokio task that processes requests.
+    /// Wires an internal notification channel into the router, so
+    /// notifications emitted during request handling (progress, log
+    /// messages, list-changed) are delivered to the client. To push
+    /// notifications from the host process's own tasks, use
+    /// [`with_notifications`](Self::with_notifications) instead.
+    ///
+    /// Note: this overwrites any notification sender previously set on the
+    /// router, matching the transport-owns-the-channel behavior of
+    /// [`HttpTransport::new`](crate::transport::HttpTransport::new).
     pub fn new(router: McpRouter) -> Self {
+        let (notification_tx, notification_rx) = notification_channel(64);
+        let router = router.with_notification_sender(notification_tx);
+        Self::with_notifications(router, notification_rx)
+    }
+
+    /// Create a channel transport with a caller-owned notification receiver.
+    ///
+    /// Mirrors [`HttpTransport::with_notifications`]: the host process keeps
+    /// the sender (its own clone from [`notification_channel`], or via
+    /// [`McpRouter::notification_sender`]) and pushes
+    /// [`ServerNotification`](crate::context::ServerNotification)s from its
+    /// own tasks; the transport serializes them into JSON-RPC notification
+    /// frames and interleaves them into [`recv`](ClientTransport::recv).
+    ///
+    /// The router passed here should already carry the matching sender (see
+    /// the module-level example) so notifications emitted during request
+    /// handling flow through the same channel.
+    ///
+    /// [`HttpTransport::with_notifications`]: crate::transport::HttpTransport::with_notifications
+    pub fn with_notifications(
+        router: McpRouter,
+        mut notification_rx: NotificationReceiver,
+    ) -> Self {
         let (request_tx, mut request_rx) = mpsc::channel::<String>(64);
         let (response_tx, response_rx) = mpsc::channel::<String>(64);
 
-        let (notification_tx, _notification_rx) = notification_channel(64);
-        let router = router.with_notification_sender(notification_tx);
-        let mut service = JsonRpcService::new(router.clone());
+        // Notification pump: serialize ServerNotifications into JSON-RPC
+        // notification frames on the shared response stream.
+        let notification_out = response_tx.clone();
+        tokio::spawn(async move {
+            while let Some(notification) = notification_rx.recv().await {
+                if let Some(json) = crate::transport::stdio::serialize_notification(&notification)
+                    && notification_out.send(json).await.is_err()
+                {
+                    break; // Client dropped
+                }
+            }
+        });
+
+        let service = JsonRpcService::new(router.clone());
 
         tokio::spawn(async move {
             while let Some(raw_request) = request_rx.recv().await {
@@ -79,36 +160,42 @@ impl ChannelTransport {
                     continue;
                 }
 
-                // Process the request through JsonRpcService
-                let response = service.call_single(req).await;
+                // Process each request in its own task so a slow call does
+                // not block the transport. The client correlates responses
+                // by request id, so completion order does not matter.
+                let mut service = service.clone();
+                let response_out = response_tx.clone();
+                tokio::spawn(async move {
+                    let response = service.call_single(req).await;
 
-                let json = match response {
-                    Ok(resp) => match serde_json::to_string(&resp) {
-                        Ok(j) => j,
-                        Err(e) => {
-                            tracing::error!(
-                                "ChannelTransport: failed to serialize response: {}",
-                                e
-                            );
-                            continue;
-                        }
-                    },
-                    Err(e) => {
-                        // Convert error to a JSON-RPC error response
-                        let err_resp = JsonRpcResponse::error(
-                            None,
-                            tower_mcp_types::JsonRpcError::internal_error(e.to_string()),
-                        );
-                        match serde_json::to_string(&err_resp) {
+                    let json = match response {
+                        Ok(resp) => match serde_json::to_string(&resp) {
                             Ok(j) => j,
-                            Err(_) => continue,
+                            Err(e) => {
+                                tracing::error!(
+                                    "ChannelTransport: failed to serialize response: {}",
+                                    e
+                                );
+                                return;
+                            }
+                        },
+                        Err(e) => {
+                            // Convert error to a JSON-RPC error response
+                            let err_resp = JsonRpcResponse::error(
+                                None,
+                                tower_mcp_types::JsonRpcError::internal_error(e.to_string()),
+                            );
+                            match serde_json::to_string(&err_resp) {
+                                Ok(j) => j,
+                                Err(_) => return,
+                            }
                         }
-                    }
-                };
+                    };
 
-                if response_tx.send(json).await.is_err() {
-                    break; // Client dropped
-                }
+                    // Best effort: if the client dropped, the send fails and
+                    // the task simply ends.
+                    let _ = response_out.send(json).await;
+                });
             }
         });
 

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -1,0 +1,167 @@
+//! ChannelTransport behavior tests (#955): server-notification delivery to
+//! the in-process client, and concurrent request processing.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tower_mcp::client::{ChannelTransport, McpClient, NotificationHandler};
+use tower_mcp::context::{ServerNotification, notification_channel};
+use tower_mcp::extract::RawArgs;
+use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+
+fn slow_tool(name: &str, delay_ms: u64) -> tower_mcp::Tool {
+    ToolBuilder::new(name)
+        .description("Sleeps, then answers")
+        .extractor_handler((), move |RawArgs(_): RawArgs| async move {
+            tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            Ok(CallToolResult::text("done"))
+        })
+        .build()
+}
+
+/// A host-pushed notification arrives client-side while a request is still
+/// in flight.
+#[tokio::test]
+async fn notification_delivered_while_request_in_flight() {
+    let (notif_tx, notif_rx) = notification_channel(64);
+    let router = McpRouter::new()
+        .server_info("channel-test", "1.0.0")
+        .tool(slow_tool("slow", 400))
+        .with_notification_sender(notif_tx.clone());
+
+    let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    let handler = NotificationHandler::new().on_tools_changed(move || {
+        let _ = seen_tx.send(());
+    });
+
+    let transport = ChannelTransport::with_notifications(router, notif_rx);
+    let client = Arc::new(
+        McpClient::connect_with_handler(transport, handler)
+            .await
+            .expect("connect"),
+    );
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    // Start a slow call, then push a notification while it is in flight.
+    let call_client = client.clone();
+    let call = tokio::spawn(async move {
+        call_client
+            .call_tool("slow", serde_json::json!({}))
+            .await
+            .expect("slow call")
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    notif_tx
+        .send(ServerNotification::ToolsListChanged)
+        .await
+        .expect("push notification");
+
+    // The notification must arrive before the slow call completes.
+    tokio::time::timeout(Duration::from_millis(200), seen_rx.recv())
+        .await
+        .expect("notification not delivered while request was in flight")
+        .expect("handler channel closed");
+    assert!(!call.is_finished(), "slow call should still be in flight");
+
+    let result = call.await.expect("join");
+    assert!(!result.is_error);
+}
+
+/// Two concurrent calls complete independently: the slow call does not block
+/// the fast one.
+#[tokio::test]
+async fn concurrent_requests_do_not_serialize() {
+    let router = McpRouter::new()
+        .server_info("channel-test", "1.0.0")
+        .tool(slow_tool("slow", 500))
+        .tool(slow_tool("fast", 10));
+
+    let transport = ChannelTransport::new(router);
+    let client = Arc::new(McpClient::connect(transport).await.expect("connect"));
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    let start = std::time::Instant::now();
+
+    let slow_client = client.clone();
+    let slow = tokio::spawn(async move {
+        slow_client
+            .call_tool("slow", serde_json::json!({}))
+            .await
+            .expect("slow call");
+        start.elapsed()
+    });
+    // Give the slow call a head start so serial processing would block us.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    let fast_client = client.clone();
+    let fast = tokio::spawn(async move {
+        fast_client
+            .call_tool("fast", serde_json::json!({}))
+            .await
+            .expect("fast call");
+        start.elapsed()
+    });
+
+    let (slow_elapsed, fast_elapsed) = (slow.await.expect("join"), fast.await.expect("join"));
+
+    assert!(
+        fast_elapsed < Duration::from_millis(250),
+        "fast call should not wait behind the slow call, took {fast_elapsed:?}"
+    );
+    assert!(
+        slow_elapsed >= Duration::from_millis(500),
+        "slow call should actually be slow, took {slow_elapsed:?}"
+    );
+}
+
+/// The default constructor also delivers router-emitted notifications (the
+/// receiver is no longer discarded).
+#[tokio::test]
+async fn default_constructor_delivers_router_notifications() {
+    let router = McpRouter::new().server_info("channel-test", "1.0.0").tool(
+        ToolBuilder::new("notifier")
+            .description("Emits a log notification via context")
+            .extractor_handler(
+                (),
+                |ctx: tower_mcp::extract::Context, RawArgs(_): RawArgs| async move {
+                    ctx.send_log(tower_mcp::protocol::LoggingMessageParams::new(
+                        tower_mcp::protocol::LogLevel::Info,
+                        serde_json::json!("hello from the tool"),
+                    ));
+                    Ok(CallToolResult::text("ok"))
+                },
+            )
+            .build(),
+    );
+
+    let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    let handler = NotificationHandler::new().on_log_message(move |msg| {
+        let _ = seen_tx.send(format!("{:?}", msg.data));
+    });
+
+    let transport = ChannelTransport::new(router);
+    let client = McpClient::connect_with_handler(transport, handler)
+        .await
+        .expect("connect");
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    client
+        .call_tool("notifier", serde_json::json!({}))
+        .await
+        .expect("call");
+
+    let msg = tokio::time::timeout(Duration::from_millis(500), seen_rx.recv())
+        .await
+        .expect("log notification not delivered")
+        .expect("handler channel closed");
+    assert!(msg.contains("hello from the tool"), "got: {msg}");
+}


### PR DESCRIPTION
Closes #955.

## Plan

ChannelTransport (in-process client-to-router transport) currently discards server notifications (`channel.rs:54` builds a channel and drops the receiver) and processes requests serially. Consumer: repol runs its REPL as an in-process McpClient over this transport; server push is its notification stream (repol M2.1, its only blocking tower-mcp dependency).

1. `ChannelTransport::with_notifications(router, notification_rx)` mirroring `HttpTransport::with_notifications`: accept an external `NotificationReceiver`, serialize `ServerNotification`s into JSON-RPC notification frames, and interleave them into `recv()` so `NotificationHandler` works identically to the network transports. The host keeps the sender via `router.notification_sender()` or its own channel.
2. `ChannelTransport::new` stops discarding: it wires an internal channel and delivers notifications emitted through the router-attached sender (progress, list_changed), so the default constructor also gains delivery.
3. Spawn per request (JsonRpcService is Clone; the client correlates responses by id with a pending map, so out-of-order completion is safe).

## Acceptance (from #955)

- Test: a server notification arrives client-side while a request is in flight.
- Test: two concurrent call_tool requests complete independently (slow call does not block fast call).