### PR TITLE
feat(mcp-repl): auto-reconnect and session resurrection

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -56,6 +56,29 @@ mcp-repl --http https://internal.example/mcp --header "X-Api-Key: abc"
 `--bearer` and `--header` apply only to `--http`; they are ignored (with a
 warning) for the demo and stdio-child transports.
 
+### Reconnecting
+
+A remote server that restarts, OOMs, or sits behind an edge returning 502/503
+loses the session, and every later request fails with a not-initialized or
+session-expired error. On an `--http` connection the REPL notices this,
+re-runs the handshake against a fresh transport, re-fetches the surface, and
+retries the command once:
+
+```text
+> search query=tower
+[reconnected]
+... results ...
+```
+
+The retry is bounded to a single attempt, so a server that is really down
+fails fast with its original error rather than hanging the prompt. Task ids
+do not survive a reconnect (they belong to the session that created them), so
+`task`, `wait`, and `cancel` never trigger one.
+
+Pass `--no-reconnect` to turn this off and see session-loss errors as they
+arrive. stdio children and `--demo` are never reconnected: there, a lost
+session means the server process itself is gone.
+
 ## What to try
 
 ```text

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -21,7 +21,7 @@ use reedline::{
     Suggestion, default_emacs_keybindings,
 };
 
-use tower_mcp::client::McpClient;
+use crate::session::Session;
 
 use crate::style;
 use crate::{BUILTINS, Surface};
@@ -74,7 +74,9 @@ impl Prompt for ReplPrompt {
 
 pub struct ReplCompleter {
     surface: Arc<RwLock<Surface>>,
-    client: Arc<McpClient>,
+    /// The session rather than the client: a reconnect swaps the client out,
+    /// and completions issued afterwards must go to the live one.
+    session: Arc<Session>,
     runtime: tokio::runtime::Handle,
 }
 
@@ -105,12 +107,12 @@ fn word_suggestion(
 impl ReplCompleter {
     pub fn new(
         surface: Arc<RwLock<Surface>>,
-        client: Arc<McpClient>,
+        session: Arc<Session>,
         runtime: tokio::runtime::Handle,
     ) -> Self {
         Self {
             surface,
-            client,
+            session,
             runtime,
         }
     }
@@ -125,7 +127,7 @@ impl ReplCompleter {
         arg: &str,
         partial: &str,
     ) -> Vec<String> {
-        let client = self.client.clone();
+        let client = self.session.client();
         let (prompt, arg, partial) = (prompt.to_string(), arg.to_string(), partial.to_string());
         self.runtime
             .block_on(async move {
@@ -150,7 +152,7 @@ impl ReplCompleter {
         var: &str,
         partial: &str,
     ) -> Vec<String> {
-        let client = self.client.clone();
+        let client = self.session.client();
         let (template, var, partial) = (
             uri_template.to_string(),
             var.to_string(),
@@ -490,7 +492,7 @@ impl Highlighter for ReplHighlighter {
 pub fn spawn_readline_thread(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
-    client: Arc<McpClient>,
+    session: Arc<Session>,
     runtime: tokio::runtime::Handle,
     line_tx: tokio::sync::mpsc::Sender<String>,
     ack_rx: std::sync::mpsc::Receiver<()>,
@@ -505,7 +507,7 @@ pub fn spawn_readline_thread(
         run_interactive(
             server_name,
             surface,
-            client,
+            session,
             runtime,
             &line_tx,
             &ack_rx,
@@ -557,14 +559,14 @@ fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mp
 fn run_interactive(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
-    client: Arc<McpClient>,
+    session: Arc<Session>,
     runtime: tokio::runtime::Handle,
     line_tx: &tokio::sync::mpsc::Sender<String>,
     ack_rx: &std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
     persist_history: bool,
 ) {
-    let completer = ReplCompleter::new(surface.clone(), client, runtime);
+    let completer = ReplCompleter::new(surface.clone(), session, runtime);
     let highlighter = ReplHighlighter::new(surface);
 
     let menu = ColumnarMenu::default().with_name(MENU_NAME);

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -24,9 +24,11 @@
 
 mod editor;
 mod elicit;
+mod session;
 mod style;
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -44,6 +46,7 @@ use tower_mcp::protocol::{
 };
 
 use elicit::ReplClientHandler;
+use session::{Connector, Session, is_not_initialized, is_session_lost};
 use style::{json_pretty, paint, tag, task_status_style};
 
 #[derive(Parser)]
@@ -98,6 +101,12 @@ struct Args {
     /// Do not persist command history to ~/.mcp-repl_history.
     #[arg(long)]
     no_history: bool,
+
+    /// Do not transparently re-establish an `--http` session that the server
+    /// has lost (restart, OOM, or a 502/503 from the edge in front of it).
+    /// Session-loss errors surface as-is instead.
+    #[arg(long)]
+    no_reconnect: bool,
 
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
@@ -316,17 +325,58 @@ fn print_counts(surface: &Surface) {
     );
 }
 
-/// True when the server rejected a request because the session is not yet
-/// initialized (JSON-RPC `-32600` naming `notifications/initialized`). This
-/// is retryable at startup: against a multi-instance server without a shared
-/// session store, the initialize handshake and a follow-up request can land
-/// on different instances, so a brief retry often lands on a consistent one.
-fn is_not_initialized(e: &tower_mcp::Error) -> bool {
-    matches!(
-        e,
-        tower_mcp::Error::JsonRpc(j)
-            if j.code == -32600 && j.message.contains("notifications/initialized")
-    )
+/// Run one request, and if it fails because the server lost the session,
+/// rebuild the connection and run it exactly once more.
+///
+/// The retry is deliberately bounded to a single attempt: a server that is
+/// down stays down, and a loop here would turn one dead command into a long
+/// unresponsive prompt. On the second failure the original error surfaces
+/// with a hint, which is what the user would have seen without reconnection.
+///
+/// `op` runs against whichever client is current, so it takes the client as
+/// an argument rather than closing over one: the second call must use the
+/// client the reconnect installed, not the dead one.
+async fn with_reconnect<T, F, Fut>(
+    session: &Session,
+    surface: &Arc<RwLock<Surface>>,
+    op: F,
+) -> Result<T, tower_mcp::Error>
+where
+    F: Fn(Arc<McpClient>) -> Fut,
+    Fut: Future<Output = Result<T, tower_mcp::Error>>,
+{
+    let seen = session.generation();
+    let err = match op(session.client()).await {
+        Ok(value) => return Ok(value),
+        Err(e) => e,
+    };
+    if !session.can_reconnect() || !is_session_lost(&err) {
+        return Err(err);
+    }
+    if let Err(reconnect_err) = session.reconnect(seen).await {
+        eprintln!("reconnect failed: {reconnect_err}");
+        return Err(err);
+    }
+    // The surface belongs to the old session: a restarted server may expose a
+    // different set of tools, and the completer and command dispatch both read
+    // this. Refresh before the retry so the retried command and the next
+    // prompt agree on what exists.
+    *surface.write().unwrap() = fetch_surface(&session.client()).await;
+    // stderr, so the note does not land in the middle of `--json` output
+    // being piped somewhere.
+    eprintln!("{}", paint(Style::new().dimmed(), "[reconnected]"));
+
+    let retried = op(session.client()).await;
+    if let Err(e) = &retried
+        && is_session_lost(e)
+    {
+        eprintln!(
+            "still no session after reconnecting. The server is likely down or \
+             restart-looping; check its logs, or pass --no-reconnect to see the \
+             raw errors."
+        );
+    }
+    retried
 }
 
 /// Fetch the server surface once. Returns the surface plus whether any list
@@ -373,6 +423,28 @@ async fn fetch_surface_once(client: &McpClient) -> (Surface, bool) {
 
 async fn fetch_surface(client: &McpClient) -> Surface {
     fetch_surface_once(client).await.0
+}
+
+/// Re-fetch the surface, reconnecting first if the fetch shows the session is
+/// gone. The four list calls swallow their own errors, so not-initialized is
+/// the one session-loss signal that survives to here; the typed session
+/// errors would have shown up as empty lists with a warning.
+async fn refresh_surface(session: &Session) -> Surface {
+    let (fresh, not_initialized) = fetch_surface_once(&session.client()).await;
+    if !not_initialized || !session.can_reconnect() {
+        return fresh;
+    }
+    let seen = session.generation();
+    match session.reconnect(seen).await {
+        Ok(()) => {
+            eprintln!("{}", paint(Style::new().dimmed(), "[reconnected]"));
+            fetch_surface(&session.client()).await
+        }
+        Err(e) => {
+            eprintln!("reconnect failed: {e}");
+            fresh
+        }
+    }
 }
 
 /// Startup surface fetch with a bounded retry on the not-initialized
@@ -525,6 +597,68 @@ fn demo_router() -> tower_mcp::McpRouter {
         )
 }
 
+/// The notification callbacks: log and progress messages print inline,
+/// `list_changed` notifications nudge the event loop to refresh the surface.
+/// Built per client, since a reconnect installs a new one.
+fn notification_handler(refresh_tx: tokio::sync::mpsc::UnboundedSender<()>) -> NotificationHandler {
+    let t = refresh_tx.clone();
+    let r = refresh_tx.clone();
+    let p = refresh_tx;
+    NotificationHandler::new()
+        .on_tools_changed(move || {
+            let _ = t.send(());
+        })
+        .on_resources_changed(move || {
+            let _ = r.send(());
+        })
+        .on_prompts_changed(move || {
+            let _ = p.send(());
+        })
+        .on_progress(|p| {
+            let pct = match (p.progress, p.total) {
+                (done, Some(total)) if total > 0.0 => {
+                    format!(" {:.0}%", 100.0 * done / total)
+                }
+                _ => String::new(),
+            };
+            println!(
+                "{} {}",
+                tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
+                p.message.as_deref().unwrap_or("")
+            );
+        })
+        .on_log_message(|m| {
+            println!(
+                "{} {}",
+                tag(log_level_style(m.level), &format!("log {}", m.level)),
+                m.data
+            );
+        })
+}
+
+/// The recipe for rebuilding an `--http` connection: a brand new transport
+/// (so no dead `Mcp-Session-Id` is carried over), a fresh handler, and the
+/// initialize handshake, exactly as at startup.
+fn http_connector(
+    url: String,
+    config: HttpClientConfig,
+    make_handler: Arc<dyn Fn() -> ReplClientHandler + Send + Sync>,
+) -> Connector {
+    Box::new(move || {
+        let (url, config, handler) = (url.clone(), config.clone(), make_handler());
+        Box::pin(async move {
+            let client = McpClient::builder()
+                .with_elicitation()
+                .connect(HttpClientTransport::with_config(url, config), handler)
+                .await?;
+            client
+                .initialize("mcp-repl", env!("CARGO_PKG_VERSION"))
+                .await?;
+            Ok(client)
+        })
+    })
+}
+
 fn log_level_style(level: LogLevel) -> Style {
     match level {
         LogLevel::Emergency | LogLevel::Alert | LogLevel::Critical | LogLevel::Error => {
@@ -558,69 +692,54 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Notifications print inline and trigger surface refreshes.
     let (refresh_tx, mut refresh_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-    let notifications = {
-        let t = refresh_tx.clone();
-        let r = refresh_tx.clone();
-        let p = refresh_tx;
-        NotificationHandler::new()
-            .on_tools_changed(move || {
-                let _ = t.send(());
-            })
-            .on_resources_changed(move || {
-                let _ = r.send(());
-            })
-            .on_prompts_changed(move || {
-                let _ = p.send(());
-            })
-            .on_progress(|p| {
-                let pct = match (p.progress, p.total) {
-                    (done, Some(total)) if total > 0.0 => {
-                        format!(" {:.0}%", 100.0 * done / total)
-                    }
-                    _ => String::new(),
-                };
-                println!(
-                    "{} {}",
-                    tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
-                    p.message.as_deref().unwrap_or("")
-                );
-            })
-            .on_log_message(|m| {
-                println!(
-                    "{} {}",
-                    tag(log_level_style(m.level), &format!("log {}", m.level)),
-                    m.data
-                );
-            })
+
+    // A reconnect needs a fresh handler for the new client, so build handlers
+    // through a factory rather than once.
+    let make_handler: Arc<dyn Fn() -> ReplClientHandler + Send + Sync> = {
+        let refresh_tx = refresh_tx.clone();
+        let at_prompt = at_prompt.clone();
+        Arc::new(move || {
+            ReplClientHandler::new(notification_handler(refresh_tx.clone()), at_prompt.clone())
+        })
     };
-    let handler = ReplClientHandler::new(notifications, at_prompt.clone());
+    drop(refresh_tx);
 
     if args.http.is_none() && (args.bearer.is_some() || !args.headers.is_empty()) {
         eprintln!("warning: --bearer/--header apply only to --http; ignoring them here");
     }
 
     let builder = McpClient::builder().with_elicitation();
+    // Only `--http` can be resurrected. A stdio child that dies takes its
+    // stdin and stdout with it (respawning it is a separate concern), and the
+    // in-process demo router cannot lose a session at all.
+    let mut connector: Option<Connector> = None;
     let client = if args.demo {
         builder
-            .connect(ChannelTransport::new(demo_router()), handler)
+            .connect(ChannelTransport::new(demo_router()), make_handler())
             .await?
     } else if let Some(url) = &args.http {
         let config = build_http_config(args.bearer.clone(), &args.headers)?;
+        if !args.no_reconnect {
+            connector = Some(http_connector(
+                url.clone(),
+                config.clone(),
+                make_handler.clone(),
+            ));
+        }
         builder
             .connect(
                 HttpClientTransport::with_config(url.clone(), config),
-                handler,
+                make_handler(),
             )
             .await?
     } else if !args.command.is_empty() {
         let cmd_args: Vec<&str> = args.command[1..].iter().map(|s| s.as_str()).collect();
         let transport = StdioClientTransport::spawn(&args.command[0], &cmd_args).await?;
-        builder.connect(transport, handler).await?
+        builder.connect(transport, make_handler()).await?
     } else {
         eprintln!("usage: mcp-repl <server command...> | --http <url> | --demo");
         std::process::exit(2);
     };
-    let client = Arc::new(client);
 
     let init = client
         .initialize("mcp-repl", env!("CARGO_PKG_VERSION"))
@@ -629,6 +748,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     if !quiet {
         print_banner(&init);
     }
+    let session = Arc::new(Session::new(client, connector));
+    let client = session.client();
 
     let surface = Arc::new(RwLock::new(fetch_surface_initial(&client).await));
     if !quiet {
@@ -651,7 +772,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     if one_shot {
         let mut jobs: Vec<(String, String)> = Vec::new();
         for cmd in &args.exec {
-            if handle_line(&client, &surface, &mut jobs, cmd.trim()).await {
+            if handle_line(&session, &surface, &mut jobs, cmd.trim()).await {
                 break;
             }
         }
@@ -668,7 +789,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     editor::spawn_readline_thread(
         server_name,
         surface.clone(),
-        client.clone(),
+        session.clone(),
         tokio::runtime::Handle::current(),
         line_tx,
         ack_rx,
@@ -681,7 +802,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     loop {
         tokio::select! {
             Some(()) = refresh_rx.recv() => {
-                let fresh = fetch_surface(&client).await;
+                let fresh = fetch_surface(&session.client()).await;
                 println!("{} {} tools, {} prompts, {} resources",
                     tag(Style::new().fg(Color::Cyan), "surface changed"),
                     fresh.tools.len(), fresh.prompts.len(), fresh.resources.len());
@@ -689,7 +810,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             }
             maybe_line = line_rx.recv() => {
                 let Some(line) = maybe_line else { break };
-                let quit = handle_line(&client, &surface, &mut jobs, line.trim()).await;
+                let quit = handle_line(&session, &surface, &mut jobs, line.trim()).await;
                 let _ = ack_tx.send(());
                 if quit {
                     break;
@@ -701,7 +822,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 }
 
 async fn handle_line(
-    client: &Arc<McpClient>,
+    session: &Arc<Session>,
     surface: &Arc<RwLock<Surface>>,
     jobs: &mut Vec<(String, String)>,
     line: &str,
@@ -709,6 +830,7 @@ async fn handle_line(
     if line.is_empty() {
         return false;
     }
+    let client = session.client();
     let mut tokens: Vec<&str> = line.split_whitespace().collect();
     let background = tokens.last() == Some(&"&");
     if background {
@@ -848,7 +970,13 @@ async fn handle_line(
                 return false;
             };
             let started = std::time::Instant::now();
-            match client.read_resource(uri).await {
+            match with_reconnect(
+                session,
+                surface,
+                |c| async move { c.read_resource(uri).await },
+            )
+            .await
+            {
                 Ok(result) if json_output() => {
                     println!(
                         "{}",
@@ -901,7 +1029,12 @@ async fn handle_line(
                 }
             }
             let started = std::time::Instant::now();
-            match client.get_prompt(name, Some(prompt_args)).await {
+            match with_reconnect(session, surface, |c| {
+                let prompt_args = prompt_args.clone();
+                async move { c.get_prompt(name, Some(prompt_args)).await }
+            })
+            .await
+            {
                 Ok(result) if json_output() => {
                     println!(
                         "{}",
@@ -953,7 +1086,7 @@ async fn handle_line(
                     return false;
                 }
             };
-            run_tool(client, jobs, name, arguments, background).await;
+            run_tool(session, surface, jobs, name, arguments, background).await;
         }
         "jobs" => {
             if jobs.is_empty() {
@@ -969,6 +1102,9 @@ async fn handle_line(
                 }
             }
         }
+        // Task commands do not reconnect: a task id belongs to the session
+        // that created it, so a fresh session would only report it missing.
+        // "(gone)" from `jobs` is the honest answer there.
         "task" | "wait" | "cancel" => {
             let Some(id) = rest.first() else {
                 println!("usage: {cmd} <task-id>");
@@ -1004,7 +1140,7 @@ async fn handle_line(
             }
         }
         "refresh" => {
-            let fresh = fetch_surface(client).await;
+            let fresh = refresh_surface(session).await;
             println!(
                 "{} tools, {} prompts, {} resources, {} templates",
                 fresh.tools.len(),
@@ -1045,7 +1181,7 @@ async fn handle_line(
                 return false;
             };
             let arguments = parse_kv_args(&schema, rest);
-            run_tool(client, jobs, tool_name, arguments, background).await;
+            run_tool(session, surface, jobs, tool_name, arguments, background).await;
         }
     }
     false
@@ -1170,14 +1306,20 @@ fn describe(surface: &Surface, name: &str) {
 }
 
 async fn run_tool(
-    client: &Arc<McpClient>,
+    session: &Arc<Session>,
+    surface: &Arc<RwLock<Surface>>,
     jobs: &mut Vec<(String, String)>,
     name: &str,
     arguments: serde_json::Value,
     background: bool,
 ) {
     if background {
-        match client.call_tool_as_task(name, arguments, None).await {
+        match with_reconnect(session, surface, |c| {
+            let arguments = arguments.clone();
+            async move { c.call_tool_as_task(name, arguments, None).await }
+        })
+        .await
+        {
             Ok(created) => {
                 if json_output() {
                     println!(
@@ -1207,7 +1349,12 @@ async fn run_tool(
         return;
     }
     let started = std::time::Instant::now();
-    match client.call_tool(name, arguments).await {
+    match with_reconnect(session, surface, |c| {
+        let arguments = arguments.clone();
+        async move { c.call_tool(name, arguments).await }
+    })
+    .await
+    {
         Ok(result) => {
             if result.is_error {
                 note_error();
@@ -1316,29 +1463,154 @@ mod tests {
         let _ = std::fs::remove_file(&path);
     }
 
-    #[test]
-    fn detects_not_initialized_startup_error() {
-        assert!(is_not_initialized(&jsonrpc(
-            -32600,
-            "Client must send notifications/initialized before making requests"
-        )));
+    /// A connected, initialized client over the in-process demo router, so
+    /// the reconnect path can be exercised without a socket.
+    async fn demo_client() -> McpClient {
+        let client = McpClient::builder()
+            .connect_simple(ChannelTransport::new(demo_router()))
+            .await
+            .unwrap();
+        client.initialize("mcp-repl-test", "0").await.unwrap();
+        client
     }
 
-    #[test]
-    fn does_not_match_unrelated_errors() {
-        // Same code, different message.
-        assert!(!is_not_initialized(&jsonrpc(
-            -32600,
-            "some other invalid request"
-        )));
-        // Right message text, different code.
-        assert!(!is_not_initialized(&jsonrpc(
-            -32602,
-            "notifications/initialized"
-        )));
-        // A transport error is never the not-initialized case.
-        assert!(!is_not_initialized(&tower_mcp::Error::Transport(
-            "boom".into()
-        )));
+    /// A session whose connector builds a fresh demo client, counting how
+    /// many times it is asked to.
+    async fn demo_session() -> (Arc<Session>, Arc<std::sync::atomic::AtomicUsize>) {
+        let connects = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counter = connects.clone();
+        let connector: Connector = Box::new(move || {
+            let counter = counter.clone();
+            Box::pin(async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                Ok(demo_client().await)
+            })
+        });
+        (
+            Arc::new(Session::new(demo_client().await, Some(connector))),
+            connects,
+        )
+    }
+
+    /// The regression this fixes: the server drops the session mid-command,
+    /// so the call fails with not-initialized. The next attempt must succeed
+    /// on a rebuilt session rather than leaving a dead prompt.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dropped_session_is_rebuilt_and_the_command_retried() {
+        let (session, connects) = demo_session().await;
+        let surface = Arc::new(RwLock::new(Surface::default()));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dead = Arc::as_ptr(&session.client()) as usize;
+        let seen: Arc<RwLock<Vec<usize>>> = Arc::new(RwLock::new(Vec::new()));
+
+        let (calls, saw) = (attempts.clone(), seen.clone());
+        let result = with_reconnect(&session, &surface, |c| {
+            let (calls, saw) = (calls.clone(), saw.clone());
+            async move {
+                saw.write().unwrap().push(Arc::as_ptr(&c) as usize);
+                // First attempt sees the session the server has forgotten.
+                if calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                    return Err(jsonrpc(
+                        -32600,
+                        "Client must send notifications/initialized before making requests",
+                    ));
+                }
+                c.call_tool("echo", serde_json::json!({ "message": "alive" }))
+                    .await
+            }
+        })
+        .await
+        .expect("the retried call should succeed on the rebuilt session");
+
+        assert_eq!(attempts.load(Ordering::SeqCst), 2, "one retry, not a loop");
+        // The retry has to run against the rebuilt client, not the dead one.
+        let seen = seen.read().unwrap();
+        assert_eq!(seen[0], dead);
+        assert_ne!(seen[1], dead, "the retry reused the dead client");
+        assert_eq!(
+            connects.load(Ordering::SeqCst),
+            1,
+            "reconnected exactly once"
+        );
+        assert_eq!(session.generation(), 1);
+        match result.content.first() {
+            Some(Content::Text { text, .. }) => assert_eq!(text, "alive"),
+            other => panic!("unexpected content: {other:?}"),
+        }
+        // The surface is re-fetched from the new session, not left stale.
+        assert!(
+            !surface.read().unwrap().tools.is_empty(),
+            "surface should be refreshed after reconnect"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_still_dead_server_surfaces_the_error_after_one_retry() {
+        let (session, connects) = demo_session().await;
+        let surface = Arc::new(RwLock::new(Surface::default()));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let calls = attempts.clone();
+        let err = with_reconnect(&session, &surface, |_c| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(tower_mcp::Error::Transport(
+                    "HTTP 503 Service Unavailable from server: ".into(),
+                ))
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert!(is_session_lost(&err));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2, "bounded to one retry");
+        assert_eq!(connects.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ordinary_errors_do_not_reconnect() {
+        let (session, connects) = demo_session().await;
+        let surface = Arc::new(RwLock::new(Surface::default()));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        let calls = attempts.clone();
+        let err = with_reconnect(&session, &surface, |_c| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(jsonrpc(-32602, "Invalid params"))
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, tower_mcp::Error::JsonRpc(j) if j.code == -32602));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1, "no retry");
+        assert_eq!(connects.load(Ordering::SeqCst), 0, "no reconnect");
+    }
+
+    /// `--no-reconnect`, and the stdio/demo transports, produce a session with
+    /// no connector: session-loss errors must pass straight through.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_session_without_a_connector_never_retries() {
+        let session = Arc::new(Session::new(demo_client().await, None));
+        let surface = Arc::new(RwLock::new(Surface::default()));
+        let attempts = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        assert!(!session.can_reconnect());
+        let calls = attempts.clone();
+        let err = with_reconnect(&session, &surface, |_c| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Err::<(), _>(tower_mcp::Error::SessionExpired)
+            }
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, tower_mcp::Error::SessionExpired));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 }

--- a/examples/mcp-repl/src/session.rs
+++ b/examples/mcp-repl/src/session.rs
@@ -1,0 +1,218 @@
+//! Session resurrection: keeping the REPL usable when the server loses the
+//! session underneath it.
+//!
+//! A remote MCP server that restarts, OOMs, or sits behind an edge returning
+//! 502/503 leaves the client holding a session id the server no longer knows.
+//! Every subsequent request fails, and without recovery the prompt is dead
+//! until the user quits and reconnects by hand.
+//!
+//! [`Session`] holds the live [`McpClient`] behind a swappable slot plus the
+//! recipe for building a fresh one. When a command fails with a session-loss
+//! error, the REPL rebuilds the connection from scratch (new transport, new
+//! session id, fresh handshake) and retries the command once.
+//!
+//! Rebuilding rather than reusing the transport is deliberate: the existing
+//! HTTP transport still carries the dead `Mcp-Session-Id`, so re-initializing
+//! on it can fail the same way. A new transport starts from no session at all.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+use tower_mcp::client::McpClient;
+
+/// Builds a fully connected and initialized client. Called once per
+/// reconnect, so it must construct a new transport each time.
+pub type Connector = Box<
+    dyn Fn() -> Pin<Box<dyn Future<Output = Result<McpClient, tower_mcp::Error>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// The live client plus, when the transport supports it, the means to
+/// re-establish it.
+pub struct Session {
+    client: RwLock<Arc<McpClient>>,
+    connector: Option<Connector>,
+    /// Serializes reconnects so two failing commands do not both rebuild.
+    reconnecting: tokio::sync::Mutex<()>,
+    /// Bumped on every successful reconnect. A caller that saw generation N
+    /// and finds N+1 after taking the lock knows someone else already
+    /// reconnected and skips its own attempt.
+    generation: AtomicU64,
+}
+
+impl Session {
+    /// A `None` connector means no recovery path, which is the right answer
+    /// for stdio children and the in-process demo router: there, a dropped
+    /// session means the server itself is gone.
+    pub fn new(client: McpClient, connector: Option<Connector>) -> Self {
+        Self {
+            client: RwLock::new(Arc::new(client)),
+            connector,
+            reconnecting: tokio::sync::Mutex::new(()),
+            generation: AtomicU64::new(0),
+        }
+    }
+
+    /// The client to issue the next request on. Cloned out rather than
+    /// borrowed so a reconnect can swap the slot without waiting on callers.
+    pub fn client(&self) -> Arc<McpClient> {
+        self.client.read().unwrap().clone()
+    }
+
+    pub fn can_reconnect(&self) -> bool {
+        self.connector.is_some()
+    }
+
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    /// Rebuild the connection, unless another caller already did so since
+    /// `seen` was read. Returns `Ok(())` either way; the caller should
+    /// re-read [`Session::client`] afterwards.
+    pub async fn reconnect(&self, seen: u64) -> Result<(), tower_mcp::Error> {
+        let Some(connector) = &self.connector else {
+            return Err(tower_mcp::Error::Transport(
+                "this transport cannot be reconnected".to_string(),
+            ));
+        };
+        let _guard = self.reconnecting.lock().await;
+        if self.generation() != seen {
+            return Ok(());
+        }
+        // A restarting server is usually a second or two from ready; a short
+        // pause makes the retry land after the bind rather than during it.
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        let fresh = connector().await?;
+        *self.client.write().unwrap() = Arc::new(fresh);
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+/// True when the server rejected a request because the session is not yet
+/// initialized (JSON-RPC `-32600` naming `notifications/initialized`). This
+/// is retryable at startup: against a multi-instance server without a shared
+/// session store, the initialize handshake and a follow-up request can land
+/// on different instances, so a brief retry often lands on a consistent one.
+/// Mid-session it means the opposite thing, that the session the handshake
+/// established is gone, which is what [`is_session_lost`] keys on.
+pub fn is_not_initialized(e: &tower_mcp::Error) -> bool {
+    matches!(
+        e,
+        tower_mcp::Error::JsonRpc(j)
+            if j.code == -32600 && j.message.contains("notifications/initialized")
+    )
+}
+
+/// True when an error means the session the handshake established no longer
+/// exists on the server, so a fresh handshake would plausibly succeed.
+///
+/// The cases:
+///
+/// - [`tower_mcp::Error::SessionExpired`], the client's own name for HTTP 404
+///   against a live session id. The library retries this internally when
+///   session recovery is on, so it only reaches here once that has failed.
+/// - not-initialized, which mid-session means the server forgot the session
+///   (restart, OOM, redeploy, or a request scattered to another instance).
+/// - a closed transport, from the client's message loop shutting down.
+/// - HTTP 410 Gone, and 502/503 from an edge in front of a restarting server.
+///   These arrive as `Transport` strings, since the transport only maps 404
+///   to a typed variant.
+///
+/// Everything else, including 4xx auth failures and tool errors, is a real
+/// error and must surface unchanged: reconnecting would hide it behind a
+/// second identical failure.
+pub fn is_session_lost(e: &tower_mcp::Error) -> bool {
+    if matches!(e, tower_mcp::Error::SessionExpired) || is_not_initialized(e) {
+        return true;
+    }
+    match e {
+        tower_mcp::Error::Transport(msg) => {
+            msg.contains("Transport closed")
+                || msg.contains("Connection closed")
+                || msg.contains("HTTP 410")
+                || msg.contains("HTTP 502")
+                || msg.contains("HTTP 503")
+        }
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jsonrpc(code: i32, message: &str) -> tower_mcp::Error {
+        tower_mcp::Error::JsonRpc(tower_mcp::error::JsonRpcError {
+            code,
+            message: message.to_string(),
+            data: None,
+        })
+    }
+
+    #[test]
+    fn session_loss_covers_the_documented_conditions() {
+        assert!(is_session_lost(&tower_mcp::Error::SessionExpired));
+        assert!(is_session_lost(&jsonrpc(
+            -32600,
+            "Client must send notifications/initialized before making requests"
+        )));
+        assert!(is_session_lost(&tower_mcp::Error::Transport(
+            "Transport closed".into()
+        )));
+        assert!(is_session_lost(&tower_mcp::Error::Transport(
+            "Connection closed".into()
+        )));
+        for status in ["HTTP 410 Gone", "HTTP 502 Bad Gateway", "HTTP 503"] {
+            assert!(
+                is_session_lost(&tower_mcp::Error::Transport(format!(
+                    "{status} from server: "
+                ))),
+                "{status} should count as session loss"
+            );
+        }
+    }
+
+    #[test]
+    fn session_loss_does_not_swallow_real_errors() {
+        // Auth and not-found are the server answering, not the session dying.
+        assert!(!is_session_lost(&tower_mcp::Error::Transport(
+            "HTTP 401 Unauthorized from server: bad token".into()
+        )));
+        assert!(!is_session_lost(&tower_mcp::Error::Transport(
+            "HTTP 404 from http://x/mcp: MCP endpoint not found".into()
+        )));
+        assert!(!is_session_lost(&jsonrpc(-32602, "Invalid params")));
+        assert!(!is_session_lost(&tower_mcp::Error::tool("boom")));
+    }
+
+    #[test]
+    fn detects_not_initialized_startup_error() {
+        assert!(is_not_initialized(&jsonrpc(
+            -32600,
+            "Client must send notifications/initialized before making requests"
+        )));
+    }
+
+    #[test]
+    fn does_not_match_unrelated_errors() {
+        // Same code, different message.
+        assert!(!is_not_initialized(&jsonrpc(
+            -32600,
+            "some other invalid request"
+        )));
+        // Right message text, different code.
+        assert!(!is_not_initialized(&jsonrpc(
+            -32602,
+            "notifications/initialized"
+        )));
+        // A transport error is never the not-initialized case.
+        assert!(!is_not_initialized(&tower_mcp::Error::Transport(
+            "boom".into()
+        )));
+    }
+}


### PR DESCRIPTION
Closes #1006.

A remote server that restarts, OOMs, or sits behind an edge returning 502/503 leaves the REPL holding a session the server no longer knows. Every later command failed and the prompt stayed dead until the user quit and reconnected by hand. This is what the cratesio fly OOM produced.

## Design

`Session` (new `src/session.rs`) holds the live `McpClient` behind a swappable slot plus, when the transport supports it, a `Connector`: the recipe for building a fresh connected and initialized client. `with_reconnect` in `main.rs` runs one request against the current client and, on a session-loss error, rebuilds and runs it exactly once more.

Rebuilding rather than re-initializing is deliberate: the existing HTTP transport still carries the dead `Mcp-Session-Id`, so re-initializing on it can fail the same way. A new transport starts from no session at all.

## Behavior

- [x] Detection: `Error::SessionExpired`, mid-session not-initialized (`-32600` naming `notifications/initialized`), a closed transport, and HTTP 410/502/503. The last three arrive as `Transport` strings, since the client only maps 404 to a typed variant.
- [x] Ordinary errors pass through untouched: auth failures, `HTTP 404` endpoint-not-found, invalid params, tool errors. Reconnecting on those would hide the real failure behind a second identical one.
- [x] The surface is re-fetched from the new session before the retry, so the retried command and the next prompt agree on what exists. The editor now holds the `Session` rather than a client, so tab completion after a reconnect reaches the live connection too.
- [x] A dim `[reconnected]` note, on stderr so it does not land in the middle of `--json` output being piped somewhere.
- [x] Bounded: one retry, after a 250ms pause. A server that is still down surfaces its original error with a hint pointing at `--no-reconnect`.
- [x] `--no-reconnect` opts out.
- [x] `refresh` gets the same treatment: the four list calls swallow their own errors, so not-initialized is the one session-loss signal that reaches it.

Scope decisions:

- HTTP only, per the issue. A stdio child that dies takes its stdin and stdout with it, and respawning it is a separate concern. `--demo` runs in-process and cannot lose a session.
- `task`, `wait`, and `cancel` never reconnect. A task id belongs to the session that created it, so a fresh session would only report it missing; `(gone)` from `jobs` is the honest answer.

## Testing

Nine tests, four of them driving the reconnect path end to end against the in-process demo router (`ChannelTransport`), so no socket is needed:

- `dropped_session_is_rebuilt_and_the_command_retried`: the first attempt fails with not-initialized, and the call then succeeds. Asserts exactly one retry, exactly one reconnect, the generation bump, the echoed result, that the surface was refreshed from the new session, and that the retry ran against a different client instance than the dead one.
- `a_still_dead_server_surfaces_the_error_after_one_retry`: repeated 503, bounded to one retry.
- `ordinary_errors_do_not_reconnect` and `a_session_without_a_connector_never_retries` (the `--no-reconnect` / stdio / demo shape).
- Table tests over `is_session_lost` for every documented condition and the errors it must not swallow.

The session drop is simulated at the boundary where the REPL sees it (the client error) rather than by killing a real HTTP server, which keeps the test in the example crate's existing unit-test setup with no server dependency.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test --workspace` all pass.
