### PR TITLE
fix(http): enforce schema-defined MCP headers

### DIFF
--- a/conformance-baseline-draft.yml
+++ b/conformance-baseline-draft.yml
@@ -7,9 +7,10 @@
 # Remove entries as the phases land; CI fails when a baselined scenario
 # starts passing (stale entry) or a non-baselined scenario fails.
 #
-# Status at 0.2.0-alpha.10 after the final HTTP lifecycle/listen work in
-# #952: 92/104 checks pass; the server-stateless scenario passes all 30
-# checks and is no longer baselined. Note that
+# Status at 0.2.0-alpha.10 after the final HTTP lifecycle/listen and
+# schema-aware custom-header work in #952: 94/104 checks pass;
+# server-stateless passes 30/30 and http-custom-header-server-validation
+# passes 9/9. Note that
 # input-required-result-missing-input-response and
 # input-required-result-ignore-extra-params report "0 passed, 0 failed" in
 # the summary (they run no checks pending MRTR fixture tools) but the
@@ -21,12 +22,6 @@
 # `client:` keys; reasons live in these comments.
 
 server:
-  # SEP-2243 (7/9 checks pass): the two failures need schema-aware rejection
-  # when an x-mcp-header-annotated argument is present in the body but its
-  # Mcp-Param-* header is missing; the transport does not yet consult tool
-  # schemas during header validation (#952).
-  - http-custom-header-server-validation
-
   # SEP-2322 MRTR is not implemented (#950). Scenarios that fully pass do so
   # because correct non-MRTR behavior (rejecting unsupported methods)
   # coincides with the spec; the two zero-check entries below also need the

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1727,6 +1727,27 @@ impl McpRouter {
         }
     }
 
