### PR TITLE
feat(types): 2026-07-28 model surface (resultType, MRTR, subscriptions, meta split)

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -6519,4 +6519,27 @@ mod draft_2026_07_28_tests {
             json!({"progressToken": "p"})
         );
     }
+
+    #[test]
+    fn meta_survives_on_a_request_with_no_other_params() {
+        // Guard against the rmcp _meta-drop bug (rust-sdk#993): a params struct
+        // whose only populated field is `_meta` must round-trip `_meta` intact.
+        let params = ListToolsParams {
+            cursor: None,
+            meta: Some(RequestMeta {
+                protocol_version: Some(UPCOMING_PROTOCOL_VERSION.to_string()),
+                ..Default::default()
+            }),
+        };
+        let v = serde_json::to_value(&params).unwrap();
+        assert_eq!(
+            v["_meta"]["io.modelcontextprotocol/protocolVersion"],
+            json!(UPCOMING_PROTOCOL_VERSION)
+        );
+        let back: ListToolsParams = serde_json::from_value(v).unwrap();
+        assert_eq!(
+            back.meta.unwrap().protocol_version.as_deref(),
+            Some(UPCOMING_PROTOCOL_VERSION)
+        );
+    }
 }

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -4575,6 +4575,45 @@ impl ResultType {
             Some(s) => ResultType::from(s.to_string()),
         }
     }
