### PR TITLE
feat(server): implement final HTTP lifecycle

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -90,7 +90,7 @@ jobs:
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: server/discover" \
-            -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}' \
+            -d '{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}' \
             -D /tmp/discover-headers.txt \
             -o /tmp/discover-body.json
           response=$(cat /tmp/discover-body.json)
@@ -111,17 +111,20 @@ jobs:
           fi
           echo "PASS: server/discover response does not include mcp-session-id header"
 
-      - name: Check stateless tools/call without _meta (#862)
+      - name: Check final request without _meta is rejected (#952)
         run: |
-          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+          http_status=$(curl -s -o /tmp/missing-meta.json -w "%{http_code}" \
+            -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: tools/call" \
             -H "Mcp-Name: test_simple_text" \
             -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"test_simple_text","arguments":{}}}')
+          response=$(cat /tmp/missing-meta.json)
           echo "stateless tools/call response: $response"
-          echo "$response" | grep -q '"result"' || { echo "FAIL: no result field"; exit 1; }
-          echo "PASS: stateless tools/call succeeded"
+          test "$http_status" = "400" || { echo "FAIL: expected HTTP 400, got $http_status"; exit 1; }
+          echo "$response" | grep -q -- '-32602' || { echo "FAIL: expected InvalidParams (-32602)"; exit 1; }
+          echo "PASS: missing final request metadata rejected"
 
       - name: Check test_per_request_meta with _meta block (#870)
         run: |
@@ -147,88 +150,40 @@ jobs:
           echo "$response" | grep -q 'test-client' || { echo "FAIL: client_name not reflected"; exit 1; }
           echo "PASS: per-request _meta threaded to handler"
 
-      - name: Check test_per_request_meta without _meta returns no meta (#870)
+      - name: Check test_per_request_meta without _meta is rejected (#952)
         run: |
-          response=$(curl -s -X POST http://127.0.0.1:3001/mcp \
+          http_status=$(curl -s -o /tmp/no-meta.json -w "%{http_code}" \
+            -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: tools/call" \
             -H "Mcp-Name: test_per_request_meta" \
             -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"test_per_request_meta","arguments":{}}}')
+          response=$(cat /tmp/no-meta.json)
           echo "no-meta response: $response"
-          echo "$response" | grep -q '"no meta"' || { echo "FAIL: expected 'no meta' text"; exit 1; }
-          echo "PASS: absent _meta returns 'no meta'"
+          test "$http_status" = "400" || { echo "FAIL: expected HTTP 400, got $http_status"; exit 1; }
+          echo "$response" | grep -q -- '-32602' || { echo "FAIL: expected InvalidParams (-32602)"; exit 1; }
+          echo "PASS: absent required _meta is rejected"
 
       - name: Check subscriptions/listen opens SSE stream with 2026-07-28 (#868)
         run: |
-          # Step 1: establish a 2025-11-25 session to get an mcp-session-id.
-          # (2026-07-28 initialize is stateless and returns no session ID.)
-          curl -s -X POST http://127.0.0.1:3001/mcp \
-            -H "Content-Type: application/json" \
-            -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","clientInfo":{"name":"ci-test","version":"1.0"},"capabilities":{}}}' \
-            -D /tmp/init-headers.txt \
-            -o /tmp/init-body.json
-          session_id=$(grep -i "mcp-session-id" /tmp/init-headers.txt | awk '{print $2}' | tr -d '\r')
-          echo "Session ID: $session_id"
-          if [ -z "$session_id" ]; then
-            echo "FAIL: no mcp-session-id in initialize response"
-            cat /tmp/init-headers.txt
-            exit 1
-          fi
-
-          # Step 1b: send notifications/initialized to complete the handshake.
-          # The server enforces this before accepting tool/resource requests.
-          curl -s -X POST http://127.0.0.1:3001/mcp \
-            -H "Content-Type: application/json" \
-            -H "mcp-session-id: $session_id" \
-            -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' \
-            -o /dev/null
-
-          # Step 2: open subscriptions/listen SSE stream in the background, capture output.
-          # Sending MCP-Protocol-Version: 2026-07-28 on the request overrides the
-          # session's negotiated version and enables the SSE stream.
-          curl -s --max-time 5 \
+          # The final stream is sessionless. Capture the first SSE frame; curl
+          # times out because the subscription intentionally remains open.
+          curl -sN --max-time 2 \
             -X POST http://127.0.0.1:3001/mcp \
             -H "Content-Type: application/json" \
             -H "MCP-Protocol-Version: 2026-07-28" \
             -H "Mcp-Method: subscriptions/listen" \
             -H "Accept: text/event-stream" \
-            -H "mcp-session-id: $session_id" \
-            -d '{"jsonrpc":"2.0","id":5,"method":"subscriptions/listen","params":{}}' \
-            -o /tmp/sse-stream.txt &
-          SSE_PID=$!
-          sleep 1
-
-          # Step 3: confirm SSE stream content-type (via a parallel content-type probe).
-          content_type=$(curl -s -o /dev/null -w "%{content_type}" \
-            --max-time 3 \
-            -X POST http://127.0.0.1:3001/mcp \
-            -H "Content-Type: application/json" \
-            -H "MCP-Protocol-Version: 2026-07-28" \
-            -H "Mcp-Method: subscriptions/listen" \
-            -H "Accept: text/event-stream" \
-            -d '{"jsonrpc":"2.0","id":6,"method":"subscriptions/listen","params":{}}' || true)
-          echo "subscriptions/listen Content-Type: $content_type"
-          echo "$content_type" | grep -q "text/event-stream" || { echo "FAIL: expected text/event-stream"; kill $SSE_PID 2>/dev/null; exit 1; }
-          echo "PASS: subscriptions/listen returns SSE stream for 2026-07-28"
-
-          # Step 4: trigger log notifications on the established session.
-          # test_tool_with_logging sends three log notifications via ctx.send_log().
-          curl -s -X POST http://127.0.0.1:3001/mcp \
-            -H "Content-Type: application/json" \
-            -H "Mcp-Method: tools/call" \
-            -H "Mcp-Name: test_tool_with_logging" \
-            -H "mcp-session-id: $session_id" \
-            -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"test_tool_with_logging","arguments":{}}}' \
-            -o /dev/null
-          sleep 1
-
-          # Step 5: verify at least one SSE data line arrived.
-          kill $SSE_PID 2>/dev/null || true
+            -d '{"jsonrpc":"2.0","id":5,"method":"subscriptions/listen","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"notifications":{"toolsListChanged":true}}}' \
+            -D /tmp/sse-headers.txt \
+            -o /tmp/sse-stream.txt || true
+          grep -qi "content-type: text/event-stream" /tmp/sse-headers.txt || { echo "FAIL: expected text/event-stream"; exit 1; }
           echo "SSE stream output:"
           cat /tmp/sse-stream.txt
-          grep -q "^data:" /tmp/sse-stream.txt || { echo "FAIL: no data: lines in SSE stream"; exit 1; }
-          echo "PASS: notification event appeared in subscriptions/listen SSE stream"
+          grep -q '"notifications/subscriptions/acknowledged"' /tmp/sse-stream.txt || { echo "FAIL: missing acknowledgment"; exit 1; }
+          grep -q '"io.modelcontextprotocol/subscriptionId":5' /tmp/sse-stream.txt || { echo "FAIL: missing subscription ID"; exit 1; }
+          echo "PASS: subscriptions/listen returned its tagged acknowledgment"
 
       - name: Check subscriptions/listen returns JSON-RPC error without 2026-07-28 (#868)
         run: |

--- a/conformance-baseline-draft.yml
+++ b/conformance-baseline-draft.yml
@@ -7,11 +7,10 @@
 # Remove entries as the phases land; CI fails when a baselined scenario
 # starts passing (stale entry) or a non-baselined scenario fails.
 #
-# Status at 0.2.0-alpha.10 (2026-07-28, re-baselined after the 2026-07-28
-# protocol finalization): 67/101 checks pass, unchanged from alpha.9's
-# 66/102 modulo the harness dropping one check between versions. No
-# regressions from finalization; the failing scenario set is identical to
-# alpha.9's. Note that input-required-result-missing-input-response and
+# Status at 0.2.0-alpha.10 after the final HTTP lifecycle/listen work in
+# #952: 92/104 checks pass; the server-stateless scenario passes all 30
+# checks and is no longer baselined. Note that
+# input-required-result-missing-input-response and
 # input-required-result-ignore-extra-params report "0 passed, 0 failed" in
 # the summary (they run no checks pending MRTR fixture tools) but the
 # harness's expected-failures gate still counts a zero-check scenario as an
@@ -22,14 +21,6 @@
 # `client:` keys; reasons live in these comments.
 
 server:
-  # SEP-2575/2567 stateless core gaps (4/28 checks pass): required
-  # per-request _meta validation (-32602 + HTTP 400), HTTP status mapping
-  # (400/404 for version/header/capability/method errors), per-request
-  # capability gating (-32021), subscriptions/listen
-  # acknowledgment/subscriptionId/filter semantics.
-  # Types work in #949; transport and listen semantics in #952.
-  - server-stateless
-
   # SEP-2243 (7/9 checks pass): the two failures need schema-aware rejection
   # when an x-mcp-header-annotated argument is present in the body but its
   # Mcp-Param-* header is missing; the transport does not yet consult tool

--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -44,6 +44,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::protocol::ClientCapabilities;
+
 /// Type-erased error type used for middleware composition.
 ///
 /// This is the standard error type in the tower ecosystem, used by
@@ -317,6 +319,28 @@ impl JsonRpcError {
         Self::mcp_error(McpErrorCode::HeaderMismatch, message)
     }
 
+    /// SEP-2575: the client did not advertise capabilities required to
+    /// service the request.
+    ///
+    /// The error data identifies the missing capability shape:
+    ///
+    /// ```text
+    /// data: { requiredCapabilities: { ... } }
+    /// ```
+    pub fn missing_required_client_capability(required_capabilities: ClientCapabilities) -> Self {
+        let data = MissingRequiredClientCapabilityData {
+            required_capabilities,
+        };
+        Self {
+            code: McpErrorCode::MissingRequiredClientCapability.code(),
+            message: "Client is missing a capability required by this request".to_string(),
+            data: Some(
+                serde_json::to_value(&data)
+                    .expect("MissingRequiredClientCapabilityData is serializable"),
+            ),
+        }
+    }
+
     /// SEP-2575: server does not support the protocol version the client
     /// requested. The error data carries both the AS-supported versions
     /// and the version the client asked for, matching the spec shape:
@@ -345,6 +369,14 @@ impl JsonRpcError {
             ),
         }
     }
+}
+
+/// SEP-2575 error data for `MissingRequiredClientCapability` (-32021).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MissingRequiredClientCapabilityData {
+    /// The client capability shape required to service the request.
+    pub required_capabilities: ClientCapabilities,
 }
 
 /// SEP-2575 error data for `UnsupportedProtocolVersion` (-32022).
@@ -648,6 +680,28 @@ mod tests {
         let parsed: UnsupportedProtocolVersionData = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(parsed.supported, original.supported);
         assert_eq!(parsed.requested, original.requested);
+    }
+
+    #[test]
+    fn missing_required_client_capability_has_spec_shape() {
+        let required = ClientCapabilities {
+            sampling: Some(Default::default()),
+            ..Default::default()
+        };
+        let err = JsonRpcError::missing_required_client_capability(required);
+        assert_eq!(
+            err.code,
+            McpErrorCode::MissingRequiredClientCapability.code()
+        );
+        let data = err.data.expect("data must be present");
+        assert_eq!(
+            data,
+            serde_json::json!({
+                "requiredCapabilities": {
+                    "sampling": {}
+                }
+            })
+        );
     }
 
     // =========================================================================

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -113,6 +113,7 @@ pub mod testing;
 
 // Convenience re-exports
 pub use error::{
-    BoxError, Error, ErrorCode, JsonRpcError, McpErrorCode, Result, ResultExt, ToolError,
+    BoxError, Error, ErrorCode, JsonRpcError, McpErrorCode, MissingRequiredClientCapabilityData,
+    Result, ResultExt, ToolError,
 };
 pub use protocol::{CallToolResult, Content, GetPromptResult, ReadResourceResult};

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -610,6 +610,36 @@ impl RequestContext {
         let _ = tx.try_send(ServerNotification::Progress(params));
     }
 
+    /// Notify subscribed clients that the tool list changed.
+    pub fn notify_tools_list_changed(&self) -> bool {
+        self.notification_tx
+            .as_ref()
+            .is_some_and(|tx| tx.try_send(ServerNotification::ToolsListChanged).is_ok())
+    }
+
+    /// Notify subscribed clients that the prompt list changed.
+    pub fn notify_prompts_list_changed(&self) -> bool {
+        self.notification_tx
+            .as_ref()
+            .is_some_and(|tx| tx.try_send(ServerNotification::PromptsListChanged).is_ok())
+    }
+
+    /// Notify subscribed clients that the resource list changed.
+    pub fn notify_resources_list_changed(&self) -> bool {
+        self.notification_tx.as_ref().is_some_and(|tx| {
+            tx.try_send(ServerNotification::ResourcesListChanged)
+                .is_ok()
+        })
+    }
+
+    /// Notify subscribed clients that one resource changed.
+    pub fn notify_resource_updated(&self, uri: impl Into<String>) -> bool {
+        self.notification_tx.as_ref().is_some_and(|tx| {
+            tx.try_send(ServerNotification::ResourceUpdated { uri: uri.into() })
+                .is_ok()
+        })
+    }
+
     /// Send a log message notification to the client
     ///
     /// This is a no-op if no notification sender is configured.
@@ -630,6 +660,33 @@ impl RequestContext {
         let Some(tx) = &self.notification_tx else {
             return;
         };
+
+        // The final protocol removed logging/setLevel. Log delivery is instead
+        // authorized per request: no logLevel means no log notifications.
+        #[cfg(feature = "stateless")]
+        if let Some(meta) = self.per_request_meta()
+            && meta.protocol_version.as_deref()
+                == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        {
+            let Some(request_level) = meta.log_level else {
+                return;
+            };
+            let request_level = match request_level {
+                crate::stateless::LogLevel::Debug => LogLevel::Debug,
+                crate::stateless::LogLevel::Info => LogLevel::Info,
+                crate::stateless::LogLevel::Notice => LogLevel::Notice,
+                crate::stateless::LogLevel::Warning => LogLevel::Warning,
+                crate::stateless::LogLevel::Error => LogLevel::Error,
+                crate::stateless::LogLevel::Critical => LogLevel::Critical,
+                crate::stateless::LogLevel::Alert => LogLevel::Alert,
+                crate::stateless::LogLevel::Emergency => LogLevel::Emergency,
+            };
+            if params.level > request_level {
+                return;
+            }
+            let _ = tx.try_send(ServerNotification::LogMessage(params));
+            return;
+        }
 
         // Filter by minimum log level set via logging/setLevel
         // LogLevel derives Ord with Emergency < Alert < ... < Debug,
@@ -1305,6 +1362,50 @@ mod tests {
             rx.try_recv().is_ok(),
             "Debug should pass when no min level is set"
         );
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn final_request_log_level_is_required_and_filters_per_request() {
+        let (tx, mut rx) = notification_channel(10);
+        let mut extensions = Extensions::new();
+        extensions.insert(crate::stateless::StatelessRequestMeta {
+            protocol_version: Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            client_capabilities: Some(Default::default()),
+            ..Default::default()
+        });
+        let ctx = RequestContext::new(RequestId::Number(1))
+            .with_notification_sender(tx.clone())
+            .with_extensions(Arc::new(extensions));
+        ctx.send_log(LoggingMessageParams::new(
+            LogLevel::Emergency,
+            serde_json::Value::Null,
+        ));
+        assert!(
+            rx.try_recv().is_err(),
+            "final requests without logLevel must receive no logs"
+        );
+
+        let mut extensions = Extensions::new();
+        extensions.insert(crate::stateless::StatelessRequestMeta {
+            protocol_version: Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            client_capabilities: Some(Default::default()),
+            log_level: Some(crate::stateless::LogLevel::Warning),
+            ..Default::default()
+        });
+        let ctx = RequestContext::new(RequestId::Number(2))
+            .with_notification_sender(tx)
+            .with_extensions(Arc::new(extensions));
+        ctx.send_log(LoggingMessageParams::new(
+            LogLevel::Info,
+            serde_json::Value::Null,
+        ));
+        assert!(rx.try_recv().is_err(), "Info must be filtered at Warning");
+        ctx.send_log(LoggingMessageParams::new(
+            LogLevel::Error,
+            serde_json::Value::Null,
+        ));
+        assert!(rx.try_recv().is_ok(), "Error must pass at Warning");
     }
 
     fn make_task_object(id: &str, status: TaskStatus) -> serde_json::Value {

--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -1061,6 +1061,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            required_client_capabilities: None,
             service,
             input_schema: self.input_schema,
         }
@@ -1185,6 +1186,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            required_client_capabilities: None,
             service,
             input_schema: self.input_schema,
         }
@@ -1289,6 +1291,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            required_client_capabilities: None,
             service,
             input_schema,
         }

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -65,6 +65,32 @@ fn task_store_error(e: TaskStoreError) -> Error {
     )))
 }
 
