### PR TITLE
docs(mcp-repl): live cratesio-mcp example and related tools

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -23,6 +23,22 @@ cargo run -p mcp-repl -- cargo run --example getting_started
 cargo run -p mcp-repl -- --http http://127.0.0.1:3001/mcp
 ```
 
+### Try it against a live server
+
+[cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp) (an MCP server
+for the crates.io registry, also built on tower-mcp) runs a public instance:
+
+```bash
+cargo run -p mcp-repl -- --http https://cratesio-mcp.fly.dev/
+```
+
+```text
+cratesio-mcp> search_crates query=tower-mcp per_page=3
+cratesio-mcp> get_crate_health name=serde
+cratesio-mcp> read crates://tokio/info
+cratesio-mcp> prompt analyze_crate crate_name=axum
+```
+
 ## What to try
 
 ```text
@@ -97,6 +113,14 @@ and description are shown, empty input accepts the default, and EOF
 cancels. Try `test_elicitation` against the conformance server. If a
 background task elicits while the editor owns the terminal, the request is
 declined rather than fighting the editor for stdin.
+
+## Related tools
+
+- [mcp-probe](https://github.com/conikeec/mcp-probe): a Rust TUI debugging
+  toolkit for MCP servers (ratatui dashboard, protocol analysis, timing
+  metrics, compliance checks). Complementary rather than overlapping:
+  mcp-probe is a debugging platform you inspect a server with; mcp-repl is a
+  shell you drive one from.
 
 ## Notes
 


### PR DESCRIPTION
Two doc additions to the mcp-repl README, landed before the pending release PR so the first published crate ships them:

1. A real-server example: the hosted [cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp) instance at `https://cratesio-mcp.fly.dev/` (MCP endpoint is the root path, not `/mcp`; verified live from the REPL, including `get_summary` with markdown-rendered output and `search_crates` with key=value coercion).
2. A related-tools section referencing [mcp-probe](https://github.com/conikeec/mcp-probe) (Rust TUI debugging toolkit) with complementary positioning: a debugging platform you inspect a server with, versus a shell you drive one from.