+
+    /// Stamp this discriminator onto a serialized result object, gated on the
+    /// negotiated protocol version. Returns `true` when the field was written.
+    ///
+    /// This is how `resultType` reaches the result base: the field is required
+    /// on 2026-07-28 results but must not appear on 2025-11-25 ones, and serde
+    /// cannot see the negotiated version, so the gate lives here rather than in
+    /// each result struct. Serialize the result, then stamp the value on its way
+    /// out. Nothing is written when
+    /// [`version_carries_result_type`] is false, when `result` is not a JSON
+    /// object, or when the result already carries a `resultType` (results that
+    /// own their discriminator, such as [`InputRequiredResult`] and
+    /// [`CreateTaskResult`], keep it on every version).
+    pub fn stamp_into(&self, result: &mut Value, protocol_version: &str) -> bool {
+        if !version_carries_result_type(protocol_version) {
+            return false;
+        }
+        let Some(obj) = result.as_object_mut() else {
+            return false;
+        };
+        if obj.contains_key("resultType") {
+            return false;
+        }
+        obj.insert(
+            "resultType".to_string(),
+            Value::String(self.as_str().to_string()),
+        );
+        true
+    }
+}
+
+/// Whether results on the given negotiated protocol version carry the SEP-2322
+/// `resultType` discriminator.
+///
+/// `resultType` is part of the 2026-07-28 spec (SEP-2322); on 2025-11-25 it is
+/// absent and readers apply the "absent means `complete`" rule. Version strings
+/// are YYYY-MM-DD dates, so lexicographic comparison is correct.
+pub fn version_carries_result_type(protocol_version: &str) -> bool {
+    protocol_version >= UPCOMING_PROTOCOL_VERSION
 }
 
 impl From<String> for ResultType {
@@ -6541,5 +6580,85 @@ mod draft_2026_07_28_tests {
             back.meta.unwrap().protocol_version.as_deref(),
             Some(UPCOMING_PROTOCOL_VERSION)
         );
+    }
+
+    #[test]
+    fn result_type_stamp_is_gated_on_the_negotiated_version() {
+        let result = CallToolResult::text("hi");
+        let baseline = serde_json::to_value(&result).unwrap();
+
+        // 2025-11-25 output is untouched: no resultType, byte-identical.
+        let mut v = baseline.clone();
+        assert!(!ResultType::Complete.stamp_into(&mut v, "2025-11-25"));
+        assert_eq!(v, baseline);
+
+        // 2026-07-28 carries the discriminator.
+        let mut v = baseline.clone();
+        assert!(ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert_eq!(v["resultType"], json!("complete"));
+        assert_eq!(v["content"], baseline["content"]);
+
+        // Versions after 2026-07-28 keep carrying it (dates compare in order).
+        let mut v = baseline.clone();
+        assert!(ResultType::Complete.stamp_into(&mut v, "2027-01-01"));
+        assert_eq!(v["resultType"], json!("complete"));
+
+        assert!(!version_carries_result_type("2025-11-25"));
+        assert!(version_carries_result_type(UPCOMING_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    fn result_type_stamp_leaves_owned_discriminators_alone() {
+        // InputRequiredResult and CreateTaskResult write their own resultType;
+        // stamping must not overwrite it with "complete".
+        let mut v = serde_json::to_value(InputRequiredResult::new()).unwrap();
+        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert_eq!(v["resultType"], json!("input_required"));
+
+        let mut v = json!({"resultType": RESULT_TYPE_TASK, "taskId": "t1"});
+        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert_eq!(v["resultType"], json!("task"));
+
+        // A non-object result (the empty result some methods return) is a no-op.
+        let mut v = json!(null);
+        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert_eq!(v, json!(null));
+    }
+
+    #[test]
+    fn stamped_result_round_trips_and_reads_back_as_complete() {
+        // Draft-schema shape of a complete tools/call result: the discriminator
+        // rides alongside the 2025-11-25 body and is ignored by readers that
+        // deserialize into the concrete result type.
+        let example = json!({
+            "resultType": "complete",
+            "content": [{"type": "text", "text": "42"}],
+            "isError": false
+        });
+        assert_eq!(
+            ResultType::from_result_value(&example),
+            ResultType::Complete
+        );
+        let parsed: CallToolResult = serde_json::from_value(example).unwrap();
+        let mut round_tripped = serde_json::to_value(&parsed).unwrap();
+        assert!(ResultType::Complete.stamp_into(&mut round_tripped, UPCOMING_PROTOCOL_VERSION));
+        assert_eq!(round_tripped["resultType"], json!("complete"));
+        assert_eq!(round_tripped["content"][0]["text"], json!("42"));
+
+        // An input_required result reads back through the same entry point.
+        let example = json!({
+            "resultType": "input_required",
+            "inputRequests": {"r1": {"method": "elicitation/create", "params": {
+                "message": "which file?",
+                "requestedSchema": {"type": "object", "properties": {}}
+            }}}
+        });
+        assert_eq!(
+            ResultType::from_result_value(&example),
+            ResultType::InputRequired
+        );
+        let parsed: InputRequiredResult = serde_json::from_value(example).unwrap();
+        assert_eq!(parsed.result_type, ResultType::InputRequired);
+        assert!(parsed.input_requests.is_some_and(|r| r.contains_key("r1")));
     }
 }

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -525,13 +525,69 @@ pub enum ProgressToken {
     Number(i64),
 }
 
-/// Request metadata that can include progress token
+/// Request metadata (`_meta`).
+///
+/// Carries the progress token (all versions) and, under 2026-07-28 (SEP-2575),
+/// the per-request protocol version, client identity, client capabilities, and
+/// log level that replaced the `initialize` handshake. Every 2026-07-28 key is
+/// optional here so a single type serves both protocol versions: a 2025-11-25
+/// request carries none of them and serializes byte-identically. Use
+/// [`RequestMeta::validate_for_version`] to enforce the keys a version requires.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestMeta {
-    /// Progress token for receiving progress notifications
+    /// Progress token for receiving progress notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub progress_token: Option<ProgressToken>,
+    /// SEP-2575: the MCP protocol version for this request. Required on
+    /// 2026-07-28; on the HTTP transport it MUST match the
+    /// `MCP-Protocol-Version` header.
+    #[serde(
+        rename = "io.modelcontextprotocol/protocolVersion",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub protocol_version: Option<String>,
+    /// SEP-2575: self-reported client software identity. Optional.
+    #[serde(
+        rename = "io.modelcontextprotocol/clientInfo",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_info: Option<Implementation>,
+    /// SEP-2575: the client's capabilities for this specific request. Required
+    /// on 2026-07-28; declared per-request rather than once at initialization.
+    #[serde(
+        rename = "io.modelcontextprotocol/clientCapabilities",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub client_capabilities: Option<ClientCapabilities>,
+    /// SEP-2575: desired log level for this request. Optional.
+    ///
+    /// Deprecated as of 2026-07-28 (SEP-2577); it replaced the `logging/setLevel`
+    /// RPC. If absent, the server MUST NOT emit `notifications/message` for the
+    /// request.
+    #[serde(
+        rename = "io.modelcontextprotocol/logLevel",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub log_level: Option<LogLevel>,
+}
+
+impl RequestMeta {
+    /// Validate that the `_meta` keys the given protocol version requires are
+    /// present. Under 2026-07-28 (SEP-2575), `protocolVersion` and
+    /// `clientCapabilities` are required; earlier versions carry neither and
+    /// always pass.
+    pub fn validate_for_version(&self, protocol_version: &str) -> Result<(), MissingMetaKey> {
+        if protocol_version == UPCOMING_PROTOCOL_VERSION {
+            if self.protocol_version.is_none() {
+                return Err(MissingMetaKey("io.modelcontextprotocol/protocolVersion"));
+            }
+            if self.client_capabilities.is_none() {
+                return Err(MissingMetaKey("io.modelcontextprotocol/clientCapabilities"));
+            }
+        }
+        Ok(())
+    }
 }
 
 /// High-level MCP response
@@ -1604,6 +1660,12 @@ pub struct DiscoverResult {
 /// future SEPs can add optional fields without breaking callers.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SubscriptionsListenParams {
+    /// SEP-2575: the notification types the client opts in to on this stream.
+    /// The draft schema requires this field; it is optional here so existing
+    /// callers keep compiling, and the transport enforces presence on the
+    /// 2026-07-28 path (#952).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notifications: Option<SubscriptionFilter>,
     /// Optional protocol-level metadata.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Value>,
@@ -1971,6 +2033,22 @@ pub struct CallToolParams {
     pub name: String,
     #[serde(default)]
     pub arguments: Value,
+    /// SEP-2322: responses to the server's [`InputRequests`] from a prior
+    /// `input_required` result, sent on retry of the original request.
+    #[serde(
+        rename = "inputResponses",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input_responses: Option<InputResponses>,
+    /// SEP-2322: opaque request state echoed back from a prior `input_required`
+    /// result.
+    #[serde(
+        rename = "requestState",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub request_state: Option<String>,
     /// Request metadata including progress token
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<RequestMeta>,
@@ -2604,6 +2682,22 @@ pub struct ResourceDefinition {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReadResourceParams {
     pub uri: String,
+    /// SEP-2322: responses to the server's [`InputRequests`] from a prior
+    /// `input_required` result, sent on retry of the original request.
+    #[serde(
+        rename = "inputResponses",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input_responses: Option<InputResponses>,
+    /// SEP-2322: opaque request state echoed back from a prior `input_required`
+    /// result.
+    #[serde(
+        rename = "requestState",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub request_state: Option<String>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<RequestMeta>,
@@ -3009,6 +3103,22 @@ pub struct GetPromptParams {
     pub name: String,
     #[serde(default)]
     pub arguments: std::collections::HashMap<String, String>,
+    /// SEP-2322: responses to the server's [`InputRequests`] from a prior
+    /// `input_required` result, sent on retry of the original request.
+    #[serde(
+        rename = "inputResponses",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input_responses: Option<InputResponses>,
+    /// SEP-2322: opaque request state echoed back from a prior `input_required`
+    /// result.
+    #[serde(
+        rename = "requestState",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub request_state: Option<String>,
     /// Optional protocol-level metadata
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<RequestMeta>,
@@ -4406,6 +4516,278 @@ impl McpNotification {
             }),
         }
     }
+}
+
+// =============================================================================
+// 2026-07-28 draft surface: result discrimination, Multi Round-Trip Requests
+// (SEP-2322), subscription streams (SEP-2575), and the meta model split.
+//
+// Everything here is additive and version-gated by omission: every new field
+// uses `skip_serializing_if`, so a value carrying none of it serializes
+// byte-identically to 2025-11-25 output. These shapes track the current
+// `2026-07-28` draft schema; a re-verify-against-final checkpoint is in #929.
+// =============================================================================
+
+/// The type discriminator carried by a 2026-07-28 result (SEP-2322).
+///
+/// The draft schema requires `resultType` on every result. For backward
+/// compatibility a client MUST treat an absent field as [`ResultType::Complete`];
+/// use [`ResultType::from_result_value`] to read it with that rule applied.
+/// `Complete` is the [`Default`].
+///
+/// The wire form is an open string. `"complete"` and `"input_required"` are
+/// defined by SEP-2322; extensions (for example the Tasks extension's
+/// `"task"`) may define further values, captured by [`ResultType::Other`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[non_exhaustive]
+pub enum ResultType {
+    /// The request completed; the result carries the final content.
+    #[default]
+    Complete,
+    /// The server needs more input before it can complete the request; the
+    /// result is an [`InputRequiredResult`].
+    InputRequired,
+    /// A value not defined by SEP-2322, for example an extension discriminator.
+    Other(String),
+}
+
+impl ResultType {
+    /// The wire string for this discriminator.
+    pub fn as_str(&self) -> &str {
+        match self {
+            ResultType::Complete => "complete",
+            ResultType::InputRequired => "input_required",
+            ResultType::Other(s) => s.as_str(),
+        }
+    }
+
+    /// Whether this is the default `"complete"` discriminator.
+    pub fn is_complete(&self) -> bool {
+        matches!(self, ResultType::Complete)
+    }
+
+    /// Read the discriminator from a raw result object, applying the SEP-2322
+    /// backward-compatibility rule: a missing (or non-string) `resultType`
+    /// reads as [`ResultType::Complete`].
+    pub fn from_result_value(value: &Value) -> ResultType {
+        match value.get("resultType").and_then(Value::as_str) {
+            None => ResultType::Complete,
+            Some(s) => ResultType::from(s.to_string()),
+        }
+    }
+}
+
+impl From<String> for ResultType {
+    fn from(s: String) -> ResultType {
+        match s.as_str() {
+            "complete" => ResultType::Complete,
+            "input_required" => ResultType::InputRequired,
+            _ => ResultType::Other(s),
+        }
+    }
+}
+
+impl From<ResultType> for String {
+    fn from(r: ResultType) -> String {
+        match r {
+            ResultType::Complete => "complete".to_string(),
+            ResultType::InputRequired => "input_required".to_string(),
+            ResultType::Other(s) => s,
+        }
+    }
+}
+
+impl serde::Serialize for ResultType {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ResultType {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<ResultType, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(ResultType::from(s))
+    }
+}
+
+/// A single server-initiated request the client must fulfil during a Multi
+/// Round-Trip Request (SEP-2322). Serialized adjacently as `{method, params}`,
+/// mirroring the JSON-RPC request embedded in an [`InputRequests`] map.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "method", content = "params")]
+#[non_exhaustive]
+pub enum InputRequest {
+    /// `sampling/createMessage`
+    #[serde(rename = "sampling/createMessage")]
+    CreateMessage(CreateMessageParams),
+    /// `roots/list`
+    #[serde(rename = "roots/list")]
+    ListRoots(ListRootsParams),
+    /// `elicitation/create`
+    #[serde(rename = "elicitation/create")]
+    Elicit(ElicitRequestParams),
+}
+
+impl InputRequest {
+    /// The MCP method name for this input request.
+    pub fn method_name(&self) -> &str {
+        match self {
+            InputRequest::CreateMessage(_) => "sampling/createMessage",
+            InputRequest::ListRoots(_) => "roots/list",
+            InputRequest::Elicit(_) => "elicitation/create",
+        }
+    }
+}
+
+/// A single client response to a server-initiated [`InputRequest`] (SEP-2322).
+/// Untagged: the wire value is the bare result object, correlated to its
+/// request by its key in the [`InputResponses`] map.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum InputResponse {
+    /// Result of a `sampling/createMessage` request.
+    CreateMessage(CreateMessageResult),
+    /// Result of a `roots/list` request.
+    ListRoots(ListRootsResult),
+    /// Result of an `elicitation/create` request.
+    Elicit(ElicitResult),
+}
+
+/// Map of server-initiated requests the client must fulfil, keyed by
+/// server-assigned identifiers (SEP-2322).
+pub type InputRequests = std::collections::BTreeMap<String, InputRequest>;
+
+/// Map of client responses to [`InputRequests`], keyed by the same
+/// identifiers (SEP-2322).
+pub type InputResponses = std::collections::BTreeMap<String, InputResponse>;
+
+/// A 2026-07-28 result signalling the server needs more input before it can
+/// complete the original request (SEP-2322).
+///
+/// At least one of `input_requests` or `request_state` is present. The client
+/// fulfils the requests, then retries the original request carrying the
+/// matching `inputResponses` (and echoing `requestState`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InputRequiredResult {
+    /// Always [`ResultType::InputRequired`].
+    #[serde(rename = "resultType", default = "result_type_input_required")]
+    pub result_type: ResultType,
+    /// Requests the server needs fulfilled before the client retries.
+    #[serde(
+        rename = "inputRequests",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub input_requests: Option<InputRequests>,
+    /// Opaque blob the client echoes back on retry. The client MUST NOT
+    /// interpret it.
+    #[serde(
+        rename = "requestState",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub request_state: Option<String>,
+    /// Result-level metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Value>,
+}
+
+fn result_type_input_required() -> ResultType {
+    ResultType::InputRequired
+}
+
+impl InputRequiredResult {
+    /// An empty `input_required` result. Set `input_requests` and/or
+    /// `request_state` before returning it.
+    pub fn new() -> Self {
+        InputRequiredResult {
+            result_type: ResultType::InputRequired,
+            input_requests: None,
+            request_state: None,
+            meta: None,
+        }
+    }
+}
+
+impl Default for InputRequiredResult {
+    fn default() -> Self {
+        InputRequiredResult::new()
+    }
+}
+
+/// Notification meta (`_meta`) carried by notifications delivered on a
+/// `subscriptions/listen` stream (SEP-2575).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct NotificationMeta {
+    /// Identifies the subscription stream a notification was delivered on: the
+    /// JSON-RPC id of the `subscriptions/listen` request that opened it.
+    /// Absent on notifications not delivered via a subscription stream.
+    #[serde(
+        rename = "io.modelcontextprotocol/subscriptionId",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub subscription_id: Option<RequestId>,
+}
+
+/// Result meta (`_meta`) fields the server may attach to a response (SEP-2575).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ResultMeta {
+    /// Identifies the server software producing the response. Self-reported and
+    /// unverified; intended for display, logging, and debugging.
+    #[serde(
+        rename = "io.modelcontextprotocol/serverInfo",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub server_info: Option<Implementation>,
+}
+
+/// A required `_meta` key was missing for the negotiated protocol version.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingMetaKey(pub &'static str);
+
+impl std::fmt::Display for MissingMetaKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "missing required _meta key for the negotiated protocol version: {}",
+            self.0
+        )
+    }
+}
+
+impl std::error::Error for MissingMetaKey {}
+
+/// Notification types a client opts in to on a `subscriptions/listen` stream
+/// (SEP-2575). Replaces the 2025-11-25 `resources/subscribe` RPC. The server
+/// MUST NOT send a notification type the client did not request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscriptionFilter {
+    /// Receive `notifications/tools/list_changed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tools_list_changed: Option<bool>,
+    /// Receive `notifications/prompts/list_changed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompts_list_changed: Option<bool>,
+    /// Receive `notifications/resources/list_changed`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resources_list_changed: Option<bool>,
+    /// Resource URIs to receive `notifications/resources/updated` for.
+    /// Replaces the former `resources/subscribe` RPC.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resource_subscriptions: Option<Vec<String>>,
+}
+
+/// Parameters for a `notifications/subscriptions/acknowledged` notification
+/// (SEP-2575): the subset of requested notification types the server will honor.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SubscriptionsAcknowledgedParams {
+    /// The notification types the server agreed to honor. Types the server does
+    /// not support are omitted.
+    pub notifications: SubscriptionFilter,
 }
 
 #[cfg(test)]
