### PR TITLE
feat(client): task-augmented tool calls and a tasks API on McpClient

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -3430,6 +3430,15 @@ pub struct TaskObject {
     /// Suggested polling interval in milliseconds
     #[serde(skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
+    /// SEP-2663 DetailedTask payload for `completed` tasks: exactly the
+    /// result the synchronous request would have returned. Absent for
+    /// non-terminal and non-completed statuses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub result: Option<CallToolResult>,
+    /// SEP-2663 DetailedTask payload for `failed` tasks: the JSON-RPC error
+    /// object describing the execution failure. Absent otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<crate::error::JsonRpcError>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -5818,6 +5827,8 @@ mod tests {
             last_updated_at: "2025-11-25T10:30:00Z".into(),
             ttl: Some(60_000),
             poll_interval: Some(5_000),
+            result: None,
+            error: None,
             meta: None,
         }
     }

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -107,6 +107,8 @@ impl Task {
             last_updated_at: self.last_updated_at_str.clone(),
             ttl: Some(self.ttl),
             poll_interval: Some(self.poll_interval),
+            result: None,
+            error: None,
             meta: None,
         }
     }

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -63,14 +63,15 @@ use tokio::task::JoinHandle;
 
 use crate::error::{Error, Result};
 use crate::protocol::{
-    CallToolParams, CallToolResult, ClientCapabilities, CompleteParams, CompleteResult,
-    CompletionArgument, CompletionReference, ElicitationCapability, GetPromptParams,
-    GetPromptResult, Implementation, InitializeParams, InitializeResult, JsonRpcNotification,
-    JsonRpcRequest, ListPromptsParams, ListPromptsResult, ListResourceTemplatesParams,
-    ListResourceTemplatesResult, ListResourcesParams, ListResourcesResult, ListRootsResult,
-    ListToolsParams, ListToolsResult, PromptDefinition, ReadResourceParams, ReadResourceResult,
-    RequestId, ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability,
-    SamplingCapability, ToolDefinition, notifications,
+    CallToolParams, CallToolResult, CancelTaskParams, ClientCapabilities, CompleteParams,
+    CompleteResult, CompletionArgument, CompletionReference, CreateTaskResult,
+    ElicitationCapability, GetPromptParams, GetPromptResult, GetTaskInfoParams, Implementation,
+    InitializeParams, InitializeResult, JsonRpcNotification, JsonRpcRequest, ListPromptsParams,
+    ListPromptsResult, ListResourceTemplatesParams, ListResourceTemplatesResult,
+    ListResourcesParams, ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult,
+    PromptDefinition, ReadResourceParams, ReadResourceResult, RequestId, ResourceDefinition,
+    ResourceTemplateDefinition, Root, RootsCapability, SamplingCapability, TaskObject,
+    TaskRequestParams, ToolDefinition, notifications,
 };
 use tower_mcp_types::JsonRpcError;
 
@@ -390,6 +391,85 @@ impl McpClient {
             task: None,
         };
         self.send_request("tools/call", &params).await
