### PR TITLE
test: property tests for wire and state-machine boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1999,6 +2024,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2333,6 +2367,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -3116,6 +3162,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "pin-project-lite",
+ "proptest",
  "regex",
  "reqwest",
  "schemars",
@@ -3152,6 +3199,7 @@ name = "tower-mcp-types"
 version = "0.14.0"
 dependencies = [
  "base64 0.23.0",
+ "proptest",
  "serde",
  "serde_json",
  "thiserror",
@@ -3332,6 +3380,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3449,6 +3503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/crates/tower-mcp-types/Cargo.toml
+++ b/crates/tower-mcp-types/Cargo.toml
@@ -23,3 +23,6 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 base64.workspace = true
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/tower-mcp-types/tests/property.rs
+++ b/crates/tower-mcp-types/tests/property.rs
@@ -1,0 +1,68 @@
+//! Property tests for JSON-RPC envelope classification (#1028).
+//!
+//! The untagged `JsonRpcMessage` classifier sees untrusted wire input, so
+//! parsing arbitrary JSON or text must never panic, and well-formed messages
+//! must classify and round-trip correctly.
+
+use proptest::prelude::*;
+use tower_mcp_types::protocol::JsonRpcMessage;
+
+/// A bounded arbitrary JSON value.
+fn arb_json() -> impl Strategy<Value = serde_json::Value> {
+    let leaf = prop_oneof![
+        Just(serde_json::Value::Null),
+        any::<bool>().prop_map(serde_json::Value::Bool),
+        any::<i64>().prop_map(|n| serde_json::json!(n)),
+        ".*".prop_map(serde_json::Value::String),
+    ];
+    leaf.prop_recursive(4, 32, 6, |inner| {
+        prop_oneof![
+            prop::collection::vec(inner.clone(), 0..6).prop_map(serde_json::Value::Array),
+            prop::collection::hash_map("[a-zA-Z0-9_]{0,8}", inner, 0..6)
+                .prop_map(|m| serde_json::Value::Object(m.into_iter().collect())),
+        ]
+    })
+}
+
+proptest! {
+    /// Classifying arbitrary JSON never panics.
+    #[test]
+    fn classify_arbitrary_json_never_panics(v in arb_json()) {
+        let _ = serde_json::from_value::<JsonRpcMessage>(v);
+    }
+
+    /// Classifying arbitrary text never panics.
+    #[test]
+    fn classify_arbitrary_text_never_panics(s in ".*") {
+        let _ = serde_json::from_str::<JsonRpcMessage>(&s);
+    }
+
+    /// A well-formed request classifies as a single (non-batch) message and its
+    /// method survives a round-trip.
+    #[test]
+    fn well_formed_request_round_trips(method in "[a-z/_]{1,20}", id in any::<i64>()) {
+        let json = serde_json::json!({ "jsonrpc": "2.0", "id": id, "method": method });
+        let msg: JsonRpcMessage = serde_json::from_value(json).unwrap();
+        prop_assert!(!msg.is_batch());
+        prop_assert_eq!(msg.len(), 1);
+        let reencoded = serde_json::to_value(&msg).unwrap();
+        let seen = reencoded
+            .as_array()
+            .and_then(|a| a.first())
+            .unwrap_or(&reencoded)
+            .get("method")
+            .and_then(|m| m.as_str());
+        prop_assert_eq!(seen, Some(method.as_str()));
+    }
+
+    /// A JSON array of requests classifies as a batch of the right length.
+    #[test]
+    fn batch_classifies_and_counts(n in 1usize..8) {
+        let reqs: Vec<serde_json::Value> = (0..n)
+            .map(|i| serde_json::json!({ "jsonrpc": "2.0", "id": i, "method": "ping" }))
+            .collect();
+        let msg: JsonRpcMessage = serde_json::from_value(serde_json::Value::Array(reqs)).unwrap();
+        prop_assert!(msg.is_batch());
+        prop_assert_eq!(msg.len(), n);
+    }
+}

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -36,6 +36,7 @@ tower-resilience = { workspace = true, optional = true, default-features = false
 
 [dev-dependencies]
 async-trait.workspace = true
+proptest = "1"
 tokio-test = "0.4"
 tower = { workspace = true, features = ["timeout", "limit"] }
 tower-mcp-types = { path = "../tower-mcp-types", features = ["testing"] }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -7113,3 +7113,23 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+mod cursor_property_tests {
+    use super::{decode_cursor, encode_cursor};
+    use proptest::prelude::*;
+
+    proptest! {
+        /// A cursor round-trips: decode(encode(n)) == n.
+        #[test]
+        fn cursor_round_trips(offset in any::<usize>()) {
+            prop_assert_eq!(decode_cursor(&encode_cursor(offset)).unwrap(), offset);
+        }
+
+        /// Decoding arbitrary client input never panics; it is Ok or a clean Err.
+        #[test]
+        fn decode_cursor_never_panics(s in ".*") {
+            let _ = decode_cursor(&s);
+        }
+    }
+}

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -491,3 +491,31 @@ mod tests {
         assert!(meta.client_capabilities.is_none());
     }
 }
+
+#[cfg(test)]
+mod version_property_tests {
+    use super::validate_protocol_version;
+    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
+    use proptest::prelude::*;
+
+    proptest! {
+        /// Validating an arbitrary version string never panics.
+        #[test]
+        fn validate_never_panics(v in ".*") {
+            let _ = validate_protocol_version(&v);
+        }
+
+        /// Every supported version validates.
+        #[test]
+        fn supported_versions_accept(i in 0usize..SUPPORTED_PROTOCOL_VERSIONS.len()) {
+            prop_assert!(validate_protocol_version(SUPPORTED_PROTOCOL_VERSIONS[i]).is_ok());
+        }
+
+        /// Anything not in the supported set is rejected.
+        #[test]
+        fn unsupported_versions_reject(v in ".*") {
+            prop_assume!(!SUPPORTED_PROTOCOL_VERSIONS.contains(&v.as_str()));
+            prop_assert!(validate_protocol_version(&v).is_err());
+        }
+    }
+}

--- a/crates/tower-mcp/tests/property.rs
+++ b/crates/tower-mcp/tests/property.rs
@@ -1,0 +1,47 @@
+//! Property tests for URI-template matching (#1028).
+//!
+//! `match_uri` sees untrusted URIs, so matching arbitrary input must never
+//! panic. Expanding a template with a value and matching it back must extract
+//! that value; an extra path segment must not match a single-variable template.
+
+use proptest::prelude::*;
+use std::collections::HashMap;
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
+
+/// A `db://users/{id}` template with a trivial handler (unused by matching).
+fn users_template() -> ResourceTemplate {
+    ResourceTemplateBuilder::new("db://users/{id}").handler(
+        |_uri: String, _vars: HashMap<String, String>| async move {
+            Ok(ReadResourceResult::default())
+        },
+    )
+}
+
+proptest! {
+    /// Matching arbitrary input against a template never panics.
+    #[test]
+    fn match_uri_never_panics(uri in ".*") {
+        let template = users_template();
+        let _ = template.match_uri(&uri);
+    }
+
+    /// Expanding the template with a slash-free value and matching it back
+    /// extracts that value.
+    #[test]
+    fn expand_then_match_round_trips(id in "[^/ ]{1,20}") {
+        let template = users_template();
+        let caps = template
+            .match_uri(&format!("db://users/{id}"))
+            .expect("a slash-free segment should match");
+        prop_assert_eq!(caps.get("id").map(String::as_str), Some(id.as_str()));
+    }
+
+    /// An extra path segment does not match a single-variable template.
+    #[test]
+    fn extra_path_segment_does_not_match(a in "[^/ ]{1,10}", b in "[^/ ]{1,10}") {
+        let template = users_template();
+        let uri = format!("db://users/{a}/{b}");
+        prop_assert!(template.match_uri(&uri).is_none());
+    }
+}


### PR DESCRIPTION
Implements #1028 (property half): adds proptest coverage to the stable boundaries where malformed or adversarial input matters. These run in the normal test suite, so they are already wired into CI. Scoped to the stable 2025-11-25 surface, so nothing here moves with the 2026-07-28 finalization.

## Targets
- **Pagination cursors** (`encode_cursor` / `decode_cursor`): roundtrip, and `decode_cursor` never panics on arbitrary input.
- **Protocol version negotiation** (`validate_protocol_version`): never panics; supported versions accept, everything else is rejected.
- **JSON-RPC envelope classification** (`JsonRpcMessage`, untagged): parsing arbitrary JSON never panics.
- **URI templates** (`ResourceTemplate::match_uri`, RFC 6570 Level 1): matching arbitrary URIs never panics; expand-then-match roundtrips and extracts the variable.

Fuzz targets (cargo-fuzz) are a possible follow-up; property tests give the immediate no-panic and roundtrip guarantees without a nightly toolchain or a separate CI job.

Closes #1028.