+    /// Return a snapshot of a registered tool's input schema.
+    ///
+    /// HTTP transport validation uses this before dispatch to enforce
+    /// SEP-2243 `x-mcp-header` mappings. Static tools take precedence over
+    /// dynamic tools, matching `tools/list` and `tools/call`.
+    pub(crate) fn tool_input_schema(&self, name: &str) -> Option<serde_json::Value> {
+        if let Some(tool) = self.inner.tools.get(name) {
+            return Some(tool.input_schema.clone());
+        }
+        #[cfg(feature = "dynamic-tools")]
+        if let Some(tool) = self
+            .inner
+            .dynamic_tools
+            .as_ref()
+            .and_then(|tools| tools.get(name))
+        {
+            return Some(tool.input_schema.clone());
+        }
+        None
+    }
+
     fn capabilities(&self) -> ServerCapabilities {
         let has_resources =
             !self.inner.resources.is_empty() || !self.inner.resource_templates.is_empty();

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1732,6 +1732,7 @@ impl McpRouter {
     /// HTTP transport validation uses this before dispatch to enforce
     /// SEP-2243 `x-mcp-header` mappings. Static tools take precedence over
     /// dynamic tools, matching `tools/list` and `tools/call`.
+    #[cfg(feature = "http")]
     pub(crate) fn tool_input_schema(&self, name: &str) -> Option<serde_json::Value> {
         if let Some(tool) = self.inner.tools.get(name) {
             return Some(tool.input_schema.clone());

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -2502,6 +2502,28 @@ fn is_response(parsed: &serde_json::Value) -> bool {
         && (parsed.get("result").is_some() || parsed.get("error").is_some())
 }
 
+/// Resolve the selected tool's input schema when the transport owns an
+/// [`McpRouter`]. Pre-built services do not expose their tool registry, so
+/// supplied custom headers can still be checked there but missing headers
+/// cannot be inferred before dispatch.
+fn request_tool_input_schema(
+    service_source: &ServiceSource,
+    parsed: &serde_json::Value,
+) -> Option<serde_json::Value> {
+    if parsed.get("method").and_then(serde_json::Value::as_str) != Some("tools/call") {
+        return None;
+    }
+    let name = parsed
+        .get("params")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|params| params.get("name"))
+        .and_then(serde_json::Value::as_str)?;
+    match service_source {
+        ServiceSource::Router { router, .. } => router.tool_input_schema(name),
+        ServiceSource::Service(_) => None,
+    }
+}
+
 /// Return whether an HTTP request claims the modern, per-request-metadata
 /// protocol era.
 ///
@@ -2680,6 +2702,7 @@ async fn handle_post(
         .and_then(|method| method.as_str())
         .unwrap_or_default()
         .to_string();
+    let tool_input_schema = request_tool_input_schema(&state.service_source, &parsed);
     let modern_request = claims_modern_protocol(&headers, &parsed);
 
     // The modern protocol is selected by its per-request `_meta` envelope,
@@ -2726,7 +2749,12 @@ async fn handle_post(
         }
 
         let sep_2243_mode = super::http_headers::mode_for_version(&body_version);
-        if let Err(error) = super::http_headers::validate(&headers, &parsed, sep_2243_mode) {
+        if let Err(error) = super::http_headers::validate_with_tool_schema(
+            &headers,
+            &parsed,
+            sep_2243_mode,
+            tool_input_schema.as_ref(),
+        ) {
             tracing::warn!(
                 mode = ?sep_2243_mode,
                 version = %body_version,
@@ -2788,7 +2816,12 @@ async fn handle_post(
             // SEP-2243 validation before `parsed` is consumed by deserialization.
             // 2026-07-28 falls into strict mode, so missing Mcp-Method is an error.
             let sep_2243_mode = super::http_headers::mode_for_version(version);
-            if let Err(err) = super::http_headers::validate(&headers, &parsed, sep_2243_mode) {
+            if let Err(err) = super::http_headers::validate_with_tool_schema(
+                &headers,
+                &parsed,
+                sep_2243_mode,
+                tool_input_schema.as_ref(),
+            ) {
                 tracing::warn!(
                     mode = ?sep_2243_mode,
                     version = %version,
@@ -3235,7 +3268,12 @@ async fn handle_post(
         session.protocol_version.read().await.clone()
     };
     let sep_2243_mode = super::http_headers::mode_for_version(&sep_2243_version);
-    if let Err(err) = super::http_headers::validate(&headers, &parsed, sep_2243_mode) {
+    if let Err(err) = super::http_headers::validate_with_tool_schema(
+        &headers,
+        &parsed,
+        sep_2243_mode,
+        tool_input_schema.as_ref(),
+    ) {
         tracing::warn!(
             mode = ?sep_2243_mode,
             version = %sep_2243_version,
@@ -5116,6 +5154,79 @@ mod tests {
             ))
             .unwrap();
         let response = app.oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn sep_2243_final_request_requires_schema_annotated_header() {
+        use crate::extract::RawArgs;
+        use crate::{CallToolResult, ToolBuilder};
+
+        let tool = ToolBuilder::new("route")
+            .input_schema(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "tenant_id": {
+                        "type": "string",
+                        "x-mcp-header": "Tenant"
+                    }
+                }
+            }))
+            .extractor_handler((), |RawArgs(args): RawArgs| async move {
+                Ok(CallToolResult::text(args["tenant_id"].to_string()))
+            })
+            .build();
+        let app = HttpTransport::new(
+            McpRouter::new()
+                .server_info("header-test", "1.0.0")
+                .tool(tool),
+        )
+        .disable_origin_validation()
+        .into_router();
+
+        let request = |custom_header: Option<&'static str>| {
+            let mut builder = Request::builder()
+                .method("POST")
+                .uri("/")
+                .header("Content-Type", "application/json")
+                .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+                .header(MCP_METHOD_HEADER, "tools/call")
+                .header(MCP_NAME_HEADER, "route");
+            if let Some(value) = custom_header {
+                builder = builder.header("Mcp-Param-Tenant", value);
+            }
+            builder
+                .body(Body::from(
+                    serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": 9,
+                        "method": "tools/call",
+                        "params": {
+                            "name": "route",
+                            "arguments": {"tenant_id": "acme"},
+                            "_meta": {
+                                "io.modelcontextprotocol/protocolVersion":
+                                    EXPERIMENTAL_PROTOCOL_VERSION,
+                                "io.modelcontextprotocol/clientCapabilities": {}
+                            }
+                        }
+                    })
+                    .to_string(),
+                ))
+                .unwrap()
+        };
+
+        let response = app.clone().oneshot(request(None)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let error: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(error["id"], 9);
+        assert_eq!(error["error"]["code"], -32020);
+
+        let response = app.oneshot(request(Some("acme"))).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
     }
 

--- a/crates/tower-mcp/src/transport/http_headers.rs
+++ b/crates/tower-mcp/src/transport/http_headers.rs
@@ -1,7 +1,7 @@
 //! SEP-2243: HTTP header standardization for the Streamable HTTP transport.
 //!
 //! This module implements the server-side validation rules from SEP-2243
-//! (FINAL 2026-04-15). The SEP requires POST requests to include several
+//! (FINAL 2026-07-28). The SEP requires POST requests to include several
 //! headers that mirror fields from the JSON-RPC body so that network
 //! intermediaries (load balancers, proxies, observability tools, WAFs)
 //! can route and process MCP traffic without parsing the body.
@@ -27,7 +27,7 @@
 //! Mcp-Param-{Name}: =?base64?{Base64Value}?=
 //! ```
 //!
-//! The `=?base64?` prefix is case-insensitive.
+//! The `=?base64?` prefix and `?=` suffix are case-sensitive.
 //!
 //! ## Errors
 //!
@@ -57,7 +57,7 @@ use super::http::{MCP_METHOD_HEADER, MCP_NAME_HEADER, MCP_PARAM_HEADER_PREFIX};
 
 /// Base64 sentinel prefix used for Base64-encoded header values.
 ///
-/// Per SEP-2243 this prefix is case-insensitive.
+/// Per SEP-2243 this prefix is case-sensitive.
 const BASE64_PREFIX: &str = "=?base64?";
 /// Base64 sentinel suffix used for Base64-encoded header values.
 const BASE64_SUFFIX: &str = "?=";
@@ -98,10 +98,26 @@ pub(super) fn mode_for_version(version: &str) -> Sep2243Mode {
 ///
 /// The caller is responsible for short-circuiting with a `400 Bad
 /// Request` response.
-pub(super) fn validate(
+#[cfg(test)]
+fn validate(
     headers: &axum::http::HeaderMap,
     parsed: &Value,
     mode: Sep2243Mode,
+) -> Result<(), JsonRpcError> {
+    validate_with_tool_schema(headers, parsed, mode, None)
+}
+
+/// Validate SEP-2243 headers with the selected tool's input schema.
+///
+/// Supplying the schema lets the server enforce the body-to-header direction:
+/// every non-null argument whose property carries `x-mcp-header` must have its
+/// declared `Mcp-Param-*` header. Without a schema, supplied headers are still
+/// checked using their suffix as a best-effort body property name.
+pub(super) fn validate_with_tool_schema(
+    headers: &axum::http::HeaderMap,
+    parsed: &Value,
+    mode: Sep2243Mode,
+    tool_input_schema: Option<&Value>,
 ) -> Result<(), JsonRpcError> {
     let body_method = parsed
         .get("method")
@@ -133,8 +149,9 @@ pub(super) fn validate(
     // authoritative value per SEP-2243 — header values are advisory for
     // routing and are validated against the body).
     let name_source: Option<NameSource> = match body_method.as_deref() {
-        Some("tools/call") | Some("prompts/get") => Some(NameSource::ParamsName),
-        Some("resources/read") => Some(NameSource::ParamsUri),
+        Some("tools/call") | Some("prompts/get") => Some(NameSource::Name),
+        Some("resources/read") => Some(NameSource::Uri),
+        Some("tasks/get" | "tasks/update" | "tasks/cancel") => Some(NameSource::TaskId),
         _ => None,
     };
 
@@ -163,12 +180,14 @@ pub(super) fn validate(
         }
     }
 
-    // Mcp-Param-* validation: every Mcp-Param-{Name} header must
-    // correspond to a value in params.arguments.{Name} (case-insensitive
-    // match on the header suffix). Per the SEP, header-omitted-but-body-
-    // present is a non-conforming client and a server-side error in
-    // strict mode; we mirror the same.
-    validate_param_headers(headers, parsed, mode)?;
+    if let Some(schema) = tool_input_schema {
+        validate_schema_param_headers(headers, parsed, mode, schema)?;
+    } else {
+        // A pre-built Service does not expose a tool registry. Continue to
+        // validate any supplied Mcp-Param-* values, but missing headers cannot
+        // be inferred without the selected tool's schema.
+        validate_param_headers(headers, parsed, mode)?;
+    }
 
     Ok(())
 }
@@ -178,17 +197,20 @@ pub(super) fn validate(
 #[derive(Debug, Clone, Copy)]
 enum NameSource {
     /// `params.name` (`tools/call`, `prompts/get`).
-    ParamsName,
+    Name,
     /// `params.uri` (`resources/read`).
-    ParamsUri,
+    Uri,
+    /// `params.taskId` (`tasks/get`, `tasks/update`, `tasks/cancel`).
+    TaskId,
 }
 
 impl NameSource {
     fn extract(self, parsed: &Value) -> Option<String> {
         let params = parsed.get("params")?;
         let key = match self {
-            NameSource::ParamsName => "name",
-            NameSource::ParamsUri => "uri",
+            NameSource::Name => "name",
+            NameSource::Uri => "uri",
+            NameSource::TaskId => "taskId",
         };
         params.get(key).and_then(|v| v.as_str()).map(str::to_string)
     }
@@ -213,15 +235,10 @@ fn header_str(headers: &axum::http::HeaderMap, name: &str) -> Result<Option<Stri
 }
 
 /// Decode the SEP-2243 Base64 sentinel `=?base64?...?=` if present.
-/// Otherwise return the raw value. The prefix is case-insensitive per
-/// the spec's "Base64 Decoding" conformance table (`=?BASE64?...?=` is
-/// accepted).
+/// Otherwise return the raw value. The final specification requires the
+/// sentinel markers to use exactly this lowercase spelling.
 fn decode_sentinel(value: &str) -> Result<String, String> {
-    let lower = value.to_ascii_lowercase();
-    if lower.starts_with(BASE64_PREFIX) && value.ends_with(BASE64_SUFFIX) {
-        // Strip the prefix using the original casing length; the
-        // lowercase form is byte-length-equal because the prefix is
-        // ASCII.
+    if value.starts_with(BASE64_PREFIX) && value.ends_with(BASE64_SUFFIX) {
         let body = &value[BASE64_PREFIX.len()..value.len() - BASE64_SUFFIX.len()];
         let bytes = base64::engine::general_purpose::STANDARD
             .decode(body)
@@ -230,6 +247,199 @@ fn decode_sentinel(value: &str) -> Result<String, String> {
     } else {
         Ok(value.to_string())
     }
+}
+
+#[derive(Debug)]
+struct CustomHeaderMapping {
+    suffix: String,
+    property_path: Vec<String>,
+}
+
+/// Collect the statically reachable `x-mcp-header` annotations from a tool
+/// input schema. Traversal follows only `properties` chains, exactly matching
+/// SEP-2243's extraction rule.
+fn custom_header_mappings(schema: &Value) -> Result<Vec<CustomHeaderMapping>, JsonRpcError> {
+    fn annotation_count(value: &Value) -> usize {
+        match value {
+            Value::Object(object) => {
+                usize::from(object.contains_key("x-mcp-header"))
+                    + object.values().map(annotation_count).sum::<usize>()
+            }
+            Value::Array(values) => values.iter().map(annotation_count).sum(),
+            _ => 0,
+        }
+    }
+
+    fn is_tchar(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'!' | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+    }
+
+    fn primitive_header_type(schema: &Value) -> bool {
+        match schema.get("type") {
+            Some(Value::String(kind)) => matches!(kind.as_str(), "string" | "integer" | "boolean"),
+            Some(Value::Array(kinds)) => {
+                let mut primitive = false;
+                for kind in kinds {
+                    match kind.as_str() {
+                        Some("string" | "integer" | "boolean") if !primitive => primitive = true,
+                        Some("null") => {}
+                        _ => return false,
+                    }
+                }
+                primitive
+            }
+            _ => false,
+        }
+    }
+
+    fn walk(
+        schema: &Value,
+        path: &mut Vec<String>,
+        seen: &mut std::collections::HashSet<String>,
+        mappings: &mut Vec<CustomHeaderMapping>,
+    ) -> Result<(), JsonRpcError> {
+        let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+            return Ok(());
+        };
+
+        for (property_name, property_schema) in properties {
+            path.push(property_name.clone());
+            if let Some(annotation) = property_schema.get("x-mcp-header") {
+                let suffix = annotation.as_str().ok_or_else(|| {
+                    JsonRpcError::header_mismatch(format!(
+                        "x-mcp-header at {} must be a string",
+                        path.join(".")
+                    ))
+                })?;
+                if suffix.is_empty() || !suffix.bytes().all(is_tchar) {
+                    return Err(JsonRpcError::header_mismatch(format!(
+                        "invalid x-mcp-header value {suffix:?} at {}",
+                        path.join(".")
+                    )));
+                }
+                if !primitive_header_type(property_schema) {
+                    return Err(JsonRpcError::header_mismatch(format!(
+                        "x-mcp-header at {} requires a string, integer, or boolean property",
+                        path.join(".")
+                    )));
+                }
+                if !seen.insert(suffix.to_ascii_lowercase()) {
+                    return Err(JsonRpcError::header_mismatch(format!(
+                        "duplicate x-mcp-header value {suffix:?}"
+                    )));
+                }
+                mappings.push(CustomHeaderMapping {
+                    suffix: suffix.to_string(),
+                    property_path: path.clone(),
+                });
+            }
+            walk(property_schema, path, seen, mappings)?;
+            path.pop();
+        }
+        Ok(())
+    }
+
+    let mut seen = std::collections::HashSet::new();
+    let mut mappings = Vec::new();
+    walk(schema, &mut Vec::new(), &mut seen, &mut mappings)?;
+    if annotation_count(schema) != mappings.len() {
+        return Err(JsonRpcError::header_mismatch(
+            "x-mcp-header annotation is not statically reachable through properties",
+        ));
+    }
+    Ok(mappings)
+}
+
+fn value_at_property_path<'a>(root: &'a Value, path: &[String]) -> Option<&'a Value> {
+    path.iter().try_fold(root, |value, key| value.get(key))
+}
+
+/// Validate custom parameter headers using the selected tool's schema.
+fn validate_schema_param_headers(
+    headers: &axum::http::HeaderMap,
+    parsed: &Value,
+    mode: Sep2243Mode,
+    schema: &Value,
+) -> Result<(), JsonRpcError> {
+    let mappings = custom_header_mappings(schema)?;
+    let arguments = parsed
+        .get("params")
+        .and_then(|params| params.get("arguments"))
+        .unwrap_or(&Value::Null);
+
+    for mapping in mappings {
+        let full_name = format!("{MCP_PARAM_HEADER_PREFIX}{}", mapping.suffix);
+        let header_name =
+            axum::http::HeaderName::from_bytes(full_name.as_bytes()).map_err(|e| {
+                JsonRpcError::header_mismatch(format!(
+                    "invalid x-mcp-header value {:?}: {e}",
+                    mapping.suffix
+                ))
+            })?;
+        let values: Vec<_> = headers.get_all(&header_name).iter().collect();
+        if values.len() > 1 {
+            return Err(JsonRpcError::header_mismatch(format!(
+                "duplicate {full_name} header"
+            )));
+        }
+
+        let body_value = value_at_property_path(arguments, &mapping.property_path)
+            .filter(|value| !value.is_null());
+        match (values.first(), body_value) {
+            (None, Some(_)) if matches!(mode, Sep2243Mode::Strict) => {
+                return Err(JsonRpcError::header_mismatch(format!(
+                    "{full_name} header is required when argument {} is present",
+                    mapping.property_path.join(".")
+                )));
+            }
+            (Some(_), None) => {
+                return Err(JsonRpcError::header_mismatch(format!(
+                    "{full_name} header is present but argument {} is missing or null",
+                    mapping.property_path.join(".")
+                )));
+            }
+            (Some(raw), Some(body_value)) => {
+                let value = raw.to_str().map_err(|e| {
+                    JsonRpcError::header_mismatch(format!(
+                        "{full_name} contains invalid bytes: {e}"
+                    ))
+                })?;
+                let decoded = decode_sentinel(value.trim()).map_err(|message| {
+                    JsonRpcError::header_mismatch(format!("{full_name}: {message}"))
+                })?;
+                let body_repr = json_value_to_header_string(body_value).map_err(|message| {
+                    JsonRpcError::header_mismatch(format!(
+                        "{full_name}: body value cannot be represented as a header: {message}"
+                    ))
+                })?;
+                if decoded != body_repr {
+                    return Err(JsonRpcError::header_mismatch(format!(
+                        "{full_name} header value {decoded:?} does not match body value {body_repr:?}"
+                    )));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
 }
 
 /// Validate every `Mcp-Param-*` header against the corresponding entry
@@ -496,6 +706,32 @@ mod tests {
     }
 
     #[test]
+    fn task_methods_use_task_id_as_mcp_name() {
+        for method in ["tasks/get", "tasks/update", "tasks/cancel"] {
+            let body = json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": method,
+                "params": {"taskId": "task-123"}
+            });
+            validate(
+                &hm(&[("mcp-method", method), ("mcp-name", "task-123")]),
+                &body,
+                Sep2243Mode::Strict,
+            )
+            .unwrap();
+
+            let err = validate(
+                &hm(&[("mcp-method", method), ("mcp-name", "other-task")]),
+                &body,
+                Sep2243Mode::Strict,
+            )
+            .unwrap_err();
+            assert_eq!(err.code, -32020, "method={method}");
+        }
+    }
+
+    #[test]
     fn other_methods_dont_require_mcp_name() {
         let body = json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"});
         validate(
@@ -540,10 +776,10 @@ mod tests {
     }
 
     #[test]
-    fn base64_sentinel_case_insensitive_prefix() {
+    fn base64_sentinel_prefix_is_case_sensitive() {
         let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
                           "params": {"name": "Hello"}});
-        validate(
+        let err = validate(
             &hm(&[
                 ("mcp-method", "tools/call"),
                 ("mcp-name", "=?BASE64?SGVsbG8=?="),
@@ -551,7 +787,8 @@ mod tests {
             &body,
             Sep2243Mode::Strict,
         )
-        .unwrap();
+        .unwrap_err();
+        assert_eq!(err.code, -32020);
     }
 
     #[test]
@@ -647,6 +884,158 @@ mod tests {
             Sep2243Mode::Strict,
         )
         .unwrap();
+    }
+
+    #[test]
+    fn schema_requires_annotated_argument_header_in_strict_mode() {
+        let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "route", "arguments": {"tenant_id": "acme"}}});
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tenant_id": {"type": "string", "x-mcp-header": "Tenant"}
+            }
+        });
+        let err = validate_with_tool_schema(
+            &hm(&[("mcp-method", "tools/call"), ("mcp-name", "route")]),
+            &body,
+            Sep2243Mode::Strict,
+            Some(&schema),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32020);
+        assert!(err.message.contains("mcp-param-Tenant"));
+    }
+
+    #[test]
+    fn schema_maps_annotation_name_to_exact_nested_property_path() {
+        let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {
+            "name": "route",
+            "arguments": {"routing": {"tenant_id": "acme"}}
+        }});
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "routing": {
+                    "type": "object",
+                    "properties": {
+                        "tenant_id": {"type": "string", "x-mcp-header": "Tenant"}
+                    }
+                }
+            }
+        });
+        validate_with_tool_schema(
+            &hm(&[
+                ("mcp-method", "tools/call"),
+                ("mcp-name", "route"),
+                ("mcp-param-tenant", "acme"),
+            ]),
+            &body,
+            Sep2243Mode::Strict,
+            Some(&schema),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn schema_does_not_require_header_for_missing_or_null_argument() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tenant": {
+                    "type": ["string", "null"],
+                    "x-mcp-header": "Tenant"
+                }
+            }
+        });
+        for arguments in [json!({}), json!({"tenant": null})] {
+            let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "route", "arguments": arguments}});
+            validate_with_tool_schema(
+                &hm(&[("mcp-method", "tools/call"), ("mcp-name", "route")]),
+                &body,
+                Sep2243Mode::Strict,
+                Some(&schema),
+            )
+            .unwrap();
+        }
+    }
+
+    #[test]
+    fn schema_missing_header_remains_optional_in_lenient_mode() {
+        let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "route", "arguments": {"tenant": "acme"}}});
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "tenant": {"type": "string", "x-mcp-header": "Tenant"}
+            }
+        });
+        validate_with_tool_schema(
+            &hm(&[("mcp-method", "tools/call"), ("mcp-name", "route")]),
+            &body,
+            Sep2243Mode::Lenient,
+            Some(&schema),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn schema_rejects_duplicate_annotation_names_case_insensitively() {
+        let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {"name": "route", "arguments": {}}});
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "a": {"type": "string", "x-mcp-header": "Tenant"},
+                "b": {"type": "string", "x-mcp-header": "TENANT"}
+            }
+        });
+        let err = validate_with_tool_schema(
+            &hm(&[("mcp-method", "tools/call"), ("mcp-name", "route")]),
+            &body,
+            Sep2243Mode::Strict,
+            Some(&schema),
+        )
+        .unwrap_err();
+        assert_eq!(err.code, -32020);
+        assert!(err.message.contains("duplicate x-mcp-header"));
+    }
+
+    #[test]
+    fn schema_rejects_annotations_outside_direct_properties_chains() {
+        for schema in [
+            json!({
+                "type": "object",
+                "allOf": [{
+                    "properties": {
+                        "tenant": {"type": "string", "x-mcp-header": "Tenant"}
+                    }
+                }]
+            }),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "tenant": {"type": "string", "x-mcp-header": "Tenant"}
+                    }
+                }
+            }),
+        ] {
+            let body = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+                "params": {"name": "route", "arguments": {}}});
+            let err = validate_with_tool_schema(
+                &hm(&[("mcp-method", "tools/call"), ("mcp-name", "route")]),
+                &body,
+                Sep2243Mode::Strict,
+                Some(&schema),
+            )
+            .unwrap_err();
+            assert_eq!(err.code, -32020);
+            assert!(err.message.contains("not statically reachable"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
Completes the remaining server-side SEP-2243 work in #952.

## Summary

- resolve the selected static or dynamic tool input schema before HTTP dispatch
- require each non-null body argument annotated with `x-mcp-header` to carry its declared `Mcp-Param-*` header on the final protocol path
- map annotation names to exact nested `properties` paths instead of assuming the header suffix equals the JSON key
- enforce primitive types, RFC 9110 token syntax, case-insensitive uniqueness, direct-properties reachability, duplicate request-header rejection, and null/missing omission semantics
- use `params.taskId` as `Mcp-Name` for `tasks/get`, `tasks/update`, and `tasks/cancel`
- align Base64 sentinel recognition with the final spec's exact lowercase marker
- remove the now-green custom-header scenario from the final conformance baseline

For `HttpTransport::from_service`, supplied custom headers remain best-effort validated; missing custom headers cannot be inferred because an opaque service does not expose a tool-schema registry. `HttpTransport::new(McpRouter)` provides full validation, including dynamic tools.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tower-mcp --no-default-features --features http`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (801 + 148 unit tests)
- `cargo test --test '*' --all-features`
- `cargo test --doc --all-features`
- official `http-custom-header-server-validation`: **9/9 passed, 0 failures, 0 warnings**
- official full 2026-07-28 server suite: **94/104 passed**, baseline clean; all 10 remaining failures are MRTR and tracked by #950