### PR TITLE
ci: publish line coverage with cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,58 @@ jobs:
         env:
           RUSTDOCFLAGS: -Dwarnings
 
+  # Line, region and function coverage. Branch coverage is deliberately
+  # absent: `cargo llvm-cov --branch` needs nightly, and on this workspace
+  # the nightly llvm-cov crashes (SIGSEGV) generating any report format
+  # from branch-instrumented data. Revisit when that stabilises.
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Run tests with coverage instrumentation
+        run: cargo llvm-cov --workspace --all-features --no-report
+      - name: Generate reports
+        run: |
+          cargo llvm-cov report --lcov --output-path lcov.info
+          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
+          cargo llvm-cov report > coverage.txt
+      - name: Write job summary
+        run: |
+          jq -r '
+            .data[0].totals
+            | "| Metric | Covered | Total | Percent |",
+              "| --- | ---: | ---: | ---: |",
+              "| Lines | \(.lines.covered) | \(.lines.count) | \(.lines.percent * 100 | round / 100)% |",
+              "| Regions | \(.regions.covered) | \(.regions.count) | \(.regions.percent * 100 | round / 100)% |",
+              "| Functions | \(.functions.covered) | \(.functions.count) | \(.functions.percent * 100 | round / 100)% |"
+          ' coverage-summary.json >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo ""
+            echo "No threshold is enforced. \`lcov.info\` is attached to the run"
+            echo "as the \`coverage\` artifact."
+            echo ""
+            echo "<details><summary>Per-file coverage</summary>"
+            echo ""
+            echo '```'
+            cat coverage.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: |
+            lcov.info
+            coverage-summary.json
+            coverage.txt
+
   examples:
     name: Examples
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.swo
 .tmp/
 CLAUDE.md
+
+# cargo-llvm-cov report output (see the Coverage job in ci.yml)
+/lcov.info
+/coverage-summary.json
+/coverage.txt


### PR DESCRIPTION
Closes #1029.

There was no coverage job, so the less-exercised paths were invisible: nothing said which transport or lifecycle code the suite never enters. This adds a `Coverage` job that runs the workspace test suite under `cargo-llvm-cov` and publishes the result.

## What it publishes

Two ways, so the number is legible without downloading anything and the raw data is still there when you want it:

- **Job summary**: a totals table (lines, regions, functions) plus the full per-file table in a collapsed `<details>`.
- **`coverage` artifact**: `lcov.info` for any external viewer, `coverage-summary.json` for the totals, `coverage.txt` for the per-file table.

No threshold is enforced. The issue says to establish a baseline first, and enforcing against an unmeasured tree would just pick a number.

## Baseline

Measured locally at `origin/main` with the same commands the job runs:

| Metric | Covered | Total | Percent |
| --- | ---: | ---: | ---: |
| Lines | 24958 | 30775 | 81.10% |
| Regions | 36789 | 44793 | 82.13% |
| Functions | 3000 | 3855 | 77.82% |

The transport and lifecycle paths the issue calls out, by line coverage:

| File | Lines |
| --- | ---: |
| `transport/unix.rs` | 0.00% |
| `transport/websocket.rs` | 38.76% |
| `transport/stdio.rs` | 64.58% |
| `transport/childproc.rs` | 71.48% |
| `client/transport.rs` | 75.00% |
| `transport/http.rs` | 86.79% |
| `transport/service.rs` | 92.21% |
| `transport/http_headers.rs` | 92.90% |
| `session_store.rs` | 97.24% |
| `session.rs` | 97.40% |
| `stateless.rs` | 98.18% |

`transport/unix.rs` at 0% is the sharpest result: it compiles under `--all-features` and no test enters it. `tools/rmcp-compat/src/main.rs` is also 0%, which is expected for a binary.

## Branch coverage is not included

`cargo llvm-cov --branch` requires nightly (`-Z coverage-options=branch`; the flag is documented as unstable and warns on stable). I built the workspace under nightly with `--branch` and every report format then crashed:

```
error: failed to generate report: process didn't exit successfully:
  `.../llvm-cov export -format=text ... -summary-only` (signal: 11 (SIGSEGV))
```

Same for `report` (text) and `report --lcov`. Rather than land a job that is permanently red or permanently warning and produces nothing, branch coverage is left out, with the reason recorded in a comment above the job so the next person does not rediscover it. Line and region coverage together already answer the question the issue asks.

## Notes

- Runs on stable with `llvm-tools-preview`; `cargo-llvm-cov` via `taiki-e/install-action`, consistent with the repo's other pinned actions.
- `--workspace --all-features`, matching what the `Test` job compiles.
- The instrumented build and both report steps were run locally against this tree and pass under the repo's `RUSTFLAGS: -Dwarnings`; the job-summary shell and `jq` were run against the real report output.
- `lcov.info`, `coverage-summary.json` and `coverage.txt` added to `.gitignore` so a local run leaves no untracked files.
- No Rust source changes.
