### PR TITLE
docs: reconcile versions, example count, and conformance figures

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tower-mcp = "0.12"
+tower-mcp = "0.14"
 ```
 
 Tool input types use `schemars::JsonSchema`, and the derive must come from the
@@ -123,7 +123,7 @@ Example with features:
 
 ```toml
 [dependencies]
-tower-mcp = { version = "0.12", features = ["full"] }
+tower-mcp = { version = "0.14", features = ["full"] }
 ```
 
 ### Types Only
@@ -135,7 +135,7 @@ any context where you want to serialize/deserialize MCP messages without a runti
 
 ```toml
 [dependencies]
-tower-mcp-types = "0.12"
+tower-mcp-types = "0.14"
 ```
 
 `tower-mcp-types` provides all types from `tower_mcp::protocol` and `tower_mcp::error`
@@ -633,7 +633,7 @@ We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](h
 
 A full-featured MCP server for querying [crates.io](https://crates.io) is available as a standalone project: [cratesio-mcp](https://github.com/joshrotenberg/cratesio-mcp). A demo instance is deployed at **https://cratesio-mcp.fly.dev** -- connect with any MCP client that supports HTTP transport.
 
-The repo includes 24 focused examples organized by topic:
+The repo includes 31 examples; a selection organized by topic (the full set lives in [`examples/`](examples/)):
 
 | Category | Examples |
 |----------|----------|

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,10 +2,11 @@
 
 ## Current Status
 
-- **Version**: 0.9.x
-- **Spec version**: 2025-11-25
-- **Server conformance**: 39/39 (100%)
-- **Client conformance**: 265/265 checks, 24/24 scenarios (100%)
+- **Version**: 0.14.x
+- **Spec version**: 2025-11-25 (plus the 2026-07-28 draft behind the `stateless` feature)
+- **Server conformance (2025-11-25)**: 39/39
+- **Client conformance (2025-11-25)**: 264/266 (two offline-access gaps, tracked in #953)
+- **Server conformance (2026-07-28 draft)**: 66/102 (gaps baselined, tracked in #929)
 - **MSRV**: 1.90 (Rust 2024 edition)
 
 ## SDK Tier Assessment
@@ -15,10 +16,10 @@ tower-mcp targets Tier 2 per the [MCP SDK Tiering System](https://modelcontextpr
 | # | Requirement | Status |
 |---|-------------|--------|
 | 1 | Server conformance >= 80% | 100% (39/39) |
-| 2 | Client conformance >= 80% | 100% (265/265) |
+| 2 | Client conformance >= 80% | 264/266 |
 | 3 | Issue triage within 1 month | Active |
 | 4 | P0 resolution within 2 weeks | 0 open |
-| 5 | Stable release >= 1.0.0 | 0.9.x -- pre-1.0 |
+| 5 | Stable release >= 1.0.0 | 0.14.x -- pre-1.0 |
 | 6 | Spec tracking within 6 months | Current (2025-11-25) |
 | 7 | Documentation coverage | In progress |
 | 8 | Dependency update policy | dependabot.yml |


### PR DESCRIPTION
Reconciles stale/inconsistent numbers across docs so they are current and agree.

- README install snippets `0.12` -> `0.14` (three places).
- README example count `24` -> `31`, with a pointer to the full `examples/` set.
- ROADMAP Current Status and tier table: version `0.9.x` -> `0.14.x`; client conformance aligned to the README (`264/266`, not `265/265`); added the 2026-07-28 draft server figure (`66/102`).

Closes #1026.