### PR TITLE
feat(mcp-repl): reedline, colored output, describe, template completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -366,15 +369,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "clipboard-win"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
-dependencies = [
- "error-code",
-]
-
-[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,6 +456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +506,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -597,6 +628,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,6 +684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,6 +717,12 @@ dependencies = [
  "signature",
  "spki",
 ]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
@@ -698,12 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endian-type"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,12 +780,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "error-code"
-version = "3.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "fancy-regex"
@@ -1014,15 +1070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1294,6 +1341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1451,6 +1507,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,8 +1552,10 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 name = "mcp-repl"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "clap",
- "rustyline",
+ "nu-ansi-term",
+ "reedline",
  "serde_json",
  "tokio",
  "tower-mcp",
@@ -1523,29 +1587,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -1869,16 +1913,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "radix_trie"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
-dependencies = [
- "endian-type",
- "nibble_vec",
-]
-
-[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1983,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "reedline"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826c1fc22a2b1f14c3f6a80fc3d56adfbfb913d07f170bce4246700de7adfd50"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "thiserror",
+ "unicase",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2256,28 +2310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rustyline"
-version = "17.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
-dependencies = [
- "bitflags",
- "cfg-if",
- "clipboard-win",
- "fd-lock",
- "home",
- "libc",
- "log",
- "memchr",
- "nix",
- "radix_trie",
- "unicode-segmentation",
- "unicode-width",
- "utf8parse",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2545,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,10 +2665,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"
@@ -3131,6 +3214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,6 +3323,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "walkdir"
@@ -3367,6 +3465,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3488,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -13,8 +13,10 @@ path = "src/main.rs"
 
 [dependencies]
 tower-mcp = { workspace = true, features = ["http-client"] }
+async-trait.workspace = true
 tokio.workspace = true
 serde_json.workspace = true
 clap.workspace = true
 tracing-subscriber.workspace = true
-rustyline = "17"
+reedline = "0.49"
+nu-ansi-term = "0.50"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -6,6 +6,10 @@ get built-ins, tab completion is powered by the server itself where the
 protocol allows, and the command table refreshes live when the server's
 surface changes.
 
+The editor is [reedline](https://crates.io/crates/reedline) (nushell's line
+editor): a columnar completion menu with per-candidate descriptions, live
+input highlighting, and fish-style history hints.
+
 ## Run
 
 ```bash
@@ -25,6 +29,7 @@ cargo run -p mcp-repl -- --http http://127.0.0.1:3001/mcp
 getting-started> help                      # built-ins plus the server's tools
 getting-started> add a=2 b=3               # tools are commands; args coerced by inputSchema
 getting-started> echo message="hi there"   # tab-completes argument names
+getting-started> describe add              # input/output schemas, colored
 getting-started> read source://getting_started.rs
 getting-started> prompt greet name=World   # prompt args tab-complete via completion/complete
 ```
@@ -46,12 +51,63 @@ Progress and log notifications print inline as they arrive, and
 dynamic servers (see the `dynamic_capabilities` example) grow and shrink the
 REPL's vocabulary live.
 
+## Completion
+
+Tab opens a columnar menu. What gets completed:
+
+- The command word: built-ins plus every tool, each with its description.
+- Tool argument names from the tool's `inputSchema` properties (with type,
+  required flag, and description), and enum values after `key=` when the
+  property declares an `enum`.
+- `read <uri>`: resource URIs and template URI templates. When the partial
+  reaches a template's `{variable}`, the server's `completion/complete` is
+  asked to complete the variable (2s timeout, best-effort). Try
+  `read note://<Tab>` in `--demo`.
+- `prompt <name> <arg>=`: argument values via `completion/complete`, and
+  argument names from the prompt definition.
+- `describe <name>`: everything on the surface, labeled by kind.
+
+## describe
+
+`describe <name>` looks up a tool, prompt, resource, or template by name:
+
+- Tools: behavior hints, task support, and the input/output schemas as
+  syntax-colored JSON.
+- Prompts: the argument table (name, required/optional, description).
+- Resources and templates: URI, name, MIME type, size, and description.
+
+## Output rendering
+
+- JSON output (schema dumps, `info` capabilities, non-text content) is
+  pretty-printed with a small built-in syntax colorizer.
+- Text content that looks like markdown gets a light terminal rendering:
+  bold headings, dimmed code fences, styled inline code and bold spans,
+  colored bullets.
+- Progress, log, and task lines are tagged with dim brackets; task statuses
+  are colored (working=yellow, completed=green, failed/cancelled=red).
+
+All styling degrades to plain text when `NO_COLOR` is set or stdout is not
+a terminal. `--color always|never|auto` overrides the detection.
+
+## Elicitation
+
+Tools that request user input via `elicitation/create` prompt for each
+field at the terminal during a foreground call: the field's type, default,
+and description are shown, empty input accepts the default, and EOF
+cancels. Try `test_elicitation` against the conformance server. If a
+background task elicits while the editor owns the terminal, the request is
+declined rather than fighting the editor for stdin.
+
 ## Notes
 
-- Tab completion for prompt argument values calls the server's
-  `completion/complete`, one of the least-exercised capabilities in the
-  protocol. Servers that do not implement it simply contribute nothing.
+- Tab completion for prompt argument values and resource template variables
+  calls the server's `completion/complete`, one of the least-exercised
+  capabilities in the protocol. Servers that do not implement it simply
+  contribute nothing.
 - A spawned stdio child's stderr passes through to the terminal, which keeps
   server-side tracing visible while you explore.
 - `call <tool> <json>` is the escape hatch when `key=value` coercion is not
   enough.
+- When stdin is not a tty, the REPL reads lines directly (no editor), so
+  piping a script of commands works:
+  `printf 'echo message=hi\nquit\n' | mcp-repl --demo`.

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -1,0 +1,600 @@
+//! The reedline editor: prompt, completer, live highlighter, and the
+//! dedicated readline thread.
+//!
+//! The editor runs on its own std thread; lines cross into async via a
+//! tokio mpsc channel and an ack channel paces the prompt so it only
+//! reappears after the previous command finished printing. The completer
+//! blocks on this thread, which lives outside the tokio runtime, so
+//! `Handle::block_on` is safe here.
+
+use std::borrow::Cow;
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Duration;
+
+use nu_ansi_term::{Color, Style};
+use reedline::{
+    ColumnarMenu, Completer, DefaultHinter, Emacs, Highlighter, KeyCode, KeyModifiers, MenuBuilder,
+    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline,
+    ReedlineEvent, ReedlineMenu, Signal, Span, StyledText, Suggestion, default_emacs_keybindings,
+};
+
+use tower_mcp::client::McpClient;
+
+use crate::style;
+use crate::{BUILTINS, Surface};
+
+const MENU_NAME: &str = "completion_menu";
+
+// ---------------------------------------------------------------------------
+// Prompt
+// ---------------------------------------------------------------------------
+
+struct ReplPrompt {
+    server_name: String,
+}
+
+impl Prompt for ReplPrompt {
+    fn render_prompt_left(&self) -> Cow<'_, str> {
+        Cow::Borrowed(&self.server_name)
+    }
+
+    fn render_prompt_right(&self) -> Cow<'_, str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_indicator(&self, _prompt_mode: PromptEditMode) -> Cow<'_, str> {
+        Cow::Borrowed("> ")
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<'_, str> {
+        Cow::Borrowed("::: ")
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<'_, str> {
+        let status = match history_search.status {
+            PromptHistorySearchStatus::Passing => "",
+            PromptHistorySearchStatus::Failing => "failing ",
+        };
+        Cow::Owned(format!(
+            "({}reverse-search: {}) ",
+            status, history_search.term
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Completer
+// ---------------------------------------------------------------------------
+
+pub struct ReplCompleter {
+    surface: Arc<RwLock<Surface>>,
+    client: Arc<McpClient>,
+    runtime: tokio::runtime::Handle,
+}
+
+fn suggestion(value: impl Into<String>, description: Option<String>, span: Span) -> Suggestion {
+    Suggestion {
+        value: value.into(),
+        display_override: None,
+        description,
+        style: None,
+        extra: None,
+        span,
+        append_whitespace: false,
+        match_indices: None,
+    }
+}
+
+fn word_suggestion(
+    value: impl Into<String>,
+    description: Option<String>,
+    span: Span,
+) -> Suggestion {
+    Suggestion {
+        append_whitespace: true,
+        ..suggestion(value, description, span)
+    }
+}
+
+impl ReplCompleter {
+    pub fn new(
+        surface: Arc<RwLock<Surface>>,
+        client: Arc<McpClient>,
+        runtime: tokio::runtime::Handle,
+    ) -> Self {
+        Self {
+            surface,
+            client,
+            runtime,
+        }
+    }
+
+    /// Server-powered completion for prompt argument values
+    /// (`completion/complete` with a prompt reference). Safe to block here:
+    /// the completer runs on the dedicated readline thread, outside the
+    /// async runtime.
+    fn complete_prompt_arg_via_server(
+        &self,
+        prompt: &str,
+        arg: &str,
+        partial: &str,
+    ) -> Vec<String> {
+        let client = self.client.clone();
+        let (prompt, arg, partial) = (prompt.to_string(), arg.to_string(), partial.to_string());
+        self.runtime
+            .block_on(async move {
+                tokio::time::timeout(
+                    Duration::from_secs(2),
+                    client.complete_prompt_arg(&prompt, &arg, &partial),
+                )
+                .await
+            })
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|r| r.completion.values)
+            .unwrap_or_default()
+    }
+
+    /// Server-powered completion for a resource template variable
+    /// (`completion/complete` with a resource reference). Same blocking
+    /// pattern as prompt arguments: 2s timeout, best-effort.
+    fn complete_template_var_via_server(
+        &self,
+        uri_template: &str,
+        var: &str,
+        partial: &str,
+    ) -> Vec<String> {
+        let client = self.client.clone();
+        let (template, var, partial) = (
+            uri_template.to_string(),
+            var.to_string(),
+            partial.to_string(),
+        );
+        self.runtime
+            .block_on(async move {
+                tokio::time::timeout(
+                    Duration::from_secs(2),
+                    client.complete_resource_uri(&template, &var, &partial),
+                )
+                .await
+            })
+            .ok()
+            .and_then(|r| r.ok())
+            .map(|r| r.completion.values)
+            .unwrap_or_default()
+    }
+
+    /// Completions for `read <partial>`: literal resource URIs, template
+    /// URI templates, and server-completed template variables when the
+    /// partial has reached a template's `{variable}`.
+    fn complete_resource_word(&self, surface: &Surface, word: &str, span: Span) -> Vec<Suggestion> {
+        let mut out = Vec::new();
+        for r in &surface.resources {
+            if r.uri.starts_with(word) {
+                out.push(word_suggestion(&r.uri, Some(r.name.clone()), span));
+            }
+        }
+        for t in &surface.templates {
+            if t.uri_template.starts_with(word) {
+                out.push(suggestion(&t.uri_template, Some(t.name.clone()), span));
+            }
+            // Template variable completion: `file:///{path}` with word
+            // `file:///src/` asks the server to complete `path` = `src/`.
+            let Some(open) = t.uri_template.find('{') else {
+                continue;
+            };
+            let Some(close_rel) = t.uri_template[open..].find('}') else {
+                continue;
+            };
+            let close = open + close_rel;
+            let static_prefix = &t.uri_template[..open];
+            if word.len() < static_prefix.len() || !word.starts_with(static_prefix) {
+                continue;
+            }
+            let var = &t.uri_template[open + 1..close];
+            let suffix = &t.uri_template[close + 1..];
+            let partial_value = &word[static_prefix.len()..];
+            for v in self.complete_template_var_via_server(&t.uri_template, var, partial_value) {
+                let mut full = format!("{static_prefix}{v}");
+                if !suffix.contains('{') {
+                    full.push_str(suffix);
+                }
+                out.push(suggestion(full, Some(format!("{var} ({})", t.name)), span));
+            }
+        }
+        out
+    }
+
+    /// Completions for `describe <name>`: every named thing on the surface.
+    fn complete_describe_word(surface: &Surface, word: &str, span: Span) -> Vec<Suggestion> {
+        let mut out = Vec::new();
+        for t in &surface.tools {
+            if t.name.starts_with(word) {
+                out.push(word_suggestion(&t.name, Some("tool".to_string()), span));
+            }
+        }
+        for p in &surface.prompts {
+            if p.name.starts_with(word) {
+                out.push(word_suggestion(&p.name, Some("prompt".to_string()), span));
+            }
+        }
+        for r in &surface.resources {
+            if r.uri.starts_with(word) {
+                out.push(word_suggestion(&r.uri, Some("resource".to_string()), span));
+            }
+        }
+        for t in &surface.templates {
+            if t.uri_template.starts_with(word) {
+                out.push(word_suggestion(
+                    &t.uri_template,
+                    Some("template".to_string()),
+                    span,
+                ));
+            }
+        }
+        out
+    }
+}
+
+impl Completer for ReplCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let head = &line[..pos];
+        let (word_start, word) = match head.rfind(char::is_whitespace) {
+            Some(i) => (i + 1, &head[i + 1..]),
+            None => (0, head),
+        };
+        let span = Span::new(word_start, pos);
+        let surface = self.surface.read().unwrap();
+        let mut out: Vec<Suggestion> = Vec::new();
+
+        let first = head.split_whitespace().next().unwrap_or("");
+        let completing_first = word_start == 0;
+
+        if completing_first {
+            // First word: built-ins plus every tool name.
+            for (name, desc) in BUILTINS {
+                if name.starts_with(word) {
+                    out.push(word_suggestion(*name, Some(desc.to_string()), span));
+                }
+            }
+            for t in &surface.tools {
+                if t.name.starts_with(word) {
+                    out.push(word_suggestion(&t.name, t.description.clone(), span));
+                }
+            }
+            return out;
+        }
+
+        match first {
+            "read" => {
+                out.extend(self.complete_resource_word(&surface, word, span));
+            }
+            "describe" => {
+                out.extend(Self::complete_describe_word(&surface, word, span));
+            }
+            "prompt" => {
+                let words = head.split_whitespace().count();
+                let second_word = words == 2 && !head.ends_with(' ');
+                let naming_prompt = second_word || words == 1;
+                if naming_prompt {
+                    for p in &surface.prompts {
+                        if p.name.starts_with(word) {
+                            out.push(word_suggestion(&p.name, p.description.clone(), span));
+                        }
+                    }
+                } else if let Some(prompt_name) = head.split_whitespace().nth(1) {
+                    if let Some((arg_name, partial)) = word.split_once('=') {
+                        // Argument value: ask the server (completion/complete).
+                        for v in self.complete_prompt_arg_via_server(prompt_name, arg_name, partial)
+                        {
+                            out.push(word_suggestion(format!("{arg_name}={v}"), None, span));
+                        }
+                    } else if let Some(p) = surface.prompts.iter().find(|p| p.name == prompt_name) {
+                        // Argument name: from the prompt definition.
+                        for a in &p.arguments {
+                            if a.name.starts_with(word) {
+                                let desc = match (&a.description, a.required) {
+                                    (Some(d), true) => Some(format!("(required) {d}")),
+                                    (Some(d), false) => Some(d.clone()),
+                                    (None, true) => Some("(required)".to_string()),
+                                    (None, false) => None,
+                                };
+                                out.push(suggestion(format!("{}=", a.name), desc, span));
+                            }
+                        }
+                    }
+                }
+            }
+            "call" => {
+                for t in &surface.tools {
+                    if t.name.starts_with(word) {
+                        out.push(word_suggestion(&t.name, t.description.clone(), span));
+                    }
+                }
+            }
+            tool_name => {
+                // Dynamic tool command: complete argument names from the
+                // tool's inputSchema properties, and enum values after `=`.
+                let Some(tool) = surface.tools.iter().find(|t| t.name == tool_name) else {
+                    return out;
+                };
+                let Some(props) = tool
+                    .input_schema
+                    .get("properties")
+                    .and_then(|p| p.as_object())
+                else {
+                    return out;
+                };
+                if let Some((arg_name, partial)) = word.split_once('=') {
+                    // Enum values from the property schema, when declared.
+                    if let Some(values) = props
+                        .get(arg_name)
+                        .and_then(|s| s.get("enum"))
+                        .and_then(|e| e.as_array())
+                    {
+                        for v in values {
+                            if let Some(v) = v.as_str()
+                                && v.starts_with(partial)
+                            {
+                                out.push(word_suggestion(format!("{arg_name}={v}"), None, span));
+                            }
+                        }
+                    }
+                } else {
+                    let required: Vec<&str> = tool
+                        .input_schema
+                        .get("required")
+                        .and_then(|r| r.as_array())
+                        .map(|r| r.iter().filter_map(|v| v.as_str()).collect())
+                        .unwrap_or_default();
+                    for (key, prop) in props {
+                        if !key.starts_with(word) {
+                            continue;
+                        }
+                        let ty = prop.get("type").and_then(|t| t.as_str()).unwrap_or("");
+                        let desc = prop
+                            .get("description")
+                            .and_then(|d| d.as_str())
+                            .unwrap_or("");
+                        let req = if required.contains(&key.as_str()) {
+                            "required "
+                        } else {
+                            ""
+                        };
+                        let full = format!("{req}{ty} {desc}");
+                        let full = full.trim();
+                        let desc = (!full.is_empty()).then(|| full.to_string());
+                        out.push(suggestion(format!("{key}="), desc, span));
+                    }
+                }
+            }
+        }
+
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Highlighter
+// ---------------------------------------------------------------------------
+
+/// Live input highlighting: the command word is styled by validity
+/// (built-in, known tool, or unknown), `key=` argument names are cyan,
+/// and JSON-literal values get the same palette as output rendering.
+pub struct ReplHighlighter {
+    surface: Arc<RwLock<Surface>>,
+}
+
+impl ReplHighlighter {
+    pub fn new(surface: Arc<RwLock<Surface>>) -> Self {
+        Self { surface }
+    }
+
+    fn command_style(&self, word: &str) -> Style {
+        if BUILTINS.iter().any(|(name, _)| *name == word) {
+            return Style::new().fg(Color::Cyan).bold();
+        }
+        let surface = self.surface.read().unwrap();
+        if surface.tools.iter().any(|t| t.name == word) {
+            return Style::new().fg(Color::Green).bold();
+        }
+        // Prefix of something completable: neutral while typing.
+        let is_prefix = BUILTINS.iter().any(|(name, _)| name.starts_with(word))
+            || surface.tools.iter().any(|t| t.name.starts_with(word));
+        if is_prefix {
+            Style::new()
+        } else {
+            Style::new().fg(Color::Red)
+        }
+    }
+}
+
+fn value_style(raw: &str) -> Style {
+    match serde_json::from_str::<serde_json::Value>(raw) {
+        Ok(serde_json::Value::Number(_)) => Style::new().fg(Color::Yellow),
+        Ok(serde_json::Value::Bool(_)) | Ok(serde_json::Value::Null) => {
+            Style::new().fg(Color::Purple)
+        }
+        Ok(serde_json::Value::String(_)) => Style::new().fg(Color::Green),
+        Ok(_) => Style::new().fg(Color::Green).dimmed(),
+        Err(_) => Style::new(),
+    }
+}
+
+impl Highlighter for ReplHighlighter {
+    fn highlight(&self, line: &str, _cursor: usize) -> StyledText {
+        let mut styled = StyledText::new();
+        if !style::colors_enabled() {
+            styled.push((Style::new(), line.to_string()));
+            return styled;
+        }
+
+        let mut seen_command = false;
+        let mut rest = line;
+        while !rest.is_empty() {
+            let token_start = match rest.find(|c: char| !c.is_whitespace()) {
+                Some(i) => i,
+                None => {
+                    styled.push((Style::new(), rest.to_string()));
+                    break;
+                }
+            };
+            if token_start > 0 {
+                styled.push((Style::new(), rest[..token_start].to_string()));
+            }
+            let token_end = rest[token_start..]
+                .find(char::is_whitespace)
+                .map(|i| token_start + i)
+                .unwrap_or(rest.len());
+            let token = &rest[token_start..token_end];
+
+            if !seen_command {
+                styled.push((self.command_style(token), token.to_string()));
+                seen_command = true;
+            } else if token == "&" {
+                styled.push((Style::new().fg(Color::Purple).bold(), token.to_string()));
+            } else if let Some((key, value)) = token.split_once('=') {
+                styled.push((Style::new().fg(Color::Cyan), format!("{key}=")));
+                styled.push((value_style(value), value.to_string()));
+            } else {
+                styled.push((value_style(token), token.to_string()));
+            }
+
+            rest = &rest[token_end..];
+        }
+        if line.is_empty() {
+            styled.push((Style::new(), String::new()));
+        }
+        styled
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Readline thread
+// ---------------------------------------------------------------------------
+
+/// Spawn the readline thread. Lines are sent over `line_tx`; after each
+/// line, the thread blocks on `ack_rx` until the command has finished
+/// printing. `at_prompt` is true while the editor owns the terminal
+/// (used to refuse elicitation prompts that would fight over stdin).
+///
+/// When stdin is not a tty (piped input), falls back to a plain
+/// line-reader so non-interactive use keeps working.
+pub fn spawn_readline_thread(
+    server_name: String,
+    surface: Arc<RwLock<Surface>>,
+    client: Arc<McpClient>,
+    runtime: tokio::runtime::Handle,
+    line_tx: tokio::sync::mpsc::Sender<String>,
+    ack_rx: std::sync::mpsc::Receiver<()>,
+    at_prompt: Arc<AtomicBool>,
+) {
+    std::thread::spawn(move || {
+        if !std::io::stdin().is_terminal() {
+            run_piped(&line_tx, &ack_rx);
+            return;
+        }
+        run_interactive(
+            server_name,
+            surface,
+            client,
+            runtime,
+            &line_tx,
+            &ack_rx,
+            at_prompt,
+        );
+    });
+}
+
+fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mpsc::Receiver<()>) {
+    let stdin = std::io::stdin();
+    let mut buf = String::new();
+    loop {
+        buf.clear();
+        // Scope the stdin lock to the read: holding it while waiting on
+        // the ack channel would deadlock the elicitation handler, which
+        // reads stdin during a foreground tool call.
+        let read = {
+            let mut lock = stdin.lock();
+            std::io::BufRead::read_line(&mut lock, &mut buf)
+        };
+        match read {
+            Ok(0) | Err(_) => {
+                let _ = line_tx.blocking_send("quit".to_string());
+                break;
+            }
+            Ok(_) => {
+                if line_tx
+                    .blocking_send(buf.trim_end_matches('\n').to_string())
+                    .is_err()
+                    || ack_rx.recv().is_err()
+                {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn run_interactive(
+    server_name: String,
+    surface: Arc<RwLock<Surface>>,
+    client: Arc<McpClient>,
+    runtime: tokio::runtime::Handle,
+    line_tx: &tokio::sync::mpsc::Sender<String>,
+    ack_rx: &std::sync::mpsc::Receiver<()>,
+    at_prompt: Arc<AtomicBool>,
+) {
+    let completer = ReplCompleter::new(surface.clone(), client, runtime);
+    let highlighter = ReplHighlighter::new(surface);
+
+    let menu = ColumnarMenu::default().with_name(MENU_NAME);
+    let mut keybindings = default_emacs_keybindings();
+    keybindings.add_binding(
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        ReedlineEvent::UntilFound(vec![
+            ReedlineEvent::Menu(MENU_NAME.to_string()),
+            ReedlineEvent::MenuNext,
+        ]),
+    );
+
+    let mut editor = Reedline::create()
+        .with_completer(Box::new(completer))
+        .with_menu(ReedlineMenu::EngineCompleter(Box::new(menu)))
+        .with_edit_mode(Box::new(Emacs::new(keybindings)))
+        .with_highlighter(Box::new(highlighter))
+        .with_hinter(Box::new(
+            DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),
+        ))
+        .with_ansi_colors(style::colors_enabled());
+
+    let prompt = ReplPrompt { server_name };
+    loop {
+        at_prompt.store(true, Ordering::SeqCst);
+        let sig = editor.read_line(&prompt);
+        at_prompt.store(false, Ordering::SeqCst);
+        match sig {
+            Ok(Signal::Success(line)) => {
+                if line_tx.blocking_send(line).is_err() {
+                    break;
+                }
+                // Wait until the command finished printing before showing
+                // the next prompt.
+                if ack_rx.recv().is_err() {
+                    break;
+                }
+            }
+            Ok(Signal::CtrlC) => continue,
+            _ => {
+                let _ = line_tx.blocking_send("quit".to_string());
+                break;
+            }
+        }
+    }
+}

--- a/examples/mcp-repl/src/elicit.rs
+++ b/examples/mcp-repl/src/elicit.rs
@@ -1,0 +1,208 @@
+//! Terminal elicitation: when a server-side tool calls `elicitation/create`,
+//! prompt the user for the requested fields on stdin.
+//!
+//! This works because during a foreground tool call the readline thread is
+//! parked on the ack channel, not reading stdin, so plain blocking reads
+//! are safe. If the editor currently owns the terminal (a background task
+//! elicited while the user sits at the prompt), the request is declined
+//! rather than fighting reedline for raw-mode stdin.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use async_trait::async_trait;
+use nu_ansi_term::{Color, Style};
+use tower_mcp::client::{ClientHandler, NotificationHandler, ServerNotification};
+use tower_mcp::error::JsonRpcError;
+use tower_mcp::protocol::{
+    ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitRequestParams, ElicitResult,
+    PrimitiveSchemaDefinition,
+};
+
+use crate::style::{paint, tag};
+
+/// Client handler that layers terminal elicitation on top of the
+/// notification callbacks.
+pub struct ReplClientHandler {
+    notifications: NotificationHandler,
+    at_prompt: Arc<AtomicBool>,
+}
+
+impl ReplClientHandler {
+    pub fn new(notifications: NotificationHandler, at_prompt: Arc<AtomicBool>) -> Self {
+        Self {
+            notifications,
+            at_prompt,
+        }
+    }
+}
+
+#[async_trait]
+impl ClientHandler for ReplClientHandler {
+    async fn handle_elicit(
+        &self,
+        params: ElicitRequestParams,
+    ) -> Result<ElicitResult, JsonRpcError> {
+        match params {
+            ElicitRequestParams::Url(url) => {
+                println!(
+                    "{} {}",
+                    tag(Style::new().fg(Color::Purple), "elicit"),
+                    url.message
+                );
+                println!("  open: {}", paint(Style::new().underline(), &url.url));
+                Ok(ElicitResult {
+                    action: ElicitAction::Accept,
+                    content: None,
+                    meta: None,
+                })
+            }
+            ElicitRequestParams::Form(form) => {
+                if self.at_prompt.load(Ordering::SeqCst) {
+                    // The editor owns the terminal in raw mode; a second
+                    // stdin reader would corrupt it. Decline.
+                    println!(
+                        "\n{} declined a form request from the server (arrived while at the \
+                         prompt; run the tool in the foreground to answer it)",
+                        tag(Style::new().fg(Color::Purple), "elicit"),
+                    );
+                    return Ok(ElicitResult::decline());
+                }
+                // Blocking stdin reads must leave the async runtime.
+                tokio::task::spawn_blocking(move || prompt_form(&form))
+                    .await
+                    .map_err(|e| JsonRpcError::internal_error(e.to_string()))
+            }
+            _ => Ok(ElicitResult::decline()),
+        }
+    }
+
+    async fn on_notification(&self, notification: ServerNotification) {
+        self.notifications.on_notification(notification).await;
+    }
+}
+
+/// Prompt for each field of a form elicitation on stdin. EOF at any point
+/// cancels. Empty input picks the default when one exists, otherwise skips
+/// optional fields.
+fn prompt_form(form: &ElicitFormParams) -> ElicitResult {
+    println!(
+        "{} {}",
+        tag(Style::new().fg(Color::Purple), "elicit"),
+        form.message
+    );
+    let mut content: HashMap<String, ElicitFieldValue> = HashMap::new();
+    let mut names: Vec<&String> = form.requested_schema.properties.keys().collect();
+    names.sort();
+    for name in names {
+        let schema = &form.requested_schema.properties[name];
+        let required = form.requested_schema.required.iter().any(|r| r == name);
+        let (ty, detail, default) = describe_field(schema);
+        let mut prompt_line = format!("  {} ({ty}", paint(Style::new().fg(Color::Cyan), name));
+        if required {
+            prompt_line.push_str(", required");
+        }
+        if let Some(d) = &default {
+            prompt_line.push_str(&format!(", default {d}"));
+        }
+        prompt_line.push(')');
+        if let Some(detail) = detail {
+            prompt_line.push_str(&format!(" {}", paint(Style::new().dimmed(), &detail)));
+        }
+        println!("{prompt_line}");
+        loop {
+            print!("  {name}> ");
+            let _ = std::io::stdout().flush();
+            let mut buf = String::new();
+            let read = {
+                let mut lock = std::io::stdin().lock();
+                std::io::BufRead::read_line(&mut lock, &mut buf)
+            };
+            match read {
+                Ok(0) | Err(_) => return ElicitResult::cancel(),
+                Ok(_) => {}
+            }
+            let raw = buf.trim();
+            if raw.is_empty() {
+                match (&default, required) {
+                    (Some(d), _) => {
+                        content.insert(name.clone(), coerce_field(schema, d));
+                        break;
+                    }
+                    (None, false) => break,
+                    (None, true) => {
+                        println!("  (required)");
+                        continue;
+                    }
+                }
+            }
+            content.insert(name.clone(), coerce_field(schema, raw));
+            break;
+        }
+    }
+    ElicitResult::accept(content)
+}
+
+/// Type label, optional detail (description or enum choices), and default
+/// value for a field schema.
+fn describe_field(schema: &PrimitiveSchemaDefinition) -> (String, Option<String>, Option<String>) {
+    match schema {
+        PrimitiveSchemaDefinition::String(s) => (
+            "string".to_string(),
+            s.description.clone(),
+            s.default.clone(),
+        ),
+        PrimitiveSchemaDefinition::Integer(s) => (
+            "integer".to_string(),
+            s.description.clone(),
+            s.default.map(|d| d.to_string()),
+        ),
+        PrimitiveSchemaDefinition::Number(s) => (
+            "number".to_string(),
+            s.description.clone(),
+            s.default.map(|d| d.to_string()),
+        ),
+        PrimitiveSchemaDefinition::Boolean(s) => (
+            "boolean".to_string(),
+            s.description.clone(),
+            s.default.map(|d| d.to_string()),
+        ),
+        PrimitiveSchemaDefinition::SingleSelectEnum(s) => (
+            format!("one of {}", s.enum_values.join("|")),
+            s.description.clone(),
+            s.default.clone(),
+        ),
+        PrimitiveSchemaDefinition::MultiSelectEnum(s) => (
+            "comma-separated list".to_string(),
+            s.description.clone(),
+            None,
+        ),
+        _ => ("value".to_string(), None, None),
+    }
+}
+
+/// Coerce raw input to the field's declared type, falling back to the raw
+/// string when parsing fails (the server validates anyway).
+fn coerce_field(schema: &PrimitiveSchemaDefinition, raw: &str) -> ElicitFieldValue {
+    match schema {
+        PrimitiveSchemaDefinition::Integer(_) => raw
+            .parse::<i64>()
+            .map(ElicitFieldValue::Integer)
+            .unwrap_or_else(|_| ElicitFieldValue::String(raw.to_string())),
+        PrimitiveSchemaDefinition::Number(_) => raw
+            .parse::<f64>()
+            .map(ElicitFieldValue::Number)
+            .unwrap_or_else(|_| ElicitFieldValue::String(raw.to_string())),
+        PrimitiveSchemaDefinition::Boolean(_) => match raw.to_ascii_lowercase().as_str() {
+            "true" | "yes" | "y" | "1" => ElicitFieldValue::Boolean(true),
+            "false" | "no" | "n" | "0" => ElicitFieldValue::Boolean(false),
+            _ => ElicitFieldValue::String(raw.to_string()),
+        },
+        PrimitiveSchemaDefinition::MultiSelectEnum(_) => {
+            ElicitFieldValue::StringArray(raw.split(',').map(|s| s.trim().to_string()).collect())
+        }
+        _ => ElicitFieldValue::String(raw.to_string()),
+    }
+}

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -22,25 +22,28 @@
 //! task id immediately; `jobs`, `task <id>`, `wait <id>`, and `cancel <id>`
 //! manage it.
 
+mod editor;
+mod elicit;
+mod style;
+
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use clap::Parser;
-use rustyline::completion::{Completer, Pair};
-use rustyline::error::ReadlineError;
-use rustyline::highlight::Highlighter;
-use rustyline::hint::Hinter;
-use rustyline::validate::Validator;
-use rustyline::{Editor, Helper, history::DefaultHistory};
+use nu_ansi_term::{Color, Style};
 
 use tower_mcp::client::{
     ChannelTransport, HttpClientTransport, McpClient, NotificationHandler, StdioClientTransport,
 };
 use tower_mcp::protocol::{
-    Content, PromptDefinition, ResourceDefinition, ResourceTemplateDefinition, TaskObject,
-    ToolDefinition,
+    Content, LogLevel, PromptDefinition, ResourceDefinition, ResourceTemplateDefinition,
+    TaskObject, ToolDefinition,
 };
+
+use elicit::ReplClientHandler;
+use style::{json_pretty, paint, tag, task_status_style};
 
 #[derive(Parser)]
 #[command(
@@ -58,6 +61,10 @@ struct Args {
     #[arg(long, conflicts_with_all = ["http", "command"])]
     demo: bool,
 
+    /// When to emit ANSI colors (auto detects tty and NO_COLOR).
+    #[arg(long, value_enum, default_value = "auto")]
+    color: style::ColorMode,
+
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
 }
@@ -65,201 +72,34 @@ struct Args {
 /// The server surface the REPL turns into commands. Refreshed on connect
 /// and whenever a list_changed notification arrives.
 #[derive(Default)]
-struct Surface {
-    tools: Vec<ToolDefinition>,
-    prompts: Vec<PromptDefinition>,
-    resources: Vec<ResourceDefinition>,
-    templates: Vec<ResourceTemplateDefinition>,
+pub struct Surface {
+    pub tools: Vec<ToolDefinition>,
+    pub prompts: Vec<PromptDefinition>,
+    pub resources: Vec<ResourceDefinition>,
+    pub templates: Vec<ResourceTemplateDefinition>,
 }
 
-const BUILTINS: &[&str] = &[
-    "help",
-    "tools",
-    "prompts",
-    "resources",
-    "templates",
-    "read",
-    "prompt",
-    "call",
-    "jobs",
-    "task",
-    "wait",
-    "cancel",
-    "refresh",
-    "info",
-    "quit",
-    "exit",
+/// Built-in commands with the short descriptions shown in the completion
+/// menu and `help`.
+pub const BUILTINS: &[(&str, &str)] = &[
+    ("help", "list built-ins and the server's tools"),
+    ("tools", "list tools"),
+    ("prompts", "list prompts"),
+    ("resources", "list resources"),
+    ("templates", "list resource templates"),
+    ("describe", "show schemas and metadata for a name"),
+    ("read", "read a resource"),
+    ("prompt", "get a prompt"),
+    ("call", "call a tool with raw JSON"),
+    ("jobs", "list background tasks"),
+    ("task", "show a background task"),
+    ("wait", "wait for a background task"),
+    ("cancel", "cancel a background task"),
+    ("refresh", "re-fetch the server surface"),
+    ("info", "server info and capabilities"),
+    ("quit", "exit"),
+    ("exit", "exit"),
 ];
-
-struct ReplHelper {
-    surface: Arc<RwLock<Surface>>,
-    client: Arc<McpClient>,
-    runtime: tokio::runtime::Handle,
-}
-
-impl ReplHelper {
-    /// Server-powered completion for prompt argument values. Safe to block
-    /// here: the completer runs on the dedicated readline thread, outside
-    /// the async runtime.
-    fn complete_via_server(&self, prompt: &str, arg: &str, partial: &str) -> Vec<String> {
-        let client = self.client.clone();
-        let (prompt, arg, partial) = (prompt.to_string(), arg.to_string(), partial.to_string());
-        self.runtime
-            .block_on(async move {
-                tokio::time::timeout(
-                    Duration::from_secs(2),
-                    client.complete_prompt_arg(&prompt, &arg, &partial),
-                )
-                .await
-            })
-            .ok()
-            .and_then(|r| r.ok())
-            .map(|r| r.completion.values)
-            .unwrap_or_default()
-    }
-}
-
-fn pair(s: &str) -> Pair {
-    Pair {
-        display: s.to_string(),
-        replacement: s.to_string(),
-    }
-}
-
-impl Completer for ReplHelper {
-    type Candidate = Pair;
-
-    fn complete(
-        &self,
-        line: &str,
-        pos: usize,
-        _ctx: &rustyline::Context<'_>,
-    ) -> rustyline::Result<(usize, Vec<Pair>)> {
-        let head = &line[..pos];
-        let (word_start, word) = match head.rfind(char::is_whitespace) {
-            Some(i) => (i + 1, &head[i + 1..]),
-            None => (0, head),
-        };
-        let surface = self.surface.read().unwrap();
-        let mut out: Vec<Pair> = Vec::new();
-
-        let mut words = head.split_whitespace();
-        let first = words.next().unwrap_or("");
-        let completing_first = word_start == 0;
-
-        if completing_first {
-            // First word: built-ins plus every tool name.
-            out.extend(
-                BUILTINS
-                    .iter()
-                    .filter(|c| c.starts_with(word))
-                    .map(|c| pair(c)),
-            );
-            out.extend(
-                surface
-                    .tools
-                    .iter()
-                    .filter(|t| t.name.starts_with(word))
-                    .map(|t| pair(&t.name)),
-            );
-        } else {
-            match first {
-                "read" => {
-                    out.extend(
-                        surface
-                            .resources
-                            .iter()
-                            .filter(|r| r.uri.starts_with(word))
-                            .map(|r| pair(&r.uri)),
-                    );
-                    out.extend(
-                        surface
-                            .templates
-                            .iter()
-                            .filter(|t| t.uri_template.starts_with(word))
-                            .map(|t| pair(&t.uri_template)),
-                    );
-                }
-                "prompt" => {
-                    let second_word = head.split_whitespace().count() == 2 && !head.ends_with(' ');
-                    let naming_prompt = second_word || (head.split_whitespace().count() == 1);
-                    if naming_prompt {
-                        out.extend(
-                            surface
-                                .prompts
-                                .iter()
-                                .filter(|p| p.name.starts_with(word))
-                                .map(|p| pair(&p.name)),
-                        );
-                    } else if let Some(prompt_name) = head.split_whitespace().nth(1) {
-                        if let Some((arg_name, partial)) = word.split_once('=') {
-                            // Argument value: ask the server (completion/complete).
-                            for v in self.complete_via_server(prompt_name, arg_name, partial) {
-                                out.push(Pair {
-                                    display: v.clone(),
-                                    replacement: format!("{arg_name}={v}"),
-                                });
-                            }
-                        } else if let Some(p) =
-                            surface.prompts.iter().find(|p| p.name == prompt_name)
-                        {
-                            // Argument name: from the prompt definition.
-                            out.extend(
-                                p.arguments
-                                    .iter()
-                                    .filter(|a| a.name.starts_with(word))
-                                    .map(|a| Pair {
-                                        display: format!(
-                                            "{}{}",
-                                            a.name,
-                                            if a.required { " (required)" } else { "" }
-                                        ),
-                                        replacement: format!("{}=", a.name),
-                                    }),
-                            );
-                        }
-                    }
-                }
-                "call" | "task" | "wait" | "cancel" => {
-                    if first == "call" {
-                        out.extend(
-                            surface
-                                .tools
-                                .iter()
-                                .filter(|t| t.name.starts_with(word))
-                                .map(|t| pair(&t.name)),
-                        );
-                    }
-                }
-                tool_name => {
-                    // Dynamic tool command: complete argument names from the
-                    // tool's inputSchema properties.
-                    if let Some(tool) = surface.tools.iter().find(|t| t.name == tool_name)
-                        && !word.contains('=')
-                        && let Some(props) = tool
-                            .input_schema
-                            .get("properties")
-                            .and_then(|p| p.as_object())
-                    {
-                        out.extend(props.keys().filter(|k| k.starts_with(word)).map(|k| Pair {
-                            display: k.to_string(),
-                            replacement: format!("{k}="),
-                        }));
-                    }
-                }
-            }
-        }
-
-        Ok((word_start, out))
-    }
-}
-
-impl Hinter for ReplHelper {
-    type Hint = String;
-}
-impl Highlighter for ReplHelper {}
-impl Validator for ReplHelper {}
-impl Helper for ReplHelper {}
 
 /// Coerce a `key=value` string according to the tool's inputSchema.
 fn coerce_arg(schema: &serde_json::Value, key: &str, raw: &str) -> serde_json::Value {
@@ -312,7 +152,13 @@ fn parse_kv_args(schema: &serde_json::Value, tokens: &[&str]) -> serde_json::Val
 fn render_content(content: &[Content]) {
     for c in content {
         match c {
-            Content::Text { text, .. } => println!("{text}"),
+            Content::Text { text, .. } => {
+                if style::colors_enabled() && style::looks_like_markdown(text) {
+                    println!("{}", style::render_markdown(text));
+                } else {
+                    println!("{text}");
+                }
+            }
             other => {
                 let v = serde_json::to_value(other).unwrap_or_default();
                 let ty = v.get("type").and_then(|t| t.as_str()).unwrap_or("content");
@@ -320,9 +166,12 @@ fn render_content(content: &[Content]) {
                     "image" | "audio" => {
                         let mime = v.get("mimeType").and_then(|m| m.as_str()).unwrap_or("?");
                         let len = v.get("data").and_then(|d| d.as_str()).map_or(0, str::len);
-                        println!("[{ty} {mime}, {len} base64 chars]");
+                        println!(
+                            "{}",
+                            tag(Style::new(), &format!("{ty} {mime}, {len} base64 chars"))
+                        );
                     }
-                    _ => println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default()),
+                    _ => println!("{}", json_pretty(&v)),
                 }
             }
         }
@@ -332,15 +181,15 @@ fn render_content(content: &[Content]) {
 fn render_task(task: &TaskObject) {
     println!(
         "task {}  status={}  {}",
-        task.task_id,
-        task.status,
+        paint(Style::new().bold(), &task.task_id),
+        paint(task_status_style(task.status), &task.status.to_string()),
         task.status_message.as_deref().unwrap_or("")
     );
     if let Some(result) = &task.result {
         render_content(&result.content);
     }
     if let Some(err) = &task.error {
-        println!("error {}: {}", err.code, err.message);
+        println!("{} {}: {}", style::error_prefix(), err.code, err.message);
     }
 }
 
@@ -364,15 +213,88 @@ async fn fetch_surface(client: &McpClient) -> Surface {
 
 fn demo_router() -> tower_mcp::McpRouter {
     use tower_mcp::extract::RawArgs;
-    use tower_mcp::{CallToolResult, TaskSupportMode, ToolBuilder};
+    use tower_mcp::protocol::{CompleteResult, CompletionReference, ReadResourceResult};
+    use tower_mcp::resource::ResourceTemplateBuilder;
+    use tower_mcp::{CallToolResult, PromptBuilder, TaskSupportMode, ToolBuilder};
+
+    const NOTES: &[(&str, &str)] = &[
+        ("groceries", "- eggs\n- coffee"),
+        ("ideas", "# Ideas\n\n- a REPL for MCP servers"),
+        ("todo", "1. ship it"),
+    ];
+
     tower_mcp::McpRouter::new()
         .server_info("mcp-repl-demo", env!("CARGO_PKG_VERSION"))
+        .prompt(
+            PromptBuilder::new("greet")
+                .description("Generate a greeting (name tab-completes via the server)")
+                .required_arg("name", "The person to greet")
+                .handler(|args| async move {
+                    let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
+                    Ok(tower_mcp::GetPromptResult::user_message(format!(
+                        "Please greet {name} warmly."
+                    )))
+                })
+                .build(),
+        )
+        .resource_template(
+            ResourceTemplateBuilder::new("note://{name}")
+                .name("Notes")
+                .description("Tiny in-memory notes (name tab-completes via the server)")
+                .mime_type("text/markdown")
+                .handler(
+                    |uri: String, vars: std::collections::HashMap<String, String>| async move {
+                        let name = vars.get("name").cloned().unwrap_or_default();
+                        let text = NOTES
+                            .iter()
+                            .find(|(n, _)| *n == name)
+                            .map(|(_, t)| (*t).to_string())
+                            .unwrap_or_else(|| format!("no note named `{name}`"));
+                        Ok(ReadResourceResult::text(uri, text))
+                    },
+                ),
+        )
+        .completion_handler(|params| async move {
+            let partial = params.argument.value;
+            let candidates: Vec<String> = match &params.reference {
+                CompletionReference::Prompt { name } if name == "greet" => {
+                    ["Ada", "Alan", "Grace", "Linus"]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect()
+                }
+                CompletionReference::Resource { uri } if uri == "note://{name}" => {
+                    NOTES.iter().map(|(n, _)| n.to_string()).collect()
+                }
+                _ => Vec::new(),
+            };
+            Ok(CompleteResult::new(
+                candidates
+                    .into_iter()
+                    .filter(|c| c.starts_with(&partial))
+                    .collect::<Vec<_>>(),
+            ))
+        })
         .tool(
             ToolBuilder::new("echo")
                 .description("Echo a message back")
                 .extractor_handler((), |RawArgs(args): RawArgs| async move {
                     let msg = args.get("message").and_then(|v| v.as_str()).unwrap_or("");
                     Ok(CallToolResult::text(msg.to_string()))
+                })
+                .build(),
+        )
+        .tool(
+            ToolBuilder::new("about")
+                .description("Markdown-formatted notes about this demo server")
+                .extractor_handler((), |RawArgs(_): RawArgs| async move {
+                    Ok(CallToolResult::text(
+                        "# mcp-repl demo\n\n\
+                         A tiny in-process router for exploring the REPL.\n\n\
+                         - `echo message=hi` echoes back\n\
+                         - `slow_add a=2 b=3 &` runs **task-augmented**\n\
+                         - `describe slow_add` shows the tool's schemas\n",
+                    ))
                 })
                 .build(),
         )
@@ -390,6 +312,17 @@ fn demo_router() -> tower_mcp::McpRouter {
         )
 }
 
+fn log_level_style(level: LogLevel) -> Style {
+    match level {
+        LogLevel::Emergency | LogLevel::Alert | LogLevel::Critical | LogLevel::Error => {
+            Style::new().fg(Color::Red)
+        }
+        LogLevel::Warning => Style::new().fg(Color::Yellow),
+        LogLevel::Notice | LogLevel::Info => Style::new().fg(Color::Green),
+        _ => Style::new().dimmed(),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), tower_mcp::BoxError> {
     tracing_subscriber::fmt()
@@ -398,10 +331,16 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         )
         .init();
     let args = Args::parse();
+    style::init(args.color);
+
+    // True while the reedline editor owns the terminal; the elicitation
+    // handler declines form requests during that window instead of
+    // fighting over raw-mode stdin.
+    let at_prompt = Arc::new(AtomicBool::new(false));
 
     // Notifications print inline and trigger surface refreshes.
     let (refresh_tx, mut refresh_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-    let handler = {
+    let notifications = {
         let t = refresh_tx.clone();
         let r = refresh_tx.clone();
         let p = refresh_tx;
@@ -418,25 +357,39 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             .on_progress(|p| {
                 let pct = match (p.progress, p.total) {
                     (done, Some(total)) if total > 0.0 => {
-                        format!(" ({:.0}%)", 100.0 * done / total)
+                        format!(" {:.0}%", 100.0 * done / total)
                     }
                     _ => String::new(),
                 };
-                println!("[progress{pct}] {}", p.message.as_deref().unwrap_or(""));
+                println!(
+                    "{} {}",
+                    tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
+                    p.message.as_deref().unwrap_or("")
+                );
             })
             .on_log_message(|m| {
-                println!("[log {:?}] {}", m.level, m.data);
+                println!(
+                    "{} {}",
+                    tag(log_level_style(m.level), &format!("log {}", m.level)),
+                    m.data
+                );
             })
     };
+    let handler = ReplClientHandler::new(notifications, at_prompt.clone());
 
+    let builder = McpClient::builder().with_elicitation();
     let client = if args.demo {
-        McpClient::connect_with_handler(ChannelTransport::new(demo_router()), handler).await?
+        builder
+            .connect(ChannelTransport::new(demo_router()), handler)
+            .await?
     } else if let Some(url) = &args.http {
-        McpClient::connect_with_handler(HttpClientTransport::new(url.clone()), handler).await?
+        builder
+            .connect(HttpClientTransport::new(url.clone()), handler)
+            .await?
     } else if !args.command.is_empty() {
         let cmd_args: Vec<&str> = args.command[1..].iter().map(|s| s.as_str()).collect();
         let transport = StdioClientTransport::spawn(&args.command[0], &cmd_args).await?;
-        McpClient::connect_with_handler(transport, handler).await?
+        builder.connect(transport, handler).await?
     } else {
         eprintln!("usage: mcp-repl <server command...> | --http <url> | --demo");
         std::process::exit(2);
@@ -448,11 +401,20 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .await?;
     let server_name = init.server_info.name.clone();
     println!(
-        "connected: {} v{} (protocol {})",
-        server_name, init.server_info.version, init.protocol_version
+        "connected: {} v{} {}",
+        paint(Style::new().bold(), &server_name),
+        init.server_info.version,
+        paint(
+            Style::new().dimmed(),
+            &format!("(protocol {})", init.protocol_version)
+        )
     );
     if let Some(instructions) = &init.instructions {
-        println!("{instructions}");
+        if style::colors_enabled() && style::looks_like_markdown(instructions) {
+            println!("{}", style::render_markdown(instructions));
+        } else {
+            println!("{instructions}");
+        }
     }
 
     let surface = Arc::new(RwLock::new(fetch_surface(&client).await));
@@ -470,39 +432,15 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // Readline runs on its own thread; lines cross into async via channels.
     let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(1);
     let (ack_tx, ack_rx) = std::sync::mpsc::channel::<()>();
-    {
-        let helper = ReplHelper {
-            surface: surface.clone(),
-            client: client.clone(),
-            runtime: tokio::runtime::Handle::current(),
-        };
-        let prompt = format!("{server_name}> ");
-        std::thread::spawn(move || {
-            let mut editor: Editor<ReplHelper, DefaultHistory> =
-                Editor::new().expect("failed to init line editor");
-            editor.set_helper(Some(helper));
-            loop {
-                match editor.readline(&prompt) {
-                    Ok(line) => {
-                        let _ = editor.add_history_entry(line.as_str());
-                        if line_tx.blocking_send(line).is_err() {
-                            break;
-                        }
-                        // Wait until the command finished printing before
-                        // showing the next prompt.
-                        if ack_rx.recv().is_err() {
-                            break;
-                        }
-                    }
-                    Err(ReadlineError::Interrupted) => continue,
-                    Err(_) => {
-                        let _ = line_tx.blocking_send("quit".to_string());
-                        break;
-                    }
-                }
-            }
-        });
-    }
+    editor::spawn_readline_thread(
+        server_name,
+        surface.clone(),
+        client.clone(),
+        tokio::runtime::Handle::current(),
+        line_tx,
+        ack_rx,
+        at_prompt,
+    );
 
     let mut jobs: Vec<(String, String)> = Vec::new();
 
@@ -510,7 +448,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         tokio::select! {
             Some(()) = refresh_rx.recv() => {
                 let fresh = fetch_surface(&client).await;
-                println!("[surface changed: {} tools, {} prompts, {} resources]",
+                println!("{} {} tools, {} prompts, {} resources",
+                    tag(Style::new().fg(Color::Cyan), "surface changed"),
                     fresh.tools.len(), fresh.prompts.len(), fresh.resources.len());
                 *surface.write().unwrap() = fresh;
             }
@@ -541,6 +480,9 @@ async fn handle_line(
     if background {
         tokens.pop();
     }
+    if tokens.is_empty() {
+        return false;
+    }
     let cmd = tokens[0];
     let rest = &tokens[1..];
 
@@ -549,6 +491,7 @@ async fn handle_line(
         "help" => {
             println!("built-ins:");
             println!("  tools | prompts | resources | templates   list the server surface");
+            println!("  describe <name>                           schemas and metadata");
             println!("  read <uri>                                read a resource");
             println!("  prompt <name> [k=v...]                    get a prompt");
             println!("  call <tool> <json>                        call a tool with raw JSON");
@@ -560,7 +503,11 @@ async fn handle_line(
             if !s.tools.is_empty() {
                 println!("tools:");
                 for t in &s.tools {
-                    println!("  {:24} {}", t.name, t.description.as_deref().unwrap_or(""));
+                    println!(
+                        "  {:24} {}",
+                        paint(Style::new().fg(Color::Green), &t.name),
+                        t.description.as_deref().unwrap_or("")
+                    );
                 }
             }
         }
@@ -569,7 +516,11 @@ async fn handle_line(
             match cmd {
                 "tools" => {
                     for t in &s.tools {
-                        println!("{:24} {}", t.name, t.description.as_deref().unwrap_or(""));
+                        println!(
+                            "{:24} {}",
+                            paint(Style::new().fg(Color::Green), &t.name),
+                            t.description.as_deref().unwrap_or("")
+                        );
                     }
                 }
                 "prompts" => {
@@ -587,23 +538,38 @@ async fn handle_line(
                             .collect();
                         println!(
                             "{:24} {} {}",
-                            p.name,
-                            args.join(" "),
+                            paint(Style::new().fg(Color::Green), &p.name),
+                            paint(Style::new().fg(Color::Cyan), &args.join(" ")),
                             p.description.as_deref().unwrap_or("")
                         );
                     }
                 }
                 "resources" => {
                     for r in &s.resources {
-                        println!("{:40} {}", r.uri, r.name);
+                        println!(
+                            "{:40} {}",
+                            paint(Style::new().fg(Color::Green), &r.uri),
+                            r.name
+                        );
                     }
                 }
                 _ => {
                     for t in &s.templates {
-                        println!("{:40} {}", t.uri_template, t.name);
+                        println!(
+                            "{:40} {}",
+                            paint(Style::new().fg(Color::Green), &t.uri_template),
+                            t.name
+                        );
                     }
                 }
             }
+        }
+        "describe" => {
+            let Some(name) = rest.first() else {
+                println!("usage: describe <tool|prompt|resource|template>");
+                return false;
+            };
+            describe(&surface.read().unwrap(), name);
         }
         "read" => {
             let Some(uri) = rest.first() else {
@@ -614,13 +580,25 @@ async fn handle_line(
                 Ok(result) => {
                     for c in result.contents {
                         if let Some(text) = c.text {
-                            println!("{text}");
+                            let is_md = c
+                                .mime_type
+                                .as_deref()
+                                .is_some_and(|m| m.contains("markdown"))
+                                || style::looks_like_markdown(&text);
+                            if style::colors_enabled() && is_md {
+                                println!("{}", style::render_markdown(&text));
+                            } else {
+                                println!("{text}");
+                            }
                         } else if let Some(blob) = c.blob {
-                            println!("[binary {} base64 chars]", blob.len());
+                            println!(
+                                "{}",
+                                tag(Style::new(), &format!("binary {} base64 chars", blob.len()))
+                            );
                         }
                     }
                 }
-                Err(e) => println!("error: {e}"),
+                Err(e) => println!("{}: {e}", style::error_prefix()),
             }
         }
         "prompt" => {
@@ -646,10 +624,10 @@ async fn handle_line(
                             .unwrap_or_else(|| {
                                 v.get("content").map(|c| c.to_string()).unwrap_or_default()
                             });
-                        println!("[{role}] {text}");
+                        println!("{} {}", tag(Style::new().fg(Color::Cyan), role), text);
                     }
                 }
-                Err(e) => println!("error: {e}"),
+                Err(e) => println!("{}: {e}", style::error_prefix()),
             }
         }
         "call" => {
@@ -673,7 +651,10 @@ async fn handle_line(
             }
             for (id, tool) in jobs.iter() {
                 match client.task_get(id).await {
-                    Ok(task) => println!("{id}  {tool}  {}", task.status),
+                    Ok(task) => println!(
+                        "{id}  {tool}  {}",
+                        paint(task_status_style(task.status), &task.status.to_string())
+                    ),
                     Err(_) => println!("{id}  {tool}  (gone)"),
                 }
             }
@@ -696,7 +677,7 @@ async fn handle_line(
             };
             match outcome {
                 Ok(task) => render_task(&task),
-                Err(e) => println!("error: {e}"),
+                Err(e) => println!("{}: {e}", style::error_prefix()),
             }
         }
         "refresh" => {
@@ -712,12 +693,14 @@ async fn handle_line(
         }
         "info" => match client.server_info().await {
             Some(info) => {
-                println!("{} v{}", info.server_info.name, info.server_info.version);
-                println!("protocol: {}", info.protocol_version);
                 println!(
-                    "capabilities: {}",
-                    serde_json::to_string_pretty(&info.capabilities).unwrap_or_default()
+                    "{} v{}",
+                    paint(Style::new().bold(), &info.server_info.name),
+                    info.server_info.version
                 );
+                println!("protocol: {}", info.protocol_version);
+                let caps = serde_json::to_value(&info.capabilities).unwrap_or_default();
+                println!("capabilities: {}", json_pretty(&caps));
             }
             None => println!("not initialized"),
         },
@@ -730,7 +713,10 @@ async fn handle_line(
                     .map(|t| t.input_schema.clone())
             };
             let Some(schema) = schema else {
-                println!("unknown command: {tool_name} (try `help`)");
+                println!(
+                    "unknown command: {} (try `help`)",
+                    paint(Style::new().fg(Color::Red), tool_name)
+                );
                 return false;
             };
             let arguments = parse_kv_args(&schema, rest);
@@ -738,6 +724,124 @@ async fn handle_line(
         }
     }
     false
+}
+
+/// The `describe` built-in: schemas for a tool, the argument table for a
+/// prompt, metadata for a resource or template.
+fn describe(surface: &Surface, name: &str) {
+    if let Some(t) = surface.tools.iter().find(|t| t.name == name) {
+        println!(
+            "tool {}  {}",
+            paint(Style::new().fg(Color::Green).bold(), &t.name),
+            t.description.as_deref().unwrap_or("")
+        );
+        if let Some(a) = &t.annotations {
+            let mut hints = Vec::new();
+            if a.read_only_hint {
+                hints.push("read-only");
+            }
+            if a.idempotent_hint {
+                hints.push("idempotent");
+            }
+            if a.destructive_hint && !a.read_only_hint {
+                hints.push("destructive");
+            }
+            if a.open_world_hint {
+                hints.push("open-world");
+            }
+            if !hints.is_empty() {
+                println!("  hints: {}", hints.join(", "));
+            }
+        }
+        if let Some(e) = &t.execution {
+            let v = serde_json::to_value(e).unwrap_or_default();
+            if let Some(mode) = v.get("taskSupport").and_then(|m| m.as_str()) {
+                println!("  task support: {mode}");
+            }
+        }
+        println!("input schema:");
+        println!("{}", json_pretty(&t.input_schema));
+        if let Some(out) = &t.output_schema {
+            println!("output schema:");
+            println!("{}", json_pretty(out));
+        }
+        return;
+    }
+    if let Some(p) = surface.prompts.iter().find(|p| p.name == name) {
+        println!(
+            "prompt {}  {}",
+            paint(Style::new().fg(Color::Green).bold(), &p.name),
+            p.description.as_deref().unwrap_or("")
+        );
+        if p.arguments.is_empty() {
+            println!("  (no arguments)");
+        } else {
+            println!("arguments:");
+            for a in &p.arguments {
+                println!(
+                    "  {:20} {:10} {}",
+                    paint(Style::new().fg(Color::Cyan), &a.name),
+                    if a.required { "required" } else { "optional" },
+                    a.description.as_deref().unwrap_or("")
+                );
+            }
+        }
+        return;
+    }
+    if let Some(r) = surface
+        .resources
+        .iter()
+        .find(|r| r.uri == name || r.name == name)
+    {
+        println!(
+            "resource {}",
+            paint(Style::new().fg(Color::Green).bold(), &r.uri)
+        );
+        println!("  name: {}", r.name);
+        if let Some(t) = &r.title {
+            println!("  title: {t}");
+        }
+        if let Some(d) = &r.description {
+            println!("  description: {d}");
+        }
+        if let Some(m) = &r.mime_type {
+            println!("  mimeType: {m}");
+        }
+        if let Some(s) = r.size {
+            println!("  size: {s} bytes");
+        }
+        return;
+    }
+    if let Some(t) = surface
+        .templates
+        .iter()
+        .find(|t| t.uri_template == name || t.name == name)
+    {
+        println!(
+            "template {}",
+            paint(Style::new().fg(Color::Green).bold(), &t.uri_template)
+        );
+        println!("  name: {}", t.name);
+        if let Some(d) = &t.description {
+            println!("  description: {d}");
+        }
+        if let Some(m) = &t.mime_type {
+            println!("  mimeType: {m}");
+        }
+        if !t.arguments.is_empty() {
+            println!("arguments:");
+            for a in &t.arguments {
+                println!(
+                    "  {:20} {:10} {}",
+                    paint(Style::new().fg(Color::Cyan), &a.name),
+                    if a.required { "required" } else { "optional" },
+                    a.description.as_deref().unwrap_or("")
+                );
+            }
+        }
+        return;
+    }
+    println!("nothing on the surface named `{name}` (try `tools`, `prompts`, `resources`)");
 }
 
 async fn run_tool(
@@ -750,20 +854,26 @@ async fn run_tool(
     if background {
         match client.call_tool_as_task(name, arguments, None).await {
             Ok(created) => {
-                println!("[task {}] started", created.task.task_id);
+                println!(
+                    "{} started",
+                    tag(
+                        Style::new().fg(Color::Yellow),
+                        &format!("task {}", created.task.task_id)
+                    )
+                );
                 jobs.push((created.task.task_id, name.to_string()));
             }
-            Err(e) => println!("error: {e}"),
+            Err(e) => println!("{}: {e}", style::error_prefix()),
         }
         return;
     }
     match client.call_tool(name, arguments).await {
         Ok(result) => {
             if result.is_error {
-                println!("(tool error)");
+                println!("{}", tag(Style::new().fg(Color::Red), "tool error"));
             }
             render_content(&result.content);
         }
-        Err(e) => println!("error: {e}"),
+        Err(e) => println!("{}: {e}", style::error_prefix()),
     }
 }

--- a/examples/mcp-repl/src/style.rs
+++ b/examples/mcp-repl/src/style.rs
@@ -1,0 +1,273 @@
+//! Output styling: color gating, a JSON syntax colorizer, a light
+//! markdown renderer, and status-line helpers.
+//!
+//! All color degrades to plain text when `NO_COLOR` is set or stdout is
+//! not a terminal, so piped output stays clean.
+
+use std::io::IsTerminal;
+use std::sync::OnceLock;
+
+use nu_ansi_term::{Color, Style};
+use tower_mcp::protocol::TaskStatus;
+
+/// When to emit ANSI colors.
+#[derive(Clone, Copy, Debug, Default, clap::ValueEnum)]
+pub enum ColorMode {
+    /// Color when stdout is a tty and `NO_COLOR` is unset.
+    #[default]
+    Auto,
+    /// Always color, even when piped.
+    Always,
+    /// Never color.
+    Never,
+}
+
+static ENABLED: OnceLock<bool> = OnceLock::new();
+
+/// Set the color mode once, before any output. `Always` overrides
+/// `NO_COLOR` (an explicit request wins, matching cargo's behavior).
+pub fn init(mode: ColorMode) {
+    let _ = ENABLED.set(match mode {
+        ColorMode::Auto => auto_detect(),
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+    });
+}
+
+fn auto_detect() -> bool {
+    std::env::var_os("NO_COLOR").is_none() && std::io::stdout().is_terminal()
+}
+
+/// Whether ANSI styling is active.
+pub fn colors_enabled() -> bool {
+    *ENABLED.get_or_init(auto_detect)
+}
+
+/// Apply a style if colors are enabled, otherwise return the text as-is.
+pub fn paint(style: Style, text: &str) -> String {
+    if colors_enabled() {
+        style.paint(text).to_string()
+    } else {
+        text.to_string()
+    }
+}
+
+/// A `[label]` tag with dim brackets and a styled label.
+pub fn tag(style: Style, label: &str) -> String {
+    format!(
+        "{}{}{}",
+        paint(Style::new().dimmed(), "["),
+        paint(style, label),
+        paint(Style::new().dimmed(), "]")
+    )
+}
+
+/// Style for a task status: working=yellow, completed=green,
+/// failed/cancelled=red.
+pub fn task_status_style(status: TaskStatus) -> Style {
+    match status {
+        TaskStatus::Working => Style::new().fg(Color::Yellow),
+        TaskStatus::InputRequired => Style::new().fg(Color::Purple),
+        TaskStatus::Completed => Style::new().fg(Color::Green),
+        TaskStatus::Failed | TaskStatus::Cancelled => Style::new().fg(Color::Red),
+        _ => Style::new(),
+    }
+}
+
+/// Style an error line prefix.
+pub fn error_prefix() -> String {
+    paint(Style::new().fg(Color::Red).bold(), "error")
+}
+
+// ---------------------------------------------------------------------------
+// JSON colorizer
+// ---------------------------------------------------------------------------
+
+/// Pretty-print a JSON value with syntax colors (2-space indent, same
+/// shape as `serde_json::to_string_pretty`).
+pub fn json_pretty(value: &serde_json::Value) -> String {
+    let mut out = String::new();
+    write_json(&mut out, value, 0);
+    out
+}
+
+fn write_json(out: &mut String, value: &serde_json::Value, indent: usize) {
+    let pad = "  ".repeat(indent);
+    let inner_pad = "  ".repeat(indent + 1);
+    match value {
+        serde_json::Value::Null => out.push_str(&paint(Style::new().fg(Color::Purple), "null")),
+        serde_json::Value::Bool(b) => {
+            out.push_str(&paint(
+                Style::new().fg(Color::Purple),
+                if *b { "true" } else { "false" },
+            ));
+        }
+        serde_json::Value::Number(n) => {
+            out.push_str(&paint(Style::new().fg(Color::Yellow), &n.to_string()));
+        }
+        serde_json::Value::String(s) => {
+            let quoted = serde_json::to_string(s).unwrap_or_else(|_| format!("{s:?}"));
+            out.push_str(&paint(Style::new().fg(Color::Green), &quoted));
+        }
+        serde_json::Value::Array(items) => {
+            if items.is_empty() {
+                out.push_str("[]");
+                return;
+            }
+            out.push_str("[\n");
+            for (i, item) in items.iter().enumerate() {
+                out.push_str(&inner_pad);
+                write_json(out, item, indent + 1);
+                if i + 1 < items.len() {
+                    out.push(',');
+                }
+                out.push('\n');
+            }
+            out.push_str(&pad);
+            out.push(']');
+        }
+        serde_json::Value::Object(map) => {
+            if map.is_empty() {
+                out.push_str("{}");
+                return;
+            }
+            out.push_str("{\n");
+            for (i, (key, val)) in map.iter().enumerate() {
+                let quoted = serde_json::to_string(key).unwrap_or_else(|_| format!("{key:?}"));
+                out.push_str(&inner_pad);
+                out.push_str(&paint(Style::new().fg(Color::Cyan), &quoted));
+                out.push_str(": ");
+                write_json(out, val, indent + 1);
+                if i + 1 < map.len() {
+                    out.push(',');
+                }
+                out.push('\n');
+            }
+            out.push_str(&pad);
+            out.push('}');
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Markdown rendering
+// ---------------------------------------------------------------------------
+
+/// Heuristic: does this text look like markdown worth rendering?
+/// Strong signals (headings, fences) decide immediately; weak signals
+/// (bullets, inline code, bold) count too.
+pub fn looks_like_markdown(text: &str) -> bool {
+    let mut weak_signal = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || heading_level(trimmed).is_some() {
+            return true;
+        }
+        if trimmed.starts_with("- ")
+            || trimmed.starts_with("* ")
+            || trimmed.contains("**")
+            || trimmed.chars().filter(|c| *c == '`').count() >= 2
+        {
+            weak_signal = true;
+        }
+    }
+    weak_signal
+}
+
+fn heading_level(line: &str) -> Option<usize> {
+    let hashes = line.chars().take_while(|c| *c == '#').count();
+    if (1..=6).contains(&hashes) && line[hashes..].starts_with(' ') {
+        Some(hashes)
+    } else {
+        None
+    }
+}
+
+/// Render markdown-ish text for the terminal: headings bold, fenced code
+/// dimmed, inline code and bold spans styled, list bullets colored.
+pub fn render_markdown(text: &str) -> String {
+    let mut out = String::new();
+    let mut in_fence = false;
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") {
+            in_fence = !in_fence;
+            out.push_str(&paint(Style::new().dimmed(), line));
+            out.push('\n');
+            continue;
+        }
+        if in_fence {
+            out.push_str(&paint(Style::new().dimmed(), line));
+            out.push('\n');
+            continue;
+        }
+        if let Some(level) = heading_level(trimmed) {
+            let body = trimmed[level..].trim_start();
+            let style = if level <= 2 {
+                Style::new().bold().underline()
+            } else {
+                Style::new().bold()
+            };
+            out.push_str(&paint(style, body));
+            out.push('\n');
+            continue;
+        }
+        // List bullets: color the marker, render the rest inline.
+        let indent_len = line.len() - trimmed.len();
+        if let Some(rest) = trimmed
+            .strip_prefix("- ")
+            .or_else(|| trimmed.strip_prefix("* "))
+        {
+            out.push_str(&line[..indent_len]);
+            out.push_str(&paint(Style::new().fg(Color::Cyan), "•"));
+            out.push(' ');
+            out.push_str(&render_inline(rest));
+            out.push('\n');
+            continue;
+        }
+        out.push_str(&line[..indent_len]);
+        out.push_str(&render_inline(trimmed));
+        out.push('\n');
+    }
+    // lines() drops a trailing newline; the callers print with println.
+    if out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+/// Inline spans: `` `code` `` and `**bold**` (markers stripped).
+fn render_inline(line: &str) -> String {
+    // A span is (start, marker, style); pick whichever marker comes first,
+    // consume it, repeat.
+    let mut out = String::new();
+    let mut rest = line;
+    loop {
+        let code = rest.find('`').map(|i| (i, "`"));
+        let bold = rest.find("**").map(|i| (i, "**"));
+        let next = match (code, bold) {
+            (Some(c), Some(b)) => Some(if c.0 < b.0 { c } else { b }),
+            (Some(c), None) => Some(c),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        let Some((start, marker)) = next else {
+            out.push_str(rest);
+            return out;
+        };
+        let body_start = start + marker.len();
+        let Some(len) = rest[body_start..].find(marker) else {
+            // Unterminated marker: emit the rest verbatim.
+            out.push_str(rest);
+            return out;
+        };
+        let style = if marker == "`" {
+            Style::new().fg(Color::Purple)
+        } else {
+            Style::new().bold()
+        };
+        out.push_str(&rest[..start]);
+        out.push_str(&paint(style, &rest[body_start..body_start + len]));
+        rest = &rest[body_start + len + marker.len()..];
+    }
+}


### PR DESCRIPTION
UX polish pass on the mcp-repl example (#966).

## What was done

### 1. rustyline replaced by reedline

The editor is now reedline (nushell's line editor). The architecture is unchanged: the editor runs on its own std thread, lines cross into async via a tokio mpsc channel, and an ack channel paces the prompt so it reappears only after the previous command finished printing. The completer still blocks on the readline thread, which lives outside the tokio runtime, so Handle::block_on remains safe there.

- Columnar completion menu (Tab) with per-candidate descriptions: built-ins and tools show their descriptions, tool argument names show type, required flag, and property description, prompt argument names show required flag and description.
- Enum values complete after `key=` when the tool's inputSchema property declares an `enum`.
- Server-powered completion via completion/complete for prompt argument values, ported faithfully (2s timeout, best-effort, block_on on the readline thread).
- Fish-style history hints via reedline's DefaultHinter, styled dim.
- When stdin is not a tty the REPL falls back to a plain line reader, so piped scripts keep working.

### 2. Live input highlighting

A reedline Highlighter styles the command word by validity (built-in = cyan bold, known tool = green bold, prefix of a candidate = neutral, otherwise red), `key=` argument names cyan, JSON literal values by type (strings green, numbers yellow, booleans/null purple), and a trailing `&` purple bold.

### 3. Colored output rendering

- A hand-rolled JSON syntax colorizer over serde_json::Value (cyan keys, green strings, yellow numbers, purple booleans/null) used for schema dumps, `info` capabilities, and non-text content fallback. No syntax-highlighting dependency.
- Markdown rendering is hand-rolled rather than termimad: the needs are small (headings, fences, inline code, bold, bullets) and termimad would add coolor, crokey, crossbeam, lazy-regex, and minimad to a crate being prepared for crates.io publishing. Text content is rendered when it looks like markdown (heuristic: headings or fences decide immediately, bullets/inline markers count as weak signals).
- Progress, log, and task lines are tagged with dim brackets; log levels and task statuses are colored (working=yellow, completed=green, failed/cancelled=red).
- Everything degrades to plain text when NO_COLOR is set or stdout is not a tty, and `--color always|never|auto` overrides detection (always wins over NO_COLOR, matching cargo).

### 4. describe built-in

`describe <name>` finds a tool, prompt, resource, or template: tools print behavior hints, task support, and colored input/output schemas; prompts print an argument table; resources and templates print their metadata. The argument tab-completes across the whole surface, labeled by kind, and the command appears in help.

### 5. Resource template completion

Completing `read <partial>` asks the server to complete a template's `{variable}` via complete_resource_uri once the partial covers the template's static prefix, same pattern as prompt args (2s timeout, best-effort). Verified interactively through a pty against the bundled demo router, which now registers a completion handler, a `greet` prompt, and a `note://{name}` template so every completion path is exercisable offline.

### 6. Elicitation (stretch, landed)

`McpClientBuilder::with_elicitation` plus a ClientHandler that prompts for form fields on stdin during foreground tool calls: field type, default, and description are shown, empty input picks the default, EOF cancels, values are coerced to the declared type. URL-mode requests print the URL. If a form request arrives while the reedline editor owns the terminal (a background task eliciting at the prompt), the request is declined instead of fighting the editor for raw-mode stdin; an at_prompt flag shared with the readline thread guards this. Verified end to end against the conformance server's test_elicitation and test_elicitation_sep1034_defaults tools.

Fixing this surfaced a real deadlock: the piped-stdin reader held the stdin lock across the ack wait (match-scrutinee temporary lifetime), which blocked the elicitation handler's stdin read while the server waited on the elicitation. The lock is now scoped to the read.

## Dependencies

- reedline 0.49 replaces rustyline 17 (the requested migration). Its tree swaps rustyline's nix/radix_trie/clipboard-win for crossterm/strum/strip-ansi-escapes/itertools.
- nu-ansi-term 0.50: reedline's own styling type (StyledText is built from its Style), reused for all output styling instead of adding a second color crate.
- async-trait (workspace version): required to implement ClientHandler.
- termimad was evaluated and not taken (see above).

All verified to build on MSRV 1.90 with `cargo +1.90 build`.

## Verification

- Piped smoke tests against `--demo` and `--http` (conformance server): help, describe, markdown rendering, task backgrounding, jobs/wait, elicitation with and without defaults, NO_COLOR and `--color never` degradation.
- Interactive paths (menu, highlighting, server-powered completion for prompt args and template variables) driven through a pty harness answering reedline's cursor-position query.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --all-features` (26 suites, 0 failures), `cargo build` and `cargo +1.90 build` for the crate.

During testing an intermittent "Client must send notifications/initialized before making requests" warning surfaced against the HTTP transport: the first list call raced the initialized notification. That pre-existing race was fixed on main by #969 (await notification POSTs inline); after merging main the warning no longer reproduces (0 hits in repeated runs).

This PR does not touch the [package] section; #980 (registry metadata) merged to main mid-flight and has been merged into this branch.
