### PR TITLE
feat(mcp-repl): subscribe to resource updates

### DIFF
--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -501,6 +501,31 @@ impl McpClient {
         self.send_request("resources/read", &params).await
     }
 
+    /// Subscribe to `notifications/resources/updated` for one resource
+    /// (`resources/subscribe`).
+    ///
+    /// The updates themselves arrive through the notification handler, so a
+    /// client that subscribes without registering
+    /// [`NotificationHandler::on_resource_updated`] will not see them. Servers
+    /// that support this advertise `resources.subscribe` in their
+    /// capabilities; one that does not will reject the request.
+    pub async fn subscribe_resource(&self, uri: &str) -> Result<()> {
+        self.ensure_initialized()?;
+        let _: serde_json::Value = self
+            .send_request("resources/subscribe", &serde_json::json!({ "uri": uri }))
+            .await?;
+        Ok(())
+    }
+
+    /// Stop receiving updates for a resource (`resources/unsubscribe`).
+    pub async fn unsubscribe_resource(&self, uri: &str) -> Result<()> {
+        self.ensure_initialized()?;
+        let _: serde_json::Value = self
+            .send_request("resources/unsubscribe", &serde_json::json!({ "uri": uri }))
+            .await?;
+        Ok(())
+    }
+
     /// List available prompts.
     pub async fn list_prompts(&self) -> Result<ListPromptsResult> {
         self.ensure_initialized()?;

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -179,6 +179,34 @@ Progress and log notifications print inline as they arrive, and
 dynamic servers (see the `dynamic_capabilities` example) grow and shrink the
 REPL's vocabulary live.
 
+## Resource subscriptions
+
+A server that supports `resources.subscribe` will push
+`notifications/resources/updated` for the resources you ask about. The REPL
+prints those inline, the way progress and log lines arrive:
+
+```text
+demo> subscribe note://status
+subscribed note://status
+demo> subscriptions
+note://status
+[resource updated] note://status
+demo> unsubscribe note://status
+unsubscribed note://status
+```
+
+- `subscribe <uri>` and `unsubscribe <uri>` complete from the surface and
+  from what is actually subscribed, respectively.
+- The local set is only updated once the server agrees, so `subscriptions`
+  lists what the server is sending updates for, not what was asked for.
+  Re-subscribing to something already held says so rather than double-counting.
+- A server that does not advertise `resources.subscribe` gets a warning before
+  the request goes out, so the rejection is explained rather than bare.
+- An update for something this session did not subscribe to is still printed,
+  tagged `(not subscribed here)`.
+- The resource is not re-read on an update: reading may be expensive, and the
+  point is to know it moved. Follow with `read <uri>` when you want the content.
+
 ## Wire tracing
 
 Half of any "is it the client, the server, or the network?" question is

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -285,8 +285,16 @@ impl Completer for ReplCompleter {
         }
 
         match first {
-            "read" => {
+            "read" | "subscribe" => {
                 out.extend(self.complete_resource_word(&surface, word, span));
+            }
+            // Only what is actually subscribed can be unsubscribed.
+            "unsubscribe" => {
+                for uri in crate::subscribe::list() {
+                    if uri.starts_with(word) {
+                        out.push(word_suggestion(uri, None, span));
+                    }
+                }
             }
             "wire" => {
                 for state in ["on", "off"] {

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -33,6 +33,7 @@ mod editor;
 mod elicit;
 mod sampling;
 mod style;
+mod subscribe;
 mod wire;
 
 use std::collections::HashMap;
@@ -178,6 +179,9 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("templates", "list resource templates"),
     ("describe", "show schemas and metadata for a name"),
     ("read", "read a resource"),
+    ("subscribe", "watch a resource for updates"),
+    ("unsubscribe", "stop watching a resource"),
+    ("subscriptions", "list active resource subscriptions"),
     ("prompt", "get a prompt"),
     ("call", "call a tool with raw JSON"),
     ("jobs", "list background tasks"),
@@ -501,6 +505,23 @@ fn demo_router() -> tower_mcp::McpRouter {
                 })
                 .build(),
         )
+        // A concrete resource, so `read`, `subscribe`, and `unsubscribe` all
+        // have something to point at without an external server. Subscribing
+        // needs a registered URI: the router rejects a subscription to
+        // anything it does not serve.
+        .resource(
+            tower_mcp::resource::ResourceBuilder::new("note://status")
+                .name("Status")
+                .description("A one-line status note (subscribe to it)")
+                .mime_type("text/plain")
+                .handler(|| async {
+                    Ok(ReadResourceResult::text(
+                        "note://status",
+                        "all quiet on the demo server",
+                    ))
+                })
+                .build(),
+        )
         .resource_template(
             ResourceTemplateBuilder::new("note://{name}")
                 .name("Notes")
@@ -710,6 +731,20 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                     "{} {}",
                     tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
                     p.message.as_deref().unwrap_or("")
+                );
+            })
+            // A subscribed resource changed. Printed inline like progress and
+            // log lines; the content is not re-read, since a `read` may be
+            // expensive and the point is to know it moved.
+            .on_resource_updated(|uri| {
+                let known = if subscribe::contains(&uri) {
+                    String::new()
+                } else {
+                    format!(" {}", paint(Style::new().dimmed(), "(not subscribed here)"))
+                };
+                println!(
+                    "{} {uri}{known}",
+                    tag(Style::new().fg(Color::Cyan), "resource updated")
                 );
             })
             .on_log_message(|m| {
@@ -958,6 +993,8 @@ async fn handle_line(
             println!("  tools | prompts | resources | templates   list the server surface");
             println!("  describe <name>                           schemas and metadata");
             println!("  read <uri>                                read a resource");
+            println!("  subscribe <uri> | unsubscribe <uri>       watch a resource for updates");
+            println!("  subscriptions                             list active subscriptions");
             println!("  prompt <name> [k=v...]                    get a prompt");
             println!("  call <tool> <json>                        call a tool with raw JSON");
             println!("  <tool> [k=v...]                           call a tool (schema-coerced)");
@@ -1121,6 +1158,27 @@ async fn handle_line(
             }
             if !json_output() {
                 println!("{}", timing(started.elapsed()));
+            }
+        }
+        "subscribe" | "unsubscribe" => {
+            let Some(uri) = rest.first() else {
+                println!("usage: {cmd} <uri>");
+                return false;
+            };
+            handle_subscription(client, cmd, uri).await;
+        }
+        "subscriptions" => {
+            let active = subscribe::list();
+            if json_output() {
+                println!("{}", json_pretty(&serde_json::json!(active)));
+                return false;
+            }
+            if active.is_empty() {
+                println!("no active subscriptions (try `subscribe <uri>`)");
+                return false;
+            }
+            for uri in &active {
+                println!("{}", paint(Style::new().fg(Color::Green), uri));
             }
         }
         "prompt" => {
@@ -1342,6 +1400,65 @@ async fn handle_line(
         }
     }
     false
+}
+
+/// The `subscribe` and `unsubscribe` built-ins. The local set is only updated
+/// once the server has agreed, so `subscriptions` lists what the server is
+/// actually sending updates for, not what was asked for.
+async fn handle_subscription(client: &Arc<McpClient>, cmd: &str, uri: &str) {
+    // A server that does not advertise the capability will reject the call.
+    // Saying so first turns a bare protocol error into an explanation.
+    if cmd == "subscribe"
+        && let Some(info) = client.server_info().await
+        && !subscribe::server_supports(
+            &serde_json::to_value(&info.capabilities).unwrap_or_default(),
+        )
+    {
+        eprintln!(
+            "warning: {} does not advertise resources.subscribe; the request will \
+             probably be rejected",
+            info.server_info.name
+        );
+    }
+    let started = std::time::Instant::now();
+    let outcome = if cmd == "subscribe" {
+        client.subscribe_resource(uri).await
+    } else {
+        client.unsubscribe_resource(uri).await
+    };
+    match outcome {
+        Ok(()) => {
+            let changed = if cmd == "subscribe" {
+                subscribe::add(uri)
+            } else {
+                subscribe::remove(uri)
+            };
+            if json_output() {
+                println!(
+                    "{}",
+                    serde_json::json!({ cmd: uri, "alreadyInEffect": !changed })
+                );
+            } else {
+                let note = if changed {
+                    String::new()
+                } else {
+                    format!(" {}", paint(Style::new().dimmed(), "(already in effect)"))
+                };
+                println!("{cmd}d {}{note}", paint(Style::new().fg(Color::Green), uri));
+            }
+        }
+        Err(e) => {
+            note_error();
+            if json_output() {
+                println!("{}", error_json(&e.to_string()));
+            } else {
+                println!("{}: {e}", style::error_prefix());
+            }
+        }
+    }
+    if !json_output() {
+        println!("{}", timing(started.elapsed()));
+    }
 }
 
 /// The `alias` and `unalias` built-ins: define, list, show, and remove

--- a/examples/mcp-repl/src/subscribe.rs
+++ b/examples/mcp-repl/src/subscribe.rs
@@ -1,0 +1,88 @@
+//! The `subscribe` / `unsubscribe` / `subscriptions` built-ins: resource
+//! update subscriptions and the set currently held.
+//!
+//! The protocol side is two RPCs and a notification: `resources/subscribe`
+//! asks the server to send `notifications/resources/updated` for a URI, and
+//! the REPL prints those inline as they arrive, like progress and log lines.
+//! The set of active subscriptions lives here rather than being threaded
+//! through `handle_line`, since the notification callback and the command
+//! both need it and neither owns the other.
+
+use std::collections::BTreeSet;
+use std::sync::{Mutex, OnceLock};
+
+static ACTIVE: OnceLock<Mutex<BTreeSet<String>>> = OnceLock::new();
+
+fn active() -> &'static Mutex<BTreeSet<String>> {
+    ACTIVE.get_or_init(|| Mutex::new(BTreeSet::new()))
+}
+
+/// Record a subscription. False when it was already held, which is how the
+/// REPL reports a re-subscribe rather than claiming a new one.
+pub fn add(uri: &str) -> bool {
+    active().lock().unwrap().insert(uri.to_string())
+}
+
+/// Drop a subscription. False when it was not held.
+pub fn remove(uri: &str) -> bool {
+    active().lock().unwrap().remove(uri)
+}
+
+/// The active subscriptions, in URI order so repeated listings are stable.
+pub fn list() -> Vec<String> {
+    active().lock().unwrap().iter().cloned().collect()
+}
+
+/// Whether a URI is subscribed. Used to label an update that arrives for
+/// something the REPL did not ask for (a shared session, or a server that
+/// pushes updates unprompted).
+pub fn contains(uri: &str) -> bool {
+    active().lock().unwrap().contains(uri)
+}
+
+/// A server's `resources.subscribe` capability, read from the initialize
+/// result. `None` when the server was not initialized.
+///
+/// A server that does not advertise this will reject `resources/subscribe`,
+/// so the REPL says so up front rather than letting the error be the answer.
+pub fn server_supports(capabilities: &serde_json::Value) -> bool {
+    capabilities
+        .pointer("/resources/subscribe")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The registry is process-global, so one test owns it end to end rather
+    // than several racing over the same set.
+    #[test]
+    fn subscriptions_are_tracked_deduplicated_and_ordered() {
+        assert!(add("note://b"));
+        assert!(add("note://a"));
+        // A second subscribe to the same URI is not a new subscription.
+        assert!(!add("note://a"));
+        assert!(contains("note://a"));
+        assert_eq!(list(), ["note://a", "note://b"]);
+
+        assert!(remove("note://a"));
+        // Unsubscribing something not held reports that, rather than pretending.
+        assert!(!remove("note://a"));
+        assert!(!contains("note://a"));
+        assert_eq!(list(), ["note://b"]);
+        remove("note://b");
+        assert!(list().is_empty());
+    }
+
+    #[test]
+    fn capability_is_read_from_the_initialize_result() {
+        let yes = serde_json::json!({ "resources": { "subscribe": true } });
+        let no = serde_json::json!({ "resources": { "listChanged": true } });
+        assert!(server_supports(&yes));
+        assert!(!server_supports(&no));
+        // A server with no resources capability at all.
+        assert!(!server_supports(&serde_json::json!({ "tools": {} })));
+    }
+}


### PR DESCRIPTION
Closes #1013.

The protocol has resource subscriptions and the server router implements them, but the client had no way to ask: `McpClient` had no `resources/subscribe` method, so the REPL could not drive the flow at all even though `NotificationHandler::on_resource_updated` already existed.

## Client (library)

`McpClient::subscribe_resource(uri)` and `unsubscribe_resource(uri)`, alongside `read_resource`. Both return `()` on the server's empty result; updates arrive through the notification handler, which the doc comment says explicitly, since subscribing without registering `on_resource_updated` silently sees nothing.

## REPL

```text
demo> subscribe note://status
subscribed note://status
demo> subscriptions
note://status
[resource updated] note://status
demo> unsubscribe note://status
unsubscribed note://status
```

- The local set is only updated once the server agrees, so `subscriptions` lists what the server is sending updates for, not what was asked for. Re-subscribing to something already held says `(already in effect)` rather than double-counting.
- A server that does not advertise `resources.subscribe` gets a warning before the request goes out, so the rejection is explained rather than bare.
- An update for a URI this session did not subscribe to is still printed, tagged `(not subscribed here)`: a shared session or an unprompted server push is worth seeing, not hiding.
- The resource is not re-read on an update. A read may be expensive and the point is to know it moved; `read <uri>` follows when you want the content.
- Completion: `subscribe` completes from the surface's resources and templates, `unsubscribe` only from what is actually subscribed.
- Under `--json`, `{"subscribe": uri, "alreadyInEffect": false}` and an array for `subscriptions`.

The active set lives in `subscribe.rs` behind a small registry rather than being threaded through `handle_line`, because the notification callback and the command both need it and neither owns the other.

## Demo router

It served no concrete resource, only a template, so nothing could be subscribed to (the router rejects a subscription to a URI it does not serve). It now serves `note://status`, which also gives `read` something to point at under `--demo`.

## Testing

Registry tests (dedup, ordering, removing something not held) and capability-detection tests in `subscribe.rs`. Verified by hand against `--demo`: subscribe, list, unsubscribe, list again, and the rejection for an unserved URI.

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test -p mcp-repl -p tower-mcp`, and `cargo doc --no-deps --all-features` all pass. No new dependencies.
