### PR TITLE
fix(client): wake the caller when a background HTTP POST fails

### DIFF
--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -543,7 +543,9 @@ impl ClientTransport for HttpClientTransport {
         // everything sent afterwards. Without this, the spawned send path
         // let `notifications/initialized` race the next request on a pooled
         // connection, and strict servers rejected that request (#967).
-        let is_notification = serde_json::from_str::<serde_json::Value>(message)
+        let parsed_message = serde_json::from_str::<serde_json::Value>(message).ok();
+        let is_notification = parsed_message
+            .as_ref()
             .map(|v| v.get("id").is_none())
             .unwrap_or(false);
 
@@ -554,6 +556,12 @@ impl ClientTransport for HttpClientTransport {
         // client to respond via the SSE channel.
         if self.session_id.is_some() && !is_notification {
             let tx = self.incoming_tx.clone();
+            // The caller is parked on this request id in the message loop's
+            // correlation map. Every failure branch below delivers a frame
+            // carrying it, so a background POST that dies (network error,
+            // timeout, HTTP error, empty body, response stream closed early)
+            // wakes the caller with an error instead of hanging it forever.
+            let req_id = parsed_message.and_then(|v| v.get("id").cloned());
             let connected = self.connected.clone();
             let last_event_id = self.last_event_id.clone();
             let sse_retry_delay = self.sse_retry_delay.clone();
@@ -564,6 +572,14 @@ impl ClientTransport for HttpClientTransport {
                     Ok(r) => r,
                     Err(e) => {
                         tracing::error!(error = %e, "Background HTTP request failed");
+                        if let Some(id) = &req_id {
+                            let _ = tx
+                                .send(transport_error_frame(
+                                    id,
+                                    &format!("HTTP request failed: {e}"),
+                                ))
+                                .await;
+                        }
                         connected.store(false, Ordering::Release);
                         return;
                     }
@@ -579,19 +595,37 @@ impl ClientTransport for HttpClientTransport {
                 if !status.is_success() {
                     let body = response.text().await.unwrap_or_default();
 
-                    // Try to parse the error body as JSON-RPC and forward it
-                    // so the message loop can detect -32005 (SessionNotFound)
-                    // and trigger session recovery.
+                    // Forward a JSON-RPC error body so the message loop can
+                    // detect -32005 (SessionNotFound) and trigger session
+                    // recovery. If the server did not echo our request id (a
+                    // null/absent id that is not the session-level -32005
+                    // signal), inject it so the awaiting caller is woken by
+                    // this error instead of hanging.
                     if !body.is_empty()
-                        && serde_json::from_str::<serde_json::Value>(&body)
-                            .ok()
-                            .is_some_and(|v| v.get("error").is_some())
+                        && let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&body)
+                        && v.get("error").is_some()
                     {
-                        let _ = tx.send(body).await;
+                        let is_session_signal =
+                            v.pointer("/error/code").and_then(|c| c.as_i64()) == Some(-32005);
+                        if !is_session_signal
+                            && v.get("id").is_none_or(|id| id.is_null())
+                            && let Some(id) = &req_id
+                        {
+                            v["id"] = id.clone();
+                        }
+                        let _ = tx.send(v.to_string()).await;
                         return;
                     }
 
                     tracing::error!(status = %status, body = %body, "HTTP error from server");
+                    if let Some(id) = &req_id {
+                        let _ = tx
+                            .send(transport_error_frame(
+                                id,
+                                &format!("server returned HTTP {status}"),
+                            ))
+                            .await;
+                    }
                     connected.store(false, Ordering::Release);
                     return;
                 }
@@ -656,20 +690,65 @@ impl ClientTransport for HttpClientTransport {
                     // with the updated last_event_id and sse_retry_delay.
                     if had_retry && !had_data {
                         sse_reconnect_signal.notify_one();
+                    } else if !had_data {
+                        // The response stream closed without ever delivering a
+                        // data frame, so nothing correlated the request. Wake
+                        // the caller rather than leave it hanging.
+                        if let Some(id) = &req_id {
+                            let _ = tx
+                                .send(transport_error_frame(
+                                    id,
+                                    "server closed the response stream without a reply",
+                                ))
+                                .await;
+                        }
                     }
                 } else {
-                    // Non-SSE response: read body and queue for recv()
+                    // Non-SSE response: read body and queue for recv().
                     match response.text().await {
                         Ok(body) if !body.is_empty() => {
-                            for msg in extract_json_messages(&body) {
-                                let _ = tx.send(msg).await;
+                            let msgs = extract_json_messages(&body);
+                            if msgs.is_empty() {
+                                // A non-empty body that yields no JSON-RPC
+                                // frames leaves the request uncorrelated.
+                                if let Some(id) = &req_id {
+                                    let _ = tx
+                                        .send(transport_error_frame(
+                                            id,
+                                            "server returned an unparseable response body",
+                                        ))
+                                        .await;
+                                }
+                            } else {
+                                for msg in msgs {
+                                    let _ = tx.send(msg).await;
+                                }
+                            }
+                        }
+                        Ok(_) => {
+                            // 2xx with an empty body: no frame to correlate the
+                            // request, so wake the caller rather than hang.
+                            if let Some(id) = &req_id {
+                                let _ = tx
+                                    .send(transport_error_frame(
+                                        id,
+                                        "server returned an empty response body",
+                                    ))
+                                    .await;
                             }
                         }
                         Err(e) => {
                             tracing::error!(error = %e, "Failed to read response body");
+                            if let Some(id) = &req_id {
+                                let _ = tx
+                                    .send(transport_error_frame(
+                                        id,
+                                        &format!("failed to read response body: {e}"),
+                                    ))
+                                    .await;
+                            }
                             connected.store(false, Ordering::Release);
                         }
-                        _ => {}
                     }
                 }
             });
@@ -1022,6 +1101,24 @@ async fn sse_stream_loop(params: SseLoopParams) {
 ///
 /// If the body is SSE-formatted (`event: message\ndata: ...\n\n`), extracts the
 /// `data:` content from each event. Otherwise returns the body as-is.
+/// Build a JSON-RPC error frame carrying `id`.
+///
+/// A post-session request POST is spawned in the background (so the message
+/// loop can keep servicing the SSE stream), which means its failures happen
+/// out of band from the caller. The caller is parked on the request id in the
+/// message loop's correlation map; if the background POST fails before a real
+/// response reaches the incoming channel, we must still deliver a frame with
+/// this id or the caller hangs until the process exits. `-32000` is the
+/// generic server-error code; the message names the transport-level cause.
+fn transport_error_frame(id: &serde_json::Value, message: &str) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": { "code": -32000, "message": message },
+    })
+    .to_string()
+}
+
 fn extract_json_messages(body: &str) -> Vec<String> {
     let trimmed = body.trim();
     if trimmed.is_empty() {

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -18,7 +18,7 @@ use tower_mcp::{
     McpRouter, NoParams, NotificationHandler, PromptBuilder, PromptMessage, PromptRole,
     ReadResourceResult, ResourceBuilder, ResourceContent, ResourceTemplateBuilder, Root,
     SamplingContent, SamplingContentOrArray, SamplingMessage, ToolBuilder,
-    client::{HttpClientTransport, McpClient},
+    client::{HttpClientConfig, HttpClientTransport, McpClient},
     extract::{Context, RawArgs},
     transport::http::SessionConfig,
 };
@@ -2712,5 +2712,127 @@ async fn pre_session_404_reports_endpoint_not_found() {
     assert!(
         !msg.to_lowercase().contains("session"),
         "must not be reported as a session error, got: {msg}"
+    );
+}
+
+/// Read one full HTTP/1.1 request (headers + Content-Length body) from a raw
+/// connection. Returns the whole request as a string, or `None` on EOF.
+#[cfg(test)]
+async fn read_http_request(stream: &mut tokio::net::TcpStream) -> Option<String> {
+    use tokio::io::AsyncReadExt;
+    let mut buf = Vec::new();
+    let mut tmp = [0u8; 4096];
+    loop {
+        if let Some(pos) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+            let headers = String::from_utf8_lossy(&buf[..pos]).to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|l| {
+                    let (k, v) = l.split_once(':')?;
+                    k.trim()
+                        .eq_ignore_ascii_case("content-length")
+                        .then(|| v.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            let need = pos + 4 + content_length;
+            while buf.len() < need {
+                let n = stream.read(&mut tmp).await.ok()?;
+                if n == 0 {
+                    break;
+                }
+                buf.extend_from_slice(&tmp[..n]);
+            }
+            return Some(String::from_utf8_lossy(&buf).to_string());
+        }
+        let n = stream.read(&mut tmp).await.ok()?;
+        if n == 0 {
+            return (!buf.is_empty()).then(|| String::from_utf8_lossy(&buf).to_string());
+        }
+        buf.extend_from_slice(&tmp[..n]);
+    }
+}
+
+/// Regression: a post-session request whose background POST fails before
+/// delivering a response must wake the awaiting caller with an error, never
+/// hang it.
+///
+/// After the session is established, request POSTs are spawned in a background
+/// task so the message loop can keep servicing the SSE stream. That task used
+/// to drop a handful of failure modes on the floor (network error, timeout,
+/// HTTP error with a non-JSON body, empty body, response stream closed with no
+/// data), leaving the caller parked on the request id forever. This exercises
+/// the empty-body dead-end: the raw server answers `tools/list` with a `200`
+/// and no body. `Connection: close` forces a fresh connection per request so
+/// each is intercepted deterministically.
+#[tokio::test]
+async fn post_session_request_failure_wakes_caller() {
+    use tokio::io::AsyncWriteExt;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let Some(req) = read_http_request(&mut stream).await else {
+                    return;
+                };
+                let response = if req.contains("\"method\":\"initialize\"") {
+                    let body = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "protocolVersion": "2025-11-25",
+                            "capabilities": {},
+                            "serverInfo": {"name": "raw", "version": "0"}
+                        }
+                    })
+                    .to_string();
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                         mcp-session-id: raw-session\r\nmcp-protocol-version: 2025-11-25\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    )
+                } else if req.contains("notifications/initialized") {
+                    "HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        .to_string()
+                } else {
+                    // tools/list and anything else: a 2xx with an empty body,
+                    // the dead-end that used to hang the caller.
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                     Content-Length: 0\r\nConnection: close\r\n\r\n"
+                        .to_string()
+                };
+                let _ = stream.write_all(response.as_bytes()).await;
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    let url = format!("http://{addr}");
+    let config = HttpClientConfig {
+        auto_sse: false,
+        request_timeout: Duration::from_secs(5),
+        ..Default::default()
+    };
+    let transport = HttpClientTransport::with_config(url, config);
+    let client = McpClient::connect(transport).await.unwrap();
+    client.initialize("raw-client", "1.0.0").await.unwrap();
+
+    // The bug made this future never resolve; bound it so the test fails as a
+    // timeout instead of hanging the whole suite.
+    let result = tokio::time::timeout(Duration::from_secs(3), client.list_tools()).await;
+    let result = result.expect(
+        "list_tools hung: the failed background POST never woke the caller (the bug this guards)",
+    );
+    assert!(
+        result.is_err(),
+        "an empty-body response must surface as an error, got: {result:?}"
     );
 }