+    }
+
+    /// Make a task-augmented tool call (SEP-2663).
+    ///
+    /// Instead of blocking until the tool finishes, the server creates a
+    /// task and immediately returns a [`CreateTaskResult`] carrying the task
+    /// id. Poll with [`task_get`](Self::task_get) or block with
+    /// [`task_wait`](Self::task_wait); a completed task's `result` field
+    /// carries the [`CallToolResult`] the synchronous call would have
+    /// returned.
+    ///
+    /// `ttl_ms` is the requested task time-to-live in milliseconds; `None`
+    /// lets the server choose. The tool must support task execution
+    /// (advertised via the server's tasks capability); servers reject
+    /// task-augmented calls to unsupported tools.
+    pub async fn call_tool_as_task(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+        ttl_ms: Option<u64>,
+    ) -> Result<CreateTaskResult> {
+        self.ensure_initialized()?;
+        let params = CallToolParams {
+            name: name.to_string(),
+            arguments,
+            meta: None,
+            task: Some(TaskRequestParams { ttl: ttl_ms }),
+        };
+        self.send_request("tools/call", &params).await
+    }
+
+    /// Fetch a task's current state via `tasks/get` (SEP-2663).
+    ///
+    /// For `completed` tasks the returned object carries the terminal
+    /// [`CallToolResult`] in its `result` field; for `failed` tasks the
+    /// JSON-RPC error is in `error`. Unknown or expired task ids surface as
+    /// an invalid-params error from the server.
+    pub async fn task_get(&self, task_id: &str) -> Result<TaskObject> {
+        self.ensure_initialized()?;
+        let params = GetTaskInfoParams {
+            task_id: task_id.to_string(),
+            meta: None,
+        };
+        self.send_request("tasks/get", &params).await
+    }
+
+    /// Cancel a task via `tasks/cancel` (SEP-2663).
+    ///
+    /// Cancellation is cooperative: the acknowledgment is an empty result
+    /// and the observable status may remain non-terminal for a while after
+    /// the ack; poll [`task_get`](Self::task_get) to observe the terminal
+    /// state. The ack body is discarded, so legacy peers that return the
+    /// task object are also tolerated.
+    pub async fn task_cancel(&self, task_id: &str, reason: Option<String>) -> Result<()> {
+        self.ensure_initialized()?;
+        let params = CancelTaskParams {
+            task_id: task_id.to_string(),
+            reason,
+            meta: None,
+        };
+        let _ack: serde_json::Value = self.send_request("tasks/cancel", &params).await?;
+        Ok(())
+    }
+
+    /// Poll `tasks/get` until the task reaches a terminal state.
+    ///
+    /// Honors the server's suggested `pollInterval` (default 1000 ms,
+    /// clamped to 50 ms..30 s). A task purged after its TTL surfaces as the
+    /// server's task-not-found error. Wrap in
+    /// [`tokio::time::timeout`] to bound the overall wait.
+    pub async fn task_wait(&self, task_id: &str) -> Result<TaskObject> {
+        loop {
+            let task = self.task_get(task_id).await?;
+            if task.status.is_terminal() {
+                return Ok(task);
+            }
+            let interval_ms = task.poll_interval.unwrap_or(1000).clamp(50, 30_000);
+            tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
+        }
     }
 
     /// List available resources.

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2430,10 +2430,16 @@ impl McpRouter {
             McpRequest::Ping => Ok(McpResponse::Pong(EmptyResult {})),
 
             McpRequest::GetTaskInfo(params) => {
-                let task = self
+                // SEP-2663 DetailedTask: `tasks/get` carries the
+                // status-discriminated payload inline. `completed` includes
+                // the result the synchronous request would have returned;
+                // `failed` includes the JSON-RPC error. This replaced the
+                // removed blocking `tasks/result` method as the way clients
+                // retrieve a task's outcome.
+                let (mut task, result, error) = self
                     .inner
                     .task_store
-                    .get_task(&params.task_id)
+                    .get_task_result(&params.task_id)
                     .await
                     .map_err(task_store_error)?
                     .ok_or_else(|| {
@@ -2442,6 +2448,16 @@ impl McpRouter {
                             params.task_id
                         )))
                     })?;
+
+                match task.status {
+                    TaskStatus::Completed => task.result = result,
+                    TaskStatus::Failed => {
+                        task.error = Some(JsonRpcError::internal_error(
+                            error.unwrap_or_else(|| "Task failed".to_string()),
+                        ));
+                    }
+                    _ => {}
+                }
 
                 Ok(McpResponse::GetTaskInfo(task))
             }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3768,6 +3768,9 @@ mod tests {
             &self,
             task_id: &str,
         ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+            // Counted as a read: `tasks/get` dispatch fetches the snapshot so
+            // it can inline the SEP-2663 DetailedTask terminal payload.
+            self.gets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.inner.get_task_result(task_id).await
         }
 