@@ -5984,6 +6366,157 @@ mod tests {
         assert_eq!(
             json["extensions"]["io.modelcontextprotocol/tasks"],
             serde_json::json!({})
+        );
+    }
+}
+
+#[cfg(test)]
+mod draft_2026_07_28_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn result_type_wire_forms_and_backcompat() {
+        assert_eq!(
+            serde_json::to_value(ResultType::Complete).unwrap(),
+            json!("complete")
+        );
+        assert_eq!(
+            serde_json::to_value(ResultType::InputRequired).unwrap(),
+            json!("input_required")
+        );
+        assert_eq!(
+            serde_json::to_value(ResultType::Other("task".into())).unwrap(),
+            json!("task")
+        );
+        assert_eq!(
+            serde_json::from_value::<ResultType>(json!("input_required")).unwrap(),
+            ResultType::InputRequired
+        );
+        assert_eq!(
+            serde_json::from_value::<ResultType>(json!("task")).unwrap(),
+            ResultType::Other("task".into())
+        );
+        // SEP-2322 backward-compat rule: an absent resultType reads as complete.
+        assert_eq!(
+            ResultType::from_result_value(&json!({"content": []})),
+            ResultType::Complete
+        );
+        assert_eq!(
+            ResultType::from_result_value(&json!({"resultType": "input_required"})),
+            ResultType::InputRequired
+        );
+        assert!(ResultType::default().is_complete());
+    }
+
+    #[test]
+    fn input_required_result_round_trips() {
+        let requests: InputRequests =
+            serde_json::from_value(json!({ "r1": {"method": "roots/list", "params": {}} }))
+                .unwrap();
+        let result = InputRequiredResult {
+            input_requests: Some(requests),
+            request_state: Some("opaque-blob".to_string()),
+            ..InputRequiredResult::new()
+        };
+        let v = serde_json::to_value(&result).unwrap();
+        assert_eq!(v["resultType"], json!("input_required"));
+        assert_eq!(v["inputRequests"]["r1"]["method"], json!("roots/list"));
+        assert_eq!(v["requestState"], json!("opaque-blob"));
+        let back: InputRequiredResult = serde_json::from_value(v).unwrap();
+        assert_eq!(back.result_type, ResultType::InputRequired);
+        assert_eq!(back.request_state.as_deref(), Some("opaque-blob"));
+    }
+
+    #[test]
+    fn input_request_is_adjacently_tagged_and_response_untagged() {
+        let ir: InputRequest =
+            serde_json::from_value(json!({"method": "roots/list", "params": {}})).unwrap();
+        assert_eq!(ir.method_name(), "roots/list");
+        assert!(matches!(ir, InputRequest::ListRoots(_)));
+        assert_eq!(
+            serde_json::to_value(&ir).unwrap(),
+            json!({"method": "roots/list", "params": {}})
+        );
+        // Untagged response value, correlated to its request by map key.
+        let resp: InputResponse = serde_json::from_value(json!({"roots": []})).unwrap();
+        assert!(matches!(resp, InputResponse::ListRoots(_)));
+    }
+
+    #[test]
+    fn request_meta_carries_sep2575_keys_and_validates_by_version() {
+        let meta = RequestMeta {
+            protocol_version: Some(UPCOMING_PROTOCOL_VERSION.to_string()),
+            client_capabilities: Some(ClientCapabilities::default()),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&meta).unwrap();
+        assert_eq!(
+            v["io.modelcontextprotocol/protocolVersion"],
+            json!(UPCOMING_PROTOCOL_VERSION)
+        );
+        assert!(
+            v.get("io.modelcontextprotocol/clientCapabilities")
+                .is_some()
+        );
+        // Version-aware required-key validation (SEP-2575).
+        assert!(meta.validate_for_version(UPCOMING_PROTOCOL_VERSION).is_ok());
+        assert!(
+            RequestMeta::default()
+                .validate_for_version(UPCOMING_PROTOCOL_VERSION)
+                .is_err()
+        );
+        assert!(
+            RequestMeta::default()
+                .validate_for_version("2025-11-25")
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn subscription_types_round_trip() {
+        let filter = SubscriptionFilter {
+            tools_list_changed: Some(true),
+            resource_subscriptions: Some(vec!["file:///a".to_string()]),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&filter).unwrap();
+        assert_eq!(v["toolsListChanged"], json!(true));
+        assert_eq!(v["resourceSubscriptions"], json!(["file:///a"]));
+        assert!(v.get("promptsListChanged").is_none()); // None is omitted
+
+        let ack = SubscriptionsAcknowledgedParams {
+            notifications: filter,
+        };
+        let back: SubscriptionsAcknowledgedParams =
+            serde_json::from_value(serde_json::to_value(&ack).unwrap()).unwrap();
+        assert_eq!(back.notifications.tools_list_changed, Some(true));
+    }
+
+    #[test]
+    fn additions_keep_2025_11_25_output_byte_identical() {
+        // A tools/call with no MRTR/task/meta serializes exactly as before:
+        // only name + arguments, no new keys.
+        let params = CallToolParams {
+            name: "echo".to_string(),
+            arguments: json!({"message": "hi"}),
+            input_responses: None,
+            request_state: None,
+            meta: None,
+            task: None,
+        };
+        assert_eq!(
+            serde_json::to_value(&params).unwrap(),
+            json!({"name": "echo", "arguments": {"message": "hi"}})
+        );
+        // RequestMeta with only a progress token adds no SEP-2575 keys.
+        let meta = RequestMeta {
+            progress_token: Some(ProgressToken::String("p".into())),
+            ..Default::default()
+        };
+        assert_eq!(
+            serde_json::to_value(&meta).unwrap(),
+            json!({"progressToken": "p"})
         );
     }
 }

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -387,6 +387,8 @@ impl McpClient {
         let params = CallToolParams {
             name: name.to_string(),
             arguments,
+            input_responses: None,
+            request_state: None,
             meta: None,
             task: None,
         };
@@ -416,6 +418,8 @@ impl McpClient {
         let params = CallToolParams {
             name: name.to_string(),
             arguments,
+            input_responses: None,
+            request_state: None,
             meta: None,
             task: Some(TaskRequestParams { ttl: ttl_ms }),
         };
@@ -490,6 +494,8 @@ impl McpClient {
         self.ensure_initialized()?;
         let params = ReadResourceParams {
             uri: uri.to_string(),
+            input_responses: None,
+            request_state: None,
             meta: None,
         };
         self.send_request("resources/read", &params).await
@@ -649,6 +655,8 @@ impl McpClient {
         let params = GetPromptParams {
             name: name.to_string(),
             arguments: arguments.unwrap_or_default(),
+            input_responses: None,
+            request_state: None,
             meta: None,
         };
         self.send_request("prompts/get", &params).await

--- a/crates/tower-mcp/src/middleware/audit.rs
+++ b/crates/tower-mcp/src/middleware/audit.rs
@@ -295,6 +295,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "my_tool".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -315,6 +317,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(2),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///test.txt".to_string(),
                 meta: None,
             }),
@@ -332,6 +336,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(3),
             inner: McpRequest::GetPrompt(GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "review".to_string(),
                 arguments: HashMap::new(),
                 meta: None,
@@ -393,6 +399,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "test_tool".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -414,6 +422,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "nonexistent".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,

--- a/crates/tower-mcp/src/middleware/tool_call_logging.rs
+++ b/crates/tower-mcp/src/middleware/tool_call_logging.rs
@@ -295,6 +295,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "test_tool".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -320,6 +322,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "nonexistent".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -396,6 +400,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -422,6 +428,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///test".to_string(),
                 meta: None,
             }),

--- a/crates/tower-mcp/src/middleware/tracing.rs
+++ b/crates/tower-mcp/src/middleware/tracing.rs
@@ -318,6 +318,8 @@ mod tests {
 
         // Test tool call
         let req = McpRequest::CallTool(CallToolParams {
+            input_responses: None,
+            request_state: None,
             name: "my_tool".to_string(),
             arguments: Value::Null,
             meta: None,
@@ -329,6 +331,8 @@ mod tests {
 
         // Test resource read
         let req = McpRequest::ReadResource(ReadResourceParams {
+            input_responses: None,
+            request_state: None,
             uri: "file:///test.txt".to_string(),
             meta: None,
         });
@@ -338,6 +342,8 @@ mod tests {
 
         // Test prompt get
         let req = McpRequest::GetPrompt(GetPromptParams {
+            input_responses: None,
+            request_state: None,
             name: "my_prompt".to_string(),
             arguments: HashMap::new(),
             meta: None,

--- a/crates/tower-mcp/src/proxy/service.rs
+++ b/crates/tower-mcp/src/proxy/service.rs
@@ -644,6 +644,8 @@ async fn handle_call_tool(
     let inner_request = McpRequest::CallTool(CallToolParams {
         name: stripped_name,
         arguments: params.arguments,
+        input_responses: params.input_responses,
+        request_state: params.request_state,
         meta: params.meta,
         task: params.task,
     });
@@ -711,6 +713,8 @@ async fn handle_read_resource(
 ) -> Result<McpResponse, JsonRpcError> {
     let inner_request = McpRequest::ReadResource(ReadResourceParams {
         uri: stripped_uri,
+        input_responses: params.input_responses,
+        request_state: params.request_state,
         meta: params.meta,
     });
 
@@ -753,6 +757,8 @@ async fn handle_get_prompt(
     let inner_request = McpRequest::GetPrompt(GetPromptParams {
         name: stripped_name,
         arguments: params.arguments,
+        input_responses: params.input_responses,
+        request_state: params.request_state,
         meta: params.meta,
     });
 

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -203,6 +203,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 10, "b": 32}),
                 meta: None,
@@ -223,6 +225,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "text_echo".to_string(),
                 arguments: json!({"message": "hello"}),
                 meta: None,
@@ -251,6 +255,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "nonexistent_tool".to_string(),
                 arguments: json!({}),
                 meta: None,
@@ -275,6 +281,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::ReadResource(crate::protocol::ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "unknown://resource".to_string(),
                 meta: None,
             }),
@@ -297,6 +305,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::GetPrompt(crate::protocol::GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "nonexistent_prompt".to_string(),
                 arguments: Default::default(),
                 meta: None,
@@ -346,6 +356,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::ReadResource(crate::protocol::ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "text_file:///README.md".to_string(),
                 meta: None,
             }),
@@ -429,6 +441,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::GetPrompt(crate::protocol::GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "text_greet".to_string(),
                 arguments: HashMap::from([("name".to_string(), "Alice".to_string())]),
                 meta: None,
@@ -497,6 +511,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math.add".to_string(),
                 arguments: json!({"a": 1, "b": 2}),
                 meta: None,
@@ -633,6 +649,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 5, "b": 7}),
                 meta: None,
@@ -832,6 +850,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 500}),
                 meta: None,
@@ -867,6 +887,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 0}),
                 meta: None,
@@ -905,6 +927,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 1, "b": 2}),
                 meta: None,
@@ -923,6 +947,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 500}),
                 meta: None,
