### PR TITLE
feat(mcp-repl): respond to sampling/create requests

### DIFF
--- a/examples/mcp-repl/src/elicit.rs
+++ b/examples/mcp-repl/src/elicit.rs
@@ -17,14 +17,15 @@ use nu_ansi_term::{Color, Style};
 use tower_mcp::client::{ClientHandler, NotificationHandler, ServerNotification};
 use tower_mcp::error::JsonRpcError;
 use tower_mcp::protocol::{
-    ElicitAction, ElicitFieldValue, ElicitFormParams, ElicitRequestParams, ElicitResult,
-    PrimitiveSchemaDefinition,
+    CreateMessageParams, CreateMessageResult, ElicitAction, ElicitFieldValue, ElicitFormParams,
+    ElicitRequestParams, ElicitResult, PrimitiveSchemaDefinition,
 };
 
+use crate::sampling::{self, SamplingMode};
 use crate::style::{paint, tag};
 
-/// Client handler that layers terminal elicitation on top of the
-/// notification callbacks.
+/// Client handler that layers terminal elicitation and sampling on top of
+/// the notification callbacks.
 pub struct ReplClientHandler {
     notifications: NotificationHandler,
     at_prompt: Arc<AtomicBool>,
@@ -41,6 +42,41 @@ impl ReplClientHandler {
 
 #[async_trait]
 impl ClientHandler for ReplClientHandler {
+    async fn handle_create_message(
+        &self,
+        params: CreateMessageParams,
+    ) -> Result<CreateMessageResult, JsonRpcError> {
+        match sampling::mode() {
+            SamplingMode::Decline => Err(sampling::declined("--sampling decline")),
+            SamplingMode::Canned => {
+                println!(
+                    "{} answered with the canned reply",
+                    tag(Style::new().fg(Color::Purple), "sampling")
+                );
+                Ok(sampling::canned(&params))
+            }
+            SamplingMode::Prompt => {
+                if self.at_prompt.load(Ordering::SeqCst) {
+                    // Same constraint as a form elicitation: the editor holds
+                    // the terminal in raw mode and a second stdin reader
+                    // would corrupt it.
+                    println!(
+                        "\n{} declined a completion request from the server (arrived while at \
+                         the prompt; run the tool in the foreground to answer it)",
+                        tag(Style::new().fg(Color::Purple), "sampling"),
+                    );
+                    return Err(sampling::declined(
+                        "arrived while the editor held the terminal",
+                    ));
+                }
+                // Blocking stdin reads must leave the async runtime.
+                tokio::task::spawn_blocking(move || sampling::prompt(&params))
+                    .await
+                    .map_err(|e| JsonRpcError::internal_error(e.to_string()))?
+            }
+        }
+    }
+
     async fn handle_elicit(
         &self,
         params: ElicitRequestParams,

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -28,6 +28,7 @@
 mod config;
 mod editor;
 mod elicit;
+mod sampling;
 mod style;
 mod wire;
 
@@ -114,6 +115,13 @@ struct Args {
     /// (suppressed by default so only command output is emitted).
     #[arg(long)]
     verbose: bool,
+
+    /// How to answer a server's `sampling/createMessage` request: `prompt`
+    /// shows it and reads the assistant message on stdin, `canned` answers
+    /// with a fixed placeholder, `decline` refuses. Defaults to `prompt`
+    /// interactively and `decline` under --exec.
+    #[arg(long, value_enum, value_name = "STRATEGY")]
+    sampling: Option<sampling::SamplingMode>,
 
     /// Do not persist command history to ~/.mcp-repl_history.
     #[arg(long)]
@@ -705,6 +713,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 );
             })
     };
+    // Sampling has no model behind it, so the operator answers. Under --exec
+    // there is nobody to ask, so requests are refused unless --sampling says
+    // otherwise.
+    sampling::init(sampling::resolve(args.sampling, one_shot));
     let handler = ReplClientHandler::new(notifications, at_prompt.clone());
 
     // Explicit flags override profile fields: --http retargets a profile's URL
@@ -753,7 +765,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // Every transport is wrapped, whatever `--trace` says: the wrapper is what
     // records the exchange `last` reprints, and tracing can be switched on
     // mid-session with `wire on`.
-    let builder = McpClient::builder().with_elicitation();
+    // Sampling is advertised whatever the strategy: a client is allowed to
+    // refuse an individual request, and a server can only ask when the
+    // capability is declared, so `--sampling decline` still exercises the
+    // server's rejection path.
+    let builder = McpClient::builder().with_elicitation().with_sampling();
     let client = if args.demo {
         builder
             .connect(
@@ -1240,6 +1256,14 @@ async fn handle_line(
                 print_counts(&surface.read().unwrap());
                 let caps = serde_json::to_value(&info.capabilities).unwrap_or_default();
                 println!("capabilities: {}", json_pretty(&caps));
+                // What this client does with a request the server sends back.
+                println!(
+                    "{}",
+                    paint(
+                        Style::new().dimmed(),
+                        &format!("sampling: {}", sampling::mode().as_str())
+                    )
+                );
             }
             None => println!("not initialized"),
         },

--- a/examples/mcp-repl/src/sampling.rs
+++ b/examples/mcp-repl/src/sampling.rs
@@ -1,0 +1,440 @@
+//! Sampling: how the REPL answers a server's `sampling/createMessage`.
+//!
+//! mcp-repl has no model behind it, so it answers as the operator: the
+//! request is printed and the assistant message is typed on stdin, the same
+//! way elicitation collects form fields. `--sampling` picks between that and
+//! the two non-interactive strategies.
+//!
+//! Like elicitation, the interactive path only works while the readline
+//! editor is parked (a foreground tool call); a request that arrives while
+//! the editor owns the terminal in raw mode is declined instead.
+
+use std::io::BufRead;
+
+use clap::ValueEnum;
+use nu_ansi_term::{Color, Style};
+use tower_mcp::error::JsonRpcError;
+use tower_mcp::protocol::{
+    ContentRole, CreateMessageParams, CreateMessageResult, SamplingContent, SamplingContentOrArray,
+    SamplingMessage,
+};
+
+use crate::style::{paint, tag};
+
+/// How to answer a `sampling/createMessage` request.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum SamplingMode {
+    /// Print the request and read the assistant message on stdin.
+    Prompt,
+    /// Answer with a fixed placeholder message, without asking.
+    Canned,
+    /// Refuse every request.
+    Decline,
+}
+
+impl SamplingMode {
+    /// The label `info` prints.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Prompt => "prompt",
+            Self::Canned => "canned",
+            Self::Decline => "decline",
+        }
+    }
+}
+
+/// The text a `canned` reply carries. Deliberately not model-shaped: a server
+/// logging this should be able to tell no inference happened.
+pub const CANNED_REPLY: &str = "(canned reply from mcp-repl; no model was called)";
+
+/// The `model` field on a reply. The spec wants the name of the model that
+/// generated the message; nothing generated it, so say so.
+const CANNED_MODEL: &str = "mcp-repl/canned";
+const OPERATOR_MODEL: &str = "mcp-repl/operator";
+
+/// Resolve the effective mode: `--sampling` when given, otherwise `prompt`
+/// interactively and `decline` under `-e`, where there is no operator to ask
+/// and a blocked read would hang the script.
+pub fn resolve(flag: Option<SamplingMode>, one_shot: bool) -> SamplingMode {
+    match flag {
+        Some(mode) => mode,
+        None if one_shot => SamplingMode::Decline,
+        None => SamplingMode::Prompt,
+    }
+}
+
+/// The resolved mode, set once at startup. Like the color and wire settings,
+/// it is read from wherever it is needed rather than threaded through: both
+/// the handler answering a request and `info` reporting the strategy want it.
+static MODE: std::sync::OnceLock<SamplingMode> = std::sync::OnceLock::new();
+
+/// Record the resolved mode. Called once, from `main`.
+pub fn init(mode: SamplingMode) {
+    let _ = MODE.set(mode);
+}
+
+/// The mode in effect.
+pub fn mode() -> SamplingMode {
+    *MODE.get().unwrap_or(&SamplingMode::Prompt)
+}
+
+/// A refusal. Sampling has no `decline` result shape the way elicitation
+/// does, so the only way to say no is an error; `-32007` says the client
+/// refused rather than that something broke.
+pub fn declined(reason: &str) -> JsonRpcError {
+    JsonRpcError::forbidden(format!("sampling declined: {reason}"))
+}
+
+/// The request as the operator sees it before answering: what the server
+/// asked for, and every message it wants the model to see.
+pub fn render_request(params: &CreateMessageParams) -> String {
+    let mut out = String::new();
+    let mut head = format!("max {} tokens", params.max_tokens);
+    if let Some(t) = params.temperature {
+        head.push_str(&format!(", temperature {t}"));
+    }
+    if let Some(prefs) = &params.model_preferences
+        && let Some(first) = prefs.hints.first()
+        && let Some(name) = &first.name
+    {
+        head.push_str(&format!(", model hint {name}"));
+    }
+    out.push_str(&format!(
+        "{} server requests a completion ({head})\n",
+        tag(Style::new().fg(Color::Purple), "sampling")
+    ));
+    if let Some(system) = &params.system_prompt {
+        out.push_str(&format!(
+            "  {} {}\n",
+            paint(Style::new().fg(Color::Cyan), "system:"),
+            truncate(system)
+        ));
+    }
+    for message in &params.messages {
+        out.push_str(&format!(
+            "  {} {}\n",
+            paint(
+                Style::new().fg(Color::Cyan),
+                &format!("{}:", role_label(message.role))
+            ),
+            truncate(&message_text(message))
+        ));
+    }
+    out
+}
+
+fn role_label(role: ContentRole) -> &'static str {
+    match role {
+        ContentRole::Assistant => "assistant",
+        _ => "user",
+    }
+}
+
+/// One message flattened to a line. Non-text parts are summarized rather
+/// than dumped: a base64 image is not readable at the prompt.
+fn message_text(message: &SamplingMessage) -> String {
+    let parts: Vec<String> = message
+        .content
+        .items()
+        .iter()
+        .map(|c| match c {
+            SamplingContent::Text { text, .. } => text.clone(),
+            SamplingContent::Image {
+                mime_type, data, ..
+            } => {
+                format!("[image {mime_type}, {} base64 chars]", data.len())
+            }
+            SamplingContent::Audio {
+                mime_type, data, ..
+            } => {
+                format!("[audio {mime_type}, {} base64 chars]", data.len())
+            }
+            other => serde_json::to_value(other)
+                .ok()
+                .and_then(|v| {
+                    v.get("type")
+                        .and_then(|t| t.as_str())
+                        .map(|t| format!("[{t}]"))
+                })
+                .unwrap_or_else(|| "[content]".to_string()),
+        })
+        .collect();
+    parts.join(" ")
+}
+
+/// Cap a message at something a terminal can show, keeping the tail count so
+/// it is clear the model would have seen more.
+fn truncate(text: &str) -> String {
+    const CAP: usize = 2000;
+    let flat = text.replace('\n', "\n    ");
+    if flat.chars().count() <= CAP {
+        return flat;
+    }
+    let kept: String = flat.chars().take(CAP).collect();
+    let dropped = flat.chars().count() - CAP;
+    format!("{kept}... (+{dropped} more chars)")
+}
+
+/// Read the assistant message. Lines accumulate until a lone `.` submits or
+/// input ends; ending input having typed nothing cancels, which is how
+/// Ctrl-D refuses a request. Returns `None` for a refusal.
+pub fn read_reply(input: &mut impl BufRead) -> Option<String> {
+    let mut lines: Vec<String> = Vec::new();
+    loop {
+        let mut buf = String::new();
+        match input.read_line(&mut buf) {
+            Ok(0) | Err(_) => break,
+            Ok(_) => {}
+        }
+        let line = buf.trim_end_matches(['\n', '\r']);
+        if line == "." {
+            break;
+        }
+        lines.push(line.to_string());
+    }
+    let text = lines.join("\n");
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Build the reply. `max_tokens` is honored crudely (four chars a token),
+/// enough that a server asking for a short answer is not handed an essay,
+/// and the stop reason says which way it ended.
+fn reply(text: &str, model: &str, max_tokens: u32) -> CreateMessageResult {
+    let cap = (max_tokens as usize).saturating_mul(4);
+    let (text, stop_reason) = if cap > 0 && text.chars().count() > cap {
+        (text.chars().take(cap).collect::<String>(), "maxTokens")
+    } else {
+        (text.to_string(), "endTurn")
+    };
+    CreateMessageResult {
+        content: SamplingContentOrArray::Single(SamplingContent::Text {
+            text,
+            annotations: None,
+            meta: None,
+        }),
+        model: model.to_string(),
+        role: ContentRole::Assistant,
+        stop_reason: Some(stop_reason.to_string()),
+        meta: None,
+    }
+}
+
+/// The `canned` answer.
+pub fn canned(params: &CreateMessageParams) -> CreateMessageResult {
+    reply(CANNED_REPLY, CANNED_MODEL, params.max_tokens)
+}
+
+/// The `prompt` answer: show the request, read a message, wrap it. Blocking
+/// stdin reads, so callers run this off the async runtime.
+pub fn prompt(params: &CreateMessageParams) -> Result<CreateMessageResult, JsonRpcError> {
+    print!("{}", render_request(params));
+    println!(
+        "{}",
+        paint(
+            Style::new().dimmed(),
+            "  type the assistant message; `.` on its own line submits, Ctrl-D declines"
+        )
+    );
+    print!("  reply> ");
+    let _ = std::io::Write::flush(&mut std::io::stdout());
+    let mut stdin = std::io::stdin().lock();
+    match read_reply(&mut stdin) {
+        Some(text) => Ok(reply(&text, OPERATOR_MODEL, params.max_tokens)),
+        None => {
+            println!("  (declined)");
+            Err(declined("no reply given"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_mcp::protocol::{ModelHint, ModelPreferences};
+
+    fn user_text(text: &str) -> SamplingMessage {
+        SamplingMessage {
+            role: ContentRole::User,
+            content: SamplingContentOrArray::Single(SamplingContent::Text {
+                text: text.to_string(),
+                annotations: None,
+                meta: None,
+            }),
+            meta: None,
+        }
+    }
+
+    fn params(max_tokens: u32) -> CreateMessageParams {
+        CreateMessageParams::new(vec![user_text("summarize this")], max_tokens)
+    }
+
+    fn text_of(result: &CreateMessageResult) -> String {
+        result.first_text().unwrap_or_default().to_string()
+    }
+
+    #[test]
+    fn mode_defaults_to_prompt_interactively_and_decline_one_shot() {
+        assert_eq!(resolve(None, false), SamplingMode::Prompt);
+        assert_eq!(resolve(None, true), SamplingMode::Decline);
+        // An explicit flag wins either way, including asking for the
+        // interactive path under -e.
+        assert_eq!(
+            resolve(Some(SamplingMode::Canned), false),
+            SamplingMode::Canned
+        );
+        assert_eq!(
+            resolve(Some(SamplingMode::Prompt), true),
+            SamplingMode::Prompt
+        );
+    }
+
+    #[test]
+    fn canned_reply_is_marked_as_not_a_model() {
+        let result = canned(&params(200));
+        assert_eq!(text_of(&result), CANNED_REPLY);
+        assert_eq!(result.model, CANNED_MODEL);
+        assert_eq!(result.role, ContentRole::Assistant);
+        assert_eq!(result.stop_reason.as_deref(), Some("endTurn"));
+    }
+
+    #[test]
+    fn a_refusal_is_forbidden_not_an_internal_error() {
+        let err = declined("no reply given");
+        assert_eq!(err.code, -32007);
+        assert!(
+            err.message.contains("no reply given"),
+            "the reason should survive: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn max_tokens_truncates_and_says_so() {
+        let long = "x".repeat(100);
+        // 10 tokens is 40 chars.
+        let result = reply(&long, OPERATOR_MODEL, 10);
+        assert_eq!(text_of(&result).chars().count(), 40);
+        assert_eq!(result.stop_reason.as_deref(), Some("maxTokens"));
+
+        let result = reply("short", OPERATOR_MODEL, 10);
+        assert_eq!(text_of(&result), "short");
+        assert_eq!(result.stop_reason.as_deref(), Some("endTurn"));
+    }
+
+    #[test]
+    fn a_dot_submits_and_the_lines_before_it_are_the_message() {
+        let mut input = std::io::Cursor::new("first line\nsecond line\n.\nnot read\n");
+        assert_eq!(
+            read_reply(&mut input).as_deref(),
+            Some("first line\nsecond line")
+        );
+    }
+
+    #[test]
+    fn input_ending_submits_what_was_typed() {
+        // A piped reply has no terminator, only EOF.
+        let mut input = std::io::Cursor::new("piped reply\n");
+        assert_eq!(read_reply(&mut input).as_deref(), Some("piped reply"));
+    }
+
+    #[test]
+    fn typing_nothing_declines() {
+        // Ctrl-D at the first prompt.
+        let mut input = std::io::Cursor::new("");
+        assert_eq!(read_reply(&mut input), None);
+        // A dot with nothing before it is the same refusal, not an empty
+        // assistant message.
+        let mut input = std::io::Cursor::new(".\n");
+        assert_eq!(read_reply(&mut input), None);
+        // Whitespace is not a message either.
+        let mut input = std::io::Cursor::new("   \n\n.\n");
+        assert_eq!(read_reply(&mut input), None);
+    }
+
+    #[test]
+    fn the_request_shows_what_the_server_asked_for() {
+        let mut p = CreateMessageParams::new(
+            vec![
+                user_text("summarize this"),
+                SamplingMessage {
+                    role: ContentRole::Assistant,
+                    content: SamplingContentOrArray::Single(SamplingContent::Text {
+                        text: "sure".into(),
+                        annotations: None,
+                        meta: None,
+                    }),
+                    meta: None,
+                },
+            ],
+            200,
+        )
+        .system_prompt("You are a concise summarizer.");
+        p.temperature = Some(0.2);
+        p.model_preferences = Some(ModelPreferences {
+            hints: vec![ModelHint {
+                name: Some("claude-3-5-sonnet".into()),
+            }],
+            ..Default::default()
+        });
+
+        let rendered = render_request(&p);
+        assert!(rendered.contains("max 200 tokens"), "{rendered}");
+        assert!(rendered.contains("temperature 0.2"), "{rendered}");
+        assert!(
+            rendered.contains("model hint claude-3-5-sonnet"),
+            "{rendered}"
+        );
+        assert!(
+            rendered.contains("You are a concise summarizer."),
+            "{rendered}"
+        );
+        assert!(rendered.contains("summarize this"), "{rendered}");
+        // Both roles are labeled, so a multi-turn request reads as a
+        // conversation rather than one blob.
+        assert!(rendered.contains("user:"), "{rendered}");
+        assert!(rendered.contains("assistant:"), "{rendered}");
+    }
+
+    #[test]
+    fn non_text_content_is_summarized_not_dumped() {
+        let message = SamplingMessage {
+            role: ContentRole::User,
+            content: SamplingContentOrArray::Array(vec![
+                SamplingContent::Text {
+                    text: "what is this".into(),
+                    annotations: None,
+                    meta: None,
+                },
+                SamplingContent::Image {
+                    data: "A".repeat(4096),
+                    mime_type: "image/png".into(),
+                    annotations: None,
+                    meta: None,
+                },
+            ]),
+            meta: None,
+        };
+        let line = message_text(&message);
+        assert!(line.contains("what is this"), "{line}");
+        assert!(
+            line.contains("[image image/png, 4096 base64 chars]"),
+            "{line}"
+        );
+        assert!(!line.contains("AAAA"), "base64 must not reach the terminal");
+    }
+
+    #[test]
+    fn a_long_message_is_capped_with_the_dropped_count() {
+        let rendered = render_request(&CreateMessageParams::new(
+            vec![user_text(&"y".repeat(2500))],
+            200,
+        ));
+        assert!(rendered.contains("(+500 more chars)"), "not capped");
+    }
+}

--- a/examples/sampling_server.rs
+++ b/examples/sampling_server.rs
@@ -16,12 +16,13 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, McpRouter, StdioTransport, ToolBuilder,
+    CallToolResult, McpRouter, ToolBuilder,
     extract::{Context, Json},
     protocol::{
         ContentRole, CreateMessageParams, ElicitAction, ElicitFormParams, ElicitFormSchema,
         SamplingContent, SamplingContentOrArray, SamplingMessage,
     },
+    transport::stdio::BidirectionalStdioTransport,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -192,7 +193,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .tool(confirm_delete)
         .tool(slow_task);
 
-    let mut transport = StdioTransport::new(router);
+    // Bidirectional: sampling and elicitation are server-to-client requests,
+    // so the transport needs the client requester that plain `StdioTransport`
+    // does not wire up. Without it every tool here fails with
+    // "Sampling not available: no client requester configured".
+    let mut transport = BidirectionalStdioTransport::new(router);
     tracing::info!("Sampling server started");
     transport.run().await?;
 


### PR DESCRIPTION
Closes #1012.

A server that calls `sampling/createMessage` got nothing back from mcp-repl: the capability was never advertised, so a sampling-capable server could not be exercised with it at all.

## Strategies

mcp-repl has no model behind it, so it answers as the operator. `--sampling` picks how:

- `prompt` prints the request and reads the assistant message on stdin, the same way elicitation collects form fields. A lone `.` submits, and input ending with nothing typed (Ctrl-D) declines.
- `canned` answers every request with a fixed placeholder, `(canned reply from mcp-repl; no model was called)`, and reports `mcp-repl/canned` as the model. Nothing generated it, so nothing claims to have.
- `decline` refuses.

The default is `prompt` interactively and `decline` under `--exec`, where there is no operator to ask and a blocked read would hang the script.

```text
[sampling] server requests a completion (max 200 tokens)
  system: You are a concise summarizer.
  user: Please summarize the following text in 1-2 sentences:

    The quick brown fox jumps over the lazy dog.
  type the assistant message; `.` on its own line submits, Ctrl-D declines
  reply> A fox jumped over a dog.
```

## Decisions

- The capability is advertised whatever the strategy. A client may refuse an individual request, and a server can only ask when the capability is declared, so `--sampling decline` still exercises the server's rejection path rather than silencing it.
- Sampling has no `decline` result shape the way elicitation does, so a refusal is an error. It uses `-32007` (Forbidden), which says the client refused rather than that something broke; `internal_error` would read as a failure.
- The interactive path carries elicitation's constraint: a request arriving while the readline editor holds the terminal in raw mode is declined rather than fighting reedline for stdin. The message says to run the tool in the foreground.
- Messages are flattened to one line each and capped at 2000 chars with the dropped count. Image and audio parts are summarized (`[image image/png, 4096 base64 chars]`) rather than dumped as base64.
- `max_tokens` is honored crudely, four chars a token, and the stop reason says which way it ended (`maxTokens` or `endTurn`). A server asking for a short answer does not get handed an essay.
- `info` prints the strategy in effect, since it is the one thing about the connection the server's capabilities do not describe.

## The sampling_server example

`examples/sampling_server.rs` used plain `StdioTransport`, which has no client requester, so its `summarize` and `confirm_delete` tools always failed:

```text
Sampling failed: Internal error: Sampling not available: no client requester configured
```

That is a pre-existing break in the example, not something this branch introduced, but it made the issue's "works against the `sampling_server` example" acceptance unverifiable. It now uses `BidirectionalStdioTransport`. The `client_handler` example, which spawns it, was hitting the same wall.

## Testing

12 tests in `sampling.rs`: mode defaulting both ways, the canned reply's shape, the refusal code, `max_tokens` truncation and its stop reason, reply reading (dot terminator, input ending, nothing typed, whitespace-only), the rendered request across roles and preferences, non-text content summarizing, and the length cap.

Verified by hand against the example server for each path:

```text
# decline (the --exec default)
mcp-repl -e "summarize text=..." sampling_server
  -> tool error: Client error (-32007): sampling declined: --sampling decline, exit 1

# canned
mcp-repl --sampling canned -e "summarize text=..." sampling_server
  -> (canned reply from mcp-repl; no model was called), exit 0

# prompt, reply piped
printf 'A fox jumped over a dog.\n.\n' | mcp-repl --sampling prompt -e "summarize text=..." sampling_server
  -> A fox jumped over a dog., exit 0

# prompt, nothing typed
printf '' | mcp-repl --sampling prompt -e "summarize text=..." sampling_server
  -> sampling declined: no reply given, exit 1
```

`"sampling": {}` confirmed in the initialize frame under `--trace`.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace`, and `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` all pass.
