### PR TITLE
fix(client): await notification POSTs inline to preserve ordering

### DIFF
--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -536,12 +536,23 @@ impl ClientTransport for HttpClientTransport {
 
         let request = request.body(message.to_string());
 
-        // After session is established, send in a background task so the
-        // message loop can continue processing incoming SSE messages.
+        // Notifications (frames without an `id`) are awaited inline even
+        // after session establishment: the server processes a notification
+        // before answering 202, and never issues a client round-trip while
+        // doing so, so awaiting cannot deadlock and preserves ordering with
+        // everything sent afterwards. Without this, the spawned send path
+        // let `notifications/initialized` race the next request on a pooled
+        // connection, and strict servers rejected that request (#967).
+        let is_notification = serde_json::from_str::<serde_json::Value>(message)
+            .map(|v| v.get("id").is_none())
+            .unwrap_or(false);
+
+        // After session is established, send requests in a background task
+        // so the message loop can continue processing incoming SSE messages.
         // This prevents a deadlock when the server blocks on a
         // bidirectional request (sampling/elicitation) that requires the
         // client to respond via the SSE channel.
-        if self.session_id.is_some() {
+        if self.session_id.is_some() && !is_notification {
             let tx = self.incoming_tx.clone();
             let connected = self.connected.clone();
             let last_event_id = self.last_event_id.clone();
@@ -665,8 +676,9 @@ impl ClientTransport for HttpClientTransport {
             return Ok(());
         }
 
-        // Pre-session (initialize): handle synchronously to extract
-        // session headers and start the SSE stream.
+        // Pre-session (initialize) and notifications: handle synchronously.
+        // For initialize this extracts session headers and starts the SSE
+        // stream; for notifications the expected response is a bare 202.
         let response = request
             .send()
             .await

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2630,3 +2630,63 @@ async fn test_session_recovery_disabled() {
     let result = client.list_tools().await;
     assert!(result.is_err(), "Should fail without session recovery");
 }
+
+/// #967 regression: `notifications/initialized` must not race the first
+/// request after `initialize()`.
+///
+/// Post-session request POSTs are spawned in background tasks; notification
+/// POSTs must be awaited inline so a strict server (`strict_initialization`
+/// defaults to true) processes them before the next request arrives. The
+/// race depends on network timing, so an in-process server never exhibits
+/// it; this test routes the client through a TCP proxy that delays any
+/// connection carrying `notifications/initialized` by 200 ms, forcing the
+/// reordering. Before the fix the subsequent `tools/list` deterministically
+/// failed with -32600; after it, `initialize()` does not return until the
+/// notification is acknowledged, so ordering holds.
+#[tokio::test]
+async fn initialized_notification_ordering_under_strict_server() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let (url, _server) = start_server().await;
+    let upstream = url.strip_prefix("http://").unwrap().to_string();
+
+    // Delaying proxy: hold back the connection that carries the
+    // initialized notification; pass everything else straight through.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let proxy_addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut client_conn, _)) = listener.accept().await else {
+                break;
+            };
+            let upstream = upstream.clone();
+            tokio::spawn(async move {
+                let mut first = vec![0u8; 16 * 1024];
+                let n = match client_conn.read(&mut first).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(n) => n,
+                };
+                if String::from_utf8_lossy(&first[..n]).contains("notifications/initialized") {
+                    tokio::time::sleep(Duration::from_millis(200)).await;
+                }
+                let Ok(mut up) = tokio::net::TcpStream::connect(&upstream).await else {
+                    return;
+                };
+                if up.write_all(&first[..n]).await.is_err() {
+                    return;
+                }
+                let _ = tokio::io::copy_bidirectional(&mut client_conn, &mut up).await;
+            });
+        }
+    });
+
+    let proxied_url = format!("http://{proxy_addr}");
+    let transport = HttpClientTransport::new(proxied_url);
+    let client = McpClient::connect(transport).await.unwrap();
+    client.initialize("race-test", "1.0.0").await.unwrap();
+    let tools = client
+        .list_tools()
+        .await
+        .expect("tools/list must not be rejected: initialized must be acknowledged first");
+    assert!(!tools.tools.is_empty());
+}


### PR DESCRIPTION
Closes #967.

## Problem

After a session is established, HttpClientTransport::send spawns every POST in a background task (deadlock avoidance for bidirectional sampling/elicitation flows). Notifications therefore race subsequent requests on pooled connections: `notifications/initialized` can arrive after the first request, and a strict server (strict_initialization defaults to true) rejects that request with -32600. Found immediately by pointing mcp-repl (#966) at the conformance-server over HTTP.

## Fix

Frames without an `id` are notifications: their acknowledgment is an immediate 202 with no body and no server-side round-trip back to the client, so awaiting them inline cannot deadlock and preserves ordering with everything sent after. Requests keep the spawned path. The server side already processes a notification before answering 202, so awaiting the 202 is a sufficient ordering guarantee.

## Verification

- Regression test: strict-initialization HTTP server, repeated fresh connect + initialize + immediate tools/list; fails reliably before the fix, passes after.
- Existing bidirectional flows (sampling/elicitation tests) unaffected.