@@ -1160,6 +1186,8 @@ mod proxy_tests {
         let req1 = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 10}),
                 meta: None,
@@ -1170,6 +1198,8 @@ mod proxy_tests {
         let req2 = RouterRequest {
             id: RequestId::Number(2),
             inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 10}),
                 meta: None,
@@ -1299,6 +1329,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "text_echo".to_string(),
                 arguments: json!({"message": "dynamic!"}),
                 meta: None,
@@ -1416,6 +1448,8 @@ mod proxy_tests {
         let result = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow_slow_op".to_string(),
                 arguments: json!({"delay_ms": 500}),
                 meta: None,
@@ -1430,6 +1464,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 3, "b": 4}),
                 meta: None,
@@ -1501,6 +1537,8 @@ mod proxy_tests {
             let req = RouterRequest {
                 id: RequestId::Number(2),
                 inner: McpRequest::CallTool(crate::protocol::CallToolParams {
+                    input_responses: None,
+                    request_state: None,
                     name: "math_add".to_string(),
                     arguments: json!({"a": 10, "b": 20}),
                     meta: None,
@@ -1616,6 +1654,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 1, "b": 2}),
                 meta: None,
@@ -1644,6 +1684,8 @@ mod proxy_tests {
         let resp = call_proxy(
             &mut proxy,
             McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "math_add".to_string(),
                 arguments: json!({"a": 10, "b": 20}),
                 meta: None,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2966,6 +2966,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({"a": 2, "b": 3}),
                 meta: None,
@@ -3365,6 +3367,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "db://users/123".to_string(),
                 meta: None,
             }),
@@ -3421,6 +3425,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///README.md".to_string(),
                 meta: None,
             }),
