### PR TITLE
feat(types)!: align DiscoverResult with the final 2026-07-28 schema

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -95,9 +95,12 @@ jobs:
             -o /tmp/discover-body.json
           response=$(cat /tmp/discover-body.json)
           echo "server/discover response: $response"
-          # DiscoverResult serializes as camelCase: supportedVersions, serverInfo, capabilities
+          # DiscoverResult serializes as camelCase: supportedVersions, capabilities.
+          # Server identity moved into _meta["io.modelcontextprotocol/serverInfo"]
+          # in the final 2026-07-28 schema (it was a top-level serverInfo field
+          # pre-finalization).
           echo "$response" | grep -q '"supportedVersions"' || { echo "FAIL: supportedVersions missing"; exit 1; }
-          echo "$response" | grep -q '"serverInfo"' || { echo "FAIL: serverInfo missing"; exit 1; }
+          echo "$response" | grep -q '"io.modelcontextprotocol/serverInfo"' || { echo "FAIL: _meta serverInfo missing"; exit 1; }
           echo "$response" | grep -q '"capabilities"' || { echo "FAIL: capabilities missing"; exit 1; }
           echo "PASS: server/discover returned well-formed DiscoverResult"
           # server/discover must NOT set mcp-session-id: stateless responses are sessionless (#865)

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -1626,7 +1626,9 @@ pub struct DiscoverParams {}
 ///
 /// The final 2026-07-28 schema dropped the `serverInfo` body field (server
 /// identity now lives in `_meta["io.modelcontextprotocol/serverInfo"]`, via
-/// [`ResultMeta`]) and made this a [`CacheableResult`]-shaped type. This
+/// [`ResultMeta`]) and made this a `CacheableResult`-shaped type (the spec's
+/// name for the interface; this crate has no such Rust type -- each
+/// cacheable result inlines its own `ttl_ms`/`cache_scope` fields). This
 /// crate keeps `ttl_ms`/`cache_scope` as `Option` rather than the spec's
 /// required `number`/`string` -- the same "`None` means no opinion"
 /// convention used by every other cacheable result in this file (see

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -1623,7 +1623,15 @@ pub struct DiscoverParams {}
 /// replaced by `supported_versions` -- a `server/discover` call is
 /// version-independent, so the server enumerates every version it can
 /// speak and the client picks.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// The final 2026-07-28 schema dropped the `serverInfo` body field (server
+/// identity now lives in `_meta["io.modelcontextprotocol/serverInfo"]`, via
+/// [`ResultMeta`]) and made this a [`CacheableResult`]-shaped type. This
+/// crate keeps `ttl_ms`/`cache_scope` as `Option` rather than the spec's
+/// required `number`/`string` -- the same "`None` means no opinion"
+/// convention used by every other cacheable result in this file (see
+/// [`CacheScope`]) -- rather than a one-off required-field type here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiscoverResult {
     /// All protocol versions this server can speak. The client picks one
@@ -1631,14 +1639,21 @@ pub struct DiscoverResult {
     pub supported_versions: Vec<String>,
     /// Server capabilities (same shape as the `initialize` result).
     pub capabilities: ServerCapabilities,
-    /// Server implementation info.
-    pub server_info: Implementation,
+    /// SEP-2549: client-cache TTL in milliseconds for this response.
+    /// `None` means "no opinion -- client policy decides".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_ms: Option<u64>,
+    /// SEP-2549: scope the cached result applies to. `None` means scope is
+    /// unspecified.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_scope: Option<CacheScope>,
     /// Optional instructions describing how to use this server.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
-    /// Optional protocol-level metadata.
+    /// Protocol-level metadata. Carries server identity
+    /// (`io.modelcontextprotocol/serverInfo`) per SEP-2575.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Value>,
+    pub meta: Option<ResultMeta>,
 }
 
 // =============================================================================
