### PR TITLE
feat(mcp-repl): output capture and pipe filtering

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -418,6 +418,39 @@ The banner and surface listing are suppressed in `--exec` mode (pass
 `--verbose` to keep them). `--json` applies to tool calls, `read`, `prompt`,
 `tools`/`prompts`/`resources`/`templates`, and errors (`{"error": "..."}`).
 
+## Capture and filtering
+
+The REPL is a small shell. A command's result can be captured into a variable,
+referenced in later arguments, or filtered inline.
+
+```text
+demo> x = search_crates query=serde
+$x = {2 fields}
+demo> get_crate_info name=$x.crates[0].name
+...
+demo> get_crate_info name=serde | crates[0].downloads
+11897234
+```
+
+- **Capture:** `name = <command>` binds the command's result to `$name`. The
+  spaces around `=` distinguish it from a `k=v` argument and from `alias name=...`.
+- **Reference:** `$name` and `$name.path[i].field` expand in later command
+  arguments before the command runs.
+- **Filter:** `<command> | <path>` prints just the selected value. A scalar
+  prints bare; an object or array prints as JSON.
+- **Paths** are a small selector: `.field`, `[index]`, chained (`crates[0].name`).
+  An undefined variable or a missing path is an error, so a typo fails an `-e`
+  chain rather than passing silently. JMESPath is a possible future addition.
+- **`vars`** lists what is bound; **`unset <name>`** clears one. Variables live
+  for the session, so they persist across an `-e` chain:
+
+```sh
+mcp-repl -e "x = search_crates query=serde" \
+         -e "get_crate_info name=\$x.crates[0].name" <server>
+```
+
+Capture and filtering currently act on tool-call results.
+
 ## Related tools
 
 - [mcp-probe](https://github.com/conikeec/mcp-probe): a Rust TUI debugging

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -38,6 +38,7 @@ mod sampling;
 mod session;
 mod style;
 mod subscribe;
+mod vars;
 mod wire;
 
 use std::collections::HashMap;
@@ -208,6 +209,8 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("info", "replay the connection banner plus capabilities"),
     ("wire", "toggle raw JSON-RPC frame tracing (on|off)"),
     ("last", "reprint the previous request and response"),
+    ("vars", "list captured variables"),
+    ("unset", "clear a captured variable"),
     ("quit", "exit"),
     ("exit", "exit"),
 ];
@@ -1156,6 +1159,24 @@ async fn handle_line(
             return false;
         }
     };
+    // Capture (`name = cmd`), pipe (`cmd | path`), and `$var` references make
+    // the REPL a small shell: routing and substitution run before dispatch so
+    // every command sees resolved arguments. Capture and pipe act on tool
+    // results.
+    let (output, routed) = vars::route(line);
+    let command = match vars::substitute(routed) {
+        Ok(c) => c,
+        Err(e) => {
+            note_error();
+            if json_output() {
+                println!("{}", error_json(&e));
+            } else {
+                println!("{}: {e}", style::error_prefix());
+            }
+            return false;
+        }
+    };
+    let line = command.as_str();
     let client = session.client();
     let mut tokens: Vec<&str> = line.split_whitespace().collect();
     let background = tokens.last() == Some(&"&");
@@ -1187,6 +1208,13 @@ async fn handle_line(
             println!("  alias [<name>=<expansion>] | unalias <name>  command aliases");
             println!("  wire [on|off]                             trace raw JSON-RPC frames");
             println!("  last                                      reprint the previous exchange");
+            println!(
+                "  vars | unset <name>                       list or clear captured variables"
+            );
+            println!(
+                "  name = <cmd> [| <path>]                   capture a result (filter with | path)"
+            );
+            println!("  $name.path in args                        reference a captured value");
             println!("  refresh | info | quit");
             let s = surface.read().unwrap();
             if !s.tools.is_empty() {
@@ -1450,7 +1478,7 @@ async fn handle_line(
                     return false;
                 }
             };
-            run_tool(session, surface, jobs, name, arguments, background).await;
+            run_tool(session, surface, jobs, name, arguments, background, &output).await;
         }
         "bench" => {
             handle_bench(&client, surface, rest, background).await;
@@ -1586,6 +1614,36 @@ async fn handle_line(
             }
             None => println!("not initialized"),
         },