+/// Return whether `actual` contains every field and value in `required`.
+///
+/// Client capability objects are extensible, so extra advertised properties
+/// must not cause a required-capability check to fail.
+#[cfg(feature = "stateless")]
+fn json_value_contains(actual: &serde_json::Value, required: &serde_json::Value) -> bool {
+    match (actual, required) {
+        (serde_json::Value::Object(actual), serde_json::Value::Object(required)) => {
+            required.iter().all(|(key, value)| {
+                actual
+                    .get(key)
+                    .is_some_and(|a| json_value_contains(a, value))
+            })
+        }
+        _ => actual == required,
+    }
+}
+
+#[cfg(feature = "stateless")]
+fn client_capabilities_satisfy(actual: &ClientCapabilities, required: &ClientCapabilities) -> bool {
+    let actual = serde_json::to_value(actual).expect("ClientCapabilities is always serializable");
+    let required =
+        serde_json::to_value(required).expect("ClientCapabilities is always serializable");
+    json_value_contains(&actual, &required)
+}
+
 /// Apply pagination to a collected list of items.
 ///
 /// Returns the page of items and an optional `next_cursor`.
@@ -2030,6 +2056,24 @@ impl McpRouter {
                         "tool call completed"
                     );
                     return Err(filter.denial_error(&params.name));
