### PR TITLE
feat(protocol): add compile-time and runtime version policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ use tower_mcp::schemars::JsonSchema;
 | `proxy` | Multi-server aggregation proxy (`McpProxy`) |
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
 | `resilience` | Re-export tower-resilience circuit breaker, rate limiter, and bulkhead layers |
-| `stateless` | Experimental 2026-07-28 stateless protocol mode (SEP-2575 final + SEP-2567 accepted) -- version-gated sessionless dispatch, `server/discover` RPC, `subscriptions/listen` SSE endpoint, per-request `_meta` client capabilities. Requires `http`. |
+| `protocol-2026-07-28` | Compile the experimental implementation of the released 2026-07-28 protocol. Use `ProtocolSupport` to narrow the exact versions enabled by a server at runtime. |
+| `stateless` | Compatibility alias for the former 2026 protocol feature name. New integrations should use `protocol-2026-07-28`. |
 
 Example with features:
 
@@ -592,10 +593,12 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. CI fails when a baselined scenario regresses further or starts passing (stale baseline), so the baselines cannot silently rot.
 
-The `stateless` feature enables an experimental 2026-07-28 protocol path (version-gated, behind
+The `protocol-2026-07-28` feature enables the experimental implementation of the released
+2026-07-28 protocol (version-gated, behind
 `MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, and per-request
-`_meta` capabilities as defined by SEP-2575 (final) and SEP-2567 (accepted). The 2026-07-28
-version is not yet stable and is not included in `SUPPORTED_PROTOCOL_VERSIONS`.
+`_meta` capabilities as defined by SEP-2575 and SEP-2567. It is not enabled by default and is
+not yet included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
+runtime enablement are reported separately.
 
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Current Status
 
 - **Version**: 0.14.x
-- **Spec version**: 2025-11-25 (plus the 2026-07-28 draft behind the `stateless` feature)
+- **Spec version**: 2025-11-25 by default (plus the released 2026-07-28 protocol as an experimental implementation behind `protocol-2026-07-28`)
 - **Server conformance (2025-11-25)**: 39/39
 - **Client conformance (2025-11-25)**: 264/266 (two offline-access gaps, tracked in #953)
 - **Server conformance (2026-07-28)**: 67/101 (gaps baselined, tracked in #929)

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -15,13 +15,16 @@
 //!
 //! # Stateless protocol support (2026-07-28)
 //!
-//! This crate also tracks the next protocol version (`2026-07-28`) that adds
+//! This crate also tracks the experimental implementation of protocol version
+//! `2026-07-28`, which adds
 //! stateless operation, per-request `_meta`, and the `server/discover` RPC.
 //! Key items:
 //!
-//! - [`protocol::UPCOMING_PROTOCOL_VERSION`] -- the `"2026-07-28"` version
-//!   string, not yet in `SUPPORTED_PROTOCOL_VERSIONS`. Useful for codegen
-//!   tools and conformance harnesses that need to reference it explicitly.
+//! - [`protocol::EXPERIMENTAL_PROTOCOL_VERSION`] -- the `"2026-07-28"` wire
+//!   version, not yet enabled by default. Useful for codegen tools and
+//!   conformance harnesses that need to reference it explicitly.
+//! - [`protocol::KNOWN_PROTOCOL_VERSIONS`] -- every version whose wire format
+//!   is represented here, independent of runtime compile-time features.
 //! - [`protocol::DiscoverResult`] / [`protocol::DiscoverParams`] -- types for
 //!   the `server/discover` RPC (SEP-2575), which returns the server's supported
 //!   protocol versions and capabilities without requiring an `initialize`

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -14,10 +14,10 @@ use crate::error::JsonRpcError;
 /// The JSON-RPC version. MUST be "2.0".
 pub const JSONRPC_VERSION: &str = "2.0";
 
-/// The latest supported MCP protocol version.
+/// The latest protocol version enabled by default.
 pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 
-/// All supported MCP protocol versions (newest first).
+/// Protocol versions enabled by default (newest first).
 ///
 /// During initialization, the server negotiates the protocol version with the
 /// client. The server picks the newest version that both sides support.
@@ -31,18 +31,33 @@ pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 /// ```
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-03-26"];
 
-/// The next protocol version we are tracking toward but have not yet
-/// fully implemented. Documented as a constant so downstream tooling
-/// (codegen, conformance harnesses) can reference it explicitly.
+/// The released protocol version whose tower-mcp implementation is experimental.
 ///
-/// Once the implementation is feature-complete (sessionless transport,
-/// `server/discover`, `subscriptions/listen`, per-request `_meta` capabilities;
-/// see [tower-mcp#814]) this value will move into
+/// Downstream tooling (code generators, conformance harnesses, and feature-gated
+/// runtimes) can reference the wire version without implying that the full
+/// implementation is enabled. Once the implementation passes its promotion
+/// gates, this value will move into
 /// [`SUPPORTED_PROTOCOL_VERSIONS`] and become the new
 /// [`LATEST_PROTOCOL_VERSION`].
 ///
-/// [tower-mcp#814]: https://github.com/joshrotenberg/tower-mcp/issues/814
-pub const UPCOMING_PROTOCOL_VERSION: &str = "2026-07-28";
+/// See [tower-mcp#929] for the implementation and promotion checklist.
+///
+/// [tower-mcp#929]: https://github.com/joshrotenberg/tower-mcp/issues/929
+pub const EXPERIMENTAL_PROTOCOL_VERSION: &str = "2026-07-28";
+
+/// All protocol versions understood by this types crate (newest first).
+///
+/// "Known" means the crate can represent at least part of the version's wire
+/// format. It does not mean a runtime implementation was compiled or enabled.
+pub const KNOWN_PROTOCOL_VERSIONS: &[&str] =
+    &[EXPERIMENTAL_PROTOCOL_VERSION, "2025-11-25", "2025-03-26"];
+
+/// Deprecated alias for [`EXPERIMENTAL_PROTOCOL_VERSION`].
+#[deprecated(
+    since = "0.15.0",
+    note = "the 2026-07-28 spec has shipped; use EXPERIMENTAL_PROTOCOL_VERSION"
+)]
+pub const UPCOMING_PROTOCOL_VERSION: &str = EXPERIMENTAL_PROTOCOL_VERSION;
 
 /// JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -589,7 +604,7 @@ impl RequestMeta {
     /// `clientCapabilities` are required; earlier versions carry neither and
     /// always pass.
     pub fn validate_for_version(&self, protocol_version: &str) -> Result<(), MissingMetaKey> {
-        if protocol_version == UPCOMING_PROTOCOL_VERSION {
+        if protocol_version == EXPERIMENTAL_PROTOCOL_VERSION {
             if self.protocol_version.is_none() {
                 return Err(MissingMetaKey("io.modelcontextprotocol/protocolVersion"));
             }
@@ -4670,10 +4685,11 @@ impl ResultType {
 /// `resultType` discriminator.
 ///
 /// `resultType` is part of the 2026-07-28 spec (SEP-2322); on 2025-11-25 it is
-/// absent and readers apply the "absent means `complete`" rule. Version strings
-/// are YYYY-MM-DD dates, so lexicographic comparison is correct.
+/// absent and readers apply the "absent means `complete`" rule. Only known,
+/// explicitly implemented protocol versions opt in; an unknown future date
+/// must not silently inherit 2026 behavior.
 pub fn version_carries_result_type(protocol_version: &str) -> bool {
-    protocol_version >= UPCOMING_PROTOCOL_VERSION
+    protocol_version == EXPERIMENTAL_PROTOCOL_VERSION
 }
 
 impl From<String> for ResultType {
@@ -4899,21 +4915,22 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn upcoming_version_is_documented_and_not_yet_supported() {
-        // UPCOMING_PROTOCOL_VERSION points at the next protocol we're tracking
-        // toward. Until #814 ships fully, the constant exists for downstream
-        // tooling but the version must NOT appear in SUPPORTED_PROTOCOL_VERSIONS
-        // (otherwise we'd be falsely advertising compatibility).
-        assert_eq!(UPCOMING_PROTOCOL_VERSION, "2026-07-28");
+    fn experimental_version_is_known_and_not_enabled_by_default() {
+        assert_eq!(EXPERIMENTAL_PROTOCOL_VERSION, "2026-07-28");
+        assert!(KNOWN_PROTOCOL_VERSIONS.contains(&EXPERIMENTAL_PROTOCOL_VERSION));
         assert!(
-            !SUPPORTED_PROTOCOL_VERSIONS.contains(&UPCOMING_PROTOCOL_VERSION),
-            "do not promote UPCOMING_PROTOCOL_VERSION into SUPPORTED until the \
-             impl is complete; current: {:?}",
+            !SUPPORTED_PROTOCOL_VERSIONS.contains(&EXPERIMENTAL_PROTOCOL_VERSION),
+            "do not enable EXPERIMENTAL_PROTOCOL_VERSION by default until the \
+             #929 promotion gates pass; current: {:?}",
             SUPPORTED_PROTOCOL_VERSIONS
         );
-        // LATEST_PROTOCOL_VERSION is one of the SUPPORTED ones; it isn't
-        // UPCOMING until we ship 2026-07-28.
         assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&LATEST_PROTOCOL_VERSION));
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn upcoming_version_alias_remains_compatible() {
+        assert_eq!(UPCOMING_PROTOCOL_VERSION, EXPERIMENTAL_PROTOCOL_VERSION);
     }
 
     // =========================================================================
@@ -6567,24 +6584,27 @@ mod draft_2026_07_28_tests {
     #[test]
     fn request_meta_carries_sep2575_keys_and_validates_by_version() {
         let meta = RequestMeta {
-            protocol_version: Some(UPCOMING_PROTOCOL_VERSION.to_string()),
+            protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
             client_capabilities: Some(ClientCapabilities::default()),
             ..Default::default()
         };
         let v = serde_json::to_value(&meta).unwrap();
         assert_eq!(
             v["io.modelcontextprotocol/protocolVersion"],
-            json!(UPCOMING_PROTOCOL_VERSION)
+            json!(EXPERIMENTAL_PROTOCOL_VERSION)
         );
         assert!(
             v.get("io.modelcontextprotocol/clientCapabilities")
                 .is_some()
         );
         // Version-aware required-key validation (SEP-2575).
-        assert!(meta.validate_for_version(UPCOMING_PROTOCOL_VERSION).is_ok());
+        assert!(
+            meta.validate_for_version(EXPERIMENTAL_PROTOCOL_VERSION)
+                .is_ok()
+        );
         assert!(
             RequestMeta::default()
-                .validate_for_version(UPCOMING_PROTOCOL_VERSION)
+                .validate_for_version(EXPERIMENTAL_PROTOCOL_VERSION)
                 .is_err()
         );
         assert!(
@@ -6648,19 +6668,19 @@ mod draft_2026_07_28_tests {
         let params = ListToolsParams {
             cursor: None,
             meta: Some(RequestMeta {
-                protocol_version: Some(UPCOMING_PROTOCOL_VERSION.to_string()),
+                protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
                 ..Default::default()
             }),
         };
         let v = serde_json::to_value(&params).unwrap();
         assert_eq!(
             v["_meta"]["io.modelcontextprotocol/protocolVersion"],
-            json!(UPCOMING_PROTOCOL_VERSION)
+            json!(EXPERIMENTAL_PROTOCOL_VERSION)
         );
         let back: ListToolsParams = serde_json::from_value(v).unwrap();
         assert_eq!(
             back.meta.unwrap().protocol_version.as_deref(),
-            Some(UPCOMING_PROTOCOL_VERSION)
+            Some(EXPERIMENTAL_PROTOCOL_VERSION)
         );
     }
 
@@ -6676,17 +6696,18 @@ mod draft_2026_07_28_tests {
 
         // 2026-07-28 carries the discriminator.
         let mut v = baseline.clone();
-        assert!(ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert!(ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
         assert_eq!(v["resultType"], json!("complete"));
         assert_eq!(v["content"], baseline["content"]);
 
-        // Versions after 2026-07-28 keep carrying it (dates compare in order).
+        // Unknown future versions do not silently inherit 2026 semantics.
         let mut v = baseline.clone();
-        assert!(ResultType::Complete.stamp_into(&mut v, "2027-01-01"));
-        assert_eq!(v["resultType"], json!("complete"));
+        assert!(!ResultType::Complete.stamp_into(&mut v, "2027-01-01"));
+        assert_eq!(v, baseline);
 
         assert!(!version_carries_result_type("2025-11-25"));
-        assert!(version_carries_result_type(UPCOMING_PROTOCOL_VERSION));
+        assert!(version_carries_result_type(EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(!version_carries_result_type("2027-01-01"));
     }
 
     #[test]
@@ -6694,16 +6715,16 @@ mod draft_2026_07_28_tests {
         // InputRequiredResult and CreateTaskResult write their own resultType;
         // stamping must not overwrite it with "complete".
         let mut v = serde_json::to_value(InputRequiredResult::new()).unwrap();
-        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
         assert_eq!(v["resultType"], json!("input_required"));
 
         let mut v = json!({"resultType": RESULT_TYPE_TASK, "taskId": "t1"});
-        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
         assert_eq!(v["resultType"], json!("task"));
 
         // A non-object result (the empty result some methods return) is a no-op.
         let mut v = json!(null);
-        assert!(!ResultType::Complete.stamp_into(&mut v, UPCOMING_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
         assert_eq!(v, json!(null));
     }
 
@@ -6723,7 +6744,7 @@ mod draft_2026_07_28_tests {
         );
         let parsed: CallToolResult = serde_json::from_value(example).unwrap();
         let mut round_tripped = serde_json::to_value(&parsed).unwrap();
-        assert!(ResultType::Complete.stamp_into(&mut round_tripped, UPCOMING_PROTOCOL_VERSION));
+        assert!(ResultType::Complete.stamp_into(&mut round_tripped, EXPERIMENTAL_PROTOCOL_VERSION));
         assert_eq!(round_tripped["resultType"], json!("complete"));
         assert_eq!(round_tripped["content"][0]["text"], json!("42"));
 

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -48,7 +48,7 @@ jsonschema = "0.48"
 [features]
 default = []
 # Enable all optional features
-full = ["http", "websocket", "unix", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "stateless"]
+full = ["http", "websocket", "unix", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "protocol-2026-07-28"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
 websocket = ["dep:axum", "dep:uuid"]
@@ -72,8 +72,11 @@ proxy = []
 resilience = ["dep:tower-resilience"]
 # Proc macros for tool/resource/prompt definitions
 macros = ["dep:tower-mcp-macros"]
-# Stateless MCP mode (experimental). SEP-1442 is the legacy opt-in path; the
-# finalized 2026-07-28 mechanism is SEP-2575/2567/2243.
+# Compile the experimental MCP 2026-07-28 implementation. Runtime transports
+# may narrow the compiled set with ProtocolSupport.
+protocol-2026-07-28 = ["stateless"]
+# Compatibility alias for the former feature name. New consumers should enable
+# `protocol-2026-07-28`; existing `stateless` users retain the same behavior.
 stateless = []
 
 [dependencies.axum]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -363,9 +363,10 @@
 //!     .stateless(StatelessConfig::new());
 //! ```
 //!
-//! The 2026-07-28 protocol is experimental. The `UPCOMING_PROTOCOL_VERSION` constant in
-//! `tower_mcp::protocol` tracks the target version string and will not appear in
-//! `SUPPORTED_PROTOCOL_VERSIONS` until the spec is stable.
+//! The 2026-07-28 implementation is experimental. Enable the
+//! `protocol-2026-07-28` Cargo feature to compile it, then use
+//! [`ProtocolSupport`] to narrow the versions enabled by an individual
+//! transport at runtime.
 //!
 //! ### Router Composition
 //!
@@ -456,6 +457,10 @@ pub mod middleware;
 pub mod oauth;
 pub mod prompt;
 pub mod protocol;
+mod protocol_support;
+pub use protocol_support::{
+    COMPILED_PROTOCOL_VERSIONS, ProtocolSupport, ProtocolSupportError, is_protocol_version_compiled,
+};
 #[cfg(feature = "proxy")]
 pub mod proxy;
 #[cfg(feature = "dynamic-tools")]

--- a/crates/tower-mcp/src/protocol_support.rs
+++ b/crates/tower-mcp/src/protocol_support.rs
@@ -1,0 +1,192 @@
+//! Compile-time and runtime protocol-version policy.
+//!
+//! The types crate exposes every wire version it knows. This module answers a
+//! different question: which implementations were compiled into `tower-mcp`,
+//! and which subset should a particular transport advertise and accept?
+
+use std::collections::HashSet;
+
+#[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+use crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
+
+/// Protocol versions compiled into this build, in preference order.
+///
+/// Enabling `protocol-2026-07-28` adds the experimental implementation. The
+/// former `stateless` feature remains a compatibility alias and produces the
+/// same compiled set.
+#[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+pub const COMPILED_PROTOCOL_VERSIONS: &[&str] =
+    &[EXPERIMENTAL_PROTOCOL_VERSION, "2025-11-25", "2025-03-26"];
+
+/// Protocol versions compiled into this build, in preference order.
+#[cfg(not(any(feature = "protocol-2026-07-28", feature = "stateless")))]
+pub const COMPILED_PROTOCOL_VERSIONS: &[&str] = SUPPORTED_PROTOCOL_VERSIONS;
+
+/// Returns whether a protocol implementation is present in this build.
+pub fn is_protocol_version_compiled(version: &str) -> bool {
+    COMPILED_PROTOCOL_VERSIONS.contains(&version)
+}
+
+/// Error returned for an invalid runtime protocol configuration.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProtocolSupportError {
+    /// At least one protocol version must remain enabled.
+    #[error("at least one protocol version must be enabled")]
+    Empty,
+    /// The requested version was not compiled into this build.
+    #[error(
+        "protocol version `{version}` is not compiled into this build; compiled versions: {compiled:?}"
+    )]
+    NotCompiled {
+        /// Version requested by the application.
+        version: String,
+        /// Versions available in this build.
+        compiled: &'static [&'static str],
+    },
+    /// A version appeared more than once in the preference list.
+    #[error("protocol version `{0}` is configured more than once")]
+    Duplicate(String),
+}
+
+/// Exact, ordered protocol-version allow-list for one runtime component.
+///
+/// [`ProtocolSupport::default`] enables every version compiled into the crate.
+/// Use [`ProtocolSupport::try_new`] to narrow an individual server or client.
+/// The order is preserved and is used as the advertised preference order.
+///
+/// ```
+/// use tower_mcp::ProtocolSupport;
+///
+/// let support = ProtocolSupport::try_new(["2025-11-25"])?;
+/// assert!(support.contains("2025-11-25"));
+/// assert!(!support.contains("2025-03-26"));
+/// # Ok::<(), tower_mcp::ProtocolSupportError>(())
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProtocolSupport {
+    versions: Vec<String>,
+}
+
+impl ProtocolSupport {
+    /// Enable every protocol implementation compiled into this build.
+    pub fn compiled() -> Self {
+        Self {
+            versions: COMPILED_PROTOCOL_VERSIONS
+                .iter()
+                .map(|version| (*version).to_string())
+                .collect(),
+        }
+    }
+
+    /// Enable only the stable-by-default protocol versions.
+    ///
+    /// This excludes experimental implementations even when their Cargo
+    /// features are compiled.
+    pub fn stable() -> Self {
+        Self {
+            versions: SUPPORTED_PROTOCOL_VERSIONS
+                .iter()
+                .map(|version| (*version).to_string())
+                .collect(),
+        }
+    }
+
+    /// Construct an exact runtime allow-list.
+    ///
+    /// Versions must be compiled into the crate, must not be duplicated, and
+    /// the list must not be empty.
+    pub fn try_new<I, S>(versions: I) -> Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut configured = Vec::new();
+        let mut seen = HashSet::new();
+
+        for version in versions {
+            let version = version.into();
+            if !is_protocol_version_compiled(&version) {
+                return Err(ProtocolSupportError::NotCompiled {
+                    version,
+                    compiled: COMPILED_PROTOCOL_VERSIONS,
+                });
+            }
+            if !seen.insert(version.clone()) {
+                return Err(ProtocolSupportError::Duplicate(version));
+            }
+            configured.push(version);
+        }
+
+        if configured.is_empty() {
+            return Err(ProtocolSupportError::Empty);
+        }
+
+        Ok(Self {
+            versions: configured,
+        })
+    }
+
+    /// Enabled versions in advertised preference order.
+    pub fn versions(&self) -> &[String] {
+        &self.versions
+    }
+
+    /// Whether this runtime component should accept a version.
+    pub fn contains(&self, version: &str) -> bool {
+        self.versions.iter().any(|candidate| candidate == version)
+    }
+
+    /// Most-preferred enabled version.
+    pub fn preferred(&self) -> &str {
+        // Construction and the two built-in policies guarantee non-empty.
+        &self.versions[0]
+    }
+}
+
+impl Default for ProtocolSupport {
+    fn default() -> Self {
+        Self::compiled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stable_policy_excludes_experimental_versions() {
+        let support = ProtocolSupport::stable();
+        assert_eq!(support.versions(), SUPPORTED_PROTOCOL_VERSIONS);
+        assert_eq!(support.preferred(), "2025-11-25");
+    }
+
+    #[test]
+    fn rejects_empty_duplicate_and_uncompiled_sets() {
+        assert_eq!(
+            ProtocolSupport::try_new(Vec::<String>::new()).unwrap_err(),
+            ProtocolSupportError::Empty
+        );
+        assert_eq!(
+            ProtocolSupport::try_new(["2025-11-25", "2025-11-25"]).unwrap_err(),
+            ProtocolSupportError::Duplicate("2025-11-25".to_string())
+        );
+        assert!(matches!(
+            ProtocolSupport::try_new(["2099-01-01"]).unwrap_err(),
+            ProtocolSupportError::NotCompiled { .. }
+        ));
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[test]
+    fn experimental_feature_adds_2026_implementation() {
+        assert!(is_protocol_version_compiled(EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(ProtocolSupport::compiled().contains(EXPERIMENTAL_PROTOCOL_VERSION));
+    }
+
+    #[cfg(not(any(feature = "protocol-2026-07-28", feature = "stateless")))]
+    #[test]
+    fn default_build_does_not_compile_2026_implementation() {
+        assert!(!is_protocol_version_compiled("2026-07-28"));
+    }
+}

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1863,14 +1863,24 @@ impl McpRouter {
                     "Client initializing"
                 );
 
-                // Protocol version negotiation: respond with same version if supported,
-                // otherwise respond with our latest supported version
-                let protocol_version = if crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
-                    .contains(&params.protocol_version.as_str())
-                {
+                // HTTP and other configurable transports inject their exact
+                // runtime allow-list. Direct router use retains the stable
+                // default policy.
+                let protocol_support = extensions.get::<crate::ProtocolSupport>();
+                let requested_is_supported = protocol_support.map_or_else(
+                    || {
+                        crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                            .contains(&params.protocol_version.as_str())
+                    },
+                    |support| support.contains(&params.protocol_version),
+                );
+                let protocol_version = if requested_is_supported {
                     params.protocol_version
                 } else {
-                    crate::protocol::LATEST_PROTOCOL_VERSION.to_string()
+                    protocol_support.map_or_else(
+                        || crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
+                        |support| support.preferred().to_string(),
+                    )
                 };
 
                 // Transition session state to Initializing
@@ -1898,11 +1908,17 @@ impl McpRouter {
                 // on subsequent requests.
                 tracing::debug!("Stateless server/discover request");
                 let server_info = self.implementation();
+                let supported_versions = extensions.get::<crate::ProtocolSupport>().map_or_else(
+                    || {
+                        crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                            .iter()
+                            .map(|version| (*version).to_string())
+                            .collect()
+                    },
+                    |support| support.versions().to_vec(),
+                );
                 Ok(McpResponse::Discover(DiscoverResult {
-                    supported_versions: crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
-                        .iter()
-                        .map(|v| (*v).to_string())
-                        .collect(),
+                    supported_versions,
                     capabilities: self.capabilities(),
                     ttl_ms: None,
                     cache_scope: None,

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -2,7 +2,7 @@
 //!
 //! Implements the Streamable HTTP transport from MCP specification 2025-11-25,
 //! with version-gated support for the 2026-07-28 stateless protocol (SEP-2575 /
-//! SEP-2567) when the `stateless` feature is compiled in.
+//! SEP-2567) when the `protocol-2026-07-28` feature is compiled in.
 //!
 //! ## Features
 //!
@@ -12,18 +12,18 @@
 //! - SSE event IDs and stream resumption via `Last-Event-ID` header (SEP-1699)
 //! - Configurable session TTL and cleanup
 //! - **Sampling support**: Server-to-client LLM requests via SSE + POST
-//! - **Stateless mode** (`stateless` feature): version-gated dispatch for
-//!   2026-07-28+ clients with per-request `_meta` and no session handshake
+//! - **2026 protocol mode** (`protocol-2026-07-28` feature): version-gated
+//!   dispatch with per-request `_meta` and no session handshake
 //!
 //! ## Stateless mode (2026-07-28 protocol)
 //!
-//! When the `stateless` feature is compiled in, the transport handles two
-//! distinct stateless paths:
+//! When the `protocol-2026-07-28` feature (or its former `stateless` alias) is
+//! compiled in, the transport handles two distinct stateless paths:
 //!
-//! ### Automatic version-gated path (2026-07-28+)
+//! ### Automatic version-gated path (2026-07-28)
 //!
-//! Any request that arrives with `MCP-Protocol-Version: 2026-07-28` (or
-//! later) and no `mcp-session-id` header is dispatched statelessly, regardless
+//! Any request that arrives with `MCP-Protocol-Version: 2026-07-28` and no
+//! `mcp-session-id` header is dispatched statelessly, regardless
 //! of whether [`HttpTransport::stateless()`] was called. The client is fully
 //! self-identifying: every request carries its protocol version, client info,
 //! and client capabilities in the `_meta` object; no initialize handshake is
@@ -53,7 +53,7 @@
 //!
 //! This replaces the `GET /` SSE endpoint used by the 2025-11-25 protocol. The
 //! `GET /` endpoint is still supported for 2025-11-25 sessions; `subscriptions/listen`
-//! is only available for 2026-07-28+ clients.
+//! is only available for 2026-07-28 clients.
 //!
 //! ```text
 //! Client (2026-07-28)                          Server
@@ -79,7 +79,7 @@
 //!
 //! Validation is **lenient** for 2025-11-25 clients: headers present in the
 //! request are validated for consistency with the body, but missing headers are
-//! not an error. Validation is **strict** for 2026-07-28+ clients: `Mcp-Method`
+//! not an error. Validation is **strict** for 2026-07-28 clients: `Mcp-Method`
 //! must be present on every POST and `Mcp-Name` must be present for the three
 //! named methods. Violations return `-32020` (HeaderMismatch).
 //!
@@ -262,14 +262,14 @@ use crate::context::{
 use crate::error::{Error, JsonRpcError, Result};
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{
-    ClientCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
-    LATEST_PROTOCOL_VERSION, McpNotification, RequestId, SUPPORTED_PROTOCOL_VERSIONS,
-    UPCOMING_PROTOCOL_VERSION,
+    ClientCapabilities, EXPERIMENTAL_PROTOCOL_VERSION, Implementation, JsonRpcNotification,
+    JsonRpcRequest, JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, RequestId,
 };
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
     CatchError, InjectAnnotations, McpBoxService, ServiceFactory, identity_factory,
 };
+use crate::{ProtocolSupport, ProtocolSupportError};
 use tower::util::BoxCloneService;
 
 /// SEP-2575 per-request `_meta` extraction. Pulls `StatelessRequestMeta` from
@@ -307,12 +307,6 @@ pub const MCP_NAME_HEADER: &str = "mcp-name";
 /// marked with the `x-mcp-header` JSON Schema extension. The full header
 /// name is `Mcp-Param-{Name}`.
 pub const MCP_PARAM_HEADER_PREFIX: &str = "mcp-param-";
-
-/// First MCP protocol version that mandates SEP-2243 HTTP header
-/// validation. Prior versions are treated leniently: present headers are
-/// still validated for body consistency, but missing headers are not an
-/// error.
-pub(super) const SEP_2243_MIN_PROTOCOL_VERSION: &str = "2026-07-28";
 
 /// Default maximum POST body size in bytes (4 MiB, matching rmcp).
 ///
@@ -1271,6 +1265,8 @@ enum ServiceSource {
 struct AppState {
     /// Source for creating new session services
     service_source: ServiceSource,
+    /// Exact protocol versions accepted and advertised by this transport.
+    protocol_support: ProtocolSupport,
     /// Session store
     sessions: Arc<SessionRegistry>,
     /// Whether to validate Origin header
@@ -1331,6 +1327,7 @@ pub(crate) struct OAuthConfig {
 ///   `.layer()` is not supported in this mode.
 pub struct HttpTransport {
     service_source: ServiceSource,
+    protocol_support: ProtocolSupport,
     validate_origin: bool,
     allowed_origins: Vec<String>,
     validate_host: bool,
@@ -1375,6 +1372,7 @@ impl HttpTransport {
                 router,
                 factory: identity_factory(),
             },
+            protocol_support: ProtocolSupport::default(),
             validate_origin: true,
             allowed_origins: vec![],
             validate_host: true,
@@ -1434,6 +1432,7 @@ impl HttpTransport {
             service_source: ServiceSource::Service(Arc::new(std::sync::Mutex::new(
                 BoxCloneService::new(service),
             ))),
+            protocol_support: ProtocolSupport::default(),
             validate_origin: true,
             allowed_origins: vec![],
             validate_host: true,
@@ -1584,6 +1583,32 @@ impl HttpTransport {
     pub fn require_sessions(mut self) -> Self {
         self.optional_sessions = false;
         self
+    }
+
+    /// Set the exact protocol versions this transport accepts and advertises.
+    ///
+    /// By default, every protocol implementation compiled into tower-mcp is
+    /// enabled. This setting can narrow that set per server instance. Versions
+    /// are advertised by `server/discover` in the order supplied.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.protocol_support = support;
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    ///
+    /// Returns an error when the list is empty, duplicated, or names a version
+    /// whose Cargo feature was not compiled.
+    pub fn protocol_versions<I, S>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.protocol_support = ProtocolSupport::try_new(versions)?;
+        Ok(self)
     }
 
     /// Enable SSE-wrapping for synchronous JSON-RPC responses.
@@ -1966,6 +1991,7 @@ impl HttpTransport {
 
         Arc::new(AppState {
             service_source: self.service_source.clone(),
+            protocol_support: self.protocol_support.clone(),
             sessions,
             validate_origin: self.validate_origin,
             allowed_origins: self.allowed_origins.clone(),
@@ -2406,6 +2432,7 @@ async fn handle_post(
 
         if let Some(ref version) = version_in_play
             && is_stateless_protocol_version(version)
+            && state.protocol_support.contains(version)
             && get_session_id(&headers).is_none()
             // `subscriptions/listen` opens an SSE stream; let it fall through to the
             // dedicated intercept below rather than handling it as a plain RPC call.
@@ -2476,6 +2503,7 @@ async fn handle_post(
             };
 
             let mut ext = crate::router::Extensions::new();
+            ext.insert(state.protocol_support.clone());
             #[cfg(feature = "oauth")]
             if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
                 ext.insert(claims.clone());
@@ -2536,12 +2564,9 @@ async fn handle_post(
                         }
                     };
 
-                    // For `initialize`: the router's version negotiation falls
-                    // back to `LATEST_PROTOCOL_VERSION` ("2025-11-25") because
-                    // 2026-07-28 is not yet in `SUPPORTED_PROTOCOL_VERSIONS` at
-                    // the types layer. Patch the response to reflect the version
-                    // the transport is actually serving so the client sees the
-                    // version it requested.
+                    // Keep the response aligned with the version selected for
+                    // this sessionless request. The router also receives the
+                    // runtime allow-list through Extensions.
                     if is_init
                         && let JsonRpcResponse::Result(ref mut result) = response
                         && let Some(pv) = result.result.get_mut("protocolVersion")
@@ -2627,6 +2652,7 @@ async fn handle_post(
             };
 
             let mut ext = crate::router::Extensions::new();
+            ext.insert(state.protocol_support.clone());
             #[cfg(feature = "oauth")]
             if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
                 ext.insert(claims.clone());
@@ -2754,7 +2780,7 @@ async fn handle_post(
             } else {
                 session.protocol_version.read().await.clone()
             };
-            if version_supports_subscriptions_listen(&effective_version) {
+            if version_supports_subscriptions_listen(&effective_version, &state.protocol_support) {
                 return handle_subscriptions_listen_sse(session).await;
             } else {
                 return json_rpc_error_response(
@@ -2770,14 +2796,14 @@ async fn handle_post(
     // -32022 and `{ supported, requested }` data, not a plain-text 400.
     if !is_init
         && let Some(version) = get_protocol_version(&headers)
-        && !SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
+        && !state.protocol_support.contains(&version)
     {
         let id = extract_request_id(&parsed);
         return json_rpc_error_response(
             id,
             JsonRpcError::unsupported_protocol_version(
                 version,
-                SUPPORTED_PROTOCOL_VERSIONS.iter().copied(),
+                state.protocol_support.versions().iter().map(String::as_str),
             ),
         );
     }
@@ -2933,6 +2959,7 @@ async fn handle_post(
     // skipped to avoid pointless allocation.
     #[allow(unused_mut)]
     let mut ext = crate::router::Extensions::new();
+    ext.insert(state.protocol_support.clone());
     #[cfg(feature = "oauth")]
     if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
         ext.insert(claims.clone());
@@ -2996,20 +3023,24 @@ async fn handle_post(
 /// Returns `true` when the given protocol version string enables `subscriptions/listen`.
 ///
 /// `subscriptions/listen` is part of the 2026-07-28 spec (SEP-2575 / SEP-2567).
-/// Version strings are YYYY-MM-DD dates, so lexicographic comparison is correct.
-fn version_supports_subscriptions_listen(version: &str) -> bool {
-    version >= UPCOMING_PROTOCOL_VERSION
+/// Unknown future dates do not opt into behavior that has not been compiled
+/// and explicitly enabled.
+fn version_supports_subscriptions_listen(
+    version: &str,
+    protocol_support: &ProtocolSupport,
+) -> bool {
+    version == EXPERIMENTAL_PROTOCOL_VERSION && protocol_support.contains(version)
 }
 
 /// Returns `true` when the given protocol version string enables stateless
 /// (sessionless) mode for the HTTP transport.
 ///
 /// Stateless mode is introduced in the 2026-07-28 protocol (SEP-2575 /
-/// SEP-2567). Version strings are YYYY-MM-DD; lexicographic comparison is
-/// correct for date-ordered MCP versions.
+/// SEP-2567). Only the exact, compiled-and-enabled version opts in; unknown
+/// future dates must not silently inherit experimental behavior.
 #[cfg(feature = "stateless")]
 fn is_stateless_protocol_version(version: &str) -> bool {
-    version >= UPCOMING_PROTOCOL_VERSION
+    version == EXPERIMENTAL_PROTOCOL_VERSION
 }
 
 /// Stamp `_meta["io.modelcontextprotocol/serverInfo"]` onto a successful
@@ -3646,6 +3677,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn runtime_protocol_allowlist_drives_discovery() {
+        let transport = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .protocol_versions(["2025-03-26"])
+            .unwrap();
+        let app = transport.into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "server/discover"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["result"]["supportedVersions"],
+            serde_json::json!(["2025-03-26"])
+        );
+    }
+
+    #[tokio::test]
     async fn test_oversized_body_rejected_with_413() {
         let transport = HttpTransport::new(create_test_router())
             .disable_origin_validation()
@@ -3921,15 +3986,15 @@ mod tests {
             "error data must use 'supported', not 'supportedVersions': {:?}",
             json["error"]["data"]
         );
-        // The supported set must exactly match SUPPORTED_PROTOCOL_VERSIONS --
+        // The supported set must exactly match the compiled transport default --
         // no extras, none missing.
-        let expected: Vec<serde_json::Value> = SUPPORTED_PROTOCOL_VERSIONS
+        let expected: Vec<serde_json::Value> = crate::COMPILED_PROTOCOL_VERSIONS
             .iter()
             .map(|v| serde_json::json!(v))
             .collect();
         assert_eq!(
             supported, &expected,
-            "data.supported must exactly match SUPPORTED_PROTOCOL_VERSIONS"
+            "data.supported must exactly match COMPILED_PROTOCOL_VERSIONS"
         );
     }
 
@@ -3943,17 +4008,14 @@ mod tests {
         let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
         let app = transport.into_router();
 
-        // "1999-01-01" is below UPCOMING_PROTOCOL_VERSION ("2026-07-28"), so it
-        // does not enter the version-gated stateless block. It is also not in
-        // SUPPORTED_PROTOCOL_VERSIONS, so it triggers the -32022 version check
-        // at lines ~2370-2382. No session header is sent, exercising the
-        // sessionless request path through version validation.
+        // A future-looking unknown version must not enter the experimental
+        // stateless path merely because its date sorts after 2026-07-28.
         let req = Request::builder()
             .method("POST")
             .uri("/")
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
-            .header(MCP_PROTOCOL_VERSION_HEADER, "1999-01-01")
+            .header(MCP_PROTOCOL_VERSION_HEADER, "2099-01-01")
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
@@ -3974,7 +4036,7 @@ mod tests {
             "must return UnsupportedProtocolVersion (-32022): {json}"
         );
         assert_eq!(
-            json["error"]["data"]["requested"], "1999-01-01",
+            json["error"]["data"]["requested"], "2099-01-01",
             "data.requested must echo the version: {json}"
         );
         // Field name must be `supported`, not `supportedVersions`.
@@ -3985,13 +4047,13 @@ mod tests {
         let supported = json["error"]["data"]["supported"]
             .as_array()
             .expect("data.supported must be an array");
-        let expected: Vec<serde_json::Value> = SUPPORTED_PROTOCOL_VERSIONS
+        let expected: Vec<serde_json::Value> = crate::COMPILED_PROTOCOL_VERSIONS
             .iter()
             .map(|v| serde_json::json!(v))
             .collect();
         assert_eq!(
             supported, &expected,
-            "data.supported must exactly match SUPPORTED_PROTOCOL_VERSIONS"
+            "data.supported must exactly match COMPILED_PROTOCOL_VERSIONS"
         );
     }
 

--- a/crates/tower-mcp/src/transport/http_headers.rs
+++ b/crates/tower-mcp/src/transport/http_headers.rs
@@ -78,13 +78,11 @@ pub(super) enum Sep2243Mode {
 /// Decide which validation mode applies for the negotiated protocol
 /// version.
 ///
-/// Returns [`Sep2243Mode::Strict`] when `version` is at or beyond the
-/// SEP-2243 inclusion version, [`Sep2243Mode::Lenient`] otherwise.
-///
-/// Version strings are compared lexicographically. The MCP version
-/// format is `YYYY-MM-DD`, which sorts correctly under lexical compare.
+/// Returns [`Sep2243Mode::Strict`] for the explicitly implemented 2026-07-28
+/// protocol, [`Sep2243Mode::Lenient`] otherwise. Unsupported future versions
+/// must not silently inherit experimental behavior based on date ordering.
 pub(super) fn mode_for_version(version: &str) -> Sep2243Mode {
-    if version >= super::http::SEP_2243_MIN_PROTOCOL_VERSION {
+    if version == crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
         Sep2243Mode::Strict
     } else {
         Sep2243Mode::Lenient
@@ -371,9 +369,9 @@ mod tests {
     }
 
     #[test]
-    fn mode_strict_at_or_after_2026_07_28() {
+    fn mode_is_exactly_gated_on_2026_07_28() {
         assert_eq!(mode_for_version("2026-07-28"), Sep2243Mode::Strict);
-        assert_eq!(mode_for_version("2027-01-01"), Sep2243Mode::Strict);
+        assert_eq!(mode_for_version("2027-01-01"), Sep2243Mode::Lenient);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- distinguish protocol versions known by the types crate, compiled into `tower-mcp`, and enabled on an individual runtime
- replace the pre-release `UPCOMING_PROTOCOL_VERSION` name with `EXPERIMENTAL_PROTOCOL_VERSION` while retaining a deprecated source-compatible alias
- add the positive `protocol-2026-07-28` Cargo feature and retain `stateless` as a compatibility feature
- add `ProtocolSupport`, `COMPILED_PROTOCOL_VERSIONS`, and exact per-HTTP-transport version allow-lists
- use the runtime set consistently for initialization, `server/discover`, unsupported-version errors, and `subscriptions/listen`
- reject unknown future date strings instead of silently granting 2026 behavior

This is the first implementation slice of #929. Client lifecycle integration and the final promotion gates remain tracked there.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- default-build and `protocol-2026-07-28` focused policy/HTTP tests

Refs #929