### PR TITLE
docs: correct smaller RC-to-final doc drift (#1037 part D)

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -474,7 +474,18 @@ pub enum McpNotification {
     },
 }
 
-/// Parameters for cancellation notification
+/// Parameters for cancellation notification.
+///
+/// **Directionality changed in the final 2026-07-28 schema.** Through
+/// 2025-11-25, either side could send this notification to cancel a
+/// previously-issued request. The final 2026-07-28 schema restricts it to
+/// client-to-server only (`requestId` MUST reference a request the client
+/// issued); on stdio, the server may still send it, but solely to terminate
+/// a `subscriptions/listen` stream by referencing that request's id -- it
+/// MUST NOT use it to cancel any other request. This crate does not
+/// currently send `notifications/cancelled` from the server for any
+/// purpose, so no code changes; the `subscriptions/listen` termination case
+/// is part of #952.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelledParams {
@@ -661,7 +672,12 @@ pub struct ClientCapabilities {
     /// Experimental, non-standard capabilities
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
-    /// Declared extension support (SEP-1724/SEP-2133)
+    /// Declared extension support (SEP-1724/SEP-2133).
+    ///
+    /// Keys MUST follow the `_meta` key naming rules (reverse-DNS prefix
+    /// mandatory, e.g. `io.modelcontextprotocol/tasks`) per the final
+    /// 2026-07-28 schema. Not currently validated on receipt -- this crate
+    /// has no `_meta`-key-naming validation anywhere yet, not just here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
@@ -1720,7 +1736,12 @@ pub struct ServerCapabilities {
     /// Experimental, non-standard capabilities
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
-    /// Declared extension support (SEP-1724/SEP-2133)
+    /// Declared extension support (SEP-1724/SEP-2133).
+    ///
+    /// Keys MUST follow the `_meta` key naming rules (reverse-DNS prefix
+    /// mandatory, e.g. `io.modelcontextprotocol/tasks`) per the final
+    /// 2026-07-28 schema. Not currently validated on receipt -- this crate
+    /// has no `_meta`-key-naming validation anywhere yet, not just here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub extensions: Option<HashMap<String, serde_json::Value>>,
 }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2622,7 +2622,13 @@ impl McpRouter {
                     total = ?params.total,
                     "Progress notification"
                 );
-                // Progress notifications from client are unusual but valid
+                // Client-to-server progress notifications are unusual but
+                // valid through 2025-11-25. The final 2026-07-28 schema
+                // removes ProgressNotification from ClientNotification
+                // entirely -- clients no longer send this. Notifications are
+                // fire-and-forget with no response to reject with, so an
+                // off-spec one arriving here is simply logged and ignored
+                // rather than rejected, regardless of negotiated version.
             }
             McpNotification::RootsListChanged => {
                 tracing::info!("Client roots list changed");

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -70,10 +70,13 @@ use crate::protocol::{ClientCapabilities, Implementation, ProgressToken};
 /// }
 /// ```
 ///
-/// Three of these are REQUIRED per the spec (`protocolVersion`, `clientInfo`,
-/// `clientCapabilities`). They are typed as `Option<_>` here so deserialization
-/// stays tolerant of partial/transitional clients; server-side validation
-/// should reject requests that lack the required fields.
+/// `protocolVersion` and `clientCapabilities` are REQUIRED per the spec.
+/// `clientInfo` is a SHOULD -- clients are expected to send it on every
+/// request unless specifically configured not to, but a server MUST NOT
+/// reject a request for lacking it. All three are typed as `Option<_>` here
+/// so deserialization stays tolerant of partial/transitional clients;
+/// server-side validation should reject requests that lack the two required
+/// fields.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StatelessRequestMeta {
@@ -91,9 +94,12 @@ pub struct StatelessRequestMeta {
     )]
     pub protocol_version: Option<String>,
 
-    /// Identifies the client software making this request. REQUIRED per
-    /// SEP-2575 (the spec uses non-Option types; we keep `Option` for
-    /// deserialization tolerance).
+    /// Identifies the client software making this request. Clients SHOULD
+    /// include this on every request unless specifically configured not to
+    /// (SEP-2575, final -- earlier SEP-2575 drafts had this as REQUIRED; the
+    /// upstream schema demoted it before finalization). Self-reported and
+    /// unverified: servers SHOULD NOT use it for behavior or security
+    /// decisions, only display/logging/debugging.
     #[serde(
         rename = "io.modelcontextprotocol/clientInfo",
         skip_serializing_if = "Option::is_none"


### PR DESCRIPTION
Implements #1037 part D.

## What

Six checklist items from the RC-to-final schema diff. Verified each
individually rather than blanket-applying; three needed doc fixes, three
needed no change at all (already correct or owned elsewhere).

### Fixed

- **`StatelessRequestMeta::client_info`**: doc said REQUIRED. Final schema
  demoted `clientInfo` from MUST to SHOULD (`protocolVersion` and
  `clientCapabilities` stay REQUIRED -- confirmed against the final
  schema text, not just the changelog prose). No enforcement exists
  anywhere in this crate (`from_params()` has no validation), so this was
  already-correct behavior with wrong documentation.
- **`CancelledParams`**: final schema restricts `notifications/cancelled`
  to client-to-server, with a narrow stdio exception for a server
  terminating a `subscriptions/listen` stream (MUST NOT use it to cancel
  anything else). No code change: grepped for `CancelledParams {` outside
  tests and found nothing -- this crate never sends the notification from
  the server today. Documented the directionality change; pointed the
  stdio exception at #952.
- **router.rs progress-notification handler**: comment said client-sent
  progress notifications are "unusual but valid." Final schema removes
  `ProgressNotification` from `ClientNotification` entirely. Updated the
  comment; behavior (log and ignore) is correct either way since
  notifications have no response to reject with.
- **`ClientCapabilities`/`ServerCapabilities::extensions`**: documented the
  final schema's key-naming requirement (mandatory reverse-DNS prefix).
  Not validated -- surfaced that this crate has no `_meta`-key-naming
  validation anywhere, a bigger gap than this one field.

### Verified, no change needed

- **`ListRootsParams`**: the RC-to-final diff narrows `params` from a
  generic `RequestParams` wrapper to `{ _meta? }`. This crate's struct only
  ever had a `meta` field -- it was never modeled on a shared
  `RequestParams` type, so it already matches the final shape.
- **List-changed notifications only on `subscriptions/listen`**: this
  crate's list-changed notification variants never carried the stale RC-era
  doc wording to begin with (no typed params struct exists for them). The
  actual behavior change is #952's, not a doc fix here.

No behavior change anywhere in this PR.

## Verification

`RUSTFLAGS="-Dwarnings" RUSTDOCFLAGS="-D warnings" cargo doc --no-deps
--all-features` clean. `cargo test --workspace --all-features`: 778 passed
(main lib crate, unchanged -- doc-only), full suite green. `cargo fmt --all
-- --check` and `cargo clippy --all-targets --all-features -- -D warnings`
clean. `cargo build -p tower-mcp --examples --all-features` succeeds.