### PR TITLE
feat(mcp-repl): one-shot execution mode and persistent history

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -139,6 +139,27 @@ cancels. Try `test_elicitation` against the conformance server. If a
 background task elicits while the editor owns the terminal, the request is
 declined rather than fighting the editor for stdin.
 
+## One-shot / scripting
+
+`-e/--exec <COMMAND>` runs a command and exits instead of opening the prompt.
+Repeatable; commands run in order against the same session. The exit status is
+non-zero if any command errored, so it drops into scripts and CI.
+
+```bash
+# One call, pretty output:
+mcp-repl --http https://example/mcp -e "get_crate_info name=serde"
+
+# Raw JSON for piping to jq (--json also silences the banner and timings):
+mcp-repl --http https://example/mcp -e "search_crates query=serde" --json | jq '.content'
+
+# Several commands in one session:
+mcp-repl --demo -e "echo message=hi" -e "about"
+```
+
+The banner and surface listing are suppressed in `--exec` mode (pass
+`--verbose` to keep them). `--json` applies to tool calls, `read`, `prompt`,
+`tools`/`prompts`/`resources`/`templates`, and errors (`{"error": "..."}`).
+
 ## Related tools
 
 - [mcp-probe](https://github.com/conikeec/mcp-probe): a Rust TUI debugging

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -181,3 +181,6 @@ The banner and surface listing are suppressed in `--exec` mode (pass
 - When stdin is not a tty, the REPL reads lines directly (no editor), so
   piping a script of commands works:
   `printf 'echo message=hi\nquit\n' | mcp-repl --demo`.
+- Command history persists to `~/.mcp-repl_history` (up to 1000 entries), so
+  up-arrow recalls commands from previous sessions. Pass `--no-history` to
+  keep it in-memory only.

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -15,9 +15,10 @@ use std::time::Duration;
 
 use nu_ansi_term::{Color, Style};
 use reedline::{
-    ColumnarMenu, Completer, DefaultHinter, Emacs, Highlighter, KeyCode, KeyModifiers, MenuBuilder,
-    Prompt, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline,
-    ReedlineEvent, ReedlineMenu, Signal, Span, StyledText, Suggestion, default_emacs_keybindings,
+    ColumnarMenu, Completer, DefaultHinter, Emacs, FileBackedHistory, Highlighter, KeyCode,
+    KeyModifiers, MenuBuilder, Prompt, PromptEditMode, PromptHistorySearch,
+    PromptHistorySearchStatus, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span, StyledText,
+    Suggestion, default_emacs_keybindings,
 };
 
 use tower_mcp::client::McpClient;
@@ -485,6 +486,7 @@ impl Highlighter for ReplHighlighter {
 ///
 /// When stdin is not a tty (piped input), falls back to a plain
 /// line-reader so non-interactive use keeps working.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_readline_thread(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
@@ -493,6 +495,7 @@ pub fn spawn_readline_thread(
     line_tx: tokio::sync::mpsc::Sender<String>,
     ack_rx: std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    persist_history: bool,
 ) {
     std::thread::spawn(move || {
         if !std::io::stdin().is_terminal() {
@@ -507,8 +510,17 @@ pub fn spawn_readline_thread(
             &line_tx,
             &ack_rx,
             at_prompt,
+            persist_history,
         );
     });
+}
+
+/// The command-history file: `~/.mcp-repl_history`, shared across sessions.
+/// `None` when `$HOME` is unset (history stays in-memory).
+fn history_path() -> Option<std::path::PathBuf> {
+    let mut p = std::path::PathBuf::from(std::env::var_os("HOME")?);
+    p.push(".mcp-repl_history");
+    Some(p)
 }
 
 fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mpsc::Receiver<()>) {
@@ -541,6 +553,7 @@ fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mp
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_interactive(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
@@ -549,6 +562,7 @@ fn run_interactive(
     line_tx: &tokio::sync::mpsc::Sender<String>,
     ack_rx: &std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    persist_history: bool,
 ) {
     let completer = ReplCompleter::new(surface.clone(), client, runtime);
     let highlighter = ReplHighlighter::new(surface);
@@ -574,6 +588,16 @@ fn run_interactive(
         ))
         .with_ansi_colors(style::colors_enabled());
 
+    // Persist history across sessions (up to 1000 entries) so up-arrow recalls
+    // commands from previous runs. Best-effort: a read-only HOME just keeps
+    // history in-memory for this session.
+    if persist_history && let Some(path) = history_path() {
+        match FileBackedHistory::with_file(1000, path) {
+            Ok(history) => editor = editor.with_history(Box::new(history)),
+            Err(e) => eprintln!("warning: command history disabled: {e}"),
+        }
+    }
+
     let prompt = ReplPrompt { server_name };
     loop {
         at_prompt.store(true, Ordering::SeqCst);
@@ -581,6 +605,10 @@ fn run_interactive(
         at_prompt.store(false, Ordering::SeqCst);
         match sig {
             Ok(Signal::Success(line)) => {
+                // Flush history now: a typed `quit` exits the process from the
+                // main loop, so this thread's editor is never dropped and
+                // FileBackedHistory would otherwise not persist on exit.
+                let _ = editor.sync_history();
                 if line_tx.blocking_send(line).is_err() {
                     break;
                 }

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -27,7 +27,7 @@ mod elicit;
 mod style;
 
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -78,8 +78,43 @@ struct Args {
     #[arg(long = "header", value_name = "NAME: VALUE")]
     headers: Vec<String>,
 
+    /// Run a command and exit instead of starting the interactive prompt.
+    /// Repeatable; commands run in order against the same session. Exit status
+    /// is non-zero if any command errors. Combine with --http/--demo or a
+    /// stdio child.
+    #[arg(short = 'e', long = "exec", value_name = "COMMAND")]
+    exec: Vec<String>,
+
+    /// In --exec mode, emit raw JSON results instead of the pretty renderer,
+    /// for piping to tools like jq.
+    #[arg(long)]
+    json: bool,
+
+    /// In --exec mode, still print the startup banner and surface listing
+    /// (suppressed by default so only command output is emitted).
+    #[arg(long)]
+    verbose: bool,
+
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
+}
+
+/// Set in `--exec` mode by `--json`: render raw JSON instead of pretty output.
+static JSON_OUTPUT: AtomicBool = AtomicBool::new(false);
+/// Set whenever a command errors, so `--exec` can exit non-zero.
+static HAD_ERROR: AtomicBool = AtomicBool::new(false);
+
+fn json_output() -> bool {
+    JSON_OUTPUT.load(Ordering::Relaxed)
+}
+
+fn note_error() {
+    HAD_ERROR.store(true, Ordering::Relaxed);
+}
+
+/// A one-line JSON error object for `--json` mode.
+fn error_json(message: &str) -> String {
+    serde_json::json!({ "error": message }).to_string()
 }
 
 /// The server surface the REPL turns into commands. Refreshed on connect
@@ -502,6 +537,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .init();
     let args = Args::parse();
     style::init(args.color);
+    JSON_OUTPUT.store(args.json, Ordering::Relaxed);
+    // --exec runs commands and exits; suppress the banner and surface listing
+    // unless --verbose, so scripted output is only the command results.
+    let one_shot = !args.exec.is_empty();
+    let quiet = one_shot && !args.verbose;
 
     // True while the reedline editor owns the terminal; the elicitation
     // handler declines form requests during that window instead of
@@ -578,10 +618,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .initialize("mcp-repl", env!("CARGO_PKG_VERSION"))
         .await?;
     let server_name = init.server_info.name.clone();
-    print_banner(&init);
+    if !quiet {
+        print_banner(&init);
+    }
 
     let surface = Arc::new(RwLock::new(fetch_surface_initial(&client).await));
-    {
+    if !quiet {
         let s = surface.read().unwrap();
         print_counts(&s);
         // List the tools at startup so the surface is browsable immediately,
@@ -594,6 +636,22 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         if !instructions_list_tools {
             print_tool_overview(&s);
         }
+    }
+
+    // One-shot: run each --exec command in order, then exit non-zero if any
+    // errored. No editor, no event loop.
+    if one_shot {
+        let mut jobs: Vec<(String, String)> = Vec::new();
+        for cmd in &args.exec {
+            if handle_line(&client, &surface, &mut jobs, cmd.trim()).await {
+                break;
+            }
+        }
+        std::process::exit(if HAD_ERROR.load(Ordering::Relaxed) {
+            1
+        } else {
+            0
+        });
     }
 
     // Readline runs on its own thread; lines cross into async via channels.
@@ -680,6 +738,17 @@ async fn handle_line(
         }
         "tools" | "prompts" | "resources" | "templates" => {
             let s = surface.read().unwrap();
+            if json_output() {
+                let v = match cmd {
+                    "tools" => serde_json::to_value(&s.tools),
+                    "prompts" => serde_json::to_value(&s.prompts),
+                    "resources" => serde_json::to_value(&s.resources),
+                    _ => serde_json::to_value(&s.templates),
+                }
+                .unwrap_or_default();
+                println!("{}", json_pretty(&v));
+                return false;
+            }
             match cmd {
                 "tools" => {
                     for t in &s.tools {
@@ -771,6 +840,12 @@ async fn handle_line(
             };
             let started = std::time::Instant::now();
             match client.read_resource(uri).await {
+                Ok(result) if json_output() => {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::to_value(&result).unwrap_or_default())
+                    );
+                }
                 Ok(result) => {
                     for c in result.contents {
                         if let Some(text) = c.text {
@@ -792,9 +867,18 @@ async fn handle_line(
                         }
                     }
                 }
-                Err(e) => println!("{}: {e}", style::error_prefix()),
+                Err(e) => {
+                    note_error();
+                    if json_output() {
+                        println!("{}", error_json(&e.to_string()));
+                    } else {
+                        println!("{}: {e}", style::error_prefix());
+                    }
+                }
             }
-            println!("{}", timing(started.elapsed()));
+            if !json_output() {
+                println!("{}", timing(started.elapsed()));
+            }
         }
         "prompt" => {
             let Some(name) = rest.first() else {
@@ -809,6 +893,12 @@ async fn handle_line(
             }
             let started = std::time::Instant::now();
             match client.get_prompt(name, Some(prompt_args)).await {
+                Ok(result) if json_output() => {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::to_value(&result).unwrap_or_default())
+                    );
+                }
                 Ok(result) => {
                     for m in result.messages {
                         let v = serde_json::to_value(&m).unwrap_or_default();
@@ -823,9 +913,18 @@ async fn handle_line(
                         println!("{} {}", tag(Style::new().fg(Color::Cyan), role), text);
                     }
                 }
-                Err(e) => println!("{}: {e}", style::error_prefix()),
+                Err(e) => {
+                    note_error();
+                    if json_output() {
+                        println!("{}", error_json(&e.to_string()));
+                    } else {
+                        println!("{}: {e}", style::error_prefix());
+                    }
+                }
             }
-            println!("{}", timing(started.elapsed()));
+            if !json_output() {
+                println!("{}", timing(started.elapsed()));
+            }
         }
         "call" => {
             let Some(name) = rest.first() else {
@@ -836,7 +935,12 @@ async fn handle_line(
             let arguments: serde_json::Value = match serde_json::from_str(&json) {
                 Ok(v) => v,
                 Err(e) => {
-                    println!("invalid JSON: {e}");
+                    note_error();
+                    if json_output() {
+                        println!("{}", error_json(&format!("invalid JSON: {e}")));
+                    } else {
+                        println!("invalid JSON: {e}");
+                    }
                     return false;
                 }
             };
@@ -873,8 +977,21 @@ async fn handle_line(
                 },
             };
             match outcome {
+                Ok(task) if json_output() => {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::to_value(&task).unwrap_or_default())
+                    );
+                }
                 Ok(task) => render_task(&task),
-                Err(e) => println!("{}: {e}", style::error_prefix()),
+                Err(e) => {
+                    note_error();
+                    if json_output() {
+                        println!("{}", error_json(&e.to_string()));
+                    } else {
+                        println!("{}: {e}", style::error_prefix());
+                    }
+                }
             }
         }
         "refresh" => {
@@ -907,10 +1024,15 @@ async fn handle_line(
                     .map(|t| t.input_schema.clone())
             };
             let Some(schema) = schema else {
-                println!(
-                    "unknown command: {} (try `help`)",
-                    paint(Style::new().fg(Color::Red), tool_name)
-                );
+                note_error();
+                if json_output() {
+                    println!("{}", error_json(&format!("unknown command: {tool_name}")));
+                } else {
+                    println!(
+                        "unknown command: {} (try `help`)",
+                        paint(Style::new().fg(Color::Red), tool_name)
+                    );
+                }
                 return false;
             };
             let arguments = parse_kv_args(&schema, rest);
@@ -1048,16 +1170,30 @@ async fn run_tool(
     if background {
         match client.call_tool_as_task(name, arguments, None).await {
             Ok(created) => {
-                println!(
-                    "{} started",
-                    tag(
-                        Style::new().fg(Color::Yellow),
-                        &format!("task {}", created.task.task_id)
-                    )
-                );
+                if json_output() {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::to_value(&created).unwrap_or_default())
+                    );
+                } else {
+                    println!(
+                        "{} started",
+                        tag(
+                            Style::new().fg(Color::Yellow),
+                            &format!("task {}", created.task.task_id)
+                        )
+                    );
+                }
                 jobs.push((created.task.task_id, name.to_string()));
             }
-            Err(e) => println!("{}: {e}", style::error_prefix()),
+            Err(e) => {
+                note_error();
+                if json_output() {
+                    println!("{}", error_json(&e.to_string()));
+                } else {
+                    println!("{}: {e}", style::error_prefix());
+                }
+            }
         }
         return;
     }
@@ -1065,13 +1201,32 @@ async fn run_tool(
     match client.call_tool(name, arguments).await {
         Ok(result) => {
             if result.is_error {
-                println!("{}", tag(Style::new().fg(Color::Red), "tool error"));
+                note_error();
             }
-            render_content(&result.content);
+            if json_output() {
+                println!(
+                    "{}",
+                    json_pretty(&serde_json::to_value(&result).unwrap_or_default())
+                );
+            } else {
+                if result.is_error {
+                    println!("{}", tag(Style::new().fg(Color::Red), "tool error"));
+                }
+                render_content(&result.content);
+            }
         }
-        Err(e) => println!("{}: {e}", style::error_prefix()),
+        Err(e) => {
+            note_error();
+            if json_output() {
+                println!("{}", error_json(&e.to_string()));
+            } else {
+                println!("{}: {e}", style::error_prefix());
+            }
+        }
     }
-    println!("{}", timing(started.elapsed()));
+    if !json_output() {
+        println!("{}", timing(started.elapsed()));
+    }
 }
 
 #[cfg(test)]
@@ -1121,6 +1276,12 @@ mod tests {
     fn timing_formats_sub_second_and_seconds() {
         assert!(timing(Duration::from_millis(142)).contains("[142ms]"));
         assert!(timing(Duration::from_millis(2500)).contains("[2.50s]"));
+    }
+
+    #[test]
+    fn error_json_is_a_valid_object() {
+        let v: serde_json::Value = serde_json::from_str(&error_json("boom: it broke")).unwrap();
+        assert_eq!(v["error"], "boom: it broke");
     }
 
     #[test]

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -95,6 +95,10 @@ struct Args {
     #[arg(long)]
     verbose: bool,
 
+    /// Do not persist command history to ~/.mcp-repl_history.
+    #[arg(long)]
+    no_history: bool,
+
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
 }
@@ -665,6 +669,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         line_tx,
         ack_rx,
         at_prompt,
+        !args.no_history,
     );
 
     let mut jobs: Vec<(String, String)> = Vec::new();
@@ -1282,6 +1287,29 @@ mod tests {
     fn error_json_is_a_valid_object() {
         let v: serde_json::Value = serde_json::from_str(&error_json("boom: it broke")).unwrap();
         assert_eq!(v["error"], "boom: it broke");
+    }
+
+    // The persistent-history path relies on FileBackedHistory buffering saves
+    // in memory and only writing on sync() (which sync_history() calls). The
+    // REPL exits abruptly without dropping the editor, so it syncs after each
+    // accepted line; this pins the assumption that save + sync reaches disk.
+    #[test]
+    fn file_backed_history_writes_on_sync() {
+        use reedline::{FileBackedHistory, History, HistoryItem};
+        let path = std::env::temp_dir().join(format!("mcp-repl-hist-{}.txt", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        {
+            let mut h = FileBackedHistory::with_file(10, path.clone()).unwrap();
+            h.save(HistoryItem::from_command_line("echo persisted"))
+                .unwrap();
+            h.sync().unwrap();
+        }
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.contains("echo persisted"),
+            "history was not written to disk: {contents:?}"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]


### PR DESCRIPTION
Re-lands #1001 and #1002 onto `main`. Those PRs were stacked and merged into their base *feature* branches instead of `main`, so the code never reached `main` and #996/#997 stayed open. This is the same two commits cherry-picked onto `main` (the startup-overview commit they were built on is already here via #1000).

Closes #996, closes #997.

## One-shot mode (#996)

`-e/--exec <COMMAND>` (repeatable) runs commands and exits instead of the interactive prompt. Non-zero exit if any command errored; banner suppressed unless `--verbose`. `--json` emits raw JSON (tool calls, `read`, `prompt`, the four list commands, and errors as `{"error": "..."}`) for piping to jq.

## Persistent history (#997)

reedline `FileBackedHistory` at `~/.mcp-repl_history` (1000 entries); `--no-history` opts out. Synced after each accepted line because a typed `quit` exits without dropping the editor (a Drop-only flush would lose it). Unit test pins that `with_file` + `save` + `sync` reaches disk.

## Gates

`fmt --check`, `clippy -D warnings`, 7 unit tests pass. Both commits cherry-picked cleanly.