### PR TITLE
fix(client): bound the inline notification send so a stall cannot freeze the client

### DIFF
--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -83,6 +83,16 @@ pub struct HttpClientConfig {
     /// Timeout for HTTP requests.
     /// Default: 30 seconds.
     pub request_timeout: Duration,
+    /// Timeout for notification POSTs (frames without an `id`), capped at
+    /// `request_timeout`.
+    ///
+    /// Notifications are awaited inline so `notifications/initialized` is
+    /// ordered ahead of the first request, which blocks the client's message
+    /// loop for the duration. This bounds that block independently of
+    /// `request_timeout` so a server that stalls a notification's `202` cannot
+    /// freeze the client for the full request timeout.
+    /// Default: 5 seconds.
+    pub notification_timeout: Duration,
     /// Whether to attempt SSE reconnection on disconnect.
     /// Default: `true`.
     pub sse_reconnect: bool,
@@ -118,6 +128,7 @@ impl Default for HttpClientConfig {
             auto_sse: true,
             channel_capacity: 256,
             request_timeout: Duration::from_secs(30),
+            notification_timeout: Duration::from_secs(5),
             sse_reconnect: true,
             sse_reconnect_delay: Duration::from_secs(1),
             max_sse_reconnect_attempts: 5,
@@ -504,13 +515,32 @@ impl ClientTransport for HttpClientTransport {
             return Err(Error::Transport("Transport closed".to_string()));
         }
 
+        // Notifications (frames without an `id`) are awaited inline (below) to
+        // keep `notifications/initialized` ordered before the first request
+        // (#967). That inline await blocks the whole message loop, so it must
+        // be bounded independently: a server that stalls the notification's
+        // 202 (observed: a multi-instance server holding the POST for the full
+        // request timeout) would otherwise freeze the client with no output.
+        let parsed_message = serde_json::from_str::<serde_json::Value>(message).ok();
+        let is_notification = parsed_message
+            .as_ref()
+            .map(|v| v.get("id").is_none())
+            .unwrap_or(false);
+        let timeout = if is_notification {
+            self.config
+                .notification_timeout
+                .min(self.config.request_timeout)
+        } else {
+            self.config.request_timeout
+        };
+
         // Build request with headers
         let mut request = self
             .client
             .post(&self.url)
             .header("Content-Type", "application/json")
             .header("Accept", "application/json, text/event-stream")
-            .timeout(self.config.request_timeout);
+            .timeout(timeout);
 
         if let Some(ref session_id) = self.session_id {
             request = request.header("mcp-session-id", session_id);
@@ -536,19 +566,11 @@ impl ClientTransport for HttpClientTransport {
 
         let request = request.body(message.to_string());
 
-        // Notifications (frames without an `id`) are awaited inline even
-        // after session establishment: the server processes a notification
-        // before answering 202, and never issues a client round-trip while
-        // doing so, so awaiting cannot deadlock and preserves ordering with
-        // everything sent afterwards. Without this, the spawned send path
-        // let `notifications/initialized` race the next request on a pooled
-        // connection, and strict servers rejected that request (#967).
-        let parsed_message = serde_json::from_str::<serde_json::Value>(message).ok();
-        let is_notification = parsed_message
-            .as_ref()
-            .map(|v| v.get("id").is_none())
-            .unwrap_or(false);
-
+        // Notifications are awaited inline (bounded above) even after session
+        // establishment, so `notifications/initialized` reaches the server
+        // ahead of the first request rather than racing it on a pooled
+        // connection, which strict servers rejected (#967).
+        //
         // After session is established, send requests in a background task
         // so the message loop can continue processing incoming SSE messages.
         // This prevents a deadlock when the server blocks on a

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2836,3 +2836,94 @@ async fn post_session_request_failure_wakes_caller() {
         "an empty-body response must surface as an error, got: {result:?}"
     );
 }
+
+/// Regression: a server that stalls the `notifications/initialized` POST must
+/// not freeze the client for the full `request_timeout`.
+///
+/// The notification is awaited inline to keep it ordered ahead of the first
+/// request (#967), which blocks the single message loop for the duration.
+/// `notification_timeout` bounds that block independently. Here the raw server
+/// reads the notification POST and never answers it; with a short
+/// `notification_timeout` the client abandons it quickly and `tools/list` still
+/// completes well under the 20s `request_timeout`. Before the fix, `tools/list`
+/// waited behind the notification for the full request timeout.
+#[tokio::test]
+async fn stalled_initialized_notification_does_not_freeze_client() {
+    use tokio::io::AsyncWriteExt;
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            tokio::spawn(async move {
+                let Some(req) = read_http_request(&mut stream).await else {
+                    return;
+                };
+                if req.contains("\"method\":\"initialize\"") {
+                    let body = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "result": {
+                            "protocolVersion": "2025-11-25",
+                            "capabilities": {},
+                            "serverInfo": {"name": "raw", "version": "0"}
+                        }
+                    })
+                    .to_string();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                         mcp-session-id: raw-session\r\nmcp-protocol-version: 2025-11-25\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                } else if req.contains("notifications/initialized") {
+                    // Stall: read the POST but never answer it. The client must
+                    // give up after notification_timeout, not request_timeout.
+                    tokio::time::sleep(Duration::from_secs(3600)).await;
+                } else {
+                    // tools/list: respond normally.
+                    let body = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {"tools": [{"name": "echo", "inputSchema": {"type": "object"}}]}
+                    })
+                    .to_string();
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                         Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(resp.as_bytes()).await;
+                }
+                let _ = stream.flush().await;
+            });
+        }
+    });
+
+    let url = format!("http://{addr}");
+    let config = HttpClientConfig {
+        auto_sse: false,
+        request_timeout: Duration::from_secs(20),
+        notification_timeout: Duration::from_millis(300),
+        ..Default::default()
+    };
+    let transport = HttpClientTransport::with_config(url, config);
+    let client = McpClient::connect(transport).await.unwrap();
+    client.initialize("raw-client", "1.0.0").await.unwrap();
+
+    // The stalled notification is abandoned after ~300ms, so this resolves
+    // quickly. Before the fix it waited behind the notification for the full
+    // 20s request_timeout; bound it at 8s so a regression fails as a timeout.
+    let tools = tokio::time::timeout(Duration::from_secs(8), client.list_tools())
+        .await
+        .expect("tools/list blocked behind the stalled notification (the bug this guards)")
+        .expect("tools/list should succeed once the stalled notification is abandoned");
+    assert_eq!(tools.tools.len(), 1);
+}