@@ -3471,6 +3477,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "db://posts/123".to_string(),
                 meta: None,
             }),
@@ -3717,6 +3725,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({"a": 5, "b": 10}),
                 meta: None,
@@ -3850,6 +3860,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({"a": 2, "b": 3}),
                 meta: None,
@@ -3947,6 +3959,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({"a": 7, "b": 8}),
                 meta: None,
@@ -4006,6 +4020,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "slow".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -4074,6 +4090,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "add".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -4124,6 +4142,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "sync_only".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -4612,6 +4632,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "admin".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -4653,6 +4675,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "public".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -4692,6 +4716,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "admin".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -4772,6 +4798,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///secret.txt".to_string(),
                 meta: None,
             }),
@@ -4808,6 +4836,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///public.txt".to_string(),
                 meta: None,
             }),
@@ -4845,6 +4875,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///secret.txt".to_string(),
                 meta: None,
             }),
@@ -4924,6 +4956,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::GetPrompt(GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "system_debug".to_string(),
                 arguments: HashMap::new(),
                 meta: None,
@@ -4962,6 +4996,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::GetPrompt(GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "greeting".to_string(),
                 arguments: HashMap::new(),
                 meta: None,
@@ -5000,6 +5036,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::GetPrompt(GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "system_debug".to_string(),
                 arguments: HashMap::new(),
                 meta: None,
@@ -5250,6 +5288,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "api.echo".to_string(),
                 arguments: serde_json::json!({"value": "hello world"}),
                 meta: None,
@@ -6279,6 +6319,8 @@ mod tests {
             let req = RouterRequest {
                 id: RequestId::Number(2),
                 inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
                     name: "shared".to_string(),
                     arguments: serde_json::json!({"a": 1, "b": 2}),
                     meta: None,
@@ -6321,6 +6363,8 @@ mod tests {
             let req = RouterRequest {
                 id: RequestId::Number(1),
                 inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
                     name: "add".to_string(),
                     arguments: serde_json::json!({"a": 3, "b": 4}),
                     meta: None,
@@ -6445,6 +6489,8 @@ mod tests {
             let req = RouterRequest {
                 id: RequestId::Number(2),
                 inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
                     name: "hidden".to_string(),
                     arguments: serde_json::json!({"a": 1, "b": 2}),
                     meta: None,
@@ -6532,6 +6578,8 @@ mod tests {
             let req = RouterRequest {
                 id: RequestId::Number(1),
                 inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
                     name: "nonexistent".to_string(),
                     arguments: serde_json::json!({}),
                     meta: None,
@@ -6742,6 +6790,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(2),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "dangerous".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -6770,6 +6820,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(3),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "flippy".to_string(),
                 arguments: serde_json::json!({"a": 1, "b": 2}),
                 meta: None,
@@ -6849,6 +6901,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(6),
             inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
                 uri: "file:///hidden.txt".to_string(),
                 meta: None,
             }),
@@ -6876,6 +6930,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(8),
             inner: McpRequest::GetPrompt(GetPromptParams {
+                input_responses: None,
+                request_state: None,
                 name: "hidden_prompt".to_string(),
                 arguments: Default::default(),
                 meta: None,

--- a/crates/tower-mcp/src/transport/service.rs
+++ b/crates/tower-mcp/src/transport/service.rs
@@ -274,6 +274,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "read_data".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,
@@ -429,6 +431,8 @@ mod tests {
         let req = RouterRequest {
             id: RequestId::Number(1),
             inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
                 name: "reader".to_string(),
                 arguments: serde_json::json!({}),
                 meta: None,

--- a/crates/tower-mcp/tests/schema_validation.rs
+++ b/crates/tower-mcp/tests/schema_validation.rs
@@ -236,6 +236,8 @@ fn validate_list_resource_templates_result() {
 #[test]
 fn validate_call_tool_request_params() {
     let params = CallToolParams {
+        input_responses: None,
+        request_state: None,
         name: "test-tool".to_string(),
         arguments: json!({"key": "value"}),
         meta: None,
@@ -273,6 +275,8 @@ fn validate_initialize_request_params() {
 #[test]
 fn validate_get_prompt_request_params() {
     let params = GetPromptParams {
+        input_responses: None,
+        request_state: None,
         name: "greeting".to_string(),
         arguments: std::collections::HashMap::from([("name".to_string(), "world".to_string())]),
         meta: None,
@@ -283,6 +287,8 @@ fn validate_get_prompt_request_params() {
 #[test]
 fn validate_read_resource_request_params() {
     let params = ReadResourceParams {
+        input_responses: None,
+        request_state: None,
         uri: "file:///test.txt".to_string(),
         meta: None,
     };


### PR DESCRIPTION
Implements the remaining 2026-07-28 model surface in `tower-mcp-types`. Phase 2 of the parity roadmap (#929), closes #949. Version-gated so 2025-11-25 wire output stays byte-identical.

## Timing note

#949 says "starts after the 2026-07-28 schema is published." We are implementing against the current draft ahead of the scheduled 2026-07-28 finalization, by explicit decision: the types surface is needed either way, and encoding the current draft shape now makes the finalization diff a trim rather than a rewrite. A re-verify-against-final checkpoint is tracked in #929.

## Already landed (not re-done here)

- SEP-2549 `CacheScope` + `ttl_ms`/`cache_scope` on list/read results (#826)
- `server/discover` `DiscoverResult` end-to-end (#829)
- Tasks repackaged as the `io.modelcontextprotocol/tasks` extension; `CreateTaskResult` inlines the task and sets `resultType: "task"` via `RESULT_TYPE_TASK`, already tested (#846)

## This PR adds

- [x] `ResultType` (`"complete"` | `"input_required"` | open string) with the SEP-2322 backward-compat rule (absent reads as `Complete`) via `ResultType::from_result_value`. `InputRequiredResult` carries `resultType: "input_required"`.
- [x] MRTR (SEP-2322): `InputRequest`, `InputResponse`, `InputRequests`, `InputResponses`, `InputRequiredResult`; `inputResponses` + `requestState` params on `tools/call`, `prompts/get`, `resources/read`. The proxy forwards both fields so it stays MRTR-transparent.
- [x] Meta model (SEP-2575): `RequestMeta` extended with `protocolVersion`, `clientInfo`, `clientCapabilities`, `logLevel`; new `NotificationMeta` (`subscriptionId`) and `ResultMeta` (`serverInfo`); `RequestMeta::validate_for_version` enforces the keys 2026-07-28 requires.
- [x] Subscriptions (SEP-2575): `SubscriptionFilter`, a `notifications` field on `SubscriptionsListenParams`, and `SubscriptionsAcknowledgedParams`.

## Scope decision: resultType emission

The `ResultType` discriminator, `from_result_value` peek helper, and `InputRequiredResult` give a client everything it needs to tell a normal result from an `input_required` one. The draft additionally says a 2026-07-28 server MUST emit `resultType` on every complete result. That per-struct emission is version-dependent (a 2025-11-25 result must omit it to stay byte-identical), so it belongs at the transport/router layer that knows the negotiated version, not on the type structs. It is deferred to the transport phase (#952); this PR does not retrofit a `result_type` field onto all ~15 result structs.

## Testing

- Round-trip tests for every new shape (`draft_2026_07_28_tests`).
- Explicit assertion that 2025-11-25 output is byte-identical (no new keys on a plain `tools/call` or a progress-only `RequestMeta`).
- `_meta`-survival regression for a params-only request (rmcp rust-sdk#993).
- Full `tower-mcp-types` + `tower-mcp` suites pass; `wasm32-unknown-unknown` build of the types crate passes.