### PR TITLE
feat(mcp-repl): fetch the startup surface concurrently

### DIFF
--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -259,16 +259,24 @@ async fn fetch_surface_once(client: &McpClient) -> (Surface, bool) {
             }
         }
     }
+    // The four list calls are independent reads, so run them concurrently.
+    // The McpClient message loop multiplexes requests by id, so this is safe
+    // on a single connection, and it means startup costs one round-trip's
+    // latency instead of four in series. It also bounds the cost of a slow or
+    // unresponsive server: against a server that makes each list time out, the
+    // surface fetch now waits one `request_timeout`, not four.
+    let (tools, prompts, resources, templates) = tokio::join!(
+        client.list_all_tools(),
+        client.list_all_prompts(),
+        client.list_all_resources(),
+        client.list_all_resource_templates(),
+    );
     let mut ni = false;
     let surface = Surface {
-        tools: take("tools", client.list_all_tools().await, &mut ni),
-        prompts: take("prompts", client.list_all_prompts().await, &mut ni),
-        resources: take("resources", client.list_all_resources().await, &mut ni),
-        templates: take(
-            "resource templates",
-            client.list_all_resource_templates().await,
-            &mut ni,
-        ),
+        tools: take("tools", tools, &mut ni),
+        prompts: take("prompts", prompts, &mut ni),
+        resources: take("resources", resources, &mut ni),
+        templates: take("resource templates", templates, &mut ni),
     };
     (surface, ni)
 }


### PR DESCRIPTION
## What

`fetch_surface_once` awaited the four surface list calls (`tools`, `prompts`, `resources`, `resource templates`) in series. They are independent reads and the `McpClient` message loop multiplexes requests by id, so they can run concurrently with `tokio::join!`.

## Why

- **Faster startup:** one round-trip's latency instead of four.
- **Bounds the slow/dead-server case:** now that a failed post-session request surfaces as an error instead of hanging (#991), a server that makes each list time out would cost four `request_timeout`s in series at startup. Concurrent fetch caps that at one.

## Safety

- Concurrent requests on one connection are safe: the client's background message loop correlates responses by request id.
- Behavior is otherwise unchanged: the not-initialized retry flag (`fetch_surface_initial`) and the per-list warnings work exactly as before, since results are still processed through the same `take()` helper after the join.
- Verified against `--demo`: identical surface counts (3 tools, 1 prompt, 0 resources, 1 template).

Follow-up to #991 (the background-POST hang fix), which the user surfaced by pointing mcp-repl at a server that had gone unhealthy.