### PR TITLE
fix(mcp-repl): don't blame multi-instance for every not-initialized startup

### DIFF
--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -348,10 +348,14 @@ async fn fetch_surface_initial(client: &McpClient) -> Surface {
         if attempt == ATTEMPTS {
             eprintln!(
                 "warning: the server kept rejecting surface requests as not-initialized \
-                 after {ATTEMPTS} attempts. This usually means the server runs multiple \
-                 instances without a shared session store, so requests are routed to \
-                 instances that do not share the initialized session. Try `refresh`, or \
-                 connect to a single-instance or stateless server."
+                 after {ATTEMPTS} attempts. The session the handshake established is not \
+                 being recognized on follow-up requests. Two common causes: the server runs \
+                 multiple instances without a shared session store, so requests scatter \
+                 across instances; or a single instance restarted (crash, OOM, or redeploy) \
+                 between requests and lost its in-memory sessions. Try `refresh`. A \
+                 persistent session store or the stateless protocol avoids both; if it is a \
+                 single instance, check its logs and resources (an OOM-looping machine \
+                 flaps like this)."
             );
             return surface;
         }


### PR DESCRIPTION
The startup "not-initialized after N attempts" warning asserted the server "runs multiple instances without a shared session store." That's one cause, but a **single instance that restarts between requests** (crash, OOM, redeploy) loses its in-memory sessions and produces the identical symptom. The confident single-cause message sent a real debugging session chasing horizontal-scaling when the actual cause was an OOM-looping single machine (a 256 MB fly instance flapping 502/503).

Reworded to name both causes and point at logs/resources for the single-instance case. Comment-only user-facing string change; `fmt`/`clippy`/tests pass.

Base `main`, independent (no stacking).