### PR DESCRIPTION
## Problem

Surfaced while pointing `mcp-repl` at a hosted MCP server that was 503-ing on fly.dev: `initialize` succeeded (the banner printed), then `tools/list` hung forever with no error. The user had to kill the process.

The server outage itself is a deployment problem, not ours. But it exposed a real client bug: tower-mcp turned a transient, recoverable server failure into a permanent client hang.

## Root cause

After the session is established, `HttpClientTransport::send` spawns request POSTs in a background task so the message loop can keep servicing the SSE stream (this is what keeps bidirectional sampling/elicitation from deadlocking). The background task fed the response back to the message loop's id-correlation map on the happy path, but several failure branches just logged, set `connected = false`, and returned **without delivering any frame for the request id**:

- `request.send().await` errors (network failure, or the 30s `request_timeout` firing)
- a non-success HTTP status whose body is not a JSON-RPC error (503 HTML, empty body)
- a JSON-RPC error body the server did not tag with our request id
- a 2xx with an empty or unparseable body
- an SSE response stream that closes without ever emitting a data event

In each case the awaiting caller stayed parked on its `oneshot` in `pending_requests` forever. There is no per-request timeout at the correlation layer, so "the background POST died" == "this call never returns." Even the plain 30s timeout looked like an infinite hang, because the timeout fired inside the spawned task and never woke the caller.

## Fix

Every failure branch in the background POST now synthesizes a JSON-RPC error frame carrying the request id and pushes it to the incoming channel, so the message loop correlates it and the caller gets a clean `Err`. For a server error body missing our id, we inject it, except the session-level `-32005` signal, which is left with a null id so it still fails **all** pending requests and drives session recovery.

## Test

`post_session_request_failure_wakes_caller`: a raw TCP server establishes a session (`initialize` -> 200 + `mcp-session-id`, `notifications/initialized` -> 202), then answers `tools/list` with a `200` and an empty body. The call must return an error within 3s (bounded via `tokio::time::timeout`) instead of hanging the suite. `Connection: close` forces a fresh connection per request so the dead-end is intercepted deterministically.

All 50 `http_client` integration tests pass; `fmt --check` and `clippy --all-targets --all-features -D warnings` clean.

## Not in scope

- The cratesio-mcp / fly.dev 503 outage that surfaced this (server side).
- `mcp-repl` startup patience: with this fix a hung list errors after `request_timeout` (30s) and the REPL prints its existing per-list warning, so startup degrades to an error instead of hanging. A shorter startup timeout could be a follow-up but is not needed for correctness.