### PR TITLE
fix(mcp-repl): drop over-length crates.io keyword

### DIFF
--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository = "https://github.com/joshrotenberg/tower-mcp"
 readme = "README.md"
 description = "Interactive MCP client REPL: connects to any MCP server and turns its tools, prompts, and resources into the command set"
-keywords = ["mcp", "repl", "cli", "client", "model-context-protocol"]
+keywords = ["mcp", "repl", "cli", "client", "protocol"]
 categories = ["command-line-utilities", "development-tools"]
 
 [[bin]]


### PR DESCRIPTION
The first mcp-repl publish attempt (release-plz release step on main push) failed with `"model-context-protocol" is an invalid keyword (keywords must have less than 20 characters)`. Replaced with `protocol`; all keywords now length-validated.

Lesson recorded: `cargo publish --dry-run` does not validate keywords (server-side check at upload), so the #980 dry-run could not catch this.

Merging this will cause release-plz to publish mcp-repl 0.1.0 on the main push (the release step attempts any registry-absent version on every push; it does not wait for the release PR).