+        "vars" => {
+            let all = vars::list();
+            if json_output() {
+                let map: serde_json::Map<String, serde_json::Value> = all.into_iter().collect();
+                println!("{}", json_pretty(&serde_json::Value::Object(map)));
+            } else if all.is_empty() {
+                println!("{}", paint(Style::new().dimmed(), "no variables"));
+            } else {
+                for (name, value) in all {
+                    println!(
+                        "{} {}",
+                        paint(Style::new().fg(Color::Cyan), &format!("${name} =")),
+                        value_summary(&value)
+                    );
+                }
+            }
+        }
+        "unset" => match rest.first() {
+            Some(name) => {
+                if vars::unset(name) {
+                    if !json_output() {
+                        println!("unset ${name}");
+                    }
+                } else {
+                    note_error();
+                    command_error(&format!("no such variable `${name}`"));
+                }
+            }
+            None => command_error("usage: unset <name>"),
+        },
         tool_name => {
             let schema = {
                 let s = surface.read().unwrap();
@@ -1623,7 +1681,10 @@ async fn handle_line(
                 return false;
             };
             let arguments = parse_kv_args(&schema, rest);
-            run_tool(session, surface, jobs, tool_name, arguments, background).await;
+            run_tool(
+                session, surface, jobs, tool_name, arguments, background, &output,
+            )
+            .await;
         }
     }
     false
