### PR TITLE
feat(mcp-repl): info replays the startup banner; resources/templates cross-hint

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -48,7 +48,12 @@ getting-started> echo message="hi there"   # tab-completes argument names
 getting-started> describe add              # input/output schemas, colored
 getting-started> read source://getting_started.rs
 getting-started> prompt greet name=World   # prompt args tab-complete via completion/complete
+getting-started> info                      # replay the startup banner (identity, instructions, counts) + capabilities
 ```
+
+`resources` lists concrete resources and `templates` lists parameterized
+(`{variable}`) ones; each points at the other so a server that splits its
+resources across the two MCP lists is not confusing.
 
 Task-capable tools support shell-style backgrounding (SEP-2663):
 

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -96,7 +96,7 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("wait", "wait for a background task"),
     ("cancel", "cancel a background task"),
     ("refresh", "re-fetch the server surface"),
-    ("info", "server info and capabilities"),
+    ("info", "replay the connection banner plus capabilities"),
     ("quit", "exit"),
     ("exit", "exit"),
 ];
@@ -191,6 +191,39 @@ fn render_task(task: &TaskObject) {
     if let Some(err) = &task.error {
         println!("{} {}: {}", style::error_prefix(), err.code, err.message);
     }
+}
+
+/// The connection banner: server identity, negotiated protocol, and any
+/// server instructions (markdown-rendered when it looks like markdown).
+/// Printed at startup and replayed by the `info` command.
+fn print_banner(info: &tower_mcp::protocol::InitializeResult) {
+    println!(
+        "connected: {} v{} {}",
+        paint(Style::new().bold(), &info.server_info.name),
+        info.server_info.version,
+        paint(
+            Style::new().dimmed(),
+            &format!("(protocol {})", info.protocol_version)
+        )
+    );
+    if let Some(instructions) = &info.instructions {
+        if style::colors_enabled() && style::looks_like_markdown(instructions) {
+            println!("{}", style::render_markdown(instructions));
+        } else {
+            println!("{instructions}");
+        }
+    }
+}
+
+/// The one-line surface summary.
+fn print_counts(surface: &Surface) {
+    println!(
+        "{} tools, {} prompts, {} resources, {} templates. Type `help`.",
+        surface.tools.len(),
+        surface.prompts.len(),
+        surface.resources.len(),
+        surface.templates.len()
+    );
 }
 
 /// True when the server rejected a request because the session is not yet
@@ -457,34 +490,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .initialize("mcp-repl", env!("CARGO_PKG_VERSION"))
         .await?;
     let server_name = init.server_info.name.clone();
-    println!(
-        "connected: {} v{} {}",
-        paint(Style::new().bold(), &server_name),
-        init.server_info.version,
-        paint(
-            Style::new().dimmed(),
-            &format!("(protocol {})", init.protocol_version)
-        )
-    );
-    if let Some(instructions) = &init.instructions {
-        if style::colors_enabled() && style::looks_like_markdown(instructions) {
-            println!("{}", style::render_markdown(instructions));
-        } else {
-            println!("{instructions}");
-        }
-    }
+    print_banner(&init);
 
     let surface = Arc::new(RwLock::new(fetch_surface_initial(&client).await));
-    {
-        let s = surface.read().unwrap();
-        println!(
-            "{} tools, {} prompts, {} resources, {} templates. Type `help`.",
-            s.tools.len(),
-            s.prompts.len(),
-            s.resources.len(),
-            s.templates.len()
-        );
-    }
+    print_counts(&surface.read().unwrap());
 
     // Readline runs on its own thread; lines cross into async via channels.
     let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(1);
@@ -609,6 +618,20 @@ async fn handle_line(
                             r.name
                         );
                     }
+                    // Templates (parameterized URIs) are a separate MCP list
+                    // and easy to miss; point at them.
+                    if !s.templates.is_empty() {
+                        println!(
+                            "{}",
+                            paint(
+                                Style::new().dimmed(),
+                                &format!(
+                                    "(+ {} resource template(s) with variables, see `templates`)",
+                                    s.templates.len()
+                                )
+                            )
+                        );
+                    }
                 }
                 _ => {
                     for t in &s.templates {
@@ -616,6 +639,18 @@ async fn handle_line(
                             "{:40} {}",
                             paint(Style::new().fg(Color::Green), &t.uri_template),
                             t.name
+                        );
+                    }
+                    if !s.resources.is_empty() {
+                        println!(
+                            "{}",
+                            paint(
+                                Style::new().dimmed(),
+                                &format!(
+                                    "(+ {} concrete resource(s), see `resources`)",
+                                    s.resources.len()
+                                )
+                            )
                         );
                     }
                 }
@@ -750,12 +785,9 @@ async fn handle_line(
         }
         "info" => match client.server_info().await {
             Some(info) => {
-                println!(
-                    "{} v{}",
-                    paint(Style::new().bold(), &info.server_info.name),
-                    info.server_info.version
-                );
-                println!("protocol: {}", info.protocol_version);
+                // Replay the full startup banner, then add capabilities.
+                print_banner(&info);
+                print_counts(&surface.read().unwrap());
                 let caps = serde_json::to_value(&info.capabilities).unwrap_or_default();
                 println!("capabilities: {}", json_pretty(&caps));
             }


### PR DESCRIPTION
Two small UX improvements found while driving mcp-repl against a live server (the hosted cratesio-mcp).

## `info` replays the full startup banner

Previously `info` printed only name/version, protocol, and capabilities JSON, omitting the server `instructions` text and the surface counts, which are exactly the parts that scroll off at startup. The startup banner is now factored into `print_banner` + `print_counts`, shared between startup and `info`, so `info` is a full connection-summary replay (identity, instructions, counts) plus capabilities, and the two cannot drift.

## resources / templates cross-hint

MCP splits resources into concrete resources (`resources/list`) and parameterized templates (`resources/templates/list`). A server like cratesio-mcp that puts most of its `crates://{name}/...` entries in the template list made `resources` look like it was hiding things. Each command now points at the other:

```text
cratesio-mcp> resources
crates://recent-searches                 Recent Searches
(+ 3 resource template(s) with variables, see `templates`)
```

## Verification

- `info` verified against the live cratesio-mcp: banner + full instructions + counts + capabilities
- both cross-hints verified live
- fmt / clippy -D warnings / MSRV 1.90 / detector unit tests all clean; startup output unchanged