### PR TITLE
feat(mcp-repl): wire tracing and last-exchange inspection

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -131,6 +131,48 @@ Progress and log notifications print inline as they arrive, and
 dynamic servers (see the `dynamic_capabilities` example) grow and shrink the
 REPL's vocabulary live.
 
+## Wire tracing
+
+Half of any "is it the client, the server, or the network?" question is
+answered by the raw JSON-RPC frames. `--trace` prints every frame from the
+start; `wire on` / `wire off` toggles it mid-session.
+
+```text
+demo> wire on
+wire tracing on (frames print to stderr)
+demo> echo message=hi
+[wire ->] +4.512s
+{
+  "id": 6,
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": { "arguments": { "message": "hi" }, "name": "echo" }
+}
+[wire <-] +4.524s [12ms]
+{
+  "id": 6,
+  "jsonrpc": "2.0",
+  "result": { "content": [ { "text": "hi", "type": "text" } ] }
+}
+```
+
+Each frame carries its direction, a session-relative timestamp, and, on a
+response, the time its request was outstanding.
+
+`last` reprints the previous request and its response whether or not tracing
+was on: frames are always recorded, so the exchange you did not think to
+trace is still there. Under `--json` it prints a
+`{"request": ..., "response": ...}` object instead.
+
+Frames print to stderr, so `--json` output on stdout stays pipeable with
+tracing on.
+
+Secrets are masked before a frame is stored, so nothing unmasked reaches the
+trace or `last`: values under `authorization`, `token`, `apiKey`, `secret`,
+`password` and similar keys (separators and case ignored), and anything
+following `Bearer ` inside a string. The HTTP `Authorization` header itself
+never appears here, since it is not part of a JSON-RPC frame.
+
 ## Completion
 
 Tab opens a columnar menu. What gets completed:

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -275,6 +275,13 @@ impl Completer for ReplCompleter {
             "read" => {
                 out.extend(self.complete_resource_word(&surface, word, span));
             }
+            "wire" => {
+                for state in ["on", "off"] {
+                    if state.starts_with(word) {
+                        out.push(word_suggestion(state, None, span));
+                    }
+                }
+            }
             "describe" => {
                 out.extend(Self::complete_describe_word(&surface, word, span));
             }

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -29,6 +29,7 @@ mod config;
 mod editor;
 mod elicit;
 mod style;
+mod wire;
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -49,6 +50,7 @@ use tower_mcp::protocol::{
 
 use elicit::ReplClientHandler;
 use style::{json_pretty, paint, tag, task_status_style};
+use wire::{TracingTransport, wire};
 
 #[derive(Parser)]
 #[command(
@@ -117,6 +119,11 @@ struct Args {
     #[arg(long)]
     no_history: bool,
 
+    /// Print every JSON-RPC frame sent and received, to stderr. Equivalent to
+    /// starting with `wire on`; toggle it mid-session with `wire on|off`.
+    #[arg(long)]
+    trace: bool,
+
     /// Command (and arguments) of a stdio MCP server to spawn.
     command: Vec<String>,
 }
@@ -167,6 +174,8 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("cancel", "cancel a background task"),
     ("refresh", "re-fetch the server surface"),
     ("info", "replay the connection banner plus capabilities"),
+    ("wire", "toggle raw JSON-RPC frame tracing (on|off)"),
+    ("last", "reprint the previous request and response"),
     ("quit", "exit"),
     ("exit", "exit"),
 ];
@@ -288,7 +297,7 @@ fn print_banner(info: &tower_mcp::protocol::InitializeResult) {
 /// A dimmed `[142ms]` / `[1.23s]` annotation for how long a call took.
 /// Printed on its own trailing line after a request-issuing command, so a slow
 /// (or timing-out) call is visible without interleaving with streamed output.
-fn timing(elapsed: Duration) -> String {
+pub fn timing(elapsed: Duration) -> String {
     let body = if elapsed.as_millis() < 1000 {
         format!("[{}ms]", elapsed.as_millis())
     } else {
@@ -638,6 +647,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .init();
     let args = Args::parse();
     style::init(args.color);
+    wire::init(args.trace);
     JSON_OUTPUT.store(args.json, Ordering::Relaxed);
 
     // Server profiles are read up front: both --list-servers and profile
@@ -740,10 +750,16 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         );
     }
 
+    // Every transport is wrapped, whatever `--trace` says: the wrapper is what
+    // records the exchange `last` reprints, and tracing can be switched on
+    // mid-session with `wire on`.
     let builder = McpClient::builder().with_elicitation();
     let client = if args.demo {
         builder
-            .connect(ChannelTransport::new(demo_router()), handler)
+            .connect(
+                TracingTransport::new(ChannelTransport::new(demo_router())),
+                handler,
+            )
             .await?
     } else {
         match connection {
@@ -755,13 +771,18 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 let config =
                     build_http_config(args.bearer.clone(), &args.headers, bearer, &headers)?;
                 builder
-                    .connect(HttpClientTransport::with_config(url, config), handler)
+                    .connect(
+                        TracingTransport::new(HttpClientTransport::with_config(url, config)),
+                        handler,
+                    )
                     .await?
             }
             Some(config::Connection::Stdio { command }) => {
                 let cmd_args: Vec<&str> = command[1..].iter().map(|s| s.as_str()).collect();
                 let transport = StdioClientTransport::spawn(&command[0], &cmd_args).await?;
-                builder.connect(transport, handler).await?
+                builder
+                    .connect(TracingTransport::new(transport), handler)
+                    .await?
             }
             None => {
                 eprintln!(
@@ -883,6 +904,8 @@ async fn handle_line(
             println!("  <tool> [k=v...]                           call a tool (schema-coerced)");
             println!("  <tool> [k=v...] &                         run task-augmented (SEP-2663)");
             println!("  jobs | task <id> | wait <id> | cancel <id>  manage tasks");
+            println!("  wire [on|off]                             trace raw JSON-RPC frames");
+            println!("  last                                      reprint the previous exchange");
             println!("  refresh | info | quit");
             let s = surface.read().unwrap();
             if !s.tools.is_empty() {
@@ -1154,6 +1177,51 @@ async fn handle_line(
                 }
             }
         }
+        "wire" => match rest.first().copied() {
+            Some("on") => {
+                wire().set_trace(true);
+                println!("wire tracing on (frames print to stderr)");
+            }
+            Some("off") => {
+                wire().set_trace(false);
+                println!("wire tracing off");
+            }
+            None => println!(
+                "wire tracing is {}",
+                if wire().trace_enabled() { "on" } else { "off" }
+            ),
+            Some(other) => println!("usage: wire [on|off] (got `{other}`)"),
+        },
+        // Deliberately independent of the trace toggle: frames are recorded
+        // either way, so the exchange you did not think to trace is still there.
+        "last" => match wire().last_exchange() {
+            None => {
+                if json_output() {
+                    println!("{}", error_json("no exchange yet"));
+                } else {
+                    println!("no request has been sent yet");
+                }
+            }
+            Some((request, response)) => {
+                if json_output() {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::json!({
+                            "request": request.json,
+                            "response": response.map(|r| r.json),
+                        }))
+                    );
+                } else {
+                    println!("{}", wire::render(wire::Direction::Sent, &request));
+                    match response {
+                        Some(response) => {
+                            println!("{}", wire::render(wire::Direction::Received, &response));
+                        }
+                        None => println!("(no response recorded for it)"),
+                    }
+                }
+            }
+        },
         "refresh" => {
             let fresh = fetch_surface(client).await;
             println!(

--- a/examples/mcp-repl/src/wire.rs
+++ b/examples/mcp-repl/src/wire.rs
@@ -1,0 +1,568 @@
+//! Wire tracing: the raw JSON-RPC frames, redacted, plus the last exchange.
+//!
+//! Half of any "is it the client, the server, or the network?" question is
+//! answered by seeing the frames themselves. [`TracingTransport`] wraps any
+//! [`ClientTransport`] and reports every frame that crosses it to a [`Wire`],
+//! which records the last request/response pair and, when tracing is on,
+//! renders the frame for printing.
+//!
+//! Recording happens whether or not tracing is on, so `last` can reprint an
+//! exchange the user did not know they would want. The cost is one JSON parse
+//! per frame, which is nothing next to the round trip that produced it.
+//!
+//! Rendered frames are meant for stderr: `--json` output goes to stdout, and
+//! a trace interleaved with it would break whatever is parsing it downstream.
+//!
+//! Secrets are masked before a frame is stored, so a redacted frame is the
+//! only form that exists past this module.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use nu_ansi_term::Style;
+use serde_json::Value;
+use tower_mcp::client::ClientTransport;
+use tower_mcp::error::Result;
+
+use crate::style::{paint, tag};
+use crate::timing;
+
+/// Which way a frame went.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    /// Client to server.
+    Sent,
+    /// Server to client.
+    Received,
+}
+
+impl Direction {
+    fn label(self) -> &'static str {
+        match self {
+            Direction::Sent => "wire ->",
+            Direction::Received => "wire <-",
+        }
+    }
+}
+
+/// One frame: the parsed JSON with secrets already masked, how far into the
+/// session it crossed the wire, and, for a response, how long its request had
+/// been outstanding.
+#[derive(Clone, Debug)]
+pub struct Frame {
+    pub json: Value,
+    pub at: Duration,
+    pub elapsed: Option<Duration>,
+}
+
+/// The frame recorder. One per process in normal use (see [`wire`]); tests
+/// build their own so they do not share state.
+pub struct Wire {
+    trace: AtomicBool,
+    started: Instant,
+    state: Mutex<State>,
+}
+
+#[derive(Default)]
+struct State {
+    /// Outstanding request ids and when they were sent, for the elapsed
+    /// annotation on the matching response.
+    pending: HashMap<String, Instant>,
+    last_request: Option<Frame>,
+    last_response: Option<Frame>,
+}
+
+/// A server that never answers would otherwise grow `pending` without bound.
+/// Well past any realistic number of concurrent requests from a REPL.
+const PENDING_CAP: usize = 256;
+
+impl Wire {
+    pub fn new(trace: bool) -> Self {
+        Self {
+            trace: AtomicBool::new(trace),
+            started: Instant::now(),
+            state: Mutex::new(State::default()),
+        }
+    }
+
+    pub fn set_trace(&self, on: bool) {
+        self.trace.store(on, Ordering::Relaxed);
+    }
+
+    pub fn trace_enabled(&self) -> bool {
+        self.trace.load(Ordering::Relaxed)
+    }
+
+    /// Record an outgoing frame. Returns the rendered trace block when
+    /// tracing is on.
+    pub fn sent(&self, raw: &str) -> Option<String> {
+        let frame = self.record(Direction::Sent, raw);
+        self.trace_enabled()
+            .then(|| render(Direction::Sent, &frame))
+    }
+
+    /// Record an incoming frame. Returns the rendered trace block when
+    /// tracing is on.
+    pub fn received(&self, raw: &str) -> Option<String> {
+        let frame = self.record(Direction::Received, raw);
+        self.trace_enabled()
+            .then(|| render(Direction::Received, &frame))
+    }
+
+    /// The most recent request and, if it has arrived, its response.
+    pub fn last_exchange(&self) -> Option<(Frame, Option<Frame>)> {
+        let state = self.state.lock().unwrap();
+        let request = state.last_request.clone()?;
+        Some((request, state.last_response.clone()))
+    }
+
+    fn record(&self, dir: Direction, raw: &str) -> Frame {
+        let now = Instant::now();
+        let json = redact(&parse(raw));
+        let id = frame_id(&json);
+        // A frame carrying a `method` is a request or a notification, whichever
+        // side sent it. That is what separates our request from our response to
+        // a server-initiated one, and a server's response from its own request.
+        let has_method = json.get("method").is_some();
+
+        let mut state = self.state.lock().unwrap();
+        let mut elapsed = None;
+        if dir == Direction::Received
+            && !has_method
+            && let Some(id) = &id
+        {
+            elapsed = state
+                .pending
+                .remove(id)
+                .map(|sent| now.saturating_duration_since(sent));
+        }
+        let frame = Frame {
+            json,
+            at: now.saturating_duration_since(self.started),
+            elapsed,
+        };
+        match dir {
+            Direction::Sent => {
+                if has_method && let Some(id) = id {
+                    if state.pending.len() >= PENDING_CAP {
+                        state.pending.clear();
+                    }
+                    state.pending.insert(id, now);
+                    // A new request is a new exchange: the previous one stops
+                    // being "last" the moment this goes out.
+                    state.last_request = Some(frame.clone());
+                    state.last_response = None;
+                }
+            }
+            Direction::Received => {
+                if !has_method
+                    && id.is_some()
+                    && state.last_request.as_ref().and_then(|f| frame_id(&f.json)) == id
+                {
+                    state.last_response = Some(frame.clone());
+                }
+            }
+        }
+        frame
+    }
+}
+
+/// The process-wide recorder. Created by [`init`] at startup; the lazy
+/// fallback keeps the accessor total for any path that runs before it.
+static WIRE: OnceLock<Wire> = OnceLock::new();
+
+pub fn init(trace: bool) {
+    let _ = WIRE.set(Wire::new(trace));
+}
+
+pub fn wire() -> &'static Wire {
+    WIRE.get_or_init(|| Wire::new(false))
+}
+
+/// A frame as it prints: a dim header with direction, session-relative
+/// timestamp, and (for a response) the round-trip time, then the pretty JSON.
+pub fn render(dir: Direction, frame: &Frame) -> String {
+    let mut header = format!(
+        "{} {}",
+        tag(Style::new().dimmed(), dir.label()),
+        paint(
+            Style::new().dimmed(),
+            &format!("+{:.3}s", frame.at.as_secs_f64())
+        )
+    );
+    if let Some(elapsed) = frame.elapsed {
+        header.push(' ');
+        header.push_str(&timing(elapsed));
+    }
+    let body = serde_json::to_string_pretty(&frame.json).unwrap_or_else(|_| frame.json.to_string());
+    format!("{header}\n{}", paint(Style::new().dimmed(), &body))
+}
+
+/// A frame that is not valid JSON still deserves to be seen: it is exactly
+/// the case where the trace is the answer.
+fn parse(raw: &str) -> Value {
+    serde_json::from_str(raw).unwrap_or_else(|_| Value::String(raw.to_string()))
+}
+
+/// The JSON-RPC id as a lookup key. Numbers and strings both appear in the
+/// wild, and `null` means there is no correlation to make.
+fn frame_id(json: &Value) -> Option<String> {
+    match json.get("id")? {
+        Value::Null => None,
+        Value::String(s) => Some(s.clone()),
+        other => Some(other.to_string()),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+const REDACTED: &str = "<redacted>";
+
+/// Keys whose values never print, in normalized form (see [`normalize_key`]).
+/// Matching is exact after normalization, so a `taskToken` argument is not
+/// caught by `token`.
+const SECRET_KEYS: &[&str] = &[
+    "authorization",
+    "proxyauthorization",
+    "bearer",
+    "bearertoken",
+    "token",
+    "accesstoken",
+    "refreshtoken",
+    "idtoken",
+    "sessiontoken",
+    "apikey",
+    "xapikey",
+    "secret",
+    "clientsecret",
+    "password",
+    "passwd",
+    "passphrase",
+    "credential",
+    "credentials",
+];
+
+/// Lowercase and drop separators, so `X-Api-Key`, `x_api_key`, and `apiKey`
+/// all compare equal to the same entry.
+fn normalize_key(key: &str) -> String {
+    key.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_lowercase())
+        .collect()
+}
+
+fn is_secret_key(key: &str) -> bool {
+    let normalized = normalize_key(key);
+    SECRET_KEYS.contains(&normalized.as_str())
+}
+
+/// Mask secrets before a frame goes anywhere. Recursive: a token nested in a
+/// tool's arguments is as sensitive as one in a header map.
+fn redact(value: &Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.iter()
+                .map(|(key, val)| {
+                    if is_secret_key(key) {
+                        (key.clone(), Value::String(REDACTED.to_string()))
+                    } else {
+                        (key.clone(), redact(val))
+                    }
+                })
+                .collect(),
+        ),
+        Value::Array(items) => Value::Array(items.iter().map(redact).collect()),
+        Value::String(s) => Value::String(mask_bearer(s)),
+        other => other.clone(),
+    }
+}
+
+/// A header line echoed inside a string value (`"Authorization: Bearer abc"`
+/// in an error message, say) carries a live token where the key-name rule
+/// cannot see it. Everything after the scheme goes.
+fn mask_bearer(s: &str) -> String {
+    // ASCII-only lowercasing leaves byte offsets aligned with the original.
+    let lowered = s.to_ascii_lowercase();
+    match lowered.find("bearer ") {
+        Some(at) => format!("{}{REDACTED}", &s[..at + "bearer ".len()]),
+        None => s.to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Transport wrapper
+// ---------------------------------------------------------------------------
+
+/// Wraps any client transport and reports each frame to a [`Wire`].
+///
+/// Every method delegates, including `supports_session_recovery`: the wrapper
+/// must be invisible to the client's own session handling.
+pub struct TracingTransport<T> {
+    inner: T,
+    wire: &'static Wire,
+}
+
+impl<T: ClientTransport> TracingTransport<T> {
+    pub fn new(inner: T) -> Self {
+        Self::with_wire(inner, wire())
+    }
+
+    pub fn with_wire(inner: T, wire: &'static Wire) -> Self {
+        Self { inner, wire }
+    }
+}
+
+#[async_trait]
+impl<T: ClientTransport> ClientTransport for TracingTransport<T> {
+    async fn send(&mut self, message: &str) -> Result<()> {
+        if let Some(block) = self.wire.sent(message) {
+            eprintln!("{block}");
+        }
+        self.inner.send(message).await
+    }
+
+    async fn recv(&mut self) -> Result<Option<String>> {
+        let message = self.inner.recv().await?;
+        if let Some(raw) = &message
+            && let Some(block) = self.wire.received(raw)
+        {
+            eprintln!("{block}");
+        }
+        Ok(message)
+    }
+
+    fn is_connected(&self) -> bool {
+        self.inner.is_connected()
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.inner.close().await
+    }
+
+    async fn reset_session(&mut self) {
+        self.inner.reset_session().await;
+    }
+
+    fn supports_session_recovery(&self) -> bool {
+        self.inner.supports_session_recovery()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(id: u32, method: &str) -> String {
+        serde_json::json!({"jsonrpc": "2.0", "id": id, "method": method, "params": {}}).to_string()
+    }
+
+    fn response(id: u32) -> String {
+        serde_json::json!({"jsonrpc": "2.0", "id": id, "result": {"ok": true}}).to_string()
+    }
+
+    #[test]
+    fn a_response_is_paired_with_the_request_it_answers() {
+        let wire = Wire::new(true);
+        wire.sent(&request(1, "tools/call"));
+        wire.received(&response(1));
+
+        let (req, resp) = wire.last_exchange().expect("an exchange was recorded");
+        assert_eq!(req.json["method"], "tools/call");
+        let resp = resp.expect("the response was paired");
+        assert_eq!(resp.json["result"]["ok"], true);
+        assert!(
+            resp.elapsed.is_some(),
+            "a paired response carries its round-trip time"
+        );
+    }
+
+    #[test]
+    fn a_new_request_clears_the_previous_response() {
+        let wire = Wire::new(false);
+        wire.sent(&request(1, "tools/list"));
+        wire.received(&response(1));
+        wire.sent(&request(2, "tools/call"));
+
+        let (req, resp) = wire.last_exchange().unwrap();
+        assert_eq!(req.json["method"], "tools/call");
+        assert!(resp.is_none(), "the new request has not been answered yet");
+    }
+
+    #[test]
+    fn notifications_are_not_exchanges() {
+        let wire = Wire::new(false);
+        wire.sent(
+            &serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"})
+                .to_string(),
+        );
+        assert!(wire.last_exchange().is_none());
+    }
+
+    #[test]
+    fn a_server_initiated_request_does_not_answer_ours() {
+        let wire = Wire::new(false);
+        wire.sent(&request(1, "tools/call"));
+        // The server asks us something mid-call (sampling, elicitation). It
+        // carries an id, but it is not our response.
+        wire.received(&request(7, "sampling/createMessage"));
+
+        let (_, resp) = wire.last_exchange().unwrap();
+        assert!(resp.is_none());
+    }
+
+    #[test]
+    fn a_mismatched_response_is_not_the_last_response() {
+        let wire = Wire::new(false);
+        wire.sent(&request(1, "tools/list"));
+        wire.sent(&request(2, "tools/call"));
+        // Answers the older request, which is no longer the tracked exchange.
+        wire.received(&response(1));
+
+        let (req, resp) = wire.last_exchange().unwrap();
+        assert_eq!(req.json["id"], 2);
+        assert!(resp.is_none());
+    }
+
+    #[test]
+    fn recording_happens_with_tracing_off_but_nothing_renders() {
+        let wire = Wire::new(false);
+        assert!(wire.sent(&request(1, "tools/list")).is_none());
+        assert!(wire.received(&response(1)).is_none());
+        assert!(
+            wire.last_exchange().is_some(),
+            "`last` works without --trace"
+        );
+
+        wire.set_trace(true);
+        assert!(wire.sent(&request(2, "tools/list")).is_some());
+    }
+
+    #[test]
+    fn a_rendered_frame_shows_direction_timestamp_and_elapsed() {
+        let wire = Wire::new(true);
+        let sent = wire.sent(&request(1, "tools/call")).unwrap();
+        assert!(sent.contains("wire ->"), "{sent}");
+        assert!(sent.contains("+0."), "a session-relative timestamp: {sent}");
+        assert!(sent.contains("tools/call"), "{sent}");
+        assert!(!sent.contains("elapsed"));
+
+        let received = wire.received(&response(1)).unwrap();
+        assert!(received.contains("wire <-"), "{received}");
+        assert!(
+            received.contains("ms]") || received.contains("s]"),
+            "a response carries its round-trip time: {received}"
+        );
+    }
+
+    #[test]
+    fn an_unparseable_frame_still_traces() {
+        let wire = Wire::new(true);
+        let rendered = wire.received("<html>502 Bad Gateway</html>").unwrap();
+        assert!(rendered.contains("502 Bad Gateway"), "{rendered}");
+    }
+
+    #[test]
+    fn secrets_are_masked_by_key_name() {
+        let frame = redact(&serde_json::json!({
+            "params": {
+                "headers": {"Authorization": "Bearer sk-live-123", "X-Api-Key": "k1"},
+                "arguments": {"apiKey": "k2", "password": "hunter2", "nested": [{"token": "t"}]},
+            }
+        }));
+        let rendered = frame.to_string();
+        for secret in ["sk-live-123", "k1", "k2", "hunter2", "\"t\""] {
+            assert!(!rendered.contains(secret), "{secret} leaked: {rendered}");
+        }
+        assert_eq!(frame["params"]["headers"]["Authorization"], REDACTED);
+        assert_eq!(frame["params"]["arguments"]["nested"][0]["token"], REDACTED);
+    }
+
+    #[test]
+    fn a_bearer_token_inside_a_string_is_masked() {
+        let frame = redact(&serde_json::json!({
+            "error": {"message": "rejected Authorization: Bearer sk-live-123"}
+        }));
+        let message = frame["error"]["message"].as_str().unwrap();
+        assert!(!message.contains("sk-live-123"), "{message}");
+        assert!(message.starts_with("rejected Authorization: Bearer "));
+    }
+
+    #[test]
+    fn ordinary_values_are_left_alone() {
+        let original = serde_json::json!({
+            "params": {"name": "add", "arguments": {"a": 2, "b": 3, "taskToken": "visible"}},
+            "flags": [true, null, 1.5],
+        });
+        assert_eq!(redact(&original), original);
+    }
+
+    // -- the transport wrapper ------------------------------------------------
+
+    struct FakeTransport {
+        sent: Vec<String>,
+        incoming: Vec<String>,
+    }
+
+    #[async_trait]
+    impl ClientTransport for FakeTransport {
+        async fn send(&mut self, message: &str) -> Result<()> {
+            self.sent.push(message.to_string());
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<Option<String>> {
+            Ok(if self.incoming.is_empty() {
+                None
+            } else {
+                Some(self.incoming.remove(0))
+            })
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        async fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn supports_session_recovery(&self) -> bool {
+            true
+        }
+    }
+
+    #[tokio::test]
+    async fn the_wrapper_records_both_directions_and_delegates() {
+        // Leaked rather than global, so this test cannot collide with another.
+        let wire: &'static Wire = Box::leak(Box::new(Wire::new(false)));
+        let mut transport = TracingTransport::with_wire(
+            FakeTransport {
+                sent: Vec::new(),
+                incoming: vec![response(1)],
+            },
+            wire,
+        );
+
+        transport.send(&request(1, "tools/call")).await.unwrap();
+        let received = transport.recv().await.unwrap();
+
+        assert_eq!(received.as_deref(), Some(response(1).as_str()));
+        assert_eq!(
+            transport.inner.sent.len(),
+            1,
+            "the frame reached the inner transport"
+        );
+        assert!(
+            transport.supports_session_recovery(),
+            "the wrapper must not change how the client handles sessions"
+        );
+        let (req, resp) = wire.last_exchange().unwrap();
+        assert_eq!(req.json["method"], "tools/call");
+        assert!(resp.is_some());
+    }
+}


### PR DESCRIPTION
Closes #1007.

Half of any "is it the client, the server, or the network?" question is answered by the raw JSON-RPC frames. This puts them one keystroke away.

## Design

`TracingTransport` (new `src/wire.rs`) wraps any `ClientTransport` and reports every frame that crosses it to a `Wire` recorder. Every method delegates, including `supports_session_recovery`, so the wrapper is invisible to the client's own session handling.

Wrapping is unconditional, whatever `--trace` says. Recording is what makes `last` work for an exchange nobody thought to trace, and it is what lets tracing be switched on mid-session. The cost is one JSON parse per frame, which is nothing next to the round trip that produced it.

Pairing a response with its request keys on the JSON-RPC id, with one distinction that matters: a frame carrying a `method` is a request or a notification whichever side sent it. That is what separates a server-initiated `sampling/createMessage` from the answer to our `tools/call`, and our answer to the former from a request of our own.

## Behavior

- [x] `--trace` at startup, `wire on` / `wire off` mid-session, bare `wire` reports the current state.
- [x] Frames carry direction (`->` / `<-`), a session-relative timestamp (`+4.512s`), and, on a response, the time its request was outstanding (`[12ms]`, the same annotation tool calls already print). Pretty-printed and dimmed.
- [x] `last` reprints the previous request and its response regardless of trace state.
- [x] Secrets are masked before a frame is stored, so nothing unmasked exists past the recorder: values under `authorization` / `token` / `apiKey` / `secret` / `password` style keys (separators and case ignored, matched exactly after normalizing, so a `taskToken` argument is not caught by `token`), and anything after `Bearer ` inside a string. The HTTP `Authorization` header itself never appears in a trace, since it is not part of a JSON-RPC frame.
- [x] Frames print to stderr, so `--json` output on stdout stays pipeable with tracing on. `last` under `--json` prints a `{"request": ..., "response": ...}` object to stdout instead of the rendered block. All styling goes through the existing color gate, so `NO_COLOR` and a non-tty degrade to plain text.
- [x] A frame that is not valid JSON still traces verbatim: that is exactly the case where the trace is the answer (an HTML 502 body arriving where JSON was expected).
- [x] `wire` tab-completes `on` / `off`; both commands are in `help` and the completion menu.

Bounded: the pending-request map is cleared past 256 outstanding ids, so a server that never answers cannot grow it without end.

## Testing

Thirteen tests in `wire.rs`:

- Pairing: a response matched to its request carries the round-trip time; a new request clears the previous response; a response to a superseded request is not recorded; a server-initiated request does not count as our answer; notifications are not exchanges.
- Recording with tracing off renders nothing but still answers `last`, and `set_trace(true)` starts rendering.
- A rendered frame shows direction, timestamp, and elapsed; an unparseable frame still traces.
- Redaction: masked by key name at every depth including inside arrays, masked after `Bearer ` inside a string, and ordinary values (including `taskToken`) left byte-identical.
- The wrapper itself, against a fake transport: both directions recorded, the frame reaching the inner transport, and `supports_session_recovery` delegated.

Tests build their own `Wire` rather than touching the process-wide one, so they cannot collide.

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace`, `cargo doc --no-deps --all-features`, and the types-crate `wasm32-unknown-unknown` check all pass. Smoke-tested end to end against `--demo` with `--trace`, with `last` under both renderers.

## Note on #1006

PR #1018 (auto-reconnect, still open) rebuilds the client on session loss. When it lands, the rebuilt transport will need the same `TracingTransport::new` wrapper in its connector for tracing to survive a reconnect. Whichever of the two merges second carries that one-line change.