+                }
+
+                // Final 2026-07-28 requests declare client capabilities on
+                // every request. Reject a tool before any handler work begins
+                // when its declared requirement is not present.
+                #[cfg(feature = "stateless")]
+                if let Some(required) = tool.required_client_capabilities()
+                    && let Some(meta) = extensions.get::<crate::stateless::StatelessRequestMeta>()
+                    && meta.protocol_version.as_deref()
+                        == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+                    && !meta
+                        .client_capabilities
+                        .as_ref()
+                        .is_some_and(|actual| client_capabilities_satisfy(actual, required))
+                {
+                    return Err(Error::JsonRpc(
+                        JsonRpcError::missing_required_client_capability(required.clone()),
+                    ));
                 }
 
                 if let Some(task_params) = params.task {

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -50,7 +50,8 @@ use tower_service::Service;
 use crate::context::RequestContext;
 use crate::error::{Error, Result, ResultExt};
 use crate::protocol::{
-    CallToolResult, TaskSupportMode, ToolAnnotations, ToolDefinition, ToolExecution, ToolIcon,
+    CallToolResult, ClientCapabilities, TaskSupportMode, ToolAnnotations, ToolDefinition,
+    ToolExecution, ToolIcon,
 };
 
 // =============================================================================
@@ -488,6 +489,9 @@ pub struct Tool {
     pub annotations: Option<ToolAnnotations>,
     /// Task support mode for this tool
     pub task_support: TaskSupportMode,
+    /// Client capabilities required to invoke this tool in the modern
+    /// per-request protocol.
+    pub(crate) required_client_capabilities: Option<ClientCapabilities>,
     /// The boxed service that executes the tool
     pub(crate) service: BoxToolService,
     /// JSON Schema for the tool's input
@@ -504,6 +508,10 @@ impl std::fmt::Debug for Tool {
             .field("icons", &self.icons)
             .field("annotations", &self.annotations)
             .field("task_support", &self.task_support)
+            .field(
+                "required_client_capabilities",
+                &self.required_client_capabilities,
+            )
             .finish_non_exhaustive()
     }
 }
@@ -523,6 +531,7 @@ impl Clone for Tool {
             icons: self.icons.clone(),
             annotations: self.annotations.clone(),
             task_support: self.task_support,
+            required_client_capabilities: self.required_client_capabilities.clone(),
             service: self.service.clone(),
             input_schema: self.input_schema.clone(),
         }
@@ -587,6 +596,23 @@ impl Tool {
             // Service is Infallible, so unwrap is safe
             service.oneshot(ToolRequest::new(ctx, args)).await.unwrap()
         })
+    }
+
+    /// Require the given client capability shape before this tool may be
+    /// invoked using the modern per-request protocol.
+    ///
+    /// Required objects are matched recursively. For example, requiring
+    /// `ClientCapabilities { sampling: Some(Default::default()), .. }`
+    /// accepts any advertised `sampling` capability, including one with
+    /// additional optional fields.
+    pub fn require_client_capabilities(mut self, required: ClientCapabilities) -> Self {
+        self.required_client_capabilities = Some(required);
+        self
+    }
+
+    /// Return the client capability shape required by this tool, if any.
+    pub fn required_client_capabilities(&self) -> Option<&ClientCapabilities> {
+        self.required_client_capabilities.as_ref()
     }
 
     /// Apply a guard to this built tool.
@@ -667,6 +693,7 @@ impl Tool {
             icons: self.icons.clone(),
             annotations: self.annotations.clone(),
             task_support: self.task_support,
+            required_client_capabilities: self.required_client_capabilities.clone(),
             service: self.service.clone(),
             input_schema: self.input_schema.clone(),
         }
@@ -699,6 +726,7 @@ impl Tool {
             icons,
             annotations,
             task_support,
+            required_client_capabilities: None,
             service,
             input_schema,
         }
@@ -1402,6 +1430,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            required_client_capabilities: None,
             service,
             input_schema,
         }
@@ -1575,6 +1604,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            required_client_capabilities: None,
             service,
             input_schema,
         }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -251,21 +251,29 @@ use axum::{
     response::{IntoResponse, Response, Sse, sse::Event},
     routing::{delete, get, post},
 };
+#[cfg(feature = "stateless")]
+use tokio::sync::mpsc;
 use tokio::sync::{Mutex, RwLock, broadcast, oneshot};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
+#[cfg(feature = "stateless")]
+use crate::context::ServerNotification;
 use crate::context::{
     ChannelClientRequester, ClientRequesterHandle, NotificationReceiver, OutgoingRequestReceiver,
     notification_channel, outgoing_request_channel,
 };
 use crate::error::{Error, JsonRpcError, Result};
+#[cfg(feature = "stateless")]
+use crate::error::{ErrorCode, McpErrorCode};
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{
     ClientCapabilities, EXPERIMENTAL_PROTOCOL_VERSION, Implementation, JsonRpcNotification,
     JsonRpcRequest, JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, RequestId,
     ResultType,
 };
+#[cfg(feature = "stateless")]
+use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
     CatchError, InjectAnnotations, McpBoxService, ServiceFactory, identity_factory,