### PR DESCRIPTION
## Problem

Surfaced by pointing `mcp-repl` at a hosted MCP server that stalls `notifications/initialized`: `initialize` succeeded (banner printed), then a **30s dead freeze with no output** before `tools/list` was even sent.

Trace:
```
20:18:23.941  Sending notification notifications/initialized
20:18:53.943  Sending request tools/list      ← exactly 30s (request_timeout) later
```

## Root cause

Since #967, `notifications/initialized` is awaited **inline** in `HttpClientTransport::send` so it reaches the server ahead of the first request (rather than racing it on a pooled connection, which strict servers reject). But that await runs on the single message loop, so it blocks the entire client — and it used the full `request_timeout` (30s). A server that stalls the notification's `202` (a multi-instance server holding the POST) froze the client for 30s before any request could go out. This is the notification counterpart to the request-path dead-ends fixed in #991 (9a5de56).

## Fix

Add `HttpClientConfig::notification_timeout` (default **5s**, capped at `request_timeout`) and use it for notification POSTs. A stalled notification is abandoned quickly and the first request proceeds. Any resulting not-initialized race is already surfaced as an error (not a hang) by #991 and retried by the client's startup surface fetch. Ordering for healthy servers is unaffected (they `202` in milliseconds; the #967 ordering test delays only 200ms).

Net with #991: a slow or broken server now yields a fast error or a bounded degrade, never an open-ended freeze.

## Test

`stalled_initialized_notification_does_not_freeze_client`: a raw server reads `notifications/initialized` and never answers it; with a short `notification_timeout`, `tools/list` completes well under the 20s `request_timeout` (bounded at 8s so a regression fails as a timeout). Passed in 0.32s.

## Verification

Against the live server that triggered this: the notification is now abandoned at ~5s (was 30s), and the REPL reaches a usable prompt with a diagnostic instead of freezing. (The server itself is still multi-instance without a shared session store, so it returns an empty surface — that's a separate server-side issue.)

`fmt --check` and `clippy --all-targets --all-features -D warnings` clean.