--- a/crates/tower-mcp/tests/client_tasks.rs
+++ b/crates/tower-mcp/tests/client_tasks.rs
@@ -1,0 +1,136 @@
+//! Client tasks API acceptance tests (#957): task-augmented tool calls,
+//! polling, result retrieval, and cancellation through McpClient.
+
+use std::time::Duration;
+
+use tower_mcp::client::{ChannelTransport, McpClient};
+use tower_mcp::extract::RawArgs;
+use tower_mcp::protocol::TaskStatus;
+use tower_mcp::{CallToolResult, McpRouter, TaskSupportMode, ToolBuilder};
+
+fn task_router() -> McpRouter {
+    McpRouter::new()
+        .server_info("tasks-test", "1.0.0")
+        .tool(
+            ToolBuilder::new("compute")
+                .description("Finishes quickly with a result")
+                .task_support(TaskSupportMode::Optional)
+                .extractor_handler((), |RawArgs(_): RawArgs| async move {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok(CallToolResult::text("the answer is 42"))
+                })
+                .build(),
+        )
+        .tool(
+            ToolBuilder::new("forever")
+                .description("Runs until cancelled")
+                .task_support(TaskSupportMode::Optional)
+                .extractor_handler((), |RawArgs(_): RawArgs| async move {
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    Ok(CallToolResult::text("never happens"))
+                })
+                .build(),
+        )
+}
+
+/// Acceptance: a client starts a task-augmented call against a
+/// TaskStore-backed router, polls tasks/get, and retrieves the result.
+#[tokio::test]
+async fn task_augmented_call_polls_and_retrieves_result() {
+    let client = McpClient::connect(ChannelTransport::new(task_router()))
+        .await
+        .expect("connect");
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    let created = client
+        .call_tool_as_task("compute", serde_json::json!({}), Some(60_000))
+        .await
+        .expect("task-augmented call");
+    assert!(created.task.task_id.starts_with("task-"));
+    assert_eq!(created.task.status, TaskStatus::Working);
+    assert!(
+        created.task.result.is_none(),
+        "no result payload while working"
+    );
+
+    // Direct poll works while running or after completion.
+    let polled = client
+        .task_get(&created.task.task_id)
+        .await
+        .expect("tasks/get");
+    assert_eq!(polled.task_id, created.task.task_id);
+
+    // Wait for the terminal state; the completed task carries the result
+    // the synchronous call would have returned (SEP-2663 DetailedTask).
+    let done = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.task_wait(&created.task.task_id),
+    )
+    .await
+    .expect("task_wait timed out")
+    .expect("task_wait");
+    assert_eq!(done.status, TaskStatus::Completed);
+    let result = done.result.expect("completed task must carry its result");
+    match &result.content[0] {
+        tower_mcp::protocol::Content::Text { text, .. } => {
+            assert_eq!(text, "the answer is 42")
+        }
+        other => panic!("expected text content, got {other:?}"),
+    }
+    assert!(done.error.is_none());
+}
+
+/// Acceptance: the cancel path resolves the task and the client observes the
+/// terminal state.
+#[tokio::test]
+async fn task_cancel_resolves_to_terminal_state() {
+    let client = McpClient::connect(ChannelTransport::new(task_router()))
+        .await
+        .expect("connect");
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    let created = client
+        .call_tool_as_task("forever", serde_json::json!({}), None)
+        .await
+        .expect("task-augmented call");
+
+    // Empty ack (final SEP-2663 shape).
+    client
+        .task_cancel(&created.task.task_id, Some("test cancellation".into()))
+        .await
+        .expect("tasks/cancel");
+
+    let done = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.task_wait(&created.task.task_id),
+    )
+    .await
+    .expect("task_wait timed out")
+    .expect("task_wait");
+    assert_eq!(done.status, TaskStatus::Cancelled);
+    assert!(done.result.is_none());
+}
+
+/// Unknown task ids surface as an error, not a hang.
+#[tokio::test]
+async fn task_get_unknown_id_errors() {
+    let client = McpClient::connect(ChannelTransport::new(task_router()))
+        .await
+        .expect("connect");
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    let err = client
+        .task_get("task-does-not-exist")
+        .await
+        .expect_err("unknown task id must error");
+    assert!(err.to_string().contains("not found"), "got: {err}");
+}

--- a/crates/tower-mcp/tests/schema_validation.rs
+++ b/crates/tower-mcp/tests/schema_validation.rs
@@ -594,6 +594,8 @@ fn validate_task_object() {
         last_updated_at: "2025-01-01T00:01:00Z".to_string(),
         ttl: Some(300_000),
         poll_interval: None,
+        result: None,
+        error: None,
         meta: None,
     };
     validate_against_def(&task, "Task");
@@ -609,6 +611,8 @@ fn validate_task_completed() {
         last_updated_at: "2025-01-01T00:05:00Z".to_string(),
         ttl: Some(600_000),
         poll_interval: Some(1000),
+        result: None,
+        error: None,
         meta: None,
     };
     validate_against_def(&task, "Task");


### PR DESCRIPTION
Closes #957. Related: #951 (server final shape), #953 (client parity phase).

## Plan

The server dispatches SEP-2663 tasks but McpClient cannot reach any of it: call_tool hardcodes task: None and there are no typed task methods. Additionally, since #954 removed the legacy tasks/result method, a task's terminal result is currently unreachable by ANY client; the final SEP-2663 shape inlines the result in the tasks/get DetailedTask payload, which does not exist yet. This PR therefore pulls that #951 slice forward (SEP-2663 is final and stable since May 2026):

1. Types: TaskObject gains optional `result` (CallToolResult, present when completed) and `error` (JSON-RPC error object, present when failed) fields per the SEP-2663 DetailedTask status-discriminated payload.
2. Router: tasks/get uses the TaskStore snapshot (from #962) to inline the terminal payload.
3. Client API:
   - `call_tool_as_task(name, arguments, ttl_ms) -> CreateTaskResult`
   - `task_get(task_id) -> TaskObject`
   - `task_cancel(task_id, reason)` returning `Ok(())` (empty ack per final SEP-2663; tolerates legacy task-object acks)
   - `task_wait(task_id) -> TaskObject` polling tasks/get honoring the server's pollInterval until terminal; TTL-expired tasks surface as the store's task-not-found error

## Acceptance (from #957)

- A client starts a task-augmented call against a TaskStore-backed router, polls tasks/get, and retrieves the result.
- The cancel path resolves the task and the client observes the terminal state.

Consumer: repol evaluated driving long-running agent turns over the task extension and fell back to a run-id-over-notifications pattern because this surface was missing.