### PR TITLE
feat(mcp-repl): command aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "toml",
+ "toml_edit",
  "tower-mcp",
  "tracing-subscriber",
 ]
@@ -3032,6 +3033,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,6 +3844,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -21,6 +21,7 @@ tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 toml = "1"
+toml_edit = "0.25"
 clap.workspace = true
 tracing-subscriber.workspace = true
 reedline = "0.49"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -98,6 +98,54 @@ mcp-repl cratesio                  # a bare name works too
   `--config` file is an error. A missing file at the default location is not:
   profiles are opt-in.
 
+## Aliases
+
+Frequent commands get short names, kept in the same config file as the
+profiles:
+
+```text
+cratesio> alias dl=get_downloads
+dl = get_downloads  (profile cratesio)
+cratesio> dl crate=serde
+...
+cratesio> alias
+dl  get_downloads  (profile cratesio)
+t   tools          (global)
+cratesio> unalias dl
+removed dl (profile cratesio)
+```
+
+- `alias` lists what is in effect, `alias <name>` shows one, `alias
+  <name>=<expansion>` defines, and `unalias <name>` removes.
+- Expansion is a literal substitution of the first word with whatever
+  followed the alias appended: with `dl = "get_downloads"`, `dl crate=serde`
+  runs `get_downloads crate=serde`. An expansion that itself starts with an
+  alias expands again; a cycle is reported rather than looped.
+- An expansion can end in `&`, so an alias can run its tool task-augmented.
+- Scope: an alias defined while connected through a profile belongs to that
+  profile; otherwise it is global. `alias --global <name>=<expansion>` forces
+  the file-level table. A profile alias shadows a global one of the same
+  name, and `unalias` removes the definition that is actually in effect
+  (`--global` reaches past a profile alias to the global one).
+- Aliases cannot be named after a built-in, since expansion happens before
+  dispatch and the built-in would become unreachable. An alias that shadows a
+  *tool* is allowed, and says so when defined.
+- Every change is written back to the config file through `toml_edit`, so
+  comments, key order, and formatting elsewhere in the file survive. Removing
+  the last alias leaves the (now empty) table, because a comment above
+  `[aliases]` belongs to that table and would go with it.
+
+```toml
+[aliases]                       # every server
+t = "tools"
+
+[servers.cratesio.aliases]      # only through this profile
+dl = "get_downloads"
+```
+
+With no config file location at all (no `$HOME`, no `--config`), aliases
+still work for the session and the REPL says they were not saved.
+
 ## What to try
 
 ```text
@@ -177,7 +225,8 @@ never appears here, since it is not part of a JSON-RPC frame.
 
 Tab opens a columnar menu. What gets completed:
 
-- The command word: built-ins plus every tool, each with its description.
+- The command word: built-ins, aliases (shown with what they expand to), and
+  every tool, each with its description.
 - Tool argument names from the tool's `inputSchema` properties (with type,
   required flag, and description), and enum values after `key=` when the
   property declares an `enum`.
@@ -188,6 +237,7 @@ Tab opens a columnar menu. What gets completed:
 - `prompt <name> <arg>=`: argument values via `completion/complete`, and
   argument names from the prompt definition.
 - `describe <name>`: everything on the surface, labeled by kind.
+- `unalias <name>`: the aliases in effect, with their scope.
 
 ## describe
 

--- a/examples/mcp-repl/src/alias.rs
+++ b/examples/mcp-repl/src/alias.rs
@@ -1,0 +1,688 @@
+//! Command aliases: short names for frequent commands, kept in the same
+//! config file as the server profiles.
+//!
+//! ```toml
+//! [aliases]                       # every server sees these
+//! t = "tools"
+//! d = "describe"
+//!
+//! [servers.cratesio.aliases]      # only when connected as `cratesio`
+//! dl = "get_downloads crate"
+//! ```
+//!
+//! Expansion is a literal substitution of the first word, with whatever
+//! followed the alias appended: with `dl = "get_downloads crate"`,
+//! `dl =serde` runs `get_downloads crate=serde`. An expansion whose own
+//! first word is an alias expands again; a cycle is reported rather than
+//! looped.
+//!
+//! `alias`, `alias <name>=<expansion>`, and `unalias <name>` read and write
+//! this file. Writes go through `toml_edit`, so comments, key order, and
+//! formatting elsewhere in the file survive.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use toml_edit::{DocumentMut, InlineTable, Item, Table, value};
+
+use crate::BUILTINS;
+
+/// Which table of the config file an alias lives in.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scope {
+    /// The file-level `[aliases]` table: in effect against every server.
+    Global,
+    /// `[servers.<name>.aliases]`: in effect only through that profile.
+    Profile(String),
+}
+
+impl Scope {
+    /// How the scope is named in `alias` output and messages.
+    pub fn label(&self) -> String {
+        match self {
+            Scope::Global => "global".to_string(),
+            Scope::Profile(name) => format!("profile {name}"),
+        }
+    }
+}
+
+/// One alias as `alias` lists it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct Entry {
+    pub name: String,
+    pub expansion: String,
+    pub scope: Scope,
+}
+
+/// What a successful `alias`/`unalias` did. `warning` carries a persistence
+/// failure: the alias still applies to this session, but the config file was
+/// not updated, and saying so is better than pretending it was saved.
+#[derive(Debug)]
+pub struct Applied {
+    pub scope: Scope,
+    pub previous: Option<String>,
+    pub warning: Option<String>,
+}
+
+/// The alias tables in effect for this session: the file's global table plus
+/// the connected profile's, if any.
+#[derive(Default)]
+pub struct Aliases {
+    global: BTreeMap<String, String>,
+    profile: BTreeMap<String, String>,
+    profile_name: Option<String>,
+    path: Option<PathBuf>,
+}
+
+impl Aliases {
+    pub fn new(
+        global: BTreeMap<String, String>,
+        profile: BTreeMap<String, String>,
+        profile_name: Option<String>,
+        path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            global,
+            profile,
+            profile_name,
+            path,
+        }
+    }
+
+    /// The expansion for `name`, and where it came from. A profile alias
+    /// shadows a global one of the same name: the narrower scope is the more
+    /// deliberate one.
+    pub fn lookup(&self, name: &str) -> Option<(&str, Scope)> {
+        if let Some(expansion) = self.profile.get(name) {
+            let scope = Scope::Profile(self.profile_name.clone().unwrap_or_default());
+            return Some((expansion.as_str(), scope));
+        }
+        self.global.get(name).map(|e| (e.as_str(), Scope::Global))
+    }
+
+    /// Every alias in effect, profile ones first, each group by name. A
+    /// global alias shadowed by a profile alias is omitted: listing it would
+    /// suggest it applies.
+    pub fn entries(&self) -> Vec<Entry> {
+        let profile_scope = || Scope::Profile(self.profile_name.clone().unwrap_or_default());
+        let mut out: Vec<Entry> = self
+            .profile
+            .iter()
+            .map(|(name, expansion)| Entry {
+                name: name.clone(),
+                expansion: expansion.clone(),
+                scope: profile_scope(),
+            })
+            .collect();
+        out.extend(
+            self.global
+                .iter()
+                .filter(|(name, _)| !self.profile.contains_key(*name))
+                .map(|(name, expansion)| Entry {
+                    name: name.clone(),
+                    expansion: expansion.clone(),
+                    scope: Scope::Global,
+                }),
+        );
+        out
+    }
+
+    /// Expand a line whose first word is an alias. `Ok(None)` means the line
+    /// names no alias and should run as typed.
+    pub fn expand(&self, line: &str) -> Result<Option<String>, String> {
+        let mut current = line.to_string();
+        let mut seen: Vec<String> = Vec::new();
+        loop {
+            let trimmed = current.trim_start();
+            let (first, rest) = match trimmed.find(char::is_whitespace) {
+                Some(i) => (&trimmed[..i], trimmed[i..].trim_start()),
+                None => (trimmed, ""),
+            };
+            let Some((expansion, _)) = self.lookup(first) else {
+                break;
+            };
+            if seen.iter().any(|s| s == first) {
+                seen.push(first.to_string());
+                return Err(format!(
+                    "alias `{}` expands in a cycle ({}); break it with `unalias {}`",
+                    seen[0],
+                    seen.join(" -> "),
+                    seen[0]
+                ));
+            }
+            seen.push(first.to_string());
+            current = if rest.is_empty() {
+                expansion.to_string()
+            } else {
+                format!("{expansion} {rest}")
+            };
+        }
+        Ok((!seen.is_empty()).then_some(current))
+    }
+
+    /// Define or redefine an alias, and write it to the config file.
+    /// `global` forces the file-level table; without it an alias defined
+    /// while connected through a profile belongs to that profile.
+    pub fn define(&mut self, name: &str, expansion: &str, global: bool) -> Result<Applied, String> {
+        validate(name, expansion)?;
+        let scope = self.write_scope(global);
+        let table = self.table_mut(&scope);
+        let previous = table.insert(name.to_string(), expansion.to_string());
+        let warning = self
+            .persist(|doc| set_in_document(doc, &scope, name, expansion))
+            .err();
+        Ok(Applied {
+            scope,
+            previous,
+            warning,
+        })
+    }
+
+    /// Remove an alias. Without `global`, the profile's own alias goes first;
+    /// a global alias is only removed when the profile does not define one,
+    /// so `unalias` undoes the definition that is actually in effect.
+    pub fn remove(&mut self, name: &str, global: bool) -> Result<Applied, String> {
+        let scope = if !global && self.profile.contains_key(name) {
+            Scope::Profile(self.profile_name.clone().unwrap_or_default())
+        } else if self.global.contains_key(name) {
+            Scope::Global
+        } else if !global && self.profile_name.is_some() {
+            return Err(format!("no alias named `{name}`"));
+        } else {
+            return Err(format!("no global alias named `{name}`"));
+        };
+        let previous = self.table_mut(&scope).remove(name);
+        let warning = self
+            .persist(|doc| remove_from_document(doc, &scope, name))
+            .err();
+        Ok(Applied {
+            scope,
+            previous,
+            warning,
+        })
+    }
+
+    /// Where a definition goes when the command did not say.
+    fn write_scope(&self, global: bool) -> Scope {
+        match (&self.profile_name, global) {
+            (Some(name), false) => Scope::Profile(name.clone()),
+            _ => Scope::Global,
+        }
+    }
+
+    fn table_mut(&mut self, scope: &Scope) -> &mut BTreeMap<String, String> {
+        match scope {
+            Scope::Global => &mut self.global,
+            Scope::Profile(_) => &mut self.profile,
+        }
+    }
+
+    /// Apply `edit` to the config file, read-modify-write. A REPL with no
+    /// config path (no `$HOME`, no `--config`) keeps its aliases in memory
+    /// for the session and says so.
+    fn persist(
+        &self,
+        edit: impl FnOnce(&mut DocumentMut) -> Result<(), String>,
+    ) -> Result<(), String> {
+        let Some(path) = &self.path else {
+            return Err(
+                "no config file location (set $HOME or pass --config), so the alias applies to \
+                 this session only"
+                    .to_string(),
+            );
+        };
+        let source = match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => return Err(format!("{}: {e}", path.display())),
+        };
+        let mut doc = source
+            .parse::<DocumentMut>()
+            .map_err(|e| format!("{}: {e}", path.display()))?;
+        edit(&mut doc)?;
+        write_atomic(path, &doc.to_string()).map_err(|e| format!("{}: {e}", path.display()))
+    }
+}
+
+/// An alias name has to be a single word that dispatch can recognize, and it
+/// must not bury a built-in: expansion happens before dispatch, so an alias
+/// named `help` would make `help` unreachable.
+fn validate(name: &str, expansion: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("usage: alias <name>=<expansion>".to_string());
+    }
+    if name.chars().any(char::is_whitespace) {
+        return Err(format!("alias name `{name}` cannot contain whitespace"));
+    }
+    if name.contains('=') {
+        return Err(format!("alias name `{name}` cannot contain `=`"));
+    }
+    if let Some((builtin, _)) = BUILTINS.iter().find(|(b, _)| *b == name) {
+        return Err(format!(
+            "`{builtin}` is a built-in command, so an alias by that name would hide it"
+        ));
+    }
+    if expansion.trim().is_empty() {
+        return Err(format!(
+            "alias `{name}` needs something to expand to (usage: alias {name}=<expansion>)"
+        ));
+    }
+    Ok(())
+}
+
+/// Write to `path` through a temporary file in the same directory, so a
+/// failure part-way leaves the existing config intact rather than truncated.
+fn write_atomic(path: &Path, contents: &str) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut tmp = path.as_os_str().to_owned();
+    tmp.push(".tmp");
+    let tmp = PathBuf::from(tmp);
+    std::fs::write(&tmp, contents)?;
+    std::fs::rename(&tmp, path)
+}
+
+// ---------------------------------------------------------------------------
+// Config file edits
+// ---------------------------------------------------------------------------
+
+/// The aliases table of a scope, as it is written in the file. Both spellings
+/// are accepted: a standalone `[aliases]` table and an inline
+/// `aliases = { t = "tools" }`.
+enum AliasTable<'t> {
+    Table(&'t mut Table),
+    Inline(&'t mut InlineTable),
+}
+
+impl AliasTable<'_> {
+    fn set(&mut self, name: &str, expansion: &str) {
+        match self {
+            AliasTable::Table(t) => t[name] = value(expansion),
+            AliasTable::Inline(t) => {
+                t.insert(name, expansion.into());
+            }
+        }
+    }
+
+    fn remove(&mut self, name: &str) -> bool {
+        match self {
+            AliasTable::Table(t) => t.remove(name).is_some(),
+            AliasTable::Inline(t) => t.remove(name).is_some(),
+        }
+    }
+}
+
+/// Set `name` in the scope's aliases table, creating the table (and, for a
+/// profile scope, nothing else: the profile table must already exist).
+pub fn set_in_document(
+    doc: &mut DocumentMut,
+    scope: &Scope,
+    name: &str,
+    expansion: &str,
+) -> Result<(), String> {
+    let mut table = aliases_table(doc, scope, true)?
+        .ok_or_else(|| format!("no `{}` table in the config file", scope.label()))?;
+    table.set(name, expansion);
+    Ok(())
+}
+
+/// Remove `name` from the scope's aliases table. An emptied table is left in
+/// place: a comment above `[aliases]` is that table's decoration, so deleting
+/// the table would delete the comment with it.
+pub fn remove_from_document(
+    doc: &mut DocumentMut,
+    scope: &Scope,
+    name: &str,
+) -> Result<(), String> {
+    let Some(mut table) = aliases_table(doc, scope, false)? else {
+        return Ok(());
+    };
+    table.remove(name);
+    Ok(())
+}
+
+fn aliases_table<'d>(
+    doc: &'d mut DocumentMut,
+    scope: &Scope,
+    create: bool,
+) -> Result<Option<AliasTable<'d>>, String> {
+    let parent = match scope {
+        Scope::Global => doc.as_table_mut(),
+        Scope::Profile(profile) => {
+            let Some(servers) = child_table(doc.as_table_mut(), "servers")? else {
+                return Ok(None);
+            };
+            match child_table(servers, profile)? {
+                Some(t) => t,
+                None => return Ok(None),
+            }
+        }
+    };
+    if !parent.contains_key("aliases") {
+        if !create {
+            return Ok(None);
+        }
+        parent.insert("aliases", Item::Table(Table::new()));
+    }
+    match parent.get_mut("aliases") {
+        Some(Item::Table(t)) => Ok(Some(AliasTable::Table(t))),
+        Some(Item::Value(v)) if v.is_inline_table() => Ok(Some(AliasTable::Inline(
+            v.as_inline_table_mut().expect("checked"),
+        ))),
+        Some(_) => Err("`aliases` in the config file is not a table".to_string()),
+        None => Ok(None),
+    }
+}
+
+/// A child table by key. Only the standalone table spelling is writable here:
+/// an inline `servers = { ... }` would have to be rewritten wholesale, which
+/// is the user's call, not the REPL's.
+fn child_table<'t>(parent: &'t mut Table, key: &str) -> Result<Option<&'t mut Table>, String> {
+    match parent.get_mut(key) {
+        Some(Item::Table(t)) => Ok(Some(t)),
+        Some(_) => Err(format!(
+            "`{key}` in the config file is not a standalone table, so the alias cannot be written \
+             into it; add it to the file-level [aliases] table with `alias --global` instead"
+        )),
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn map(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn aliases(global: &[(&str, &str)], profile: &[(&str, &str)]) -> Aliases {
+        let name = (!profile.is_empty()).then(|| "cratesio".to_string());
+        Aliases::new(map(global), map(profile), name, None)
+    }
+
+    #[test]
+    fn expansion_substitutes_the_first_word_and_keeps_the_rest() {
+        let a = aliases(&[("dl", "get_downloads crate")], &[]);
+        assert_eq!(
+            a.expand("dl =serde").unwrap().as_deref(),
+            Some("get_downloads crate =serde")
+        );
+        assert_eq!(
+            a.expand("dl").unwrap().as_deref(),
+            Some("get_downloads crate")
+        );
+    }
+
+    #[test]
+    fn a_line_that_names_no_alias_is_left_alone() {
+        let a = aliases(&[("t", "tools")], &[]);
+        assert_eq!(a.expand("tools").unwrap(), None);
+        assert_eq!(a.expand("").unwrap(), None);
+        // Only the first word is a candidate; an alias elsewhere is just text.
+        assert_eq!(a.expand("describe t").unwrap(), None);
+    }
+
+    #[test]
+    fn an_expansion_naming_another_alias_expands_again() {
+        let a = aliases(&[("t", "tools"), ("lst", "t")], &[]);
+        assert_eq!(a.expand("lst").unwrap().as_deref(), Some("tools"));
+    }
+
+    #[test]
+    fn a_cycle_is_reported_rather_than_looped() {
+        let a = aliases(&[("a", "b"), ("b", "a")], &[]);
+        let err = a.expand("a x").unwrap_err();
+        assert!(err.contains("cycle"), "{err}");
+        assert!(err.contains("a -> b -> a"), "{err}");
+        assert!(err.contains("unalias a"), "{err}");
+    }
+
+    #[test]
+    fn a_trailing_ampersand_survives_expansion() {
+        // The background marker is read after expansion, so an alias can
+        // carry it (or a line can add it to an alias that does not).
+        let a = aliases(&[("sa", "slow_add a=1 b=2 &")], &[]);
+        assert_eq!(
+            a.expand("sa").unwrap().as_deref(),
+            Some("slow_add a=1 b=2 &")
+        );
+        let a = aliases(&[("sa", "slow_add a=1 b=2")], &[]);
+        assert_eq!(
+            a.expand("sa &").unwrap().as_deref(),
+            Some("slow_add a=1 b=2 &")
+        );
+    }
+
+    #[test]
+    fn a_profile_alias_shadows_the_global_one() {
+        let a = aliases(&[("t", "tools")], &[("t", "templates")]);
+        assert_eq!(a.expand("t").unwrap().as_deref(), Some("templates"));
+        assert_eq!(
+            a.lookup("t").map(|(e, s)| (e.to_string(), s)),
+            Some(("templates".to_string(), Scope::Profile("cratesio".into())))
+        );
+        // ... and the shadowed global is not listed as if it applied.
+        let entries = a.entries();
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert_eq!(entries[0].expansion, "templates");
+    }
+
+    #[test]
+    fn entries_list_profile_aliases_before_global_ones() {
+        let a = aliases(&[("z", "tools"), ("a", "prompts")], &[("p", "templates")]);
+        let names: Vec<String> = a.entries().into_iter().map(|e| e.name).collect();
+        assert_eq!(names, vec!["p", "a", "z"]);
+    }
+
+    #[test]
+    fn a_name_that_would_hide_a_builtin_is_refused() {
+        let mut a = aliases(&[], &[]);
+        let err = a.define("help", "tools", false).unwrap_err();
+        assert!(err.contains("built-in"), "{err}");
+        assert!(a.entries().is_empty());
+    }
+
+    #[test]
+    fn a_malformed_name_or_empty_expansion_is_refused() {
+        let mut a = aliases(&[], &[]);
+        assert!(
+            a.define("two words", "tools", false)
+                .unwrap_err()
+                .contains("whitespace")
+        );
+        assert!(a.define("a=b", "tools", false).unwrap_err().contains('='));
+        assert!(
+            a.define("t", "  ", false)
+                .unwrap_err()
+                .contains("expand to")
+        );
+    }
+
+    #[test]
+    fn define_reports_the_scope_and_what_it_replaced() {
+        let mut a = aliases(&[], &[("t", "tools")]);
+        let applied = a.define("t", "templates", false).unwrap();
+        assert_eq!(applied.scope, Scope::Profile("cratesio".into()));
+        assert_eq!(applied.previous.as_deref(), Some("tools"));
+        // No config path in these tests, so persistence warns rather than
+        // silently claiming a save.
+        assert!(applied.warning.is_some());
+        assert_eq!(a.expand("t").unwrap().as_deref(), Some("templates"));
+    }
+
+    #[test]
+    fn define_without_a_profile_lands_in_the_global_table() {
+        let mut a = aliases(&[], &[]);
+        assert_eq!(a.define("t", "tools", false).unwrap().scope, Scope::Global);
+        // --global forces it there even when a profile is connected.
+        let mut a = aliases(&[], &[("x", "tools")]);
+        assert_eq!(a.define("t", "tools", true).unwrap().scope, Scope::Global);
+    }
+
+    #[test]
+    fn unalias_removes_the_definition_in_effect() {
+        let mut a = aliases(&[("t", "tools")], &[("t", "templates")]);
+        assert_eq!(
+            a.remove("t", false).unwrap().scope,
+            Scope::Profile("cratesio".into())
+        );
+        // The global one is still there, and now in effect.
+        assert_eq!(a.expand("t").unwrap().as_deref(), Some("tools"));
+        assert_eq!(a.remove("t", false).unwrap().scope, Scope::Global);
+        assert_eq!(a.expand("t").unwrap(), None);
+    }
+
+    #[test]
+    fn unalias_global_does_not_reach_a_profile_alias() {
+        let mut a = aliases(&[], &[("t", "templates")]);
+        let err = a.remove("t", true).unwrap_err();
+        assert!(err.contains("no global alias"), "{err}");
+        assert_eq!(
+            a.remove("nope", false).unwrap_err(),
+            "no alias named `nope`"
+        );
+    }
+
+    // -- config file edits --------------------------------------------------
+
+    fn edited(source: &str, edit: impl FnOnce(&mut DocumentMut)) -> String {
+        let mut doc = source.parse::<DocumentMut>().unwrap();
+        edit(&mut doc);
+        doc.to_string()
+    }
+
+    const WITH_PROFILE: &str = r#"# my servers
+[servers.cratesio]
+url = "https://cratesio-mcp.fly.dev/"  # the public one
+"#;
+
+    #[test]
+    fn writing_an_alias_preserves_the_rest_of_the_file() {
+        let out = edited(WITH_PROFILE, |doc| {
+            set_in_document(doc, &Scope::Global, "t", "tools").unwrap()
+        });
+        assert!(out.contains("# my servers"), "{out}");
+        assert!(out.contains("# the public one"), "{out}");
+        assert!(out.contains("[aliases]"), "{out}");
+        assert!(out.contains(r#"t = "tools""#), "{out}");
+        // The result still parses as the config it claims to be.
+        out.parse::<DocumentMut>().unwrap();
+    }
+
+    #[test]
+    fn a_profile_alias_is_written_under_the_profile() {
+        let out = edited(WITH_PROFILE, |doc| {
+            set_in_document(
+                doc,
+                &Scope::Profile("cratesio".into()),
+                "dl",
+                "get_downloads",
+            )
+            .unwrap()
+        });
+        assert!(out.contains("[servers.cratesio.aliases]"), "{out}");
+        assert!(out.contains(r#"dl = "get_downloads""#), "{out}");
+    }
+
+    #[test]
+    fn a_profile_that_is_not_in_the_file_is_an_error_not_a_new_profile() {
+        let mut doc = WITH_PROFILE.parse::<DocumentMut>().unwrap();
+        let err =
+            set_in_document(&mut doc, &Scope::Profile("absent".into()), "t", "tools").unwrap_err();
+        assert!(err.contains("absent"), "{err}");
+    }
+
+    #[test]
+    fn redefining_replaces_the_value_in_place() {
+        let out = edited("[aliases]\nt = \"tools\"\nd = \"describe\"\n", |doc| {
+            set_in_document(doc, &Scope::Global, "t", "templates").unwrap()
+        });
+        assert!(out.contains(r#"t = "templates""#), "{out}");
+        assert!(out.contains(r#"d = "describe""#), "{out}");
+        assert!(!out.contains(r#""tools""#), "{out}");
+    }
+
+    #[test]
+    fn an_inline_aliases_table_is_edited_in_place() {
+        let out = edited(
+            "[servers.x]\nurl = \"https://example/mcp\"\naliases = { t = \"tools\" }\n",
+            |doc| {
+                set_in_document(doc, &Scope::Profile("x".into()), "d", "describe").unwrap();
+            },
+        );
+        // Still inline, now with both aliases in it.
+        assert!(out.contains("aliases = {"), "{out}");
+        assert!(out.contains(r#"t = "tools""#), "{out}");
+        assert!(out.contains(r#"d = "describe""#), "{out}");
+    }
+
+    #[test]
+    fn removing_the_last_alias_empties_the_table_but_keeps_its_comment() {
+        // The comment above `[aliases]` belongs to that table, so removing
+        // the table would take the comment with it. The stub stays instead.
+        let out = edited("# keep me\n[aliases]\nt = \"tools\"\n", |doc| {
+            remove_from_document(doc, &Scope::Global, "t").unwrap()
+        });
+        assert!(!out.contains(r#"t = "tools""#), "{out}");
+        assert!(out.contains("# keep me"), "{out}");
+        assert!(
+            crate::config::Config::parse(&out)
+                .unwrap()
+                .aliases
+                .is_empty(),
+            "the emptied table should read back as no aliases: {out}"
+        );
+
+        // A table with other aliases left in it keeps them.
+        let out = edited("[aliases]\nt = \"tools\"\nd = \"describe\"\n", |doc| {
+            remove_from_document(doc, &Scope::Global, "t").unwrap()
+        });
+        assert!(out.contains("[aliases]"), "{out}");
+        assert!(out.contains(r#"d = "describe""#), "{out}");
+    }
+
+    #[test]
+    fn removing_from_a_file_without_the_table_is_not_an_error() {
+        let out = edited(WITH_PROFILE, |doc| {
+            remove_from_document(doc, &Scope::Global, "t").unwrap();
+            remove_from_document(doc, &Scope::Profile("cratesio".into()), "t").unwrap();
+            remove_from_document(doc, &Scope::Profile("absent".into()), "t").unwrap();
+        });
+        assert_eq!(out, WITH_PROFILE);
+    }
+
+    #[test]
+    fn a_full_round_trip_through_a_real_file() {
+        let dir = std::env::temp_dir().join(format!("mcp-repl-alias-{}", std::process::id()));
+        let path = dir.join("config.toml");
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut a = Aliases::new(BTreeMap::new(), BTreeMap::new(), None, Some(path.clone()));
+
+        // The config file does not exist yet: defining creates it.
+        let applied = a.define("t", "tools", false).unwrap();
+        assert!(applied.warning.is_none(), "{:?}", applied.warning);
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(written.contains("[aliases]"), "{written}");
+        assert!(written.contains(r#"t = "tools""#), "{written}");
+
+        // And a later session reads it back as the same alias.
+        let config = crate::config::Config::parse(&written).unwrap();
+        assert_eq!(config.aliases.get("t").map(String::as_str), Some("tools"));
+
+        a.remove("t", false).unwrap();
+        let written = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            crate::config::Config::parse(&written)
+                .unwrap()
+                .aliases
+                .is_empty(),
+            "{written}"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/examples/mcp-repl/src/config.rs
+++ b/examples/mcp-repl/src/config.rs
@@ -15,7 +15,14 @@
 //! [servers.local]
 //! transport = "stdio"
 //! command = ["cargo", "run", "--example", "getting_started"]
+//!
+//! [aliases]
+//! t = "tools"
 //! ```
+//!
+//! Command aliases live in the same file: `[aliases]` for every server, and
+//! `[servers.<name>.aliases]` for one profile. See [`crate::alias`], which
+//! also writes them back.
 //!
 //! Tokens are read from the environment via `bearer_env` rather than stored in
 //! the file; an inline `bearer` literal works but warns.
@@ -25,12 +32,16 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-/// The whole config file: named profiles under `[servers.<name>]`.
+/// The whole config file: named profiles under `[servers.<name>]`, plus the
+/// command aliases every server sees under `[aliases]`.
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
     #[serde(default)]
     pub servers: BTreeMap<String, Profile>,
+    /// Command aliases in effect against every server. See [`crate::alias`].
+    #[serde(default)]
+    pub aliases: BTreeMap<String, String>,
 }
 
 /// One `[servers.<name>]` table.
@@ -51,6 +62,10 @@ pub struct Profile {
     /// The command (and arguments) of a `stdio` profile's child process.
     #[serde(default)]
     pub command: Vec<String>,
+    /// Command aliases in effect only through this profile. They shadow the
+    /// file-level `[aliases]` of the same name.
+    #[serde(default)]
+    pub aliases: BTreeMap<String, String>,
 }
 
 /// The transports a profile can name. `ws` and stateless HTTP are not
@@ -361,6 +376,34 @@ command = ["cargo", "run", "--example", "getting_started"]
         let err =
             Config::parse("[servers.x]\ntransport = \"ws\"\nurl = \"wss://example\"").unwrap_err();
         assert!(err.contains("ws"), "{err}");
+    }
+
+    #[test]
+    fn aliases_parse_at_both_scopes() {
+        let config = Config::parse(
+            r#"
+[aliases]
+t = "tools"
+
+[servers.cratesio]
+url = "https://cratesio-mcp.fly.dev/"
+aliases = { dl = "get_downloads crate" }
+"#,
+        )
+        .unwrap();
+        assert_eq!(config.aliases.get("t").map(String::as_str), Some("tools"));
+        assert_eq!(
+            config.servers["cratesio"]
+                .aliases
+                .get("dl")
+                .map(String::as_str),
+            Some("get_downloads crate")
+        );
+    }
+
+    #[test]
+    fn a_config_without_aliases_parses_to_none_of_them() {
+        assert!(Config::parse(SAMPLE).unwrap().aliases.is_empty());
     }
 
     #[test]

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -23,6 +23,7 @@ use reedline::{
 
 use tower_mcp::client::McpClient;
 
+use crate::alias::Aliases;
 use crate::style;
 use crate::{BUILTINS, Surface};
 
@@ -74,6 +75,7 @@ impl Prompt for ReplPrompt {
 
 pub struct ReplCompleter {
     surface: Arc<RwLock<Surface>>,
+    aliases: Arc<RwLock<Aliases>>,
     client: Arc<McpClient>,
     runtime: tokio::runtime::Handle,
 }
@@ -105,11 +107,13 @@ fn word_suggestion(
 impl ReplCompleter {
     pub fn new(
         surface: Arc<RwLock<Surface>>,
+        aliases: Arc<RwLock<Aliases>>,
         client: Arc<McpClient>,
         runtime: tokio::runtime::Handle,
     ) -> Self {
         Self {
             surface,
+            aliases,
             client,
             runtime,
         }
@@ -257,10 +261,19 @@ impl Completer for ReplCompleter {
         let completing_first = word_start == 0;
 
         if completing_first {
-            // First word: built-ins plus every tool name.
+            // First word: built-ins, every alias, and every tool name.
             for (name, desc) in BUILTINS {
                 if name.starts_with(word) {
                     out.push(word_suggestion(*name, Some(desc.to_string()), span));
+                }
+            }
+            for entry in self.aliases.read().unwrap().entries() {
+                if entry.name.starts_with(word) {
+                    out.push(word_suggestion(
+                        entry.name,
+                        Some(format!("alias for `{}`", entry.expansion)),
+                        span,
+                    ));
                 }
             }
             for t in &surface.tools {
@@ -284,6 +297,17 @@ impl Completer for ReplCompleter {
             }
             "describe" => {
                 out.extend(Self::complete_describe_word(&surface, word, span));
+            }
+            "unalias" => {
+                for entry in self.aliases.read().unwrap().entries() {
+                    if entry.name.starts_with(word) {
+                        out.push(word_suggestion(
+                            entry.name,
+                            Some(format!("{} ({})", entry.expansion, entry.scope.label())),
+                            span,
+                        ));
+                    }
+                }
             }
             "prompt" => {
                 let words = head.split_whitespace().count();
@@ -396,15 +420,22 @@ impl Completer for ReplCompleter {
 /// and JSON-literal values get the same palette as output rendering.
 pub struct ReplHighlighter {
     surface: Arc<RwLock<Surface>>,
+    aliases: Arc<RwLock<Aliases>>,
 }
 
 impl ReplHighlighter {
-    pub fn new(surface: Arc<RwLock<Surface>>) -> Self {
-        Self { surface }
+    pub fn new(surface: Arc<RwLock<Surface>>, aliases: Arc<RwLock<Aliases>>) -> Self {
+        Self { surface, aliases }
     }
 
     fn command_style(&self, word: &str) -> Style {
         if BUILTINS.iter().any(|(name, _)| *name == word) {
+            return Style::new().fg(Color::Cyan).bold();
+        }
+        // An alias resolves to a command, so it reads as one: same style as a
+        // built-in, since that is what it behaves like at the prompt.
+        let aliases = self.aliases.read().unwrap();
+        if aliases.lookup(word).is_some() {
             return Style::new().fg(Color::Cyan).bold();
         }
         let surface = self.surface.read().unwrap();
@@ -413,6 +444,7 @@ impl ReplHighlighter {
         }
         // Prefix of something completable: neutral while typing.
         let is_prefix = BUILTINS.iter().any(|(name, _)| name.starts_with(word))
+            || aliases.entries().iter().any(|e| e.name.starts_with(word))
             || surface.tools.iter().any(|t| t.name.starts_with(word));
         if is_prefix {
             Style::new()
@@ -497,6 +529,7 @@ impl Highlighter for ReplHighlighter {
 pub fn spawn_readline_thread(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
+    aliases: Arc<RwLock<Aliases>>,
     client: Arc<McpClient>,
     runtime: tokio::runtime::Handle,
     line_tx: tokio::sync::mpsc::Sender<String>,
@@ -512,6 +545,7 @@ pub fn spawn_readline_thread(
         run_interactive(
             server_name,
             surface,
+            aliases,
             client,
             runtime,
             &line_tx,
@@ -564,6 +598,7 @@ fn run_piped(line_tx: &tokio::sync::mpsc::Sender<String>, ack_rx: &std::sync::mp
 fn run_interactive(
     server_name: String,
     surface: Arc<RwLock<Surface>>,
+    aliases: Arc<RwLock<Aliases>>,
     client: Arc<McpClient>,
     runtime: tokio::runtime::Handle,
     line_tx: &tokio::sync::mpsc::Sender<String>,
@@ -571,8 +606,8 @@ fn run_interactive(
     at_prompt: Arc<AtomicBool>,
     persist_history: bool,
 ) {
-    let completer = ReplCompleter::new(surface.clone(), client, runtime);
-    let highlighter = ReplHighlighter::new(surface);
+    let completer = ReplCompleter::new(surface.clone(), aliases.clone(), client, runtime);
+    let highlighter = ReplHighlighter::new(surface, aliases);
 
     let menu = ColumnarMenu::default().with_name(MENU_NAME);
     let mut keybindings = default_emacs_keybindings();

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -20,11 +20,14 @@
 //! cargo run -p mcp-repl -- --server cratesio
 //! ```
 //!
-//! Inside the REPL, `help` lists the built-ins and the server's tools.
+//! Inside the REPL, `help` lists the built-ins and the server's tools, and
+//! `alias <name>=<expansion>` gives a frequent command a short name, kept in
+//! the same config file as the server profiles.
 //! A trailing `&` runs a tool task-augmented (SEP-2663): the call returns a
 //! task id immediately; `jobs`, `task <id>`, `wait <id>`, and `cancel <id>`
 //! manage it.
 
+mod alias;
 mod config;
 mod editor;
 mod elicit;
@@ -48,6 +51,7 @@ use tower_mcp::protocol::{
     TaskObject, ToolDefinition,
 };
 
+use alias::Aliases;
 use elicit::ReplClientHandler;
 use style::{json_pretty, paint, tag, task_status_style};
 use wire::{TracingTransport, wire};
@@ -172,6 +176,8 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("task", "show a background task"),
     ("wait", "wait for a background task"),
     ("cancel", "cancel a background task"),
+    ("alias", "define, list, or show a command alias"),
+    ("unalias", "remove a command alias"),
     ("refresh", "re-fetch the server surface"),
     ("info", "replay the connection banner plus capabilities"),
     ("wire", "toggle raw JSON-RPC frame tracing (on|off)"),
@@ -652,6 +658,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 
     // Server profiles are read up front: both --list-servers and profile
     // resolution need them before anything connects.
+    let config_file = config::config_path(args.config.as_deref()).map(|(path, _)| path);
     let profiles = load_config(args.config.as_deref());
     if args.list_servers {
         print_servers(&profiles);
@@ -714,6 +721,20 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         Some((name, c)) => (Some(name), Some(c)),
         None => (None, None),
     };
+
+    // Aliases come from the same file as the profiles: the global table plus
+    // the connected profile's own, which shadows it.
+    let aliases = Arc::new(RwLock::new(Aliases::new(
+        profiles.aliases.clone(),
+        profile_name
+            .as_ref()
+            .and_then(|name| profiles.servers.get(name))
+            .map(|p| p.aliases.clone())
+            .unwrap_or_default(),
+        profile_name.clone(),
+        config_file,
+    )));
+
     let connection = match (args.http.clone(), connection) {
         (
             Some(url),
@@ -823,7 +844,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     if one_shot {
         let mut jobs: Vec<(String, String)> = Vec::new();
         for cmd in &args.exec {
-            if handle_line(&client, &surface, &mut jobs, cmd.trim()).await {
+            if handle_line(&client, &surface, &aliases, &mut jobs, cmd.trim()).await {
                 break;
             }
         }
@@ -840,6 +861,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     editor::spawn_readline_thread(
         server_name,
         surface.clone(),
+        aliases.clone(),
         client.clone(),
         tokio::runtime::Handle::current(),
         line_tx,
@@ -861,7 +883,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             }
             maybe_line = line_rx.recv() => {
                 let Some(line) = maybe_line else { break };
-                let quit = handle_line(&client, &surface, &mut jobs, line.trim()).await;
+                let quit = handle_line(&client, &surface, &aliases, &mut jobs, line.trim()).await;
                 let _ = ack_tx.send(());
                 if quit {
                     break;
@@ -875,12 +897,33 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
 async fn handle_line(
     client: &Arc<McpClient>,
     surface: &Arc<RwLock<Surface>>,
+    aliases: &Arc<RwLock<Aliases>>,
     jobs: &mut Vec<(String, String)>,
     line: &str,
 ) -> bool {
     if line.is_empty() {
         return false;
     }
+    // Aliases expand before anything else looks at the line, so an expansion
+    // can carry arguments, a trailing `&`, or another alias. An alias can
+    // never be named after a built-in, so `alias`/`unalias` stay reachable.
+    let expanded;
+    let line = match aliases.read().unwrap().expand(line) {
+        Ok(None) => line,
+        Ok(Some(text)) => {
+            expanded = text;
+            expanded.trim()
+        }
+        Err(e) => {
+            note_error();
+            if json_output() {
+                println!("{}", error_json(&e));
+            } else {
+                println!("{}: {e}", style::error_prefix());
+            }
+            return false;
+        }
+    };
     let mut tokens: Vec<&str> = line.split_whitespace().collect();
     let background = tokens.last() == Some(&"&");
     if background {
@@ -904,6 +947,7 @@ async fn handle_line(
             println!("  <tool> [k=v...]                           call a tool (schema-coerced)");
             println!("  <tool> [k=v...] &                         run task-augmented (SEP-2663)");
             println!("  jobs | task <id> | wait <id> | cancel <id>  manage tasks");
+            println!("  alias [<name>=<expansion>] | unalias <name>  command aliases");
             println!("  wire [on|off]                             trace raw JSON-RPC frames");
             println!("  last                                      reprint the previous exchange");
             println!("  refresh | info | quit");
@@ -1177,6 +1221,12 @@ async fn handle_line(
                 }
             }
         }
+        "alias" | "unalias" => {
+            // Everything after the command word is taken raw: an expansion is
+            // a command line, so its spacing and any `=` belong to it.
+            let raw = line.strip_prefix(cmd).unwrap_or("").trim();
+            handle_alias(aliases, surface, cmd, raw);
+        }
         "wire" => match rest.first().copied() {
             Some("on") => {
                 wire().set_trace(true);
@@ -1268,6 +1318,178 @@ async fn handle_line(
         }
     }
     false
+}
+
+/// The `alias` and `unalias` built-ins: define, list, show, and remove
+/// command aliases, persisting each change to the config file.
+///
+/// `raw` is everything after the command word, unsplit: an expansion is a
+/// command line of its own, so its spacing is part of it.
+fn handle_alias(
+    aliases: &Arc<RwLock<Aliases>>,
+    surface: &Arc<RwLock<Surface>>,
+    cmd: &str,
+    raw: &str,
+) {
+    // A leading `--global` targets the file-level table. Only leading: a
+    // trailing one would be ambiguous with an expansion that ends in a flag.
+    let (global, rest) = match raw.strip_prefix("--global") {
+        Some(r) if r.is_empty() || r.starts_with(char::is_whitespace) => (true, r.trim_start()),
+        _ => (false, raw),
+    };
+    let rest = rest.trim();
+
+    if cmd == "unalias" {
+        if rest.is_empty() || rest.contains(char::is_whitespace) {
+            println!("usage: unalias [--global] <name>");
+            return;
+        }
+        match aliases.write().unwrap().remove(rest, global) {
+            Ok(applied) => {
+                report_alias_warning(applied.warning.as_deref());
+                if json_output() {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "removed": rest,
+                            "expansion": applied.previous,
+                            "scope": applied.scope.label(),
+                        })
+                    );
+                } else {
+                    println!(
+                        "removed {} {}",
+                        paint(Style::new().fg(Color::Cyan), rest),
+                        paint(
+                            Style::new().dimmed(),
+                            &format!("({})", applied.scope.label())
+                        )
+                    );
+                }
+            }
+            Err(e) => alias_error(&e),
+        }
+        return;
+    }
+
+    // `alias` with nothing after it lists what is in effect.
+    if rest.is_empty() {
+        let aliases = aliases.read().unwrap();
+        let entries = aliases.entries();
+        if json_output() {
+            let rendered: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| {
+                    serde_json::json!({
+                        "name": e.name,
+                        "expansion": e.expansion,
+                        "scope": e.scope.label(),
+                    })
+                })
+                .collect();
+            println!("{}", json_pretty(&serde_json::Value::Array(rendered)));
+            return;
+        }
+        if entries.is_empty() {
+            println!("no aliases defined (try `alias t=tools`)");
+            return;
+        }
+        let width = entries.iter().map(|e| e.name.len()).max().unwrap_or(0);
+        for e in &entries {
+            println!(
+                "{:width$}  {}  {}",
+                paint(Style::new().fg(Color::Cyan), &e.name),
+                e.expansion,
+                paint(Style::new().dimmed(), &format!("({})", e.scope.label()))
+            );
+        }
+        return;
+    }
+
+    // `alias <name>` shows one definition; `alias <name>=<expansion>` defines.
+    let Some((name, expansion)) = rest.split_once('=') else {
+        let aliases = aliases.read().unwrap();
+        match aliases.lookup(rest) {
+            Some((expansion, scope)) if json_output() => println!(
+                "{}",
+                serde_json::json!({
+                    "name": rest,
+                    "expansion": expansion,
+                    "scope": scope.label(),
+                })
+            ),
+            Some((expansion, scope)) => println!(
+                "{} = {}  {}",
+                paint(Style::new().fg(Color::Cyan), rest),
+                expansion,
+                paint(Style::new().dimmed(), &format!("({})", scope.label()))
+            ),
+            None => alias_error(&format!(
+                "no alias named `{rest}` (define one with `alias {rest}=<expansion>`)"
+            )),
+        }
+        return;
+    };
+    let name = name.trim();
+    match aliases
+        .write()
+        .unwrap()
+        .define(name, expansion.trim(), global)
+    {
+        Ok(applied) => {
+            report_alias_warning(applied.warning.as_deref());
+            if json_output() {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "name": name,
+                        "expansion": expansion.trim(),
+                        "scope": applied.scope.label(),
+                        "replaced": applied.previous,
+                    })
+                );
+                return;
+            }
+            println!(
+                "{} = {}  {}",
+                paint(Style::new().fg(Color::Cyan), name),
+                expansion.trim(),
+                paint(
+                    Style::new().dimmed(),
+                    &format!("({})", applied.scope.label())
+                )
+            );
+            // An alias wins over a tool of the same name, since expansion
+            // happens before dispatch. Worth saying once, at definition.
+            if surface.read().unwrap().tools.iter().any(|t| t.name == name) {
+                println!(
+                    "{}",
+                    paint(
+                        Style::new().dimmed(),
+                        &format!("note: this shadows the tool `{name}` on this server")
+                    )
+                );
+            }
+        }
+        Err(e) => alias_error(&e),
+    }
+}
+
+/// A failed write is reported without discarding the alias: it applies to
+/// this session, it just did not reach the config file.
+fn report_alias_warning(warning: Option<&str>) {
+    if let Some(w) = warning {
+        eprintln!("warning: {w}");
+    }
+}
+
+fn alias_error(message: &str) {
+    note_error();
+    if json_output() {
+        println!("{}", error_json(message));
+    } else {
+        println!("{}: {message}", style::error_prefix());
+    }
 }
 
 /// The `describe` built-in: schemas for a tool, the argument table for a


### PR DESCRIPTION
Closes #1009.

A server whose useful commands are long (`get_version_downloads`, `get_crate_health`) is typed the same way every session. `alias` gives those a short name and keeps it in the config file the server profiles already use.

## Commands

```text
cratesio> alias dl=get_downloads
dl = get_downloads  (profile cratesio)
cratesio> dl crate=serde
...
cratesio> alias
dl  get_downloads  (profile cratesio)
t   tools          (global)
cratesio> unalias dl
removed dl (profile cratesio)
```

- `alias` lists, `alias <name>` shows one, `alias <name>=<expansion>` defines, `unalias <name>` removes.
- Expansion is a literal substitution of the first word with whatever followed the alias appended, applied before anything else reads the line. So an expansion can carry arguments, end in `&` (task-augmented), or name another alias, which expands again. A cycle is reported with the chain and the `unalias` that breaks it, not looped.
- Under `--json`, each of these prints an object (or an array, for the listing) rather than the rendered line.

## Scope and persistence

- `[aliases]` applies to every server; `[servers.<name>.aliases]` applies only through that profile and shadows the global one of the same name. A definition made while connected through a profile belongs to that profile; `--global` forces the file-level table. `unalias` removes the definition actually in effect, and `--global` reaches past a profile alias to the global one.
- Writes go through `toml_edit`, so comments, key order, and formatting elsewhere in the file survive, and they land through a temporary file in the same directory so a failed write cannot truncate an existing config. Both spellings of the table are accepted, including an inline `aliases = { t = "tools" }`.
- Removing the last alias leaves the emptied table behind on purpose: a comment above `[aliases]` is that table's decoration and would be deleted with it.
- With no config file location at all (no `$HOME`, no `--config`), the alias applies to the session and the REPL says it was not saved rather than reporting a save that did not happen.

## Refusals and shadowing

A name that matches a built-in is refused: expansion runs before dispatch, so `alias help=tools` would make `help` unreachable. Shadowing a *tool* is allowed, since the tool set is per-server and a profile alias for one server should not be judged against another's surface; defining one prints a note saying what it shadows.

## Completion

`alias` and `unalias` are in `BUILTINS`, which drives first-word completion and input highlighting. Alias names complete as first words (described by what they expand to) and after `unalias` (described by expansion and scope), and highlight as commands, since that is what they behave like at the prompt.

## Testing

23 new tests. In `alias.rs`: expansion and its arguments, a line that names no alias, chained expansion, cycle detection, a trailing `&` surviving expansion, profile-over-global shadowing and listing order, every validation refusal, the scope a definition lands in, what `unalias` removes at each scope, and the config-file edits (comments preserved, profile table, inline table, redefinition in place, an absent profile erroring rather than being created, removal from a file that has no such table). One of them round-trips through a real file on disk and reads the result back through `Config::parse`. In `config.rs`: aliases parsing at both scopes, and a config without them.

Verified by hand against `--demo` and a stdio profile for the rendered, `--json`, exit-code, `--global`, and profile-scoped-write paths, checking the config file after each.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` all pass.