@@ -4881,17 +4896,20 @@ mod tests {
         let r = DiscoverResult {
             supported_versions: vec!["2026-07-28".into(), "2025-11-25".into()],
             capabilities: ServerCapabilities::default(),
-            server_info: Implementation {
-                name: "test-server".into(),
-                version: "1.0.0".into(),
-                title: None,
-                description: None,
-                icons: None,
-                website_url: None,
-                meta: None,
-            },
+            ttl_ms: None,
+            cache_scope: None,
             instructions: None,
-            meta: None,
+            meta: Some(ResultMeta {
+                server_info: Some(Implementation {
+                    name: "test-server".into(),
+                    version: "1.0.0".into(),
+                    title: None,
+                    description: None,
+                    icons: None,
+                    website_url: None,
+                    meta: None,
+                }),
+            }),
         };
         let json = serde_json::to_value(&r).unwrap();
         assert_eq!(
@@ -4902,11 +4920,30 @@ mod tests {
             json.get("protocolVersion").is_none(),
             "server/discover must use supportedVersions, not protocolVersion, got: {json}"
         );
-        assert_eq!(json["serverInfo"]["name"], "test-server");
+        assert_eq!(
+            json["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            "test-server"
+        );
         assert!(
             json.get("instructions").is_none(),
             "instructions must be omitted when None, got: {json}"
         );
+    }
+
+    #[test]
+    fn discover_result_omits_meta_ttl_and_cache_scope_when_none() {
+        let r = DiscoverResult {
+            supported_versions: vec!["2026-07-28".into()],
+            capabilities: ServerCapabilities::default(),
+            ttl_ms: None,
+            cache_scope: None,
+            instructions: None,
+            meta: None,
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert!(json.get("_meta").is_none());
+        assert!(json.get("ttlMs").is_none());
+        assert!(json.get("cacheScope").is_none());
     }
 
     // =========================================================================

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1885,27 +1885,31 @@ impl McpRouter {
                 // so clients can pick one and signal it via MCP-Protocol-Version
                 // on subsequent requests.
                 tracing::debug!("Stateless server/discover request");
+                let server_info = Implementation {
+                    name: self.inner.server_name.clone(),
+                    version: self.inner.server_version.clone(),
+                    title: self.inner.server_title.clone(),
+                    description: self.inner.server_description.clone(),
+                    icons: self.inner.server_icons.clone(),
+                    website_url: self.inner.server_website_url.clone(),
+                    meta: None,
+                };
                 Ok(McpResponse::Discover(DiscoverResult {
                     supported_versions: crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
                         .iter()
                         .map(|v| (*v).to_string())
                         .collect(),
                     capabilities: self.capabilities(),
-                    server_info: Implementation {
-                        name: self.inner.server_name.clone(),
-                        version: self.inner.server_version.clone(),
-                        title: self.inner.server_title.clone(),
-                        description: self.inner.server_description.clone(),
-                        icons: self.inner.server_icons.clone(),
-                        website_url: self.inner.server_website_url.clone(),
-                        meta: None,
-                    },
+                    ttl_ms: None,
+                    cache_scope: None,
                     instructions: if let Some(config) = &self.inner.auto_instructions {
                         Some(self.inner.generate_instructions(config))
                     } else {
                         self.inner.instructions.clone()
                     },
-                    meta: None,
+                    meta: Some(crate::protocol::ResultMeta {
+                        server_info: Some(server_info),
+                    }),
                 }))
             }
 
@@ -7072,13 +7076,14 @@ mod tests {
                     .expect("result.supportedVersions must be an array");
                 assert!(!versions.is_empty(), "supportedVersions must not be empty");
 
-                // serverInfo.name must match what we configured.
+                // Server identity lives in _meta, not the result body (SEP-2575 final).
                 assert_eq!(
-                    r.result["serverInfo"]["name"], "unit-test-server",
+                    r.result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+                    "unit-test-server",
                     "serverInfo.name must match configured value"
                 );
                 assert_eq!(
-                    r.result["serverInfo"]["version"], "4.2.0",
+                    r.result["_meta"]["io.modelcontextprotocol/serverInfo"]["version"], "4.2.0",
                     "serverInfo.version must match configured value"
                 );
 

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -393,27 +393,33 @@ mod tests {
 
     #[test]
     fn test_discover_result_serialization() {
-        use crate::protocol::{Implementation, ServerCapabilities};
+        use crate::protocol::{Implementation, ResultMeta, ServerCapabilities};
 
         let result = DiscoverResult {
             supported_versions: vec!["2025-11-25".to_string(), "2025-03-26".to_string()],
             capabilities: ServerCapabilities::default(),
-            server_info: Implementation {
-                name: "test-server".to_string(),
-                version: "1.0.0".to_string(),
-                title: None,
-                description: None,
-                icons: None,
-                website_url: None,
-                meta: None,
-            },
+            ttl_ms: None,
+            cache_scope: None,
             instructions: Some("Test instructions".to_string()),
-            meta: None,
+            meta: Some(ResultMeta {
+                server_info: Some(Implementation {
+                    name: "test-server".to_string(),
+                    version: "1.0.0".to_string(),
+                    title: None,
+                    description: None,
+                    icons: None,
+                    website_url: None,
+                    meta: None,
+                }),
+            }),
         };
 
         let json = serde_json::to_value(&result).unwrap();
         assert!(json["supportedVersions"].is_array());
-        assert_eq!(json["serverInfo"]["name"], "test-server");
+        assert_eq!(
+            json["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            "test-server"
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2550,7 +2550,7 @@ mod stateless_tests {
         let body: serde_json::Value = resp.json().await.unwrap();
         let result = &body["result"];
         assert!(result["supportedVersions"].is_array());
-        assert!(result["serverInfo"]["name"].is_string());
+        assert!(result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"].is_string());
         assert!(result["capabilities"].is_object());
     }
 }

--- a/crates/tower-mcp/tests/server_discover.rs
+++ b/crates/tower-mcp/tests/server_discover.rs
@@ -71,8 +71,14 @@ async fn discover_returns_supported_versions_and_server_info() {
         versions.iter().all(|v| v.is_string()),
         "supportedVersions entries must be strings"
     );
-    assert_eq!(result["serverInfo"]["name"], "discover-test-server");
-    assert_eq!(result["serverInfo"]["version"], "9.9.9");
+    assert_eq!(
+        result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "discover-test-server"
+    );
+    assert_eq!(
+        result["_meta"]["io.modelcontextprotocol/serverInfo"]["version"],
+        "9.9.9"
+    );
     assert!(
         result.get("protocolVersion").is_none(),
         "server/discover must NOT include singular protocolVersion -- that's the initialize shape: {result}"

--- a/examples/server_discover.rs
+++ b/examples/server_discover.rs
@@ -179,14 +179,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // The result uses supportedVersions (plural), NOT protocolVersion (singular).
     // That is the key structural difference from initialize.
     let result = &discover_body["result"];
+    // Server identity now lives in _meta, not the result body (SEP-2575 final).
+    let server_info = &result["_meta"]["io.modelcontextprotocol/serverInfo"];
     println!("Server info:");
-    println!(
-        "  name:    {}",
-        result["serverInfo"]["name"].as_str().unwrap_or("?")
-    );
+    println!("  name:    {}", server_info["name"].as_str().unwrap_or("?"));
     println!(
         "  version: {}",
-        result["serverInfo"]["version"].as_str().unwrap_or("?")
+        server_info["version"].as_str().unwrap_or("?")
     );
     println!();
 


### PR DESCRIPTION
Implements #1037 part A.

## What

The finalized 2026-07-28 schema (schema/2026-07-28/schema.ts) dropped the
`serverInfo` body field from `DiscoverResult` and made it a
`CacheableResult`-shaped type:

```ts
export interface DiscoverResult extends CacheableResult {
  supportedVersions: string[];
  capabilities: ServerCapabilities;
  instructions?: string;
}
```

Server identity now lives in `_meta["io.modelcontextprotocol/serverInfo"]`
instead.

## Breaking change

`DiscoverResult` no longer has a `server_info` field. Callers reading
`result.serverInfo` from a `server/discover` response need to read
`result._meta["io.modelcontextprotocol/serverInfo"]` instead. The
`initialize` response shape (2025-11-25 and earlier) is untouched --
`InitializeResult.server_info` stays at the top level, since that shape
didn't change in the final schema.

## Design choices

- **`ttl_ms`/`cache_scope` stay `Option`**, not the spec's required
  `number`/`string`. This matches the existing convention for every other
  `CacheableResult`-shaped type in the crate (`ListToolsResult`,
  `ReadResourceResult`, etc.): `None` means "server expresses no opinion",
  documented on `CacheScope`. A one-off required-field variant just for
  `DiscoverResult` would be inconsistent with the rest of the file.
- **`meta` is typed as `Option<ResultMeta>`**, not the raw `Option<Value>`
  every other result type uses. `ResultMeta` (added in #949's types work)
  already has the right `serverInfo` key naming, and `DiscoverResult` is a
  single struct under this crate's control, so this avoids constructing raw
  JSON at the call site. Stamping `serverInfo` generically on *every* result
  type is #1037 part B, out of scope here.

## Changed

- `crates/tower-mcp-types/src/protocol.rs`: `DiscoverResult` shape, plus a
  new test for the ttl/cache-scope omit-when-none case
- `crates/tower-mcp/src/router.rs`: discover handler now stamps
  `ResultMeta.server_info`
- `crates/tower-mcp/src/stateless.rs`, `tests/server_discover.rs`,
  `tests/http_client.rs`, `examples/server_discover.rs`: updated
  construction/assertion sites (all found via `cargo test --workspace
  --all-features`, not just `cargo check`, since two test-only call sites
  don't show up under check)

## Verification

`cargo test --workspace --all-features`: 778 passed in the main lib crate,
full suite green. `cargo fmt --all -- --check` and
`cargo clippy --all-targets --all-features -- -D warnings` clean.
`cargo build -p tower-mcp --examples --all-features` succeeds.