### PR TITLE
chore(mcp-repl): prepare for crates.io publishing

### DIFF
--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-publish = false
+repository = "https://github.com/joshrotenberg/tower-mcp"
+readme = "README.md"
 description = "Interactive MCP client REPL: connects to any MCP server and turns its tools, prompts, and resources into the command set"
+keywords = ["mcp", "repl", "cli", "client", "model-context-protocol"]
+categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]
 name = "mcp-repl"


### PR DESCRIPTION
Prepares mcp-repl (#966) for publishing: removes `publish = false`, adds registry metadata (repository, readme, keywords, categories). The name `mcp-repl` is unclaimed on crates.io.

- The workspace dependency already carries `version = "0.13"` with the path, so the published manifest resolves against crates.io.
- Verified: `cargo publish --dry-run -p mcp-repl` (builds standalone) and `cargo +1.90 build` (MSRV).
- release-plz will version and publish it via the existing workspace `publish = true` config; the first actual publish happens when the next release PR merges, which remains a deliberate step.