### PR TITLE
docs: note the 2026-07-28 removal of elicitation-complete correlation

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -3837,7 +3837,16 @@ pub struct ElicitUrlParams {
     /// The elicitation mode (defaults to url if not specified)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<ElicitMode>,
-    /// Unique ID for this elicitation (opaque to client)
+    /// Unique ID for this elicitation (opaque to client).
+    ///
+    /// **2025-11-25 and earlier only.** The final 2026-07-28 schema removes
+    /// this field: MRTR (SEP-2322, not yet implemented -- see #950) replaces
+    /// the completion-notification-plus-ID pattern with a request retry, so
+    /// there is no longer a standalone async completion to correlate. This
+    /// field stays required and unconditionally sent for now, since this
+    /// crate does not yet distinguish 2026-07-28 elicitation requests from
+    /// 2025-11-25 ones -- see [`ElicitationCompleteParams`] for the paired
+    /// notification this ID was meant to correlate with.
     pub elicitation_id: String,
     /// Message explaining why the user needs to navigate to the URL
     pub message: String,
@@ -4388,7 +4397,20 @@ pub enum ElicitFieldValue {
     StringArray(Vec<String>),
 }
 
-/// Parameters for elicitation complete notification
+/// Parameters for elicitation complete notification.
+///
+/// **2025-11-25 and earlier only.** The final 2026-07-28 schema removes this
+/// notification (and the `elicitationId` field of URL-mode elicitation, see
+/// [`ElicitUrlParams::elicitation_id`]) -- not deprecated, removed outright,
+/// unlike Roots/Sampling/Logging's SEP-2577 12-month deprecation window.
+/// Under [Multi Round-Trip Requests](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2322)
+/// (SEP-2322, not yet implemented by this crate -- see #950), the client
+/// learns the outcome of an out-of-band interaction by retrying the original
+/// request rather than receiving a server-initiated completion signal, so
+/// the correlating ID this type carries no longer fits the protocol.
+/// tower-mcp does not currently send or handle this notification on any
+/// path; this type exists for callers constructing it directly against the
+/// 2025-11-25 wire format.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ElicitationCompleteParams {

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -740,6 +740,13 @@ impl RequestContext {
     ///
     /// Returns an error if elicitation is not available (no client requester configured).
     ///
+    /// **Protocol note:** `ElicitUrlParams::elicitation_id` and the callback
+    /// notification it correlates with are a 2025-11-25-and-earlier pattern.
+    /// The final 2026-07-28 schema removes both in favor of MRTR (SEP-2322,
+    /// not yet implemented -- see #950), where the client learns the outcome
+    /// by retrying the original request instead of receiving a completion
+    /// notification.
+    ///
     /// # Example
     ///
     /// ```rust,ignore


### PR DESCRIPTION
Implements #1037 part C, scoped down to docs-only per discussion.

## Finding that changed the plan

The original #1037 plan expected real version-gating logic. Turns out:

- `ElicitationCompleteParams` (`notifications/elicitation/complete`) has no
  sender or receiver anywhere in this crate -- grepping the whole repo
  outside the type definition and its `lib.rs` re-export finds nothing.
  There is no code path to gate.
- `ElicitUrlParams::elicitation_id` is a required field on a real public API
  (`RequestContext::elicit_url()`), but the spec's stated 2026-07-28
  replacement is MRTR (SEP-2322) -- retrying the original request instead of
  a completion notification -- and MRTR isn't implemented (#950, not
  started). Gating this field now would be gating it against a replacement
  that doesn't exist yet in this crate.

So this PR documents the removal rather than coding around a dependency
that isn't there. Also worth noting: per the final changelog, this is a
**removal**, not a SEP-2577 deprecation with a 12-month window -- different
from how Roots/Sampling/Logging are handled.

## Changed

- `ElicitationCompleteParams`: doc note explaining the removal, why (MRTR),
  and that this crate sends/handles it nowhere today
- `ElicitUrlParams::elicitation_id`: doc note, same reasoning, cross-links
  to `ElicitationCompleteParams`
- `RequestContext::elicit_url()`: same note on the actual public API surface
  server authors call

No behavior change.

## Verification

`RUSTFLAGS="-Dwarnings" RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
--all-features` clean. `cargo test --workspace --all-features`: 778 passed
(main lib crate, unchanged since this is docs-only), full suite green.
`cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features
-- -D warnings` clean. `cargo build -p tower-mcp --examples --all-features`
succeeds.