@@ -1292,10 +1300,144 @@ struct AppState {
     /// responses (see [`HttpTransport::stamp_server_info()`]).
     #[cfg(feature = "stateless")]
     stamp_server_info: bool,
+    /// Active final-protocol `subscriptions/listen` streams.
+    #[cfg(feature = "stateless")]
+    modern_subscriptions: Arc<ModernSubscriptionRegistry>,
     /// Whether to wrap synchronous responses in SSE format (rmcp compat)
     sse_responses: bool,
     /// Maximum accepted POST body size in bytes
     max_body_size: usize,
+}
+
+#[cfg(feature = "stateless")]
+struct ModernSubscription {
+    subscription_id: RequestId,
+    filter: SubscriptionFilter,
+    tx: mpsc::UnboundedSender<String>,
+}
+
+/// Process-local registry for sessionless final-protocol subscriptions.
+///
+/// The 2026-07-28 transport deliberately has no session or replay state.
+/// Each listen POST owns one sender, removed when its response stream drops.
+#[cfg(feature = "stateless")]
+#[derive(Default)]
+struct ModernSubscriptionRegistry {
+    next_key: AtomicU64,
+    subscriptions: std::sync::Mutex<HashMap<u64, ModernSubscription>>,
+}
+
+#[cfg(feature = "stateless")]
+impl ModernSubscriptionRegistry {
+    fn register(
+        self: &Arc<Self>,
+        subscription_id: RequestId,
+        filter: SubscriptionFilter,
+    ) -> (mpsc::UnboundedReceiver<String>, ModernSubscriptionGuard) {
+        let key = self.next_key.fetch_add(1, Ordering::Relaxed);
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.subscriptions.lock().unwrap().insert(
+            key,
+            ModernSubscription {
+                subscription_id,
+                filter,
+                tx,
+            },
+        );
+        (
+            rx,
+            ModernSubscriptionGuard {
+                key,
+                registry: self.clone(),
+            },
+        )
+    }
+
+    /// Route subscription-scoped notifications and return whether the
+    /// notification belongs exclusively on listen streams.
+    fn publish(&self, notification: &ServerNotification) -> bool {
+        let subscription_scoped = matches!(
+            notification,
+            ServerNotification::ResourceUpdated { .. }
+                | ServerNotification::ResourcesListChanged
+                | ServerNotification::ToolsListChanged
+                | ServerNotification::PromptsListChanged
+        );
+        if !subscription_scoped {
+            return false;
+        }
+
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+        tracing::trace!(
+            active_subscriptions = subscriptions.len(),
+            notification = ?notification,
+            "Routing final-protocol subscription notification"
+        );
+        subscriptions.retain(|_, subscription| {
+            if subscription_matches(notification, &subscription.filter)
+                && let Some(json) =
+                    tagged_subscription_notification(notification, &subscription.subscription_id)
+            {
+                return subscription.tx.send(json).is_ok();
+            }
+            !subscription.tx.is_closed()
+        });
+        true
+    }
+}
+
+#[cfg(feature = "stateless")]
+struct ModernSubscriptionGuard {
+    key: u64,
+    registry: Arc<ModernSubscriptionRegistry>,
+}
+
+#[cfg(feature = "stateless")]
+impl Drop for ModernSubscriptionGuard {
+    fn drop(&mut self) {
+        self.registry
+            .subscriptions
+            .lock()
+            .unwrap()
+            .remove(&self.key);
+    }
+}
+
+#[cfg(feature = "stateless")]
+fn subscription_matches(notification: &ServerNotification, filter: &SubscriptionFilter) -> bool {
+    match notification {
+        ServerNotification::ToolsListChanged => filter.tools_list_changed == Some(true),
+        ServerNotification::PromptsListChanged => filter.prompts_list_changed == Some(true),
+        ServerNotification::ResourcesListChanged => filter.resources_list_changed == Some(true),
+        ServerNotification::ResourceUpdated { uri } => filter
+            .resource_subscriptions
+            .as_ref()
+            .is_some_and(|subscriptions| subscriptions.iter().any(|item| item == uri)),
+        _ => false,
+    }
+}
+
+#[cfg(feature = "stateless")]
+fn tagged_subscription_notification(
+    notification: &ServerNotification,
+    subscription_id: &RequestId,
+) -> Option<String> {
+    let json = crate::transport::stdio::serialize_notification(notification)?;
+    let mut value: serde_json::Value = serde_json::from_str(&json).ok()?;
+    let object = value.as_object_mut()?;
+    let params = object
+        .entry("params")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()?;
+    let meta = params
+        .entry("_meta")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()?;
+    meta.insert(
+        "io.modelcontextprotocol/subscriptionId".to_string(),
+        serde_json::to_value(subscription_id).ok()?,
+    );
+    serde_json::to_string(&value).ok()
 }
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
@@ -1971,12 +2113,39 @@ impl HttpTransport {
     }
 
     fn build_state(&self) -> Arc<AppState> {
+        #[cfg(feature = "stateless")]
+        let modern_subscriptions = Arc::new(ModernSubscriptionRegistry::default());
+
+        // Keep one transport-lifetime notification sender registered with
+        // dynamic registries. Per-request senders intentionally are not
+        // registered, but dynamic mutations still need a stable path to all
+        // active final-protocol listen streams.
+        #[cfg(feature = "stateless")]
+        let service_source = match &self.service_source {
+            ServiceSource::Router { router, factory } => {
+                let (tx, mut rx) = notification_channel(256);
+                let subscriptions = modern_subscriptions.clone();
+                tokio::spawn(async move {
+                    while let Some(notification) = rx.recv().await {
+                        subscriptions.publish(&notification);
+                    }
+                });
+                ServiceSource::Router {
+                    router: router.clone().with_notification_sender(tx),
+                    factory: factory.clone(),
+                }
+            }
+            ServiceSource::Service(service) => ServiceSource::Service(service.clone()),
+        };
+        #[cfg(not(feature = "stateless"))]
+        let service_source = self.service_source.clone();
+
         let sessions = Arc::new(SessionRegistry::new(
             self.session_config.clone(),
             self.sampling_enabled,
             self.session_store.clone(),
             self.event_store.clone(),
-            self.service_source.clone(),
+            service_source.clone(),
             self.auto_reinit_sessions,
         ));
 
@@ -1991,7 +2160,7 @@ impl HttpTransport {
         });
 
         Arc::new(AppState {
-            service_source: self.service_source.clone(),
+            service_source,
             protocol_support: self.protocol_support.clone(),
             sessions,
             validate_origin: self.validate_origin,
@@ -2005,6 +2174,8 @@ impl HttpTransport {
             stateless_config: self.stateless_config.clone(),
             #[cfg(feature = "stateless")]
             stamp_server_info: self.stamp_server_info,
+            #[cfg(feature = "stateless")]
+            modern_subscriptions,
             sse_responses: self.sse_responses,
             max_body_size: self.max_body_size,
         })
@@ -2035,7 +2206,12 @@ impl HttpTransport {
             store: state.sessions.clone(),
         };
 
-        spawn_external_notification_fanout(external_rx, state.sessions.clone());
+        spawn_external_notification_fanout(
+            external_rx,
+            state.sessions.clone(),
+            #[cfg(feature = "stateless")]
+            state.modern_subscriptions.clone(),
+        );
 
         let router = Router::new()
             .route("/", post(handle_post))
@@ -2065,7 +2241,12 @@ impl HttpTransport {
             store: state.sessions.clone(),
         };
 
-        spawn_external_notification_fanout(external_rx, state.sessions.clone());
+        spawn_external_notification_fanout(
+            external_rx,
+            state.sessions.clone(),
+            #[cfg(feature = "stateless")]
+            state.modern_subscriptions.clone(),
+        );
 
         let mcp_router = Router::new()
             .route("/", post(handle_post))
@@ -2136,12 +2317,15 @@ impl HttpTransport {
 fn spawn_external_notification_fanout(
     rx: Option<NotificationReceiver>,
     sessions: Arc<SessionRegistry>,
+    #[cfg(feature = "stateless")] modern_subscriptions: Arc<ModernSubscriptionRegistry>,
 ) {
     let Some(mut rx) = rx else {
         return;
     };
     tokio::spawn(async move {
         while let Some(notification) = rx.recv().await {
+            #[cfg(feature = "stateless")]
+            modern_subscriptions.publish(&notification);
             if let Some(json) = crate::transport::stdio::serialize_notification(&notification) {
                 sessions.broadcast_to_all(&json).await;
             }
@@ -2318,6 +2502,95 @@ fn is_response(parsed: &serde_json::Value) -> bool {
         && (parsed.get("result").is_some() || parsed.get("error").is_some())
 }
 
+/// Return whether an HTTP request claims the modern, per-request-metadata
+/// protocol era.
+///
+/// The body envelope is authoritative for era detection. The final-version
+/// header is also treated as a modern claim so a missing or malformed
+/// envelope receives the specified modern error instead of drifting into the
+/// legacy session path.
+fn claims_modern_protocol(headers: &HeaderMap, parsed: &serde_json::Value) -> bool {
+    get_protocol_version(headers).as_deref() == Some(EXPERIMENTAL_PROTOCOL_VERSION)
+        || parsed
+            .get("params")
+            .and_then(serde_json::Value::as_object)
+            .and_then(|params| params.get("_meta"))
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|meta| meta.contains_key("io.modelcontextprotocol/protocolVersion"))
+}
+
+/// Validate the required modern per-request metadata and return its declared
+/// protocol version.
+///
+/// `clientInfo` is deliberately optional in the final specification.
+fn validate_modern_request_meta(
+    parsed: &serde_json::Value,
+) -> std::result::Result<String, JsonRpcError> {
+    let params = parsed
+        .get("params")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| {
+            JsonRpcError::invalid_params("Modern requests require a params object containing _meta")
+        })?;
+    let meta = params
+        .get("_meta")
+        .and_then(serde_json::Value::as_object)
+        .ok_or_else(|| JsonRpcError::invalid_params("Modern requests require a _meta object"))?;
+    let protocol_version = meta
+        .get("io.modelcontextprotocol/protocolVersion")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            JsonRpcError::invalid_params(
+                "Missing or invalid _meta.io.modelcontextprotocol/protocolVersion",
+            )
+        })?;
+    let client_capabilities = meta
+        .get("io.modelcontextprotocol/clientCapabilities")
+        .ok_or_else(|| {
+            JsonRpcError::invalid_params("Missing _meta.io.modelcontextprotocol/clientCapabilities")
+        })?;
+    if !client_capabilities.is_object()
+        || serde_json::from_value::<ClientCapabilities>(client_capabilities.clone()).is_err()
+    {
+        return Err(JsonRpcError::invalid_params(
+            "Invalid _meta.io.modelcontextprotocol/clientCapabilities",
+        ));
+    }
+
+    Ok(protocol_version.to_string())
+}
+
+/// Methods present in legacy protocol unions but removed from the modern core.
+fn is_removed_modern_method(method: &str) -> bool {
+    matches!(
+        method,
+        "initialize"
+            | "notifications/initialized"
+            | "ping"
+            | "logging/setLevel"
+            | "resources/subscribe"
+            | "resources/unsubscribe"
+            | "notifications/roots/list_changed"
+    )
+}
+
+/// Map protocol errors whose final Streamable HTTP binding assigns a
+/// non-success status. Errors emitted after an SSE stream has opened remain
+/// in-band because the HTTP status is already committed.
+#[cfg(feature = "stateless")]
+fn modern_response_status(response: &JsonRpcResponse) -> StatusCode {
+    let JsonRpcResponse::Error(error) = response else {
+        return StatusCode::OK;
+    };
+    if error.error.code == ErrorCode::MethodNotFound as i32 {
+        StatusCode::NOT_FOUND
+    } else if error.error.code == McpErrorCode::MissingRequiredClientCapability.code() {
+        StatusCode::BAD_REQUEST
+    } else {
+        StatusCode::OK
+    }
+}
+
 /// Extract request ID from a JSON value
 fn extract_request_id(parsed: &serde_json::Value) -> Option<RequestId> {
     parsed.get("id").and_then(|id| {
@@ -2407,6 +2680,70 @@ async fn handle_post(
         .and_then(|method| method.as_str())
         .unwrap_or_default()
         .to_string();
+    let modern_request = claims_modern_protocol(&headers, &parsed);
+
+    // The modern protocol is selected by its per-request `_meta` envelope,
+    // with the final-version HTTP header also acting as a signal for malformed
+    // requests whose envelope is missing. Resolve that era before consulting
+    // any legacy session state so modern traffic cannot accidentally fall
+    // through to the initialize/session lifecycle.
+    if modern_request {
+        let id = extract_request_id(&parsed);
+        let body_version = match validate_modern_request_meta(&parsed) {
+            Ok(version) => version,
+            Err(error) => {
+                return json_rpc_error_response_with_status(id, error, StatusCode::BAD_REQUEST);
+            }
+        };
+
+        let Some(header_version) = get_protocol_version(&headers) else {
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::header_mismatch("MCP-Protocol-Version header is required"),
+                StatusCode::BAD_REQUEST,
+            );
+        };
+        if header_version != body_version {
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::header_mismatch(format!(
+                    "MCP-Protocol-Version header value {header_version:?} does not match \
+                     request _meta protocol version {body_version:?}"
+                )),
+                StatusCode::BAD_REQUEST,
+            );
+        }
+
+        if !state.protocol_support.contains(&body_version) {
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::unsupported_protocol_version(
+                    body_version,
+                    state.protocol_support.versions().iter().map(String::as_str),
+                ),
+                StatusCode::BAD_REQUEST,
+            );
+        }
+
+        let sep_2243_mode = super::http_headers::mode_for_version(&body_version);
+        if let Err(error) = super::http_headers::validate(&headers, &parsed, sep_2243_mode) {
+            tracing::warn!(
+                mode = ?sep_2243_mode,
+                version = %body_version,
+                error = %error.message,
+                "Rejecting modern request: HTTP header validation failed",
+            );
+            return json_rpc_error_response_with_status(id, error, StatusCode::BAD_REQUEST);
+        }
+
+        if is_removed_modern_method(&request_method) {
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::method_not_found(&request_method),
+                StatusCode::NOT_FOUND,
+            );
+        }
+    }
 
     // SEP-2575 / SEP-2567: version-gated stateless mode for 2026-07-28+ clients.
     //
@@ -2421,7 +2758,7 @@ async fn handle_post(
     // `stateless_config` is set on the transport.
     #[cfg(feature = "stateless")]
     {
-        let version_in_play: Option<String> = if is_init {
+        let version_in_play: Option<String> = if is_init && !modern_request {
             // For `initialize`, read the version the client is requesting from
             // the params object.
             parsed
@@ -2439,7 +2776,6 @@ async fn handle_post(
         if let Some(ref version) = version_in_play
             && is_stateless_protocol_version(version)
             && state.protocol_support.contains(version)
-            && get_session_id(&headers).is_none()
             // `subscriptions/listen` opens an SSE stream; let it fall through to the
             // dedicated intercept below rather than handling it as a plain RPC call.
             && parsed.get("method").and_then(|m| m.as_str()) != Some("subscriptions/listen")
@@ -2546,16 +2882,63 @@ async fn handle_post(
             // Race the handler against its first notification. A closed
             // channel (no sender attached, or all senders dropped) simply
             // awaits the handler.
-            let first = tokio::select! {
-                result = &mut call => FirstOutbound::Response(result),
-                maybe = notif_rx.recv() => match maybe {
-                    Some(n) => FirstOutbound::Notification(n),
-                    None => FirstOutbound::Response((&mut call).await),
-                },
+            let first = loop {
+                let outbound = tokio::select! {
+                    // A handler may enqueue a notification and complete in
+                    // the same poll. Observe the queued notification first so
+                    // it is neither dropped nor raced behind the response.
+                    biased;
+                    maybe = notif_rx.recv() => match maybe {
+                        Some(n) => FirstOutbound::Notification(n),
+                        None => FirstOutbound::Response((&mut call).await),
+                    },
+                    result = &mut call => FirstOutbound::Response(result),
+                };
+                match outbound {
+                    FirstOutbound::Notification(notification)
+                        if state.modern_subscriptions.publish(&notification) =>
+                    {
+                        continue;
+                    }
+                    outbound => break outbound,
+                }
             };
 
             match first {
                 FirstOutbound::Response(result) => {
+                    // `select!` may observe a handler's ready response in the
+                    // same poll that the handler enqueued notifications.
+                    // Drain that queue before committing a JSON response.
+                    while let Ok(notification) = notif_rx.try_recv() {
+                        if state.modern_subscriptions.publish(&notification) {
+                            continue;
+                        }
+                        let ready_call: std::pin::Pin<
+                            Box<
+                                dyn std::future::Future<
+                                        Output = crate::error::Result<JsonRpcResponse>,
+                                    > + Send,
+                            >,
+                        > = Box::pin(async move { result });
+                        let mut resp = stateless_sse_with_notifications(
+                            notification,
+                            ready_call,
+                            notif_rx,
+                            StatelessSseContext {
+                                version: version.clone(),
+                                method: request_method.clone(),
+                                cancel_guard,
+                                server_identity,
+                                subscriptions: state.modern_subscriptions.clone(),
+                            },
+                        );
+                        resp.headers_mut().insert(
+                            MCP_PROTOCOL_VERSION_HEADER,
+                            HeaderValue::from_str(version).unwrap(),
+                        );
+                        return resp;
+                    }
+
                     // Handler finished; the response is about to be
                     // produced, so dropping the connection from here on is
                     // no longer a cancellation.
@@ -2584,11 +2967,13 @@ async fn handle_post(
                         stamp_server_info(&mut response, identity);
                     }
 
+                    let status = modern_response_status(&response);
                     let mut resp = if state.sse_responses {
                         sse_json_response(&response)
                     } else {
                         axum::Json(response).into_response()
                     };
+                    *resp.status_mut() = status;
                     resp.headers_mut().insert(
                         MCP_PROTOCOL_VERSION_HEADER,
                         HeaderValue::from_str(version).unwrap(),
@@ -2601,10 +2986,13 @@ async fn handle_post(
                         first_notif,
                         call,
                         notif_rx,
-                        version.clone(),
-                        request_method.clone(),
-                        cancel_guard,
-                        server_identity,
+                        StatelessSseContext {
+                            version: version.clone(),
+                            method: request_method.clone(),
+                            cancel_guard,
+                            server_identity,
+                            subscriptions: state.modern_subscriptions.clone(),
+                        },
                     );
                     resp.headers_mut().insert(
                         MCP_PROTOCOL_VERSION_HEADER,
@@ -2694,6 +3082,13 @@ async fn handle_post(
         }
     }
 
+    // Final-protocol subscriptions are sessionless long-lived POSTs. They
+    // must be established before consulting any legacy session state.
+    #[cfg(feature = "stateless")]
+    if modern_request && request_method == "subscriptions/listen" {
+        return handle_modern_subscriptions_listen_sse(state, &parsed).await;
+    }
+
     // Get or create session
     let session = if is_init {
         // Create new session for initialize
@@ -2720,7 +3115,7 @@ async fn handle_post(
                     .into_response();
             }
         }
-    } else if let Some(session_id) = get_session_id(&headers) {
+    } else if !modern_request && let Some(session_id) = get_session_id(&headers) {
         // Client sent a session ID -- look it up
         match state.sessions.get(&session_id).await {
             Some(s) => s,
@@ -3177,16 +3572,22 @@ impl Drop for CancelOnDisconnect {
 /// notification, any further notifications as they arrive, and finally the
 /// terminal response, after which the stream ends.
 #[cfg(feature = "stateless")]
+struct StatelessSseContext {
+    version: String,
+    method: String,
+    cancel_guard: CancelOnDisconnect,
+    server_identity: Option<Implementation>,
+    subscriptions: Arc<ModernSubscriptionRegistry>,
+}
+
+#[cfg(feature = "stateless")]
 fn stateless_sse_with_notifications(
     first: crate::context::ServerNotification,
     call: std::pin::Pin<
         Box<dyn std::future::Future<Output = crate::error::Result<JsonRpcResponse>> + Send>,
     >,
     rx: crate::context::NotificationReceiver,
-    version: String,
-    method: String,
-    cancel_guard: CancelOnDisconnect,
-    server_identity: Option<Implementation>,
+    request: StatelessSseContext,
 ) -> Response {
     struct Ctx {
         call: Option<
@@ -3207,10 +3608,13 @@ fn stateless_sse_with_notifications(
         /// Stamped into `_meta.serverInfo` on the terminal response, if set
         /// (see [`HttpTransport::stamp_server_info()`]).
         server_identity: Option<Implementation>,
+        subscriptions: Arc<ModernSubscriptionRegistry>,
     }
 
     let mut queue = std::collections::VecDeque::new();
-    if let Some(json) = crate::transport::stdio::serialize_notification(&first) {
+    if !request.subscriptions.publish(&first)
+        && let Some(json) = crate::transport::stdio::serialize_notification(&first)
+    {
         queue.push_back(json);
     }
     let ctx = Ctx {
@@ -3219,10 +3623,11 @@ fn stateless_sse_with_notifications(
         rx_open: true,
         queue,
         terminal: None,
-        version,
-        method,
-        cancel_guard,
-        server_identity,
+        version: request.version,
+        method: request.method,
+        cancel_guard: request.cancel_guard,
+        server_identity: request.server_identity,
+        subscriptions: request.subscriptions,
     };
 
     let stream = futures::stream::unfold(ctx, |mut ctx| async move {
@@ -3250,8 +3655,9 @@ fn stateless_sse_with_notifications(
                     // Drain notifications that were queued before the handler
                     // finished so they precede the terminal response.
                     while let Ok(n) = ctx.rx.try_recv() {
-                        if let Some(json) =
-                            crate::transport::stdio::serialize_notification(&n)
+                        if !ctx.subscriptions.publish(&n)
+                            && let Some(json) =
+                                crate::transport::stdio::serialize_notification(&n)
                         {
                             ctx.queue.push_back(json);
                         }
@@ -3290,8 +3696,9 @@ fn stateless_sse_with_notifications(
                 maybe = ctx.rx.recv(), if ctx.rx_open => {
                     match maybe {
                         Some(n) => {
-                            if let Some(json) =
-                                crate::transport::stdio::serialize_notification(&n)
+                            if !ctx.subscriptions.publish(&n)
+                                && let Some(json) =
+                                    crate::transport::stdio::serialize_notification(&n)
                             {
                                 ctx.queue.push_back(json);
                             }
@@ -3311,6 +3718,105 @@ fn stateless_sse_with_notifications(
                 .text("ping"),
         )
         .into_response()
+}
+
+#[cfg(feature = "stateless")]
+fn accepted_subscription_filter(requested: SubscriptionFilter) -> SubscriptionFilter {
+    SubscriptionFilter {
+        tools_list_changed: requested.tools_list_changed.filter(|enabled| *enabled),
+        prompts_list_changed: requested.prompts_list_changed.filter(|enabled| *enabled),
+        resources_list_changed: requested.resources_list_changed.filter(|enabled| *enabled),
+        resource_subscriptions: requested.resource_subscriptions,
+    }
+}
+
+/// Serve the final, sessionless `subscriptions/listen` protocol over its
+/// owning POST response.
+#[cfg(feature = "stateless")]
+async fn handle_modern_subscriptions_listen_sse(
+    state: Arc<AppState>,
+    parsed: &serde_json::Value,
+) -> Response {
+    let id = extract_request_id(parsed);
+    let Some(subscription_id) = id.clone() else {
+        return json_rpc_error_response_with_status(
+            None,
+            JsonRpcError::invalid_request("subscriptions/listen requires a request id"),
+            StatusCode::BAD_REQUEST,
+        );
+    };
+    let params = match parsed
+        .get("params")
+        .cloned()
+        .ok_or_else(|| JsonRpcError::invalid_params("subscriptions/listen requires params"))
+        .and_then(|value| {
+            serde_json::from_value::<SubscriptionsListenParams>(value)
+                .map_err(|error| JsonRpcError::invalid_params(error.to_string()))
+        }) {
+        Ok(params) => params,
+        Err(error) => {
+            return json_rpc_error_response_with_status(id, error, StatusCode::BAD_REQUEST);
+        }
+    };
+    let Some(requested) = params.notifications else {
+        return json_rpc_error_response_with_status(
+            id,
+            JsonRpcError::invalid_params("subscriptions/listen requires a notifications filter"),
+            StatusCode::BAD_REQUEST,
+        );
+    };
+    let accepted = accepted_subscription_filter(requested);
+    let (rx, guard) = state
+        .modern_subscriptions
+        .register(subscription_id.clone(), accepted.clone());
+    let acknowledgment = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/subscriptions/acknowledged",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/subscriptionId": subscription_id
+            },
+            "notifications": accepted
+        }
+    })
+    .to_string();
+
+    struct ModernListenStream {
+        first: Option<String>,
+        rx: mpsc::UnboundedReceiver<String>,
+        _guard: ModernSubscriptionGuard,
+    }
+
+    let stream = futures::stream::unfold(
+        ModernListenStream {
+            first: Some(acknowledgment),
+            rx,
+            _guard: guard,
+        },
+        |mut state| async move {
+            let message = match state.first.take() {
+                Some(first) => Some(first),
+                None => state.rx.recv().await,
+            }?;
+            Some((
+                Ok::<_, Infallible>(Event::default().event(SSE_MESSAGE_EVENT).data(message)),
+                state,
+            ))
+        },
+    );
+
+    let mut response = Sse::new(stream)
+        .keep_alive(
+            axum::response::sse::KeepAlive::new()
+                .interval(Duration::from_secs(30))
+                .text("ping"),
+        )
+        .into_response();
+    response.headers_mut().insert(
+        MCP_PROTOCOL_VERSION_HEADER,
+        HeaderValue::from_static(EXPERIMENTAL_PROTOCOL_VERSION),
+    );
+    response
 }
 
 /// Serve a `subscriptions/listen` request as an SSE stream.
@@ -3710,6 +4216,16 @@ fn json_rpc_error_response(
     axum::Json(response).into_response()
 }
 
+fn json_rpc_error_response_with_status(
+    id: Option<crate::protocol::RequestId>,
+    error: JsonRpcError,
+    status: StatusCode,
+) -> Response {
+    let mut response = json_rpc_error_response(id, error);
+    *response.status_mut() = status;
+    response
+}
+
 /// HTTP 413 response for a POST body exceeding [`HttpTransport::max_body_size`].
 fn body_too_large_response(limit: usize) -> Response {
     let mut resp = json_rpc_error_response(
@@ -3810,6 +4326,37 @@ mod tests {
         let before = serde_json::to_value(&legacy).unwrap();
         apply_protocol_result_fields(&mut legacy, "resources/read", "2025-11-25");
         assert_eq!(serde_json::to_value(legacy).unwrap(), before);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn modern_subscription_registry_filters_and_tags_notifications() {
+        let registry = Arc::new(ModernSubscriptionRegistry::default());
+        let (mut rx, guard) = registry.register(
+            RequestId::String("listen-1".to_string()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+        );
+
+        assert!(registry.publish(&ServerNotification::PromptsListChanged));
+        assert!(matches!(
+            rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        assert!(registry.publish(&ServerNotification::ToolsListChanged));
+        let message = rx.recv().await.expect("matching notification");
+        let json: serde_json::Value = serde_json::from_str(&message).unwrap();
+        assert_eq!(json["method"], "notifications/tools/list_changed");
+        assert_eq!(
+            json["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+            "listen-1"
+        );
+
+        drop(guard);
+        assert!(registry.subscriptions.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
@@ -6435,10 +6982,10 @@ mod tests {
     // Chunk 5: version-gated stateless mode for 2026-07-28+ clients
     // =========================================================================
 
-    /// 2026-07-28 initialize must NOT return mcp-session-id.
+    /// 2026-07-28 removed initialize entirely.
     #[tokio::test]
     #[cfg(feature = "stateless")]
-    async fn stateless_v2026_initialize_omits_session_id() {
+    async fn stateless_v2026_initialize_is_method_not_found() {
         let transport = HttpTransport::new(create_test_router())
             .disable_origin_validation()
             .disable_host_validation();
@@ -6449,6 +6996,7 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json, text/event-stream")
             .header(MCP_METHOD_HEADER, "initialize")
+            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
@@ -6457,33 +7005,264 @@ mod tests {
                     "params": {
                         "protocolVersion": "2026-07-28",
                         "capabilities": {},
-                        "clientInfo": { "name": "sc", "version": "1.0" }
+                        "clientInfo": { "name": "sc", "version": "1.0" },
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
                     }
                 })
                 .to_string(),
             ))
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
         assert!(
             !response.headers().contains_key(MCP_SESSION_ID_HEADER),
-            "2026-07-28 initialize must not return mcp-session-id"
-        );
-        assert_eq!(
-            response
-                .headers()
-                .get(MCP_PROTOCOL_VERSION_HEADER)
-                .and_then(|v| v.to_str().ok()),
-            Some("2026-07-28")
+            "removed final method must not create a session"
         );
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["id"], 1);
+        assert_eq!(json["error"]["code"], ErrorCode::MethodNotFound.code());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn stateless_v2026_rejects_missing_required_meta_with_http_400() {
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_METHOD_HEADER, "server/discover")
+            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 101,
+                    "method": "server/discover",
+                    "params": {}
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["id"], 101);
+        assert_eq!(json["error"]["code"], ErrorCode::InvalidParams.code());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn stateless_v2026_rejects_missing_protocol_header_with_http_400() {
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_METHOD_HEADER, "server/discover")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 102,
+                    "method": "server/discover",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["id"], 102);
+        assert_eq!(json["error"]["code"], McpErrorCode::HeaderMismatch.code());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn stateless_v2026_unknown_method_is_http_404() {
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_METHOD_HEADER, "unknown/method")
+            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 103,
+                    "method": "unknown/method",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["id"], 103);
+        assert_eq!(json["error"]["code"], ErrorCode::MethodNotFound.code());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn stateless_v2026_ignores_legacy_session_and_resumption_headers() {
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_METHOD_HEADER, "tools/list")
+            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .header(MCP_SESSION_ID_HEADER, "legacy-session-that-does-not-exist")
+            .header(LAST_EVENT_ID_HEADER, "legacy-event")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 104,
+                    "method": "tools/list",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(!response.headers().contains_key(MCP_SESSION_ID_HEADER));
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["result"]["tools"].is_array());
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn stateless_v2026_enforces_tool_client_capability_requirements() {
+        use crate::{CallToolResult, SamplingCapability, ToolBuilder};
+
+        let tool = ToolBuilder::new("sample")
+            .no_params_handler(|| async { Ok(CallToolResult::text("ok")) })
+            .build()
+            .require_client_capabilities(ClientCapabilities {
+                sampling: Some(SamplingCapability::default()),
+                ..ClientCapabilities::default()
+            });
+        let router = McpRouter::new()
+            .server_info("test-server", "1.0.0")
+            .tool(tool);
+        let app = HttpTransport::new(router)
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+
+        let build_request = |id: i64, capabilities: serde_json::Value| {
+            Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .header(MCP_METHOD_HEADER, "tools/call")
+                .header(MCP_NAME_HEADER, "sample")
+                .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+                .body(Body::from(
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "sample",
+                            "arguments": {},
+                            "_meta": {
+                                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                                "io.modelcontextprotocol/clientCapabilities": capabilities
+                            }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap()
+        };
+
+        let response = app
+            .clone()
+            .oneshot(build_request(105, serde_json::json!({})))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["id"], 105);
         assert_eq!(
-            json["result"]["protocolVersion"], "2026-07-28",
-            "initialize result must carry 2026-07-28 protocol version"
+            json["error"]["code"],
+            McpErrorCode::MissingRequiredClientCapability.code()
         );
+        assert_eq!(
+            json["error"]["data"]["requiredCapabilities"],
+            serde_json::json!({ "sampling": {} })
+        );
+
+        let response = app
+            .oneshot(build_request(106, serde_json::json!({ "sampling": {} })))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["result"]["content"][0]["text"], "ok");
     }
 
     /// 2026-07-28 tools/call without session header succeeds.
@@ -6728,7 +7507,13 @@ mod tests {
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": 1,
-                    "method": "tools/list"
+                    "method": "tools/list",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
                 })
                 .to_string(),
             ))
@@ -6759,7 +7544,8 @@ mod tests {
         assert_eq!(json["result"]["cacheScope"], "private");
     }
 
-    /// 2026-07-28 stateless notification (no id) returns 202 and creates no session (#857).
+    /// A final-protocol cancellation notification returns 202 and creates no
+    /// session (#857).
     #[tokio::test]
     #[cfg(feature = "stateless")]
     async fn stateless_v2026_notification_returns_202_no_session() {
@@ -6771,11 +7557,19 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header(MCP_PROTOCOL_VERSION_HEADER, "2026-07-28")
-            .header(MCP_METHOD_HEADER, "notifications/initialized")
+            .header(MCP_METHOD_HEADER, "notifications/cancelled")
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
-                    "method": "notifications/initialized"
+                    "method": "notifications/cancelled",
+                    "params": {
+                        "requestId": 99,
+                        "reason": "test",
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
                 })
                 .to_string(),
             ))
@@ -6814,7 +7608,13 @@ mod tests {
                 serde_json::json!({
                     "jsonrpc": "2.0",
                     "id": 1,
-                    "method": "tools/list"
+                    "method": "tools/list",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
                 })
                 .to_string(),
             ))

--- a/crates/tower-mcp/tests/per_request_meta.rs
+++ b/crates/tower-mcp/tests/per_request_meta.rs
@@ -46,13 +46,23 @@ async fn call_tool(body: serde_json::Value) -> (serde_json::Value, Captured) {
     let app = HttpTransport::new(router(captured.clone()))
         .disable_origin_validation()
         .into_router();
-    let req = Request::builder()
+    let mut request = Request::builder()
         .method("POST")
         .uri("/")
         .header("Content-Type", "application/json")
-        .header("Accept", "application/json")
-        .body(Body::from(body.to_string()))
-        .unwrap();
+        .header("Accept", "application/json");
+    if body["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"]
+        == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+    {
+        request = request.header(
+            "Mcp-Protocol-Version",
+            tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION,
+        );
+        request = request
+            .header("Mcp-Method", "tools/call")
+            .header("Mcp-Name", "inspect_meta");
+    }
+    let req = request.body(Body::from(body.to_string())).unwrap();
     let response = app.oneshot(req).await.unwrap();
     assert!(
         response.status().is_success(),
@@ -205,7 +215,9 @@ async fn session_path_stashes_per_request_meta() {
         .unwrap();
     app.clone().oneshot(notif_req).await.unwrap();
 
-    // tools/call with session header AND _meta in the body.
+    // tools/call with session header AND legacy-compatible _meta in the body.
+    // The final protocolVersion marker is intentionally omitted: its
+    // presence opts the request into the final sessionless lifecycle.
     let tool_req = Request::builder()
         .method("POST")
         .uri("/")
@@ -221,7 +233,6 @@ async fn session_path_stashes_per_request_meta() {
                     "name": "inspect_meta",
                     "arguments": {},
                     "_meta": {
-                        "io.modelcontextprotocol/protocolVersion": "2025-11-25",
                         "io.modelcontextprotocol/clientInfo": {
                             "name": "session-client",
                             "version": "0.1"
@@ -252,11 +263,7 @@ async fn session_path_stashes_per_request_meta() {
         .unwrap()
         .clone()
         .expect("session-based path must stash per-request meta on the handler context");
-    assert_eq!(
-        meta.protocol_version.as_deref(),
-        Some("2025-11-25"),
-        "handler must see protocol_version from session-based _meta"
-    );
+    assert!(meta.protocol_version.is_none());
     let info = meta
         .client_info
         .expect("clientInfo must be threaded through");

--- a/crates/tower-mcp/tests/server_discover.rs
+++ b/crates/tower-mcp/tests/server_discover.rs
@@ -134,7 +134,7 @@ async fn stateless_v2026_discover_returns_supported_versions_no_session() {
         .header("Mcp-Protocol-Version", "2026-07-28")
         .header("Mcp-Method", "server/discover")
         .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":1,"method":"server/discover"}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#,
         ))
         .unwrap();
     let response = app.oneshot(req).await.unwrap();

--- a/crates/tower-mcp/tests/stateless_disconnect.rs
+++ b/crates/tower-mcp/tests/stateless_disconnect.rs
@@ -96,7 +96,14 @@ async fn stateless_client_disconnect_cancels_in_flight_handler() {
         "jsonrpc": "2.0",
         "id": 1,
         "method": "tools/call",
-        "params": {"name": "slow", "arguments": {}}
+        "params": {
+            "name": "slow",
+            "arguments": {},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
     })
     .to_string();
 
@@ -165,7 +172,14 @@ async fn stateless_normal_completion_does_not_cancel() {
         "jsonrpc": "2.0",
         "id": 1,
         "method": "tools/call",
-        "params": {"name": "fast", "arguments": {}}
+        "params": {
+            "name": "fast",
+            "arguments": {},
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }
     })
     .to_string();
 

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -2,8 +2,7 @@
 //!
 //! `subscriptions/listen` opens a server-to-client notification stream over HTTP
 //! POST. The server responds with `Content-Type: text/event-stream` (SSE)
-//! when the negotiated or requested protocol version is >= 2026-07-28
-//! (the UPCOMING_PROTOCOL_VERSION). Requests that target an older-protocol
+//! for the final 2026-07-28 protocol. Requests that target an older-protocol
 //! server receive a JSON-RPC `Method Not Found` (-32601) error instead.
 
 #![cfg(feature = "http")]
@@ -32,7 +31,7 @@ fn app() -> axum::Router {
         .into_router()
 }
 
-/// POST a `subscriptions/listen` request with the given `Mcp-Protocol-Version` header.
+/// POST a `subscriptions/listen` request with the given protocol version.
 async fn post_subscriptions_listen(protocol_version: Option<&str>) -> axum::response::Response {
     let mut builder = Request::builder()
         .method("POST")
@@ -41,12 +40,31 @@ async fn post_subscriptions_listen(protocol_version: Option<&str>) -> axum::resp
         .header("Accept", "application/json, text/event-stream");
 
     if let Some(v) = protocol_version {
-        builder = builder.header("Mcp-Protocol-Version", v);
+        builder = builder
+            .header("Mcp-Protocol-Version", v)
+            .header("Mcp-Method", "subscriptions/listen");
     }
 
+    let params = if let Some(version) = protocol_version {
+        serde_json::json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": version,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            },
+            "notifications": {}
+        })
+    } else {
+        serde_json::json!({})
+    };
     let request = builder
         .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen","params":{}}"#,
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "subscriptions/listen",
+                "params": params
+            })
+            .to_string(),
         ))
         .unwrap();
 
@@ -54,6 +72,7 @@ async fn post_subscriptions_listen(protocol_version: Option<&str>) -> axum::resp
 }
 
 #[tokio::test]
+#[cfg(feature = "stateless")]
 async fn subscriptions_listen_returns_sse_when_protocol_is_2026_07_28() {
     // Clients that request protocol 2026-07-28 get an SSE stream back.
     let response = post_subscriptions_listen(Some("2026-07-28")).await;
@@ -131,54 +150,23 @@ async fn subscriptions_listen_returns_method_not_found_for_old_protocol() {
     );
 }
 
-/// Initialize with 2025-11-25 (creates a session), then POST `subscriptions/listen`
-/// with a per-request `Mcp-Protocol-Version: 2026-07-28` header.
-///
-/// This exercises the header-override branch in `handle_post`: the session was
-/// negotiated at 2025-11-25, but the per-request header promotes the effective
-/// version to 2026-07-28, which enables the SSE path.
+/// Legacy session and replay headers are ignored by the sessionless final
+/// protocol.
 #[cfg(feature = "stateless")]
 #[tokio::test]
-async fn subscriptions_listen_via_session_with_header_override() {
+async fn subscriptions_listen_ignores_legacy_session_headers() {
     let a = app();
-
-    // Step 1: initialize with 2025-11-25 to create a session.
-    let init_request = Request::builder()
-        .method("POST")
-        .uri("/")
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1.0.0"}}}"#,
-        ))
-        .unwrap();
-
-    let init_resp = a.clone().oneshot(init_request).await.unwrap();
-    assert_eq!(
-        init_resp.status(),
-        StatusCode::OK,
-        "initialize must succeed"
-    );
-
-    let session_id = init_resp
-        .headers()
-        .get("mcp-session-id")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())
-        .expect("initialize response must include mcp-session-id header");
-
-    // Step 2: POST subscriptions/listen with session ID + Mcp-Protocol-Version: 2026-07-28.
-    // The session is at 2025-11-25 but the per-request header overrides the
-    // effective version to 2026-07-28, so the server should return SSE.
     let listen_request = Request::builder()
         .method("POST")
         .uri("/")
         .header("Content-Type", "application/json")
         .header("Accept", "application/json, text/event-stream")
-        .header("mcp-session-id", &session_id)
+        .header("mcp-session-id", "legacy-session-that-does-not-exist")
+        .header("last-event-id", "legacy-event")
         .header("Mcp-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
         .body(Body::from(
-            r#"{"jsonrpc":"2.0","id":2,"method":"subscriptions/listen","params":{}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"subscriptions/listen","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"notifications":{"toolsListChanged":true}}}"#,
         ))
         .unwrap();
 
@@ -186,7 +174,7 @@ async fn subscriptions_listen_via_session_with_header_override() {
     assert_eq!(
         listen_resp.status(),
         StatusCode::OK,
-        "subscriptions/listen with header override must return 200"
+        "final subscriptions/listen must ignore legacy session state"
     );
 
     let content_type = listen_resp
@@ -196,27 +184,38 @@ async fn subscriptions_listen_via_session_with_header_override() {
         .unwrap_or("");
     assert!(
         content_type.contains("text/event-stream"),
-        "expected Content-Type: text/event-stream for session+header override, got: {content_type}"
+        "expected Content-Type: text/event-stream, got: {content_type}"
     );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn subscriptions_listen_requires_notification_filter() {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":3,"method":"subscriptions/listen","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}}}}"#,
+        ))
+        .unwrap();
+    let response = app().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(body["id"], 3);
+    assert_eq!(body["error"]["code"], -32602);
 }
 
 /// Exercise the pure session-fallback branch (no header, session carries version).
 ///
-/// With the `stateless` feature enabled, a 2026-07-28 initialize creates a
-/// stateless session (no persisted record). With `stateless` disabled the
-/// router negotiates the version down to `LATEST_PROTOCOL_VERSION` (2025-11-25)
-/// because 2026-07-28 is not yet in `SUPPORTED_PROTOCOL_VERSIONS`. In either
-/// case the session record does not carry 2026-07-28 after a standard
-/// `initialize` handshake, so the pure headerless fallback path cannot be
-/// exercised through the HTTP API without the per-request header override.
-///
-/// The header-override test (`subscriptions_listen_via_session_with_header_override`)
-/// covers the adjacent code path; this placeholder documents the gap.
-///
-/// If 2026-07-28 is promoted to `SUPPORTED_PROTOCOL_VERSIONS`, this test can
-/// be filled in: initialize without the stateless feature, capture the session
-/// ID, and POST `subscriptions/listen` with only the session ID header (no
-/// `Mcp-Protocol-Version`).
+/// Without final-protocol support compiled in, the legacy routing behavior
+/// remains MethodNotFound.
 #[cfg(not(feature = "stateless"))]
 #[tokio::test]
 async fn subscriptions_listen_session_fallback_placeholder() {

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -3,8 +3,8 @@ use tower_mcp::protocol::{
     Content, CreateMessageParams, LogLevel, LoggingMessageParams, ResourceContent, SamplingMessage,
 };
 use tower_mcp::{
-    CallToolResult, ElicitFormParams, ElicitFormSchema, ElicitMode, TaskSupportMode, Tool,
-    ToolBuilder,
+    CallToolResult, ClientCapabilities, ElicitFormParams, ElicitFormSchema, ElicitMode,
+    SamplingCapability, TaskSupportMode, Tool, ToolBuilder,
     extract::{Context, RawArgs},
 };
 
@@ -64,7 +64,89 @@ pub fn build_tools() -> Vec<Tool> {
         // Fixtures for the official 2026-07-28 conformance suite (#948)
         build_json_schema_2020_12(),
         build_custom_header(),
+        build_missing_capability(),
+        build_logging_diagnostic(),
+        build_streaming_diagnostic(),
+        build_trigger_tool_change(),
+        build_trigger_prompt_change(),
     ]
+}
+
+/// Diagnostic fixture for the final protocol's per-request capability gate.
+fn build_missing_capability() -> Tool {
+    ToolBuilder::new("test_missing_capability")
+        .description("Requires the caller to advertise the sampling capability")
+        .extractor_handler((), |RawArgs(_args): RawArgs| async move {
+            Ok(CallToolResult::text("sampling capability present"))
+        })
+        .build()
+        .require_client_capabilities(ClientCapabilities {
+            sampling: Some(SamplingCapability::default()),
+            ..ClientCapabilities::default()
+        })
+}
+
+/// Diagnostic fixture for final per-request log-level behavior.
+fn build_logging_diagnostic() -> Tool {
+    ToolBuilder::new("test_logging_tool")
+        .description("Emits a log notification when the request authorizes logging")
+        .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
+            ctx.send_log(
+                LoggingMessageParams::new(
+                    LogLevel::Info,
+                    serde_json::json!("Diagnostic log message"),
+                )
+                .with_logger("conformance"),
+            );
+            Ok(CallToolResult::text("Logging diagnostic complete"))
+        })
+        .build()
+}
+
+/// Diagnostic fixture proving that a final-protocol handler cannot emit a
+/// legacy independent elicitation request on its response stream. MRTR-based
+/// elicitation itself remains tracked in #950.
+fn build_streaming_diagnostic() -> Tool {
+    ToolBuilder::new("test_streaming_elicitation")
+        .description("Verifies legacy in-flight elicitation is disabled on final response streams")
+        .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
+            if ctx.can_elicit() {
+                Ok(CallToolResult::error(
+                    "Legacy independent elicitation must not be available",
+                ))
+            } else {
+                Ok(CallToolResult::text(
+                    "No independent elicitation request emitted",
+                ))
+            }
+        })
+        .build()
+}
+
+fn build_trigger_tool_change() -> Tool {
+    ToolBuilder::new("test_trigger_tool_change")
+        .description("Emits a tools/list_changed notification")
+        .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
+            if ctx.notify_tools_list_changed() {
+                Ok(CallToolResult::text("Tool change emitted"))
+            } else {
+                Ok(CallToolResult::error("Notification channel unavailable"))
+            }
+        })
+        .build()
+}
+
+fn build_trigger_prompt_change() -> Tool {
+    ToolBuilder::new("test_trigger_prompt_change")
+        .description("Emits a prompts/list_changed notification")
+        .extractor_handler((), |ctx: Context, RawArgs(_args): RawArgs| async move {
+            if ctx.notify_prompts_list_changed() {
+                Ok(CallToolResult::text("Prompt change emitted"))
+            } else {
+                Ok(CallToolResult::error("Notification channel unavailable"))
+            }
+        })
+        .build()
 }
 
 /// Fixture for the `json-schema-2020-12` conformance scenario: a tool whose


### PR DESCRIPTION
Closes the final HTTP lifecycle and subscription-stream tranche of #952.

## Summary

- enforce the 2026-07-28 per-request `_meta` contract, exact runtime protocol support, header/body agreement, removed-method behavior, and final HTTP 400/404 error mapping
- add generic per-tool client capability requirements and the specified `MissingRequiredClientCapability` error shape
- honor per-request `logLevel` and suppress final-protocol logs when it is absent
- implement sessionless `subscriptions/listen` streams with acknowledgement-first ordering, notification filters, subscription IDs, multiple concurrent streams, and no legacy session/replay semantics
- route dynamic registry and request-context list-change notifications into final subscription streams
- update final conformance fixtures, CI smoke coverage, and remove the now-green `server-stateless` draft baseline

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tower-mcp --no-default-features --features http`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (793 + 148 unit tests)
- `cargo test --test '*' --all-features`
- `cargo test --doc --all-features` (all doc tests green)
- official `@modelcontextprotocol/conformance@0.2.0-alpha.10` `server-stateless` scenario for spec `2026-07-28`: **30/30 passed, 0 failures, 0 warnings**
- full final-spec server run: **92/104 checks pass**, with all remaining failures already tracked by #952 (SEP-2243 schema headers) or #950 (MRTR)

The 2026-07-28 version remains `EXPERIMENTAL`: compile-time inclusion plus runtime `ProtocolSupport` selection are in place, but promotion should wait for the remaining #952/#950 gates.