### PR TITLE
fix(client): report pre-session HTTP 404 as endpoint-not-found, not Session expired

### DIFF
--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -711,8 +711,22 @@ impl ClientTransport for HttpClientTransport {
         }
 
         if !status.is_success() {
-            if status == reqwest::StatusCode::NOT_FOUND && self.config.session_recovery {
+            // 404 only signals an expired session once a session exists.
+            // Before that (the initial `initialize`), a 404 means the URL is
+            // wrong, and reporting it as "Session expired" sends users
+            // hunting session bugs instead of checking the endpoint path.
+            if status == reqwest::StatusCode::NOT_FOUND
+                && self.config.session_recovery
+                && self.session_id.is_some()
+            {
                 return Err(Error::SessionExpired);
+            }
+            if status == reqwest::StatusCode::NOT_FOUND && self.session_id.is_none() {
+                return Err(Error::Transport(format!(
+                    "HTTP 404 from {}: MCP endpoint not found (check the endpoint path; \
+                     some servers serve MCP at the root, others at /mcp)",
+                    self.url
+                )));
             }
             let body = response.text().await.unwrap_or_default();
             return Err(Error::Transport(format!(

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2690,3 +2690,27 @@ async fn initialized_notification_ordering_under_strict_server() {
         .expect("tools/list must not be rejected: initialized must be acknowledged first");
     assert!(!tools.tools.is_empty());
 }
+
+/// #983 regression: a 404 on the very first request (no session yet) is a
+/// wrong endpoint path, not an expired session. It must surface as a
+/// transport error naming the status and URL, never as SessionExpired.
+#[tokio::test]
+async fn pre_session_404_reports_endpoint_not_found() {
+    let (url, _server) = start_server().await;
+    // The MCP endpoint of the test server is the root path; /nope is a 404.
+    let transport = HttpClientTransport::new(format!("{url}/nope"));
+    let client = McpClient::connect(transport).await.unwrap();
+    let err = client
+        .initialize("wrong-path", "1.0.0")
+        .await
+        .expect_err("initialize against a wrong path must fail");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("404") && msg.contains("/nope") && msg.contains("endpoint"),
+        "expected an endpoint-not-found transport error, got: {msg}"
+    );
+    assert!(
+        !msg.to_lowercase().contains("session"),
+        "must not be reported as a session error, got: {msg}"
+    );
+}


### PR DESCRIPTION
Closes #983.

Pointing a client at a wrong endpoint path failed with `Session expired`: `HttpClientTransport::send` mapped every 404 to `Error::SessionExpired` when session recovery was enabled, including on the first `initialize` when no session exists yet. Gate the mapping on an established session, and give the pre-session 404 an actionable message naming the URL.

Regression test: connecting to a wrong path fails `initialize` with a transport error naming 404 and the URL; existing session-recovery behavior unchanged.