### PR TITLE
feat(mcp-repl): persist command history across sessions

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -181,3 +181,6 @@ The banner and surface listing are suppressed in `--exec` mode (pass
 - When stdin is not a tty, the REPL reads lines directly (no editor), so
   piping a script of commands works:
   `printf 'echo message=hi\nquit\n' | mcp-repl --demo`.
+- Command history persists to `~/.mcp-repl_history` (up to 1000 entries), so
+  up-arrow recalls commands from previous sessions. Pass `--no-history` to
+  keep it in-memory only.

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -15,9 +15,10 @@ use std::time::Duration;
 
 use nu_ansi_term::{Color, Style};
 use reedline::{
-    ColumnarMenu, Completer, DefaultHinter, Emacs, Highlighter, KeyCode, KeyModifiers, MenuBuilder,
-    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline,
-    ReedlineEvent, ReedlineMenu, Signal, Span, StyledText, Suggestion, default_emacs_keybindings,
+    ColumnarMenu, Completer, DefaultHinter, Emacs, FileBackedHistory, Highlighter, KeyCode,
+    KeyModifiers, MenuBuilder, Prompt, PromptEditMode, PromptHistorySearch,
+    PromptHistorySearchStatus, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span, StyledText,
+    Suggestion, default_emacs_keybindings,
 };
 
 use tower_mcp::client::McpClient;
@@ -485,6 +486,7 @@ impl Highlighter for ReplHighlighter {
 ///
 /// When stdin is not a tty (piped input), falls back to a plain
 /// line-reader so non-interactive use keeps working.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_readline_thread(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
@@ -493,6 +495,7 @@ pub fn spawn_readline_thread(
     line_tx: tokio::sync::mpsc::Sender<String>,
     ack_rx: std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    persist_history: bool,
 ) {
     std::thread::spawn(move || {
         if !std::io::stdin().is_terminal() {
@@ -507,8 +510,17 @@ pub fn spawn_readline_thread(
             &line_tx,
             &ack_rx,
             at_prompt,
+            persist_history,
         );
     });
+}
+
+/// The command-history file: `~/.mcp-repl_history`, shared across sessions.
+/// `None` when `$HOME` is unset (history stays in-memory).
+fn history_path() -> Option<std::path::PathBuf> {
+    let mut p = std::path::PathBuf::from(std::env::var_os("HOME")?);
+    p.push(".mcp-repl_history");
+    Some(p)
 }
 
 fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mpsc::Receiver<()>) {
@@ -541,6 +553,7 @@ fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mp
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_interactive(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
@@ -549,6 +562,7 @@ fn run_interactive(
     line_tx: &tokio::sync::mpsc::Sender<String>,
     ack_rx: &std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    persist_history: bool,
 ) {
     let completer = ReplCompleter::new(surface.clone(), client, runtime);
     let highlighter = ReplHighlighter::new(surface);
@@ -574,6 +588,16 @@ fn run_interactive(
         ))
         .with_ansi_colors(style::colors_enabled());
 
+    // Persist history across sessions (up to 1000 entries) so up-arrow recalls
+    // commands from previous runs. Best-effort: a read-only HOME just keeps
+    // history in-memory for this session.
+    if persist_history && let Some(path) = history_path() {
+        match FileBackedHistory::with_file(1000, path) {
+            Ok(history) => editor = editor.with_history(Box::new(history)),
+            Err(e) => eprintln!("warning: command history disabled: {e}"),
+        }
+    }
+
     let prompt = ReplPrompt { server_name };
     loop {
         at_prompt.store(true, Ordering::SeqCst);
@@ -581,6 +605,10 @@ fn run_interactive(
         at_prompt.store(false, Ordering::SeqCst);
         match sig {
             Ok(Signal::Success(line)) => {
+                // Flush history now: a typed `quit` exits the process from the
+                // main loop, so this thread's editor is never dropped and
+                // FileBackedHistory would otherwise not persist on exit.
+                let _ = editor.sync_history();
                 if line_tx.blocking_send(line).is_err() {
                     break;
                 }

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -95,6 +95,10 @@ struct Args {
     #[arg(long)]
     verbose: bool,
 
+    /// Do not persist command history to ~/.mcp-repl_history.
+    #[arg(long)]
+    no_history: bool,
+
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
 }
@@ -665,6 +669,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         line_tx,
         ack_rx,
         at_prompt,
+        !args.no_history,
     );
 
     let mut jobs: Vec<(String, String)> = Vec::new();
@@ -1282,6 +1287,29 @@ mod tests {
     fn error_json_is_a_valid_object() {
         let v: serde_json::Value = serde_json::from_str(&error_json("boom: it broke")).unwrap();
         assert_eq!(v["error"], "boom: it broke");
+    }
+
+    // The persistent-history path relies on FileBackedHistory buffering saves
+    // in memory and only writing on sync() (which sync_history() calls). The
+    // REPL exits abruptly without dropping the editor, so it syncs after each
+    // accepted line; this pins the assumption that save + sync reaches disk.
+    #[test]
+    fn file_backed_history_writes_on_sync() {
+        use reedline::{FileBackedHistory, History, HistoryItem};
+        let path = std::env::temp_dir().join(format!("mcp-repl-hist-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        {
+            let mut h = FileBackedHistory::with_file(10, path.clone()).unwrap();
+            h.save(HistoryItem::from_command_line("echo persisted"))
+                .unwrap();
+            h.sync().unwrap();
+        }
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.contains("echo persisted"),
+            "history was not written to disk: {contents:?}"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]


### PR DESCRIPTION
Closes #997. **Stacked on #1001** (which is stacked on #1000). Merge order bottom-up: #1000 → #1001 → #997; bases retarget automatically as each merges.

## What

Command history was in-memory only, so up-arrow forgot everything on exit. Back it with reedline's `FileBackedHistory` at `~/.mcp-repl_history` (1000 entries) so history carries across sessions. `--no-history` keeps it in-memory only; a read-only `HOME` degrades to in-memory with a warning.

## The one subtlety

`FileBackedHistory` buffers `save()` in memory and only writes on `sync()` (confirmed by reading reedline 0.49 source). A typed `quit` exits the process from the main loop **without dropping** the readline thread's editor, so relying on `Drop` would lose history. Fix: `sync_history()` after each accepted line, flushing incrementally.

## Verified

- Unit test `file_backed_history_writes_on_sync` pins that `with_file` + `save` + `sync` reaches disk (deterministic; does not depend on driving the interactive editor headlessly — reedline's raw-mode loop can't be faithfully driven by piped input).
- `--no-history`: no file written.
- `fmt --check`, `clippy -D warnings`, 7 unit tests pass.
- No new dependencies (history path derived from `$HOME`).

Interactive up-arrow-across-restarts is best confirmed in a real terminal.