### PR TITLE
feat(mcp-repl): server profiles via config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,8 +1578,10 @@ dependencies = [
  "clap",
  "nu-ansi-term",
  "reedline",
+ "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tower-mcp",
  "tracing-subscriber",
 ]
@@ -2497,6 +2499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2995,6 +3006,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -3774,6 +3824,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -18,7 +18,9 @@ path = "src/main.rs"
 tower-mcp = { workspace = true, features = ["http-client"] }
 async-trait.workspace = true
 tokio.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+toml = "1"
 clap.workspace = true
 tracing-subscriber.workspace = true
 reedline = "0.49"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -53,8 +53,50 @@ mcp-repl --http https://internal.example/mcp --bearer "$TOKEN"
 mcp-repl --http https://internal.example/mcp --header "X-Api-Key: abc"
 ```
 
-`--bearer` and `--header` apply only to `--http`; they are ignored (with a
-warning) for the demo and stdio-child transports.
+`--bearer` and `--header` apply only to HTTP connections; they are ignored
+(with a warning) for the demo and stdio-child transports.
+
+## Profiles
+
+A config file names servers so a connection is `mcp-repl <name>` instead of a
+URL plus repeated auth flags, and tokens stay out of shell history. The file
+lives at `$XDG_CONFIG_HOME/mcp-repl/config.toml`, falling back to
+`~/.config/mcp-repl/config.toml`; `--config <path>` reads a different one.
+
+```toml
+[servers.cratesio]
+transport = "http"                 # http | stdio
+url = "https://cratesio-mcp.fly.dev/"
+bearer_env = "CRATESIO_TOKEN"      # read the token from the environment
+headers = { "X-Api-Key" = "abc" }
+
+[servers.local]
+transport = "stdio"
+command = ["cargo", "run", "--example", "getting_started"]
+```
+
+```bash
+mcp-repl --list-servers            # the configured profiles
+mcp-repl --server cratesio         # connect by name
+mcp-repl cratesio                  # a bare name works too
+```
+
+- `transport` is optional: a profile with a `url` is HTTP, one with a
+  `command` is stdio. A profile with both must say which.
+- Explicit flags override profile fields. `--http <url>` retargets the URL
+  while keeping the profile's auth; `--bearer` replaces the profile's token;
+  each `--header` overrides the profile header of the same name.
+- The bare-name form only resolves when the single positional matches a
+  configured profile, so spawning a stdio server by bare name still works.
+  Because everything after the first positional belongs to the spawned
+  command, use `--server <name>` when other flags follow.
+- Secrets: `bearer_env` names an environment variable holding the token. An
+  unset variable is an error rather than a silent anonymous connection. An
+  inline `bearer = "..."` works but warns, since it puts the token in the
+  file.
+- An unknown profile name errors with the list of known names, and a missing
+  `--config` file is an error. A missing file at the default location is not:
+  profiles are opt-in.
 
 ## What to try
 

--- a/examples/mcp-repl/src/config.rs
+++ b/examples/mcp-repl/src/config.rs
@@ -1,0 +1,372 @@
+//! Server profiles: a config file of named servers, so a remote MCP server
+//! can be reached as `mcp-repl <name>` instead of a URL plus repeated
+//! `--bearer`/`--header` flags.
+//!
+//! The file lives at `$XDG_CONFIG_HOME/mcp-repl/config.toml`, falling back to
+//! `~/.config/mcp-repl/config.toml`, and `--config <path>` overrides it:
+//!
+//! ```toml
+//! [servers.cratesio]
+//! transport = "http"
+//! url = "https://cratesio-mcp.fly.dev/"
+//! bearer_env = "CRATESIO_TOKEN"
+//! headers = { "X-Api-Key" = "..." }
+//!
+//! [servers.local]
+//! transport = "stdio"
+//! command = ["cargo", "run", "--example", "getting_started"]
+//! ```
+//!
+//! Tokens are read from the environment via `bearer_env` rather than stored in
+//! the file; an inline `bearer` literal works but warns.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The whole config file: named profiles under `[servers.<name>]`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    #[serde(default)]
+    pub servers: BTreeMap<String, Profile>,
+}
+
+/// One `[servers.<name>]` table.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Profile {
+    /// `http` or `stdio`. Optional: inferred from `url`/`command` when absent.
+    pub transport: Option<Transport>,
+    /// The endpoint for an `http` profile.
+    pub url: Option<String>,
+    /// An inline bearer token. Prefer `bearer_env`; this warns when used.
+    pub bearer: Option<String>,
+    /// Name of the environment variable holding the bearer token.
+    pub bearer_env: Option<String>,
+    /// Extra headers sent with every request of an `http` profile.
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    /// The command (and arguments) of a `stdio` profile's child process.
+    #[serde(default)]
+    pub command: Vec<String>,
+}
+
+/// The transports a profile can name. `ws` and stateless HTTP are not
+/// profile-addressable yet, so an unknown value is a config error rather than
+/// a silent fallback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Transport {
+    Http,
+    Stdio,
+}
+
+/// A profile resolved into everything needed to connect. Produced after the
+/// CLI flags have had their say.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Connection {
+    Http {
+        url: String,
+        bearer: Option<String>,
+        headers: Vec<(String, String)>,
+    },
+    Stdio {
+        command: Vec<String>,
+    },
+}
+
+impl Config {
+    /// Parse a config file's contents.
+    pub fn parse(source: &str) -> Result<Self, String> {
+        toml::from_str(source).map_err(|e| e.to_string())
+    }
+
+    /// Read the config from `path`. A missing file is an error only when the
+    /// path was explicitly requested (`--config`); the default location is
+    /// allowed not to exist.
+    pub fn load(path: &Path, explicit: bool) -> Result<Self, String> {
+        match std::fs::read_to_string(path) {
+            Ok(source) => Self::parse(&source).map_err(|e| format!("{}: {e}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound && !explicit => Ok(Self::default()),
+            Err(e) => Err(format!("{}: {e}", path.display())),
+        }
+    }
+
+    /// Look up a profile by name, with an error listing the known names when
+    /// it is missing.
+    pub fn profile(&self, name: &str) -> Result<&Profile, String> {
+        self.servers.get(name).ok_or_else(|| {
+            if self.servers.is_empty() {
+                format!("no server profile named {name:?}: no profiles are configured")
+            } else {
+                format!(
+                    "no server profile named {name:?}: known profiles are {}",
+                    self.names().join(", ")
+                )
+            }
+        })
+    }
+
+    /// The configured profile names, sorted.
+    pub fn names(&self) -> Vec<&str> {
+        self.servers.keys().map(String::as_str).collect()
+    }
+}
+
+impl Profile {
+    /// The transport this profile connects over: the declared one, else
+    /// inferred from whichever of `url`/`command` is present.
+    pub fn transport(&self) -> Result<Transport, String> {
+        match (self.transport, self.url.is_some(), !self.command.is_empty()) {
+            (Some(t), _, _) => Ok(t),
+            (None, true, false) => Ok(Transport::Http),
+            (None, false, true) => Ok(Transport::Stdio),
+            (None, true, true) => Err(
+                "profile sets both `url` and `command`: add `transport = \"http\"` or \
+                 `transport = \"stdio\"` to say which one applies"
+                    .to_string(),
+            ),
+            (None, false, false) => {
+                Err("profile has neither `url` nor `command`, so it cannot connect".to_string())
+            }
+        }
+    }
+
+    /// The bearer token for this profile: `bearer_env` read from `lookup`, or
+    /// the inline `bearer`. A `bearer_env` naming an unset variable is an
+    /// error, not a silent anonymous connection.
+    pub fn bearer_token_with(
+        &self,
+        lookup: impl Fn(&str) -> Option<String>,
+    ) -> Result<Option<String>, String> {
+        if let Some(var) = &self.bearer_env {
+            return lookup(var).map(Some).ok_or_else(|| {
+                format!(
+                    "profile sets `bearer_env = {var:?}` but that environment variable is unset"
+                )
+            });
+        }
+        Ok(self.bearer.clone())
+    }
+
+    /// Resolve into a [`Connection`], validating that the transport has the
+    /// fields it needs.
+    pub fn resolve_with(
+        &self,
+        lookup: impl Fn(&str) -> Option<String>,
+    ) -> Result<Connection, String> {
+        match self.transport()? {
+            Transport::Http => {
+                let url = self
+                    .url
+                    .clone()
+                    .ok_or("profile has `transport = \"http\"` but no `url`")?;
+                Ok(Connection::Http {
+                    url,
+                    bearer: self.bearer_token_with(lookup)?,
+                    headers: self
+                        .headers
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect(),
+                })
+            }
+            Transport::Stdio => {
+                if self.command.is_empty() {
+                    return Err("profile has `transport = \"stdio\"` but no `command`".to_string());
+                }
+                Ok(Connection::Stdio {
+                    command: self.command.clone(),
+                })
+            }
+        }
+    }
+
+    /// A one-line summary for `--list-servers`.
+    pub fn summary(&self) -> String {
+        match self.transport() {
+            Ok(Transport::Http) => format!("http   {}", self.url.as_deref().unwrap_or("(no url)")),
+            Ok(Transport::Stdio) => format!("stdio  {}", self.command.join(" ")),
+            Err(e) => format!("(invalid: {e})"),
+        }
+    }
+}
+
+/// The config file location: `--config` if given, else
+/// `$XDG_CONFIG_HOME/mcp-repl/config.toml`, else `~/.config/mcp-repl/config.toml`.
+/// The bool is true when the path was explicitly requested, which makes a
+/// missing file an error.
+pub fn config_path(explicit: Option<&str>) -> Option<(PathBuf, bool)> {
+    if let Some(p) = explicit {
+        return Some((PathBuf::from(p), true));
+    }
+    let base = match std::env::var_os("XDG_CONFIG_HOME") {
+        Some(x) if !x.is_empty() => PathBuf::from(x),
+        _ => {
+            let mut home = PathBuf::from(std::env::var_os("HOME")?);
+            home.push(".config");
+            home
+        }
+    };
+    Some((base.join("mcp-repl").join("config.toml"), false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+[servers.cratesio]
+transport = "http"
+url = "https://cratesio-mcp.fly.dev/"
+bearer_env = "CRATESIO_TOKEN"
+headers = { "X-Api-Key" = "abc" }
+
+[servers.local]
+transport = "stdio"
+command = ["cargo", "run", "--example", "getting_started"]
+"#;
+
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let map: BTreeMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        move |k: &str| map.get(k).cloned()
+    }
+
+    #[test]
+    fn parses_named_profiles() {
+        let config = Config::parse(SAMPLE).unwrap();
+        assert_eq!(config.names(), vec!["cratesio", "local"]);
+    }
+
+    #[test]
+    fn http_profile_resolves_transport_and_auth() {
+        let config = Config::parse(SAMPLE).unwrap();
+        let resolved = config
+            .profile("cratesio")
+            .unwrap()
+            .resolve_with(env(&[("CRATESIO_TOKEN", "secret")]))
+            .unwrap();
+        assert_eq!(
+            resolved,
+            Connection::Http {
+                url: "https://cratesio-mcp.fly.dev/".to_string(),
+                bearer: Some("secret".to_string()),
+                headers: vec![("X-Api-Key".to_string(), "abc".to_string())],
+            }
+        );
+    }
+
+    #[test]
+    fn stdio_profile_resolves_command() {
+        let config = Config::parse(SAMPLE).unwrap();
+        let resolved = config
+            .profile("local")
+            .unwrap()
+            .resolve_with(env(&[]))
+            .unwrap();
+        assert_eq!(
+            resolved,
+            Connection::Stdio {
+                command: vec![
+                    "cargo".to_string(),
+                    "run".to_string(),
+                    "--example".to_string(),
+                    "getting_started".to_string(),
+                ],
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_profile_lists_known_names() {
+        let config = Config::parse(SAMPLE).unwrap();
+        let err = config.profile("nope").unwrap_err();
+        assert!(err.contains("nope"), "{err}");
+        assert!(err.contains("cratesio, local"), "{err}");
+    }
+
+    #[test]
+    fn unknown_profile_with_empty_config_says_so() {
+        let err = Config::default().profile("nope").unwrap_err();
+        assert!(err.contains("no profiles are configured"), "{err}");
+    }
+
+    #[test]
+    fn unset_bearer_env_is_an_error() {
+        let config = Config::parse(SAMPLE).unwrap();
+        let err = config
+            .profile("cratesio")
+            .unwrap()
+            .resolve_with(env(&[]))
+            .unwrap_err();
+        assert!(err.contains("CRATESIO_TOKEN"), "{err}");
+    }
+
+    #[test]
+    fn inline_bearer_is_used_when_no_env_indirection() {
+        let profile: Profile = toml::from_str(
+            r#"
+            url = "https://example/mcp"
+            bearer = "literal"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(
+            profile.bearer_token_with(env(&[])).unwrap(),
+            Some("literal".to_string())
+        );
+    }
+
+    #[test]
+    fn transport_is_inferred_from_the_fields() {
+        let http: Profile = toml::from_str(r#"url = "https://example/mcp""#).unwrap();
+        assert_eq!(http.transport().unwrap(), Transport::Http);
+        let stdio: Profile = toml::from_str(r#"command = ["server"]"#).unwrap();
+        assert_eq!(stdio.transport().unwrap(), Transport::Stdio);
+    }
+
+    #[test]
+    fn ambiguous_and_empty_profiles_are_errors() {
+        let both: Profile =
+            toml::from_str("url = \"https://example/mcp\"\ncommand = [\"server\"]").unwrap();
+        assert!(both.transport().unwrap_err().contains("both"));
+        assert!(
+            Profile::default()
+                .transport()
+                .unwrap_err()
+                .contains("neither")
+        );
+    }
+
+    #[test]
+    fn declared_transport_must_have_its_fields() {
+        let profile: Profile = toml::from_str(r#"transport = "http""#).unwrap();
+        assert!(profile.resolve_with(env(&[])).unwrap_err().contains("url"));
+        let profile: Profile = toml::from_str(r#"transport = "stdio""#).unwrap();
+        assert!(
+            profile
+                .resolve_with(env(&[]))
+                .unwrap_err()
+                .contains("command")
+        );
+    }
+
+    #[test]
+    fn an_unsupported_transport_names_itself() {
+        let err =
+            Config::parse("[servers.x]\ntransport = \"ws\"\nurl = \"wss://example\"").unwrap_err();
+        assert!(err.contains("ws"), "{err}");
+    }
+
+    #[test]
+    fn a_typo_in_a_profile_key_is_rejected() {
+        let err =
+            Config::parse("[servers.x]\nurl = \"https://example\"\nbearrer = \"x\"").unwrap_err();
+        assert!(err.contains("bearrer"), "{err}");
+    }
+}

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -15,6 +15,9 @@
 //!
 //! # Connect to a streamable HTTP server:
 //! cargo run -p mcp-repl -- --http http://127.0.0.1:3001/mcp
+//!
+//! # Connect to a named profile from ~/.config/mcp-repl/config.toml:
+//! cargo run -p mcp-repl -- --server cratesio
 //! ```
 //!
 //! Inside the REPL, `help` lists the built-ins and the server's tools.
@@ -22,6 +25,7 @@
 //! task id immediately; `jobs`, `task <id>`, `wait <id>`, and `cancel <id>`
 //! manage it.
 
+mod config;
 mod editor;
 mod elicit;
 mod style;
@@ -59,8 +63,22 @@ struct Args {
     http: Option<String>,
 
     /// Serve the bundled demo router in-process (no external server needed).
-    #[arg(long, conflicts_with_all = ["http", "command"])]
+    #[arg(long, conflicts_with_all = ["http", "command", "server"])]
     demo: bool,
+
+    /// Connect using the named `[servers.<name>]` profile from the config
+    /// file. A bare positional that matches a profile name works too.
+    #[arg(long, value_name = "NAME")]
+    server: Option<String>,
+
+    /// Read server profiles from this file instead of
+    /// `$XDG_CONFIG_HOME/mcp-repl/config.toml` (or `~/.config/mcp-repl/config.toml`).
+    #[arg(long, value_name = "PATH")]
+    config: Option<String>,
+
+    /// Print the configured server profiles and exit.
+    #[arg(long)]
+    list_servers: bool,
 
     /// When to emit ANSI colors (auto detects tty and NO_COLOR).
     #[arg(long, value_enum, default_value = "auto")]
@@ -403,16 +421,26 @@ async fn fetch_surface_initial(client: &McpClient) -> Surface {
     unreachable!()
 }
 
-/// Build the HTTP client config from the auth flags. `--bearer` wins over the
-/// `MCP_BEARER` environment variable; each `--header "Name: Value"` is split on
-/// the first colon (surrounding whitespace trimmed). A header with no colon is
-/// a usage error.
+/// Build the HTTP client config from the auth flags and the resolved profile.
+/// `--bearer` wins over the profile's token, which wins over the `MCP_BEARER`
+/// environment variable; `--header` flags are applied after the profile's
+/// headers so a repeated name overrides it. Each `--header "Name: Value"` is
+/// split on the first colon (surrounding whitespace trimmed); a header with no
+/// colon is a usage error.
 fn build_http_config(
     bearer: Option<String>,
     headers: &[String],
+    profile_bearer: Option<String>,
+    profile_headers: &[(String, String)],
 ) -> Result<HttpClientConfig, String> {
     let mut config = HttpClientConfig::default();
-    if let Some(token) = bearer.or_else(|| std::env::var("MCP_BEARER").ok()) {
+    for (name, value) in profile_headers {
+        config = config.header(name.as_str(), value.as_str());
+    }
+    if let Some(token) = bearer
+        .or(profile_bearer)
+        .or_else(|| std::env::var("MCP_BEARER").ok())
+    {
         config = config.bearer_token(token);
     }
     for raw in headers {
@@ -525,6 +553,71 @@ fn demo_router() -> tower_mcp::McpRouter {
         )
 }
 
+/// Load the profile config, exiting with a usage status on a bad file. A
+/// missing file at the default location is not an error: profiles are opt-in.
+fn load_config(explicit: Option<&str>) -> config::Config {
+    let Some((path, explicit)) = config::config_path(explicit) else {
+        return config::Config::default();
+    };
+    match config::Config::load(&path, explicit) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// `--list-servers`: the configured profiles, one per line.
+fn print_servers(config: &config::Config) {
+    if config.servers.is_empty() {
+        println!("no server profiles configured");
+        return;
+    }
+    let width = config.names().iter().map(|n| n.len()).max().unwrap_or(0);
+    for (name, profile) in &config.servers {
+        println!(
+            "{:width$}  {}",
+            paint(Style::new().fg(Color::Cyan), name),
+            paint(Style::new().dimmed(), &profile.summary()),
+        );
+    }
+}
+
+/// Resolve the profile the invocation names, if any: `--server <name>`, or a
+/// bare single positional that matches a configured profile. A positional that
+/// matches nothing stays a stdio command, so spawning a server by bare name
+/// still works when no profile shadows it.
+fn resolve_profile(args: &Args, config: &config::Config) -> Option<(String, config::Connection)> {
+    let name = args
+        .server
+        .clone()
+        .or_else(|| match args.command.as_slice() {
+            [only] if config.servers.contains_key(only) => Some(only.clone()),
+            _ => None,
+        })?;
+    let profile = match config.profile(&name) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(2);
+        }
+    };
+    if profile.bearer.is_some() {
+        eprintln!(
+            "warning: profile {name:?} stores a literal `bearer` token; prefer \
+             `bearer_env = \"VAR\"` so the token is not kept in the config file"
+        );
+    }
+    match profile.resolve_with(|var| std::env::var(var).ok()) {
+        Ok(connection) => Some((name, connection)),
+        Err(e) => {
+            eprintln!("error: server profile {name:?}: {e}");
+            std::process::exit(2);
+        }
+    }
+}
+
 fn log_level_style(level: LogLevel) -> Style {
     match level {
         LogLevel::Emergency | LogLevel::Alert | LogLevel::Critical | LogLevel::Error => {
@@ -546,6 +639,15 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let args = Args::parse();
     style::init(args.color);
     JSON_OUTPUT.store(args.json, Ordering::Relaxed);
+
+    // Server profiles are read up front: both --list-servers and profile
+    // resolution need them before anything connects.
+    let profiles = load_config(args.config.as_deref());
+    if args.list_servers {
+        print_servers(&profiles);
+        return Ok(());
+    }
+    let profile = resolve_profile(&args, &profiles);
     // --exec runs commands and exits; suppress the banner and surface listing
     // unless --verbose, so scripted output is only the command results.
     let one_shot = !args.exec.is_empty();
@@ -595,8 +697,47 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     };
     let handler = ReplClientHandler::new(notifications, at_prompt.clone());
 
-    if args.http.is_none() && (args.bearer.is_some() || !args.headers.is_empty()) {
-        eprintln!("warning: --bearer/--header apply only to --http; ignoring them here");
+    // Explicit flags override profile fields: --http retargets a profile's URL
+    // while keeping its auth, and --bearer/--header are layered on in
+    // build_http_config.
+    let (profile_name, connection) = match profile {
+        Some((name, c)) => (Some(name), Some(c)),
+        None => (None, None),
+    };
+    let connection = match (args.http.clone(), connection) {
+        (
+            Some(url),
+            Some(config::Connection::Http {
+                bearer, headers, ..
+            }),
+        ) => Some(config::Connection::Http {
+            url,
+            bearer,
+            headers,
+        }),
+        (Some(url), _) => Some(config::Connection::Http {
+            url,
+            bearer: None,
+            headers: Vec::new(),
+        }),
+        (None, Some(c)) => Some(c),
+        (None, None) if !args.command.is_empty() => Some(config::Connection::Stdio {
+            command: args.command.clone(),
+        }),
+        (None, None) => None,
+    };
+
+    let over_http = matches!(connection, Some(config::Connection::Http { .. }));
+    if !over_http && (args.bearer.is_some() || !args.headers.is_empty()) {
+        eprintln!("warning: --bearer/--header apply only to HTTP servers; ignoring them here");
+    }
+    if let Some(name) = &profile_name
+        && !quiet
+    {
+        println!(
+            "{}",
+            tag(Style::new().fg(Color::Cyan), &format!("profile {name}"))
+        );
     }
 
     let builder = McpClient::builder().with_elicitation();
@@ -604,21 +745,31 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         builder
             .connect(ChannelTransport::new(demo_router()), handler)
             .await?
-    } else if let Some(url) = &args.http {
-        let config = build_http_config(args.bearer.clone(), &args.headers)?;
-        builder
-            .connect(
-                HttpClientTransport::with_config(url.clone(), config),
-                handler,
-            )
-            .await?
-    } else if !args.command.is_empty() {
-        let cmd_args: Vec<&str> = args.command[1..].iter().map(|s| s.as_str()).collect();
-        let transport = StdioClientTransport::spawn(&args.command[0], &cmd_args).await?;
-        builder.connect(transport, handler).await?
     } else {
-        eprintln!("usage: mcp-repl <server command...> | --http <url> | --demo");
-        std::process::exit(2);
+        match connection {
+            Some(config::Connection::Http {
+                url,
+                bearer,
+                headers,
+            }) => {
+                let config =
+                    build_http_config(args.bearer.clone(), &args.headers, bearer, &headers)?;
+                builder
+                    .connect(HttpClientTransport::with_config(url, config), handler)
+                    .await?
+            }
+            Some(config::Connection::Stdio { command }) => {
+                let cmd_args: Vec<&str> = command[1..].iter().map(|s| s.as_str()).collect();
+                let transport = StdioClientTransport::spawn(&command[0], &cmd_args).await?;
+                builder.connect(transport, handler).await?
+            }
+            None => {
+                eprintln!(
+                    "usage: mcp-repl <server command...> | --http <url> | --server <name> | --demo"
+                );
+                std::process::exit(2);
+            }
+        }
     };
     let client = Arc::new(client);
 
@@ -1255,6 +1406,8 @@ mod tests {
         let cfg = build_http_config(
             Some("tok".into()),
             &["X-Api-Key: abc".into(), "X-Trim :  v ".into()],
+            None,
+            &[],
         )
         .unwrap();
         assert_eq!(
@@ -1269,8 +1422,48 @@ mod tests {
     }
 
     #[test]
+    fn profile_auth_applies_and_flags_override_it() {
+        let profile_headers = [
+            ("X-Api-Key".to_string(), "from-profile".to_string()),
+            ("X-Kept".to_string(), "profile".to_string()),
+        ];
+        // No flags: the profile's token and headers are used as-is.
+        let cfg =
+            build_http_config(None, &[], Some("profile-tok".into()), &profile_headers).unwrap();
+        assert_eq!(
+            cfg.headers.get("Authorization").map(String::as_str),
+            Some("Bearer profile-tok")
+        );
+        assert_eq!(
+            cfg.headers.get("X-Api-Key").map(String::as_str),
+            Some("from-profile")
+        );
+
+        // Flags win over the profile, header by header.
+        let cfg = build_http_config(
+            Some("flag-tok".into()),
+            &["X-Api-Key: from-flag".into()],
+            Some("profile-tok".into()),
+            &profile_headers,
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.headers.get("Authorization").map(String::as_str),
+            Some("Bearer flag-tok")
+        );
+        assert_eq!(
+            cfg.headers.get("X-Api-Key").map(String::as_str),
+            Some("from-flag")
+        );
+        assert_eq!(
+            cfg.headers.get("X-Kept").map(String::as_str),
+            Some("profile")
+        );
+    }
+
+    #[test]
     fn build_http_config_rejects_header_without_colon() {
-        let err = build_http_config(Some("tok".into()), &["nope".into()]).unwrap_err();
+        let err = build_http_config(Some("tok".into()), &["nope".into()], None, &[]).unwrap_err();
         assert!(
             err.contains("nope"),
             "error should name the bad header: {err}"


### PR DESCRIPTION
Closes #1005.

Adds a named-profile config file so a remote server can be reached by name instead of a full URL plus repeated `--bearer`/`--header` flags, and so tokens stay out of shell history.

## Plan

- Config at `$XDG_CONFIG_HOME/mcp-repl/config.toml` (falling back to `~/.config/mcp-repl/config.toml`), with `--config <path>` to override the location.
- `[servers.<name>]` tables carrying `transport` (`http` | `stdio`), `url`, `bearer_env`, `bearer`, `headers`, and `command`.
- `--server <name>` resolves a profile; a bare single positional token that matches a profile name resolves it too. An unknown `--server` name errors with the list of known profiles.
- Explicit CLI flags (`--http`, `--bearer`, `--header`) override the corresponding profile fields.
- `--list-servers` prints known profiles and exits.
- Secrets: `bearer_env` reads the token from the environment. An inline `bearer` literal in the file is accepted but warns.
- Unit tests for parsing, resolution, flag override, and the unknown-name error; README Profiles section.

## Compatibility

The existing invocations (`--http <url>`, a stdio child command, `--demo`) are unchanged. Profile resolution from a bare positional only happens when the single token matches a configured profile name, so spawning a stdio server by bare name still works when no profile shadows it.