@@ -2043,6 +2104,7 @@ async fn run_tool(
     name: &str,
     arguments: serde_json::Value,
     background: bool,
+    output: &vars::Output,
 ) {
     if background {
         match with_reconnect(session, surface, |c| {
@@ -2090,16 +2152,20 @@ async fn run_tool(
             if result.is_error {
                 note_error();
             }
-            if json_output() {
-                println!(
-                    "{}",
-                    json_pretty(&serde_json::to_value(&result).unwrap_or_default())
-                );
-            } else {
-                if result.is_error {
-                    println!("{}", tag(Style::new().fg(Color::Red), "tool error"));
+            if output.is_plain() {
+                if json_output() {
+                    println!(
+                        "{}",
+                        json_pretty(&serde_json::to_value(&result).unwrap_or_default())
+                    );
+                } else {
+                    if result.is_error {
+                        println!("{}", tag(Style::new().fg(Color::Red), "tool error"));
+                    }
+                    render_content(&result.content);
                 }
-                render_content(&result.content);
+            } else {
+                emit_result(result_value(&result), output);
             }
         }
         Err(e) => {
@@ -2113,6 +2179,69 @@ async fn run_tool(
     }
     if !json_output() {
         println!("{}", timing(started.elapsed()));
+    }
+}
+
+/// Extract a tool result's data value for capture or filtering: the structured
+/// content if present, else a lone JSON text block parsed, else the content.
+fn result_value(result: &tower_mcp::CallToolResult) -> serde_json::Value {
+    if let Some(structured) = &result.structured_content {
+        return structured.clone();
+    }
+    if let [Content::Text { text, .. }] = result.content.as_slice() {
+        return serde_json::from_str(text)
+            .unwrap_or_else(|_| serde_json::Value::String(text.clone()));
+    }
+    serde_json::to_value(&result.content).unwrap_or_default()
+}
+
+/// Apply a capture/filter [`vars::Output`] to a result value: select a path,
+/// bind it to a variable, or print it (bare scalar or pretty JSON).
+fn emit_result(mut value: serde_json::Value, output: &vars::Output) {
+    if let Some(path) = &output.filter {
+        match vars::get_path(&value, path) {
+            Some(selected) => value = selected,
+            None => {
+                note_error();
+                command_error(&format!("path `{path}` not found in result"));
+                return;
+            }
+        }
+    }
+    if let Some(name) = &output.capture {
+        vars::set(name, value.clone());
+        if json_output() {
+            println!("{}", json_pretty(&value));
+        } else {
+            println!(
+                "{} {}",
+                paint(Style::new().fg(Color::Cyan), &format!("${name} =")),
+                value_summary(&value)
+            );
+        }
+    } else if json_output() {
+        println!("{}", json_pretty(&value));
+    } else {
+        render_value(&value);
+    }
+}
+
+fn value_summary(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => format!("{s:?}"),
+        serde_json::Value::Array(a) => format!("[{} items]", a.len()),
+        serde_json::Value::Object(o) => format!("{{{} fields}}", o.len()),
+        other => other.to_string(),
+    }
+}
+
+fn render_value(value: &serde_json::Value) {
+    match value {
+        serde_json::Value::String(s) => println!("{s}"),
+        serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            println!("{}", json_pretty(value))
+        }
+        other => println!("{other}"),
     }
 }
 

--- a/examples/mcp-repl/src/vars.rs
+++ b/examples/mcp-repl/src/vars.rs
@@ -1,0 +1,230 @@
+//! Session variables, a minimal path selector, and capture/pipe routing (#1011).
+//!
+//! `name = <command>` binds a command's result JSON to `$name`; `$name.path`
+//! references it in later command arguments; `<command> | <path>` filters a
+//! result before printing. The path language is deliberately small (`.field`,
+//! `[index]`, chained); JMESPath stays the future fuller option.
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+fn store() -> &'static Mutex<HashMap<String, Value>> {
+    static STORE: OnceLock<Mutex<HashMap<String, Value>>> = OnceLock::new();
+    STORE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Bind a variable to a value.
+pub fn set(name: &str, value: Value) {
+    store().lock().unwrap().insert(name.to_string(), value);
+}
+
+/// Look a variable up.
+pub fn get(name: &str) -> Option<Value> {
+    store().lock().unwrap().get(name).cloned()
+}
+
+/// Remove a variable; returns whether it existed.
+pub fn unset(name: &str) -> bool {
+    store().lock().unwrap().remove(name).is_some()
+}
+
+/// Every bound variable, sorted by name.
+pub fn list() -> Vec<(String, Value)> {
+    let store = store().lock().unwrap();
+    let mut vars: Vec<(String, Value)> =
+        store.iter().map(|(k, v)| (k.clone(), v.clone())).collect();
+    vars.sort_by(|a, b| a.0.cmp(&b.0));
+    vars
+}
+
+/// Where a command's result should go, parsed from the line.
+#[derive(Default)]
+pub struct Output {
+    /// Bind the result to this variable instead of printing it.
+    pub capture: Option<String>,
+    /// Select this path out of the result before capturing or printing.
+    pub filter: Option<String>,
+}
+
+impl Output {
+    /// No capture and no filter: render as usual.
+    pub fn is_plain(&self) -> bool {
+        self.capture.is_none() && self.filter.is_none()
+    }
+}
+
+/// Split a line into its output routing and the command to run. Recognizes
+/// `name = <command>` (capture) and `<command> | <path>` (pipe), in that order,
+/// so `x = call foo | .id` captures the filtered value.
+pub fn route(line: &str) -> (Output, &str) {
+    let (capture, rest) = match split_capture(line) {
+        Some((name, rest)) => (Some(name.to_string()), rest),
+        None => (None, line),
+    };
+    let (command, filter) = match rest.split_once(" | ") {
+        Some((cmd, path)) => (cmd.trim_end(), Some(path.trim().to_string())),
+        None => (rest, None),
+    };
+    (Output { capture, filter }, command)
+}
+
+/// `name = rest` where `name` is an identifier, distinguishing capture from
+/// `k=v` arguments (no surrounding spaces) and `alias name=...` (keyword first).
+fn split_capture(line: &str) -> Option<(&str, &str)> {
+    let (lhs, rhs) = line.split_once(" = ")?;
+    is_ident(lhs).then_some((lhs, rhs.trim_start()))
+}
+
+fn is_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic() || c == '_')
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+/// Evaluate a path like `crates[0].name` (leading `.` optional) against a value.
+/// Returns `None` on any missing key or index. An empty path yields the value.
+pub fn get_path(value: &Value, path: &str) -> Option<Value> {
+    let mut cur = value;
+    for seg in parse_path(path) {
+        cur = match seg {
+            Seg::Key(k) => cur.get(&k)?,
+            Seg::Index(i) => cur.get(i)?,
+        };
+    }
+    Some(cur.clone())
+}
+
+enum Seg {
+    Key(String),
+    Index(usize),
+}
+
+fn parse_path(path: &str) -> Vec<Seg> {
+    let mut segs = Vec::new();
+    let mut rest = path.strip_prefix('.').unwrap_or(path);
+    while !rest.is_empty() {
+        if let Some(r) = rest.strip_prefix('[') {
+            match r
+                .find(']')
+                .and_then(|end| r[..end].parse().ok().map(|i| (i, end)))
+            {
+                Some((i, end)) => {
+                    segs.push(Seg::Index(i));
+                    rest = &r[end + 1..];
+                }
+                None => break,
+            }
+        } else {
+            let end = rest.find(['.', '[']).unwrap_or(rest.len());
+            if end == 0 {
+                break;
+            }
+            segs.push(Seg::Key(rest[..end].to_string()));
+            rest = &rest[end..];
+        }
+        rest = rest.strip_prefix('.').unwrap_or(rest);
+    }
+    segs
+}
+
+/// Replace `$name` and `$name.path` references in `text` with their values.
+/// A scalar inserts bare; an array or object inserts as compact JSON. A `$` not
+/// followed by an identifier is left as-is. An undefined variable or a missing
+/// path is an error.
+pub fn substitute(text: &str) -> Result<String, String> {
+    let mut out = String::new();
+    let mut rest = text;
+    while let Some(pos) = rest.find('$') {
+        out.push_str(&rest[..pos]);
+        let after = &rest[pos + 1..];
+        let starts_ident =
+            matches!(after.chars().next(), Some(c) if c.is_ascii_alphabetic() || c == '_');
+        if !starts_ident {
+            out.push('$');
+            rest = after;
+            continue;
+        }
+        let name_len = after
+            .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+            .unwrap_or(after.len());
+        let name = &after[..name_len];
+        let tail = &after[name_len..];
+        let path_len = tail
+            .find(|c: char| !(c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '[' | ']')))
+            .unwrap_or(tail.len());
+        let path = &tail[..path_len];
+        let value = get(name).ok_or_else(|| format!("undefined variable `${name}`"))?;
+        let selected = get_path(&value, path)
+            .ok_or_else(|| format!("`${name}{path}` not found in `{name}`"))?;
+        out.push_str(&render_scalar(&selected));
+        rest = &tail[path_len..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn render_scalar(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Null => "null".to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Number(n) => n.to_string(),
+        other => serde_json::to_string(other).unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn path_selects_keys_and_indices() {
+        let v = json!({ "crates": [{ "name": "serde" }, { "name": "tokio" }] });
+        assert_eq!(get_path(&v, "crates[0].name"), Some(json!("serde")));
+        assert_eq!(get_path(&v, ".crates[1].name"), Some(json!("tokio")));
+        assert_eq!(get_path(&v, ""), Some(v.clone()));
+        assert_eq!(get_path(&v, "crates[9].name"), None);
+        assert_eq!(get_path(&v, "missing"), None);
+    }
+
+    #[test]
+    fn route_recognizes_capture_and_pipe() {
+        let (o, cmd) = route("x = search query=serde");
+        assert_eq!(o.capture.as_deref(), Some("x"));
+        assert_eq!(cmd, "search query=serde");
+
+        let (o, cmd) = route("get_crate name=serde | crates[0].name");
+        assert_eq!(o.filter.as_deref(), Some("crates[0].name"));
+        assert_eq!(cmd, "get_crate name=serde");
+
+        let (o, cmd) = route("y = call foo | .id");
+        assert_eq!(o.capture.as_deref(), Some("y"));
+        assert_eq!(o.filter.as_deref(), Some(".id"));
+        assert_eq!(cmd, "call foo");
+
+        // k=v args and alias definitions are not captures.
+        assert!(route("get_crate name=serde").0.is_plain());
+        assert!(route("query=serde").0.capture.is_none());
+    }
+
+    #[test]
+    fn substitute_resolves_scalars_and_reports_misses() {
+        set("x", json!({ "crates": [{ "name": "serde" }] }));
+        set("n", json!(42));
+        assert_eq!(
+            substitute("get_crate name=$x.crates[0].name").unwrap(),
+            "get_crate name=serde"
+        );
+        assert_eq!(substitute("bench t --n $n").unwrap(), "bench t --n 42");
+        assert_eq!(
+            substitute("a literal $5 sign").unwrap(),
+            "a literal $5 sign"
+        );
+        assert!(substitute("$missing").is_err());
+        assert!(substitute("$x.crates[9].name").is_err());
+        unset("x");
+        unset("n");
+    }
+}


### PR DESCRIPTION
Implements #1011: turn the REPL into a small shell.

## Design (the issue asked for a design pass)

- **Capture:** `name = <command>` binds the command result JSON to `$name`. Spaces around `=` disambiguate it from `k=v` args and `alias name=...`.
- **Reference:** `$name.path[i].field` in later command args, resolved and substituted before dispatch (`get_crate_info name=$x.crates[0].name`).
- **Pipe:** `<command> | <path>` filters the result through a path expression before printing.
- **Filter language:** a minimal built-in path selector (`.field`, `[index]`, chained), per the issue lean of "start minimal". No JMESPath dependency; that stays the future fuller option.
- **`vars`** lists bound variables; **`unset <name>`** clears one. Vars are session-scoped and persist across an `-e` chain.
- **Errors:** a missing var or path is a command error (non-zero exit under `-e`).
- **Scope (v1):** capture and pipe apply to tool-call results (the acceptance case). Prompt/read/listing capture can follow.

## Acceptance
- [x] Capture into named vars
- [x] Path reference in later args
- [x] Inline `|` filter
- [x] Works in `-e` chains

Closes #1011.