### PR TITLE
feat: implement final-protocol MRTR server support

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -235,7 +235,7 @@ jobs:
             --expected-failures ./conformance-baseline-client.yml
 
   draft-conformance:
-    name: Official 2026-07-28 Draft Suite
+    name: Official 2026-07-28 Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -267,15 +267,13 @@ jobs:
           cat /tmp/conformance-server-draft.log
           exit 1
 
-      - name: Run official 2026-07-28 draft suite
+      - name: Run official 2026-07-28 suite
         run: |
-          # The 0.2.0-alpha.x line carries the 2026-07-28 draft scenarios.
-          # --suite all includes draft/pending-status scenarios
-          # (server-stateless, caching, header validation, the 14 MRTR
-          # input-required-result scenarios). Known gaps are inventoried in
-          # conformance-baseline-draft.yml, one entry per parity-roadmap
-          # phase issue (#929); the job fails on unexpected failures OR on
-          # stale baseline entries that started passing.
+          # The current 0.2.0-alpha.x package carries the final 2026-07-28
+          # scenarios. --suite all includes all final-protocol checks,
+          # including stateless requests, caching, header validation, and
+          # the 14 MRTR input-required-result scenarios. The empty baseline
+          # keeps CI strict if a regression appears.
           npx @modelcontextprotocol/conformance@0.2.0-alpha.10 server \
             --url http://127.0.0.1:3001/mcp \
             --spec-version 2026-07-28 \
@@ -287,7 +285,7 @@ jobs:
         run: cat /tmp/conformance-server-draft.log
 
   draft-client-conformance:
-    name: Official 2026-07-28 Draft Client Suite
+    name: Official 2026-07-28 Client Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -300,10 +298,10 @@ jobs:
       - name: Build conformance client
         run: cargo build --manifest-path examples/conformance-client/Cargo.toml
 
-      - name: Run official 2026-07-28 draft client suite
+      - name: Run official 2026-07-28 client suite
         run: |
-          # The client half of the draft suite (#1027): the other three jobs
-          # cover stable client, stable server and draft server, so this was
+          # The client half of the final-version suite (#1027): the other three jobs
+          # cover stable client, stable server and final-version server, so this was
           # the least-visible coverage gap. Known gaps are inventoried in
           # conformance-baseline-draft-client.yml, grouped by SEP and tracked
           # in #953; the job fails on unexpected failures OR on stale baseline
@@ -334,7 +332,7 @@ jobs:
           sed 's/\x1b\[[0-9;]*m//g' "$log" > /tmp/conformance-draft-client-clean.log
           clean=/tmp/conformance-draft-client-clean.log
           {
-            echo '## Official 2026-07-28 draft client suite'
+            echo '## Official 2026-07-28 client suite'
             echo
             if grep -q '^Total:' "$clean"; then
               echo "Unbaselined: $(grep -m1 '^Total:' "$clean" | sed 's/^Total: //')"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 suites (67/101 server and 171/213 client checks at 0.2.0-alpha.10, gaps baselined per [#929](https://github.com/joshrotenberg/tower-mcp/issues/929) and [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 suites (114/114 server and 171/213 client checks at 0.2.0-alpha.10, client gaps baselined in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -588,17 +588,46 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 - **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
 - **Client (2025-11-25):** 264/266 checks (`conformance@0.1.16`; the two gaps are new offline-access scenarios, baselined in `conformance-baseline-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953))
-- **Server (2026-07-28):** 67/101 checks (`conformance@0.2.0-alpha.10`, `--suite all`); remaining gaps are baselined in `conformance-baseline-draft.yml`, one entry per phase of the parity roadmap in [#929](https://github.com/joshrotenberg/tower-mcp/issues/929)
+- **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
 - **Client (2026-07-28):** 171/213 checks (`conformance@0.2.0-alpha.10`, `--suite all`); gaps are baselined in `conformance-baseline-draft-client.yml`, grouped by SEP and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)
 
 Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. CI fails when a baselined scenario regresses further or starts passing (stale baseline), so the baselines cannot silently rot.
 
 The `protocol-2026-07-28` feature enables the experimental implementation of the released
 2026-07-28 protocol (version-gated, behind
-`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, and per-request
-`_meta` capabilities as defined by SEP-2575 and SEP-2567. It is not enabled by default and is
+`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, per-request
+`_meta` capabilities, and SEP-2322 Multi Round-Trip Requests. It is not enabled by default and is
 not yet included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
 runtime enablement are reported separately.
+
+MRTR-aware tool, prompt, resource, and resource-template handlers return
+`RequestOutcome<T>`. Retry values are exposed on `RequestContext`, while
+`RequestStateCodec` provides versioned, expiring, HMAC-SHA256 state tokens:
+
+```rust
+use tower_mcp::{
+    CallToolResult, InputRequest, InputRequiredResult, InputRequests, ListRootsParams,
+    NoParams, RequestOutcome, ToolBuilder,
+};
+
+let tool = ToolBuilder::new("workspace_summary")
+    .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+        if ctx.input_responses().is_some_and(|r| r.contains_key("roots")) {
+            return Ok(RequestOutcome::Complete(CallToolResult::text("ready")));
+        }
+
+        let requests: InputRequests = [(
+            "roots".into(),
+            InputRequest::ListRoots(ListRootsParams::default()),
+        )]
+        .into_iter()
+        .collect();
+        Ok(RequestOutcome::input_required(
+            InputRequiredResult::with_requests(requests),
+        ))
+    })
+    .build();
+```
 
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
 
@@ -627,9 +656,10 @@ runtime enablement are reported separately.
 - [x] [SSE event IDs and stream resumption](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery) (SEP-1699)
 - [x] [`_meta` field on all protocol types](https://modelcontextprotocol.io/specification/2025-11-25)
 - [x] [Strict HTTP headers: `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version` (SEP-2243)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final)
-- [x] [`server/discover` RPC -- stateless capability discovery (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
-- [x] [`subscriptions/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `stateless` feature, 2026-07-28+)
-- [x] [Per-request `_meta` client capabilities -- `StatelessRequestMeta` (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `stateless` feature, 2026-07-28+)
+- [x] [`server/discover` RPC -- stateless capability discovery (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `protocol-2026-07-28`)
+- [x] [`subscriptions/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `protocol-2026-07-28`)
+- [x] [Per-request `_meta` client capabilities -- `StatelessRequestMeta` (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `protocol-2026-07-28`)
+- [x] [Multi Round-Trip Requests for tools, prompts, and resources (SEP-2322)](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr) (requires `protocol-2026-07-28`)
 
 We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](https://github.com/joshrotenberg/tower-mcp/issues?q=label%3Asep). A weekly workflow syncs status from the upstream spec repository.
 

--- a/conformance-baseline-draft-client.yml
+++ b/conformance-baseline-draft-client.yml
@@ -1,6 +1,6 @@
-# MCP Conformance Suite -- Expected Failures Baseline (client, 2026-07-28 draft)
+# MCP Conformance Suite -- Expected Failures Baseline (client, 2026-07-28)
 #
-# Applies to the 0.2.0-alpha.x draft suite run with
+# Applies to the 0.2.0-alpha.x suite run with
 # `client --spec-version 2026-07-28 --suite all`. Each entry is a scenario
 # expected to fail (or carry SHOULD-level warnings, which the baseline checker
 # counts the same) while the client parity work in #953 is open. Remove entries
@@ -20,7 +20,7 @@ client:
   # SEP-2575: the client does not send `MCP-Protocol-Version` on the
   # initialize POST (it only sets the header once initialize has returned a
   # version), and does not populate the required per-request `_meta` fields.
-  # The draft harness answers a header-less POST with HTTP 400 / -32020, so
+  # The harness answers a header-less POST with HTTP 400 / -32020, so
   # every scenario that gets past auth and then makes an MCP call stops there.
   # This one gap accounts for most of the entries below. Client work in #953.
   - request-metadata

--- a/conformance-baseline-draft.yml
+++ b/conformance-baseline-draft.yml
@@ -1,40 +1,16 @@
-# MCP Conformance Suite -- Expected Failures Baseline (2026-07-28 draft)
+# MCP Conformance Suite -- Expected Failures Baseline (2026-07-28)
 #
-# Applies to the 0.2.0-alpha.x draft suite run with
+# Applies to the 0.2.0-alpha.x suite run with
 # `--spec-version 2026-07-28 --suite all`. Each entry is a scenario expected
 # to fail (or carry SHOULD-level warnings, which the baseline checker counts
 # the same) while the corresponding parity-roadmap issue (#929) is open.
 # Remove entries as the phases land; CI fails when a baselined scenario
 # starts passing (stale entry) or a non-baselined scenario fails.
 #
-# Status at 0.2.0-alpha.10 after the final HTTP lifecycle/listen and
-# schema-aware custom-header work in #952: 94/104 checks pass;
-# server-stateless passes 30/30 and http-custom-header-server-validation
-# passes 9/9. Note that
-# input-required-result-missing-input-response and
-# input-required-result-ignore-extra-params report "0 passed, 0 failed" in
-# the summary (they run no checks pending MRTR fixture tools) but the
-# harness's expected-failures gate still counts a zero-check scenario as an
-# unexpected failure unless baselined -- keep both entries even though the
-# summary line renders them with a checkmark.
+# Status at 0.2.0-alpha.10 after the final HTTP lifecycle, schema-aware
+# custom headers, and SEP-2322 MRTR work: all 114 server checks pass.
 #
 # Format (0.2.x suite): plain scenario-name strings under `server:` /
 # `client:` keys; reasons live in these comments.
 
-server:
-  # SEP-2322 MRTR is not implemented (#950). Scenarios that fully pass do so
-  # because correct non-MRTR behavior (rejecting unsupported methods)
-  # coincides with the spec; the two zero-check entries below also need the
-  # MRTR fixture tools to run any checks at all.
-  - input-required-result-basic-elicitation
-  - input-required-result-basic-sampling
-  - input-required-result-basic-list-roots
-  - input-required-result-request-state
-  - input-required-result-multiple-input-requests
-  - input-required-result-multi-round
-  - input-required-result-missing-input-response
-  - input-required-result-non-tool-request
-  - input-required-result-result-type
-  - input-required-result-tampered-state
-  - input-required-result-capability-check
-  - input-required-result-ignore-extra-params
+server: []

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -626,6 +626,9 @@ pub enum McpResponse {
     Initialize(InitializeResult),
     ListTools(ListToolsResult),
     CallTool(CallToolResult),
+    /// SEP-2322 response indicating that the original request needs one or
+    /// more client inputs before it can complete.
+    InputRequired(InputRequiredResult),
     ListResources(ListResourcesResult),
     ListResourceTemplates(ListResourceTemplatesResult),
     ReadResource(ReadResourceResult),
@@ -4823,11 +4826,87 @@ impl InputRequiredResult {
             meta: None,
         }
     }
+
+    /// Create an input-required result carrying the requests the client must
+    /// fulfil before retrying the original method.
+    pub fn with_requests(input_requests: InputRequests) -> Self {
+        Self {
+            input_requests: Some(input_requests),
+            ..Self::new()
+        }
+    }
+
+    /// Attach opaque server state that the client must echo unchanged on its
+    /// next attempt.
+    pub fn with_request_state(mut self, request_state: impl Into<String>) -> Self {
+        self.request_state = Some(request_state.into());
+        self
+    }
+
+    /// Validate the invariants required by SEP-2322.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.result_type != ResultType::InputRequired {
+            return Err("resultType must be \"input_required\"");
+        }
+        if self.input_requests.is_none() && self.request_state.is_none() {
+            return Err("at least one of inputRequests or requestState must be present");
+        }
+        Ok(())
+    }
 }
 
 impl Default for InputRequiredResult {
     fn default() -> Self {
         InputRequiredResult::new()
+    }
+}
+
+/// Result of a request that may either complete or ask the client for
+/// additional input (SEP-2322).
+///
+/// This is the server-handler outcome for `tools/call`, `prompts/get`, and
+/// `resources/read`. Ordinary handlers continue returning their established
+/// complete result type; MRTR-aware handlers return this enum.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum RequestOutcome<T> {
+    /// The request completed normally.
+    Complete(T),
+    /// The client must fulfil the embedded requests and retry.
+    InputRequired(InputRequiredResult),
+}
+
+impl<T> RequestOutcome<T> {
+    /// Create an input-required outcome.
+    pub fn input_required(result: InputRequiredResult) -> Self {
+        RequestOutcome::InputRequired(result)
+    }
+
+    /// Whether this outcome completed the request.
+    pub fn is_complete(&self) -> bool {
+        matches!(self, RequestOutcome::Complete(_))
+    }
+
+    /// Borrow the complete result, if present.
+    pub fn as_complete(&self) -> Option<&T> {
+        match self {
+            RequestOutcome::Complete(result) => Some(result),
+            RequestOutcome::InputRequired(_) => None,
+        }
+    }
+
+    /// Borrow the input-required result, if present.
+    pub fn as_input_required(&self) -> Option<&InputRequiredResult> {
+        match self {
+            RequestOutcome::Complete(_) => None,
+            RequestOutcome::InputRequired(result) => Some(result),
+        }
+    }
+}
+
+impl<T> From<T> for RequestOutcome<T> {
+    fn from(result: T) -> Self {
+        RequestOutcome::Complete(result)
     }
 }
 
@@ -6564,6 +6643,33 @@ mod draft_2026_07_28_tests {
         let back: InputRequiredResult = serde_json::from_value(v).unwrap();
         assert_eq!(back.result_type, ResultType::InputRequired);
         assert_eq!(back.request_state.as_deref(), Some("opaque-blob"));
+    }
+
+    #[test]
+    fn input_required_builders_validate_and_request_outcome_preserves_variant() {
+        let requests: InputRequests = [(
+            "roots".to_string(),
+            InputRequest::ListRoots(ListRootsParams::default()),
+        )]
+        .into_iter()
+        .collect();
+        let result =
+            InputRequiredResult::with_requests(requests).with_request_state("opaque-state");
+        assert!(result.validate().is_ok());
+
+        let outcome: RequestOutcome<CallToolResult> = RequestOutcome::input_required(result);
+        assert!(!outcome.is_complete());
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("opaque-state")
+        );
+
+        assert!(InputRequiredResult::new().validate().is_err());
+        let complete: RequestOutcome<CallToolResult> = CallToolResult::text("done").into();
+        assert!(complete.is_complete());
+        assert!(complete.as_complete().is_some());
     }
 
     #[test]

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -77,7 +77,7 @@ macros = ["dep:tower-mcp-macros"]
 protocol-2026-07-28 = ["stateless"]
 # Compatibility alias for the former feature name. New consumers should enable
 # `protocol-2026-07-28`; existing `stateless` users retain the same behavior.
-stateless = []
+stateless = ["dep:sha2"]
 
 [dependencies.axum]
 workspace = true

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -509,6 +509,32 @@ impl RequestContext {
         self.extension::<crate::stateless::StatelessRequestMeta>()
     }
 
+    /// SEP-2322 continuation values supplied by the client on this attempt.
+    #[cfg(feature = "stateless")]
+    pub fn mrtr(&self) -> Option<&crate::mrtr::MrtrRequest> {
+        self.extension::<crate::mrtr::MrtrRequest>()
+    }
+
+    /// Client responses from the prior MRTR round, if any.
+    #[cfg(feature = "stateless")]
+    pub fn input_responses(&self) -> Option<&crate::protocol::InputResponses> {
+        self.mrtr()
+            .and_then(crate::mrtr::MrtrRequest::input_responses)
+    }
+
+    /// Opaque request state echoed by the client, if any.
+    #[cfg(feature = "stateless")]
+    pub fn request_state(&self) -> Option<&str> {
+        self.mrtr()
+            .and_then(crate::mrtr::MrtrRequest::request_state)
+    }
+
+    /// Router-configured request-state codec shared by this handler.
+    #[cfg(feature = "stateless")]
+    pub fn request_state_codec(&self) -> Option<&crate::mrtr::RequestStateCodec> {
+        self.extension::<crate::mrtr::RequestStateCodec>()
+    }
+
     /// Get the request ID
     pub fn request_id(&self) -> &RequestId {
         &self.request_id

--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -1062,7 +1062,9 @@ where
             annotations: self.annotations,
             task_support: self.task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
             input_schema: self.input_schema,
         }
     }
@@ -1187,7 +1189,9 @@ where
             annotations: self.annotations,
             task_support: self.task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
             input_schema: self.input_schema,
         }
     }
@@ -1292,7 +1296,9 @@ where
             annotations: self.annotations,
             task_support: self.task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
             input_schema,
         }
     }

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -136,9 +136,11 @@
 //! - [`GetPromptResult`] - Prompt expansion result
 //! - [`Content`] - Text, image, audio, or resource content
 //!
-//! ### Stateless (2026-07-28, requires `stateless` feature)
+//! ### Experimental 2026-07-28 protocol (requires `protocol-2026-07-28`)
 //! - [`stateless::StatelessRequestMeta`] - Per-request `_meta` carrying protocol version,
 //!   client identity, and client capabilities for sessionless 2026-07-28 requests
+//! - [`RequestOutcome`] and [`InputRequiredResult`] - SEP-2322 Multi Round-Trip Request results
+//! - [`RequestStateCodec`] - Expiring, integrity-protected continuation state
 //!
 //! ## Feature Flags
 //!
@@ -156,9 +158,11 @@
 //! - `http-client` - HTTP client transport for connecting to remote MCP servers
 //! - `oauth-client` - OAuth 2.0 client-side token acquisition via client credentials grant (requires `http-client`)
 //! - `macros` - Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`)
-//! - `stateless` - Experimental 2026-07-28 stateless protocol mode (SEP-2575 + SEP-2567). Enables
+//! - `protocol-2026-07-28` - Compile the experimental implementation of the released final
+//!   protocol. Use [`ProtocolSupport`] to select enabled versions at runtime. Enables
 //!   version-gated sessionless dispatch, `server/discover` RPC, per-request `_meta` via
-//!   [`stateless::StatelessRequestMeta`], and `subscriptions/listen` SSE endpoint. Requires `http`.
+//!   [`stateless::StatelessRequestMeta`], `subscriptions/listen`, and SEP-2322 MRTR handlers.
+//! - `stateless` - Compatibility alias for the former 2026 protocol feature name.
 //!
 //! ## Middleware Placement Guide
 //!
@@ -332,10 +336,10 @@
 //!     .build();
 //! ```
 //!
-//! ### Stateless Mode (2026-07-28, requires `stateless` + `http` features)
+//! ### Stateless Mode (2026-07-28, requires `protocol-2026-07-28` + `http`)
 //!
-//! The `stateless` feature enables experimental support for the 2026-07-28 MCP protocol
-//! (SEP-2575 final + SEP-2567 accepted). In this mode the initialize/initialized handshake
+//! The `protocol-2026-07-28` feature enables experimental support for the final
+//! 2026-07-28 MCP protocol. In this mode the initialize/initialized handshake
 //! is replaced by two new RPCs:
 //!
 //! - **`server/discover`** -- stateless capability discovery. Clients that send requests with
@@ -348,8 +352,8 @@
 //!
 //! Per-request client identity and capabilities ride in each request's `_meta` object via
 //! [`stateless::StatelessRequestMeta`] rather than being negotiated once at session open.
-//! The `MCP-Protocol-Version` header value is the version gate: requests carrying `2026-07-28`
-//! or later route through the stateless path; older requests continue through the
+//! The `MCP-Protocol-Version` header value is the version gate: requests carrying exactly
+//! `2026-07-28` route through the stateless path; older requests continue through the
 //! session-based path unchanged.
 //!
 //! ```rust,ignore
@@ -429,15 +433,19 @@
 //!
 //! ## MCP Specification
 //!
-//! This crate implements the MCP specification (2025-11-25):
-//! <https://modelcontextprotocol.io/specification/2025-11-25>
+//! This crate implements MCP 2025-11-25 by default and provides an
+//! experimental implementation of the released 2026-07-28 specification:
+//! <https://modelcontextprotocol.io/specification/2026-07-28>
 //!
-//! The `stateless` feature additionally tracks the upcoming 2026-07-28 protocol defined by:
-//! - [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (accepted) --
+//! Enable it with `protocol-2026-07-28`; the legacy `stateless` feature name
+//! remains a compatibility alias. Major final-version work includes:
+//! - [SEP-2322](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2322) --
+//!   Multi Round-Trip Requests
+//! - [SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) --
 //!   `subscriptions/listen` SSE endpoint
-//! - [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (final) --
+//! - [SEP-2575](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) --
 //!   stateless session model, `server/discover`, per-request `_meta`
-//! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final) --
+//! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) --
 //!   strict HTTP headers (`Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`)
 
 pub mod async_task;
@@ -453,6 +461,8 @@ pub mod extract;
 pub mod filter;
 pub mod jsonrpc;
 pub mod middleware;
+#[cfg(feature = "stateless")]
+pub mod mrtr;
 #[cfg(feature = "oauth")]
 pub mod oauth;
 pub mod prompt;
@@ -522,6 +532,10 @@ pub use middleware::{
     AuditLayer, AuditService, McpTracingLayer, McpTracingService, ToolCallLoggingLayer,
     ToolCallLoggingService,
 };
+#[cfg(feature = "stateless")]
+pub use mrtr::{MrtrRequest, RequestStateCodec, RequestStateError};
+#[cfg(feature = "stateless")]
+pub use prompt::MrtrPromptHandler;
 pub use prompt::{BoxPromptService, Prompt, PromptBuilder, PromptHandler, PromptRequest};
 #[allow(deprecated)]
 pub use protocol::{
@@ -537,7 +551,8 @@ pub use protocol::{
     ElicitationCompleteParams, ElicitationFormCapability, ElicitationUrlCapability, EmptyResult,
     GetPromptParams, GetPromptResult, GetPromptResultBuilder, GetTaskInfoParams,
     GetTaskResultParams, IconTheme, Implementation, IncludeContext, InitializeParams,
-    InitializeResult, IntegerSchema, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification,
+    InitializeResult, InputRequest, InputRequests, InputRequiredResult, InputResponse,
+    InputResponses, IntegerSchema, JsonRpcErrorResponse, JsonRpcMessage, JsonRpcNotification,
     JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage, JsonRpcResultResponse,
     ListPromptsParams, ListPromptsResult, ListResourceTemplatesParams, ListResourceTemplatesResult,
     ListResourcesParams, ListResourcesResult, ListRootsParams, ListRootsResult, ListTasksParams,
@@ -546,10 +561,10 @@ pub use protocol::{
     MultiSelectEnumItems, MultiSelectEnumSchema, NumberSchema, PrimitiveSchemaDefinition,
     ProgressParams, ProgressToken, PromptArgument, PromptDefinition, PromptMessage,
     PromptReference, PromptRole, PromptsCapability, ReadResourceParams, ReadResourceResult,
-    RequestId, RequestMeta, ResourceContent, ResourceDefinition, ResourceReference,
-    ResourceTemplateDefinition, ResourcesCapability, Root, RootsCapability, SamplingCapability,
-    SamplingContent, SamplingContentOrArray, SamplingContextCapability, SamplingMessage,
-    SamplingTool, SamplingToolsCapability, ServerCapabilities, SetLogLevelParams,
+    RequestId, RequestMeta, RequestOutcome, ResourceContent, ResourceDefinition, ResourceReference,
+    ResourceTemplateDefinition, ResourcesCapability, ResultType, Root, RootsCapability,
+    SamplingCapability, SamplingContent, SamplingContentOrArray, SamplingContextCapability,
+    SamplingMessage, SamplingTool, SamplingToolsCapability, ServerCapabilities, SetLogLevelParams,
     SingleSelectEnumSchema, StringSchema, SubscribeResourceParams, TaskInfo, TaskObject,
     TaskRequestParams, TaskStatus, TaskStatusChangedParams, TaskStatusParams, TaskSupportMode,
     TasksCancelCapability, TasksCapability, TasksListCapability, TasksRequestsCapability,
@@ -567,8 +582,12 @@ pub use resource::{
     BoxResourceService, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
     ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,
 };
+#[cfg(feature = "stateless")]
+pub use resource::{MrtrResourceHandler, MrtrResourceTemplateHandler};
 pub use router::{McpRouter, RouterRequest, RouterResponse, ToolAnnotationsMap};
 pub use session::{SessionPhase, SessionState};
+#[cfg(feature = "stateless")]
+pub use tool::MrtrToolHandler;
 pub use tool::{BoxToolService, GuardLayer, NoParams, Tool, ToolBuilder, ToolHandler, ToolRequest};
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,

--- a/crates/tower-mcp/src/mrtr.rs
+++ b/crates/tower-mcp/src/mrtr.rs
@@ -1,0 +1,375 @@
+//! Server-side helpers for Multi Round-Trip Requests (SEP-2322).
+//!
+//! The final protocol carries continuation state through an untrusted client.
+//! [`RequestStateCodec`] produces versioned, expiring, HMAC-SHA256-protected
+//! tokens so stateless server instances can share continuation state safely by
+//! sharing the same key.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
+
+use crate::protocol::InputResponses;
+
+const TOKEN_VERSION: &str = "v1";
+const SHA256_BLOCK_SIZE: usize = 64;
+const DEFAULT_MAX_TOKEN_BYTES: usize = 64 * 1024;
+
+/// MRTR continuation values supplied on a retry of the original request.
+///
+/// The router inserts this value into [`crate::RequestContext`] for
+/// `tools/call`, `prompts/get`, and `resources/read`. Handlers can use
+/// [`RequestContext::mrtr`](crate::RequestContext::mrtr) or the convenience
+/// accessors on the context.
+#[derive(Debug, Clone, Default)]
+pub struct MrtrRequest {
+    input_responses: Option<InputResponses>,
+    request_state: Option<String>,
+}
+
+impl MrtrRequest {
+    pub(crate) fn new(
+        input_responses: Option<InputResponses>,
+        request_state: Option<String>,
+    ) -> Self {
+        Self {
+            input_responses,
+            request_state,
+        }
+    }
+
+    /// Client responses keyed by the identifiers from the prior
+    /// `inputRequests` map.
+    pub fn input_responses(&self) -> Option<&InputResponses> {
+        self.input_responses.as_ref()
+    }
+
+    /// Opaque continuation token echoed by the client.
+    pub fn request_state(&self) -> Option<&str> {
+        self.request_state.as_deref()
+    }
+
+    /// Consume the continuation values.
+    pub fn into_parts(self) -> (Option<InputResponses>, Option<String>) {
+        (self.input_responses, self.request_state)
+    }
+}
+
+/// Errors produced while encoding or validating opaque MRTR request state.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RequestStateError {
+    /// HMAC keys shorter than 256 bits do not meet this codec's minimum.
+    #[error("request-state key must be at least 32 bytes")]
+    WeakKey,
+    /// The configured TTL must allow the state to live for some amount of time.
+    #[error("request-state TTL must be greater than zero")]
+    ZeroTtl,
+    /// The serialized state exceeded the configured token-size limit.
+    #[error("request-state token exceeds the configured maximum of {0} bytes")]
+    TooLarge(usize),
+    /// The token did not have the versioned three-part wire shape.
+    #[error("request-state token is malformed")]
+    Malformed,
+    /// The token uses a codec version this server does not understand.
+    #[error("unsupported request-state token version")]
+    UnsupportedVersion,
+    /// The HMAC did not match the payload.
+    #[error("request-state integrity verification failed")]
+    Integrity,
+    /// The token is no longer valid.
+    #[error("request-state token has expired")]
+    Expired,
+    /// A token bound to one authorization subject was used by another.
+    #[error("request-state token is not bound to the current subject")]
+    SubjectMismatch,
+    /// The state value could not be serialized.
+    #[error("failed to serialize request state: {0}")]
+    Encode(#[source] serde_json::Error),
+    /// The state value could not be decoded as the expected type.
+    #[error("failed to decode request state: {0}")]
+    Decode(#[source] serde_json::Error),
+    /// The system clock is earlier than the Unix epoch.
+    #[error("system clock is earlier than the Unix epoch")]
+    Clock,
+}
+
+#[derive(Debug, Serialize, serde::Deserialize)]
+struct StateEnvelope<T> {
+    issued_at: u64,
+    expires_at: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    subject: Option<String>,
+    state: T,
+}
+
+/// HMAC-SHA256 codec for opaque, expiring MRTR `requestState` values.
+///
+/// Construct the codec with the same key and TTL on every server instance
+/// that may receive a retry. Use [`encode_for`](Self::encode_for) and
+/// [`decode_for`](Self::decode_for) when an authenticated subject is
+/// available; subject binding prevents one user from replaying another user's
+/// continuation token.
+#[derive(Clone)]
+pub struct RequestStateCodec {
+    key: std::sync::Arc<[u8]>,
+    ttl: Duration,
+    max_token_bytes: usize,
+}
+
+impl std::fmt::Debug for RequestStateCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RequestStateCodec")
+            .field("key", &"<redacted>")
+            .field("ttl", &self.ttl)
+            .field("max_token_bytes", &self.max_token_bytes)
+            .finish()
+    }
+}
+
+impl RequestStateCodec {
+    /// Create a codec from a shared key and token TTL.
+    ///
+    /// The key must contain at least 32 bytes of entropy. Configuration
+    /// secrets should be decoded to raw bytes before calling this constructor.
+    pub fn new(key: impl AsRef<[u8]>, ttl: Duration) -> Result<Self, RequestStateError> {
+        let key = key.as_ref();
+        if key.len() < 32 {
+            return Err(RequestStateError::WeakKey);
+        }
+        if ttl.is_zero() {
+            return Err(RequestStateError::ZeroTtl);
+        }
+        Ok(Self {
+            key: std::sync::Arc::from(key),
+            ttl,
+            max_token_bytes: DEFAULT_MAX_TOKEN_BYTES,
+        })
+    }
+
+    /// Set the maximum accepted and emitted token size.
+    pub fn with_max_token_bytes(mut self, max_token_bytes: usize) -> Self {
+        self.max_token_bytes = max_token_bytes;
+        self
+    }
+
+    /// Encode state without authorization-subject binding.
+    pub fn encode<T: Serialize>(&self, state: &T) -> Result<String, RequestStateError> {
+        self.encode_at(None, state, unix_seconds()?)
+    }
+
+    /// Encode state bound to an authenticated subject identifier.
+    pub fn encode_for<T: Serialize>(
+        &self,
+        subject: impl Into<String>,
+        state: &T,
+    ) -> Result<String, RequestStateError> {
+        self.encode_at(Some(subject.into()), state, unix_seconds()?)
+    }
+
+    /// Verify and decode state that was not subject-bound.
+    pub fn decode<T: DeserializeOwned>(&self, token: &str) -> Result<T, RequestStateError> {
+        self.decode_at(token, None, unix_seconds()?)
+    }
+
+    /// Verify and decode state for the current authenticated subject.
+    pub fn decode_for<T: DeserializeOwned>(
+        &self,
+        token: &str,
+        subject: &str,
+    ) -> Result<T, RequestStateError> {
+        self.decode_at(token, Some(subject), unix_seconds()?)
+    }
+
+    fn encode_at<T: Serialize>(
+        &self,
+        subject: Option<String>,
+        state: &T,
+        now: u64,
+    ) -> Result<String, RequestStateError> {
+        let ttl = self.ttl.as_secs();
+        let envelope = StateEnvelope {
+            issued_at: now,
+            expires_at: now.saturating_add(ttl),
+            subject,
+            state,
+        };
+        let payload = serde_json::to_vec(&envelope).map_err(RequestStateError::Encode)?;
+        let payload = URL_SAFE_NO_PAD.encode(payload);
+        let signed = format!("{TOKEN_VERSION}.{payload}");
+        let signature = URL_SAFE_NO_PAD.encode(hmac_sha256(&self.key, signed.as_bytes()));
+        let token = format!("{signed}.{signature}");
+        if token.len() > self.max_token_bytes {
+            return Err(RequestStateError::TooLarge(self.max_token_bytes));
+        }
+        Ok(token)
+    }
+
+    fn decode_at<T: DeserializeOwned>(
+        &self,
+        token: &str,
+        subject: Option<&str>,
+        now: u64,
+    ) -> Result<T, RequestStateError> {
+        if token.len() > self.max_token_bytes {
+            return Err(RequestStateError::TooLarge(self.max_token_bytes));
+        }
+        let mut parts = token.split('.');
+        let version = parts.next().ok_or(RequestStateError::Malformed)?;
+        let payload = parts.next().ok_or(RequestStateError::Malformed)?;
+        let signature = parts.next().ok_or(RequestStateError::Malformed)?;
+        if parts.next().is_some() {
+            return Err(RequestStateError::Malformed);
+        }
+        if version != TOKEN_VERSION {
+            return Err(RequestStateError::UnsupportedVersion);
+        }
+
+        let supplied_signature = URL_SAFE_NO_PAD
+            .decode(signature)
+            .map_err(|_| RequestStateError::Malformed)?;
+        let signed = format!("{version}.{payload}");
+        let expected_signature = hmac_sha256(&self.key, signed.as_bytes());
+        if !constant_time_eq(&supplied_signature, &expected_signature) {
+            return Err(RequestStateError::Integrity);
+        }
+
+        let payload = URL_SAFE_NO_PAD
+            .decode(payload)
+            .map_err(|_| RequestStateError::Malformed)?;
+        let envelope: StateEnvelope<T> =
+            serde_json::from_slice(&payload).map_err(RequestStateError::Decode)?;
+        if now > envelope.expires_at {
+            return Err(RequestStateError::Expired);
+        }
+        match (envelope.subject.as_deref(), subject) {
+            (None, None) => {}
+            (Some(expected), Some(actual)) if expected == actual => {}
+            _ => return Err(RequestStateError::SubjectMismatch),
+        }
+        Ok(envelope.state)
+    }
+}
+
+fn unix_seconds() -> Result<u64, RequestStateError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|_| RequestStateError::Clock)
+}
+
+fn hmac_sha256(key: &[u8], message: &[u8]) -> [u8; 32] {
+    let mut normalized = [0u8; SHA256_BLOCK_SIZE];
+    if key.len() > SHA256_BLOCK_SIZE {
+        normalized[..32].copy_from_slice(&Sha256::digest(key));
+    } else {
+        normalized[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; SHA256_BLOCK_SIZE];
+    let mut outer_pad = [0x5cu8; SHA256_BLOCK_SIZE];
+    for ((inner, outer), key_byte) in inner_pad
+        .iter_mut()
+        .zip(outer_pad.iter_mut())
+        .zip(normalized)
+    {
+        *inner ^= key_byte;
+        *outer ^= key_byte;
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(message);
+    let inner = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner);
+    outer.finalize().into()
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY: &[u8; 32] = b"0123456789abcdef0123456789abcdef";
+
+    #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    struct State {
+        round: u8,
+        value: String,
+    }
+
+    #[test]
+    fn round_trips_shared_state() {
+        let first = RequestStateCodec::new(KEY, Duration::from_secs(60)).unwrap();
+        let second = RequestStateCodec::new(KEY, Duration::from_secs(60)).unwrap();
+        let state = State {
+            round: 2,
+            value: "kept".into(),
+        };
+        let token = first.encode_at(None, &state, 100).unwrap();
+        assert_eq!(second.decode_at::<State>(&token, None, 120).unwrap(), state);
+    }
+
+    #[test]
+    fn rejects_tampering_expiry_and_wrong_subject() {
+        let codec = RequestStateCodec::new(KEY, Duration::from_secs(10)).unwrap();
+        let token = codec
+            .encode_at(
+                Some("alice".into()),
+                &State {
+                    round: 1,
+                    value: "x".into(),
+                },
+                100,
+            )
+            .unwrap();
+
+        assert!(matches!(
+            codec.decode_at::<State>(&format!("{token}x"), Some("alice"), 101),
+            Err(RequestStateError::Integrity | RequestStateError::Malformed)
+        ));
+        assert!(matches!(
+            codec.decode_at::<State>(&token, Some("bob"), 101),
+            Err(RequestStateError::SubjectMismatch)
+        ));
+        assert!(matches!(
+            codec.decode_at::<State>(&token, Some("alice"), 111),
+            Err(RequestStateError::Expired)
+        ));
+    }
+
+    #[test]
+    fn enforces_key_ttl_and_size_limits() {
+        assert!(matches!(
+            RequestStateCodec::new(b"short", Duration::from_secs(1)),
+            Err(RequestStateError::WeakKey)
+        ));
+        assert!(matches!(
+            RequestStateCodec::new(KEY, Duration::ZERO),
+            Err(RequestStateError::ZeroTtl)
+        ));
+        let codec = RequestStateCodec::new(KEY, Duration::from_secs(1))
+            .unwrap()
+            .with_max_token_bytes(8);
+        assert!(matches!(
+            codec.encode(&"too large"),
+            Err(RequestStateError::TooLarge(8))
+        ));
+    }
+}

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -61,7 +61,7 @@ use crate::context::RequestContext;
 use crate::error::{Error, Result};
 use crate::protocol::{
     Content, GetPromptResult, PromptArgument, PromptDefinition, PromptMessage, PromptRole,
-    RequestId, ToolIcon,
+    RequestId, RequestOutcome, ToolIcon,
 };
 
 /// A boxed future for prompt handlers
@@ -298,6 +298,18 @@ pub trait PromptHandler: Send + Sync {
     }
 }
 
+/// Prompt handler that may return an SEP-2322 input-required continuation.
+#[cfg(feature = "stateless")]
+pub trait MrtrPromptHandler: Send + Sync {
+    /// Resolve a prompt attempt with continuation values available through
+    /// the request context.
+    fn get(
+        &self,
+        ctx: RequestContext,
+        arguments: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<GetPromptResult>>>;
+}
+
 /// A complete prompt definition with handler
 pub struct Prompt {
     /// The prompt name (must be unique within the router).
@@ -310,7 +322,9 @@ pub struct Prompt {
     pub icons: Option<Vec<ToolIcon>>,
     /// The arguments this prompt accepts.
     pub arguments: Vec<PromptArgument>,
-    handler: Arc<dyn PromptHandler>,
+    handler: Option<Arc<dyn PromptHandler>>,
+    #[cfg(feature = "stateless")]
+    mrtr_handler: Option<Arc<dyn MrtrPromptHandler>>,
 }
 
 impl Clone for Prompt {
@@ -322,6 +336,8 @@ impl Clone for Prompt {
             icons: self.icons.clone(),
             arguments: self.arguments.clone(),
             handler: self.handler.clone(),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: self.mrtr_handler.clone(),
         }
     }
 }
@@ -361,7 +377,14 @@ impl Prompt {
         &self,
         arguments: HashMap<String, String>,
     ) -> BoxFuture<'_, Result<GetPromptResult>> {
-        self.handler.get(arguments)
+        match &self.handler {
+            Some(handler) => handler.get(arguments),
+            None => Box::pin(async {
+                Err(Error::invalid_params(
+                    "MRTR prompt requires get_outcome_with_context",
+                ))
+            }),
+        }
     }
 
     /// Get the prompt with request context
@@ -372,12 +395,46 @@ impl Prompt {
         ctx: RequestContext,
         arguments: HashMap<String, String>,
     ) -> BoxFuture<'_, Result<GetPromptResult>> {
-        self.handler.get_with_context(ctx, arguments)
+        match &self.handler {
+            Some(handler) => handler.get_with_context(ctx, arguments),
+            None => Box::pin(async {
+                Err(Error::invalid_params(
+                    "MRTR prompt requires get_outcome_with_context",
+                ))
+            }),
+        }
+    }
+
+    /// Get the prompt while preserving an SEP-2322 input-required outcome.
+    pub fn get_outcome_with_context(
+        &self,
+        ctx: RequestContext,
+        arguments: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<GetPromptResult>>> {
+        #[cfg(feature = "stateless")]
+        if let Some(handler) = &self.mrtr_handler {
+            return handler.get(ctx, arguments);
+        }
+        match &self.handler {
+            Some(handler) => Box::pin(async move {
+                handler
+                    .get_with_context(ctx, arguments)
+                    .await
+                    .map(RequestOutcome::Complete)
+            }),
+            None => Box::pin(async {
+                Err(Error::invalid_params(
+                    "prompt has neither a complete nor MRTR handler",
+                ))
+            }),
+        }
     }
 
     /// Returns true if this prompt uses context
     pub fn uses_context(&self) -> bool {
-        self.handler.uses_context()
+        self.handler
+            .as_ref()
+            .is_none_or(|handler| handler.uses_context())
     }
 }
 
@@ -582,6 +639,23 @@ impl PromptBuilder {
         }
     }
 
+    /// Set an SEP-2322 prompt handler that may return input-required.
+    #[cfg(feature = "stateless")]
+    pub fn mrtr_handler<F, Fut>(self, handler: F) -> PromptBuilderWithMrtrHandler<F>
+    where
+        F: Fn(RequestContext, HashMap<String, String>) -> Fut + Send + Sync + Clone + 'static,
+        Fut: Future<Output = Result<RequestOutcome<GetPromptResult>>> + Send + 'static,
+    {
+        PromptBuilderWithMrtrHandler {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            icons: self.icons,
+            arguments: self.arguments,
+            handler,
+        }
+    }
+
     /// Create a static prompt (no arguments needed)
     pub fn static_prompt(self, messages: Vec<PromptMessage>) -> Prompt {
         let description = self.description.clone();
@@ -640,6 +714,17 @@ pub struct PromptBuilderWithHandler<F> {
     handler: F,
 }
 
+#[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct PromptBuilderWithMrtrHandler<F> {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    icons: Option<Vec<ToolIcon>>,
+    arguments: Vec<PromptArgument>,
+    handler: F,
+}
+
 impl<F, Fut> PromptBuilderWithHandler<F>
 where
     F: Fn(HashMap<String, String>) -> Fut + Send + Sync + Clone + 'static,
@@ -653,9 +738,11 @@ where
             description: self.description,
             icons: self.icons,
             arguments: self.arguments,
-            handler: Arc::new(FnHandler {
+            handler: Some(Arc::new(FnHandler {
                 handler: self.handler,
-            }),
+            })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 
@@ -711,9 +798,33 @@ where
             description: self.description,
             icons: self.icons,
             arguments: self.arguments,
-            handler: Arc::new(ServiceHandler {
+            handler: Some(Arc::new(ServiceHandler {
                 service: Mutex::new(boxed),
-            }),
+            })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> PromptBuilderWithMrtrHandler<F>
+where
+    F: Fn(RequestContext, HashMap<String, String>) -> Fut + Send + Sync + Clone + 'static,
+    Fut: Future<Output = Result<RequestOutcome<GetPromptResult>>> + Send + 'static,
+{
+    /// Build the MRTR-capable prompt.
+    pub fn build(self) -> Prompt {
+        Prompt {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            icons: self.icons,
+            arguments: self.arguments,
+            handler: None,
+            mrtr_handler: Some(Arc::new(MrtrContextHandler {
+                handler: self.handler,
+            })),
         }
     }
 }
@@ -742,9 +853,11 @@ where
             description: self.description,
             icons: self.icons,
             arguments: self.arguments,
-            handler: Arc::new(ContextAwareHandler {
+            handler: Some(Arc::new(ContextAwareHandler {
                 handler: self.handler,
-            }),
+            })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 
@@ -768,9 +881,11 @@ where
             description: self.description,
             icons: self.icons,
             arguments: self.arguments,
-            handler: Arc::new(ServiceContextHandler {
+            handler: Some(Arc::new(ServiceContextHandler {
                 service: Mutex::new(boxed),
-            }),
+            })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 }
@@ -797,6 +912,26 @@ where
 /// Handler that receives request context
 struct ContextAwareHandler<F> {
     handler: F,
+}
+
+#[cfg(feature = "stateless")]
+struct MrtrContextHandler<F> {
+    handler: F,
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> MrtrPromptHandler for MrtrContextHandler<F>
+where
+    F: Fn(RequestContext, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<GetPromptResult>>> + Send + 'static,
+{
+    fn get(
+        &self,
+        ctx: RequestContext,
+        arguments: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<GetPromptResult>>> {
+        Box::pin((self.handler)(ctx, arguments))
+    }
 }
 
 impl<F, Fut> PromptHandler for ContextAwareHandler<F>
@@ -982,7 +1117,9 @@ pub trait McpPrompt: Send + Sync + 'static {
             description: Some(Self::DESCRIPTION.to_string()),
             icons: None,
             arguments,
-            handler: Arc::new(McpPromptHandler { prompt }),
+            handler: Some(Arc::new(McpPromptHandler { prompt })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 }
@@ -1335,6 +1472,29 @@ mod tests {
         args.insert("name".to_string(), "Bob".to_string());
         let result = prompt.get(args).await.unwrap();
         assert_eq!(result.messages.len(), 1);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn test_mrtr_builder_preserves_input_required_outcome() {
+        let prompt = PromptBuilder::new("continue")
+            .mrtr_handler(|_ctx, _args| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("signed-state"),
+                ))
+            })
+            .build();
+
+        let outcome = prompt
+            .get_outcome_with_context(RequestContext::new(RequestId::Number(1)), HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("signed-state")
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -84,7 +84,7 @@ use tower_service::Service;
 use crate::context::RequestContext;
 use crate::error::{Error, Result};
 use crate::protocol::{
-    ContentAnnotations, ReadResourceResult, ResourceContent, ResourceDefinition,
+    ContentAnnotations, ReadResourceResult, RequestOutcome, ResourceContent, ResourceDefinition,
     ResourceTemplateDefinition, ToolIcon,
 };
 
@@ -242,6 +242,16 @@ pub trait ResourceHandler: Send + Sync {
     }
 }
 
+/// Resource handler that may return an SEP-2322 input-required continuation.
+#[cfg(feature = "stateless")]
+pub trait MrtrResourceHandler: Send + Sync {
+    /// Read a resource attempt with continuation values in the context.
+    fn read(
+        &self,
+        ctx: RequestContext,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>>;
+}
+
 /// Adapts a `ResourceHandler` to a Tower `Service<ResourceRequest>`.
 ///
 /// This is an internal adapter that bridges the handler abstraction to the
@@ -316,7 +326,9 @@ pub struct Resource {
     /// Optional annotations (audience, priority hints)
     pub annotations: Option<ContentAnnotations>,
     /// The boxed service that reads the resource
-    service: BoxResourceService,
+    service: Option<BoxResourceService>,
+    #[cfg(feature = "stateless")]
+    mrtr_handler: Option<Arc<dyn MrtrResourceHandler>>,
 }
 
 impl Clone for Resource {
@@ -331,6 +343,8 @@ impl Clone for Resource {
             size: self.size,
             annotations: self.annotations.clone(),
             service: self.service.clone(),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: self.mrtr_handler.clone(),
         }
     }
 }
@@ -396,16 +410,59 @@ impl Resource {
     /// Any errors from the handler or middleware are converted to error responses
     /// in the result contents.
     pub fn read_with_context(&self, ctx: RequestContext) -> BoxFuture<'static, ReadResourceResult> {
-        use tower::ServiceExt;
-        let service = self.service.clone();
+        let resource = self.clone();
         let uri = self.uri.clone();
         Box::pin(async move {
-            // ServiceExt::oneshot properly handles poll_ready before call
-            // Service is Infallible, so unwrap is safe
-            service
+            match resource.read_outcome_with_context(ctx).await {
+                Ok(RequestOutcome::Complete(result)) => result,
+                Ok(RequestOutcome::InputRequired(_)) => ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".into()),
+                        text: Some(
+                            "resource requires additional client input; use read_outcome_with_context"
+                                .into(),
+                        ),
+                        blob: None,
+                        meta: None,
+                    }],
+                    ..ReadResourceResult::default()
+                },
+                Err(error) => ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".into()),
+                        text: Some(error.to_string()),
+                        blob: None,
+                        meta: None,
+                    }],
+                    ..ReadResourceResult::default()
+                },
+            }
+        })
+    }
+
+    /// Read the resource while preserving an SEP-2322 continuation.
+    pub fn read_outcome_with_context(
+        &self,
+        ctx: RequestContext,
+    ) -> BoxFuture<'static, Result<RequestOutcome<ReadResourceResult>>> {
+        use tower::ServiceExt;
+        #[cfg(feature = "stateless")]
+        if let Some(handler) = self.mrtr_handler.clone() {
+            return Box::pin(async move { handler.read(ctx).await });
+        }
+        let service = self
+            .service
+            .clone()
+            .expect("resource must have a complete or MRTR handler");
+        let uri = self.uri.clone();
+        Box::pin(async move {
+            let result = service
                 .oneshot(ResourceRequest::new(ctx, uri))
                 .await
-                .unwrap()
+                .unwrap();
+            Ok(RequestOutcome::Complete(result))
         })
     }
 
@@ -435,7 +492,36 @@ impl Resource {
             icons,
             size,
             annotations,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+        }
+    }
+
+    #[cfg(feature = "stateless")]
+    #[allow(clippy::too_many_arguments)]
+    fn from_mrtr_handler<H: MrtrResourceHandler + 'static>(
+        uri: String,
+        name: String,
+        title: Option<String>,
+        description: Option<String>,
+        mime_type: Option<String>,
+        icons: Option<Vec<ToolIcon>>,
+        size: Option<u64>,
+        annotations: Option<ContentAnnotations>,
+        handler: H,
+    ) -> Self {
+        Self {
+            uri,
+            name,
+            title,
+            description,
+            mime_type,
+            icons,
+            size,
+            annotations,
+            service: None,
+            mrtr_handler: Some(Arc::new(handler)),
         }
     }
 }
@@ -647,6 +733,26 @@ impl ResourceBuilder {
         }
     }
 
+    /// Set an SEP-2322 resource handler that may return input-required.
+    #[cfg(feature = "stateless")]
+    pub fn mrtr_handler<F, Fut>(self, handler: F) -> ResourceBuilderWithMrtrHandler<F>
+    where
+        F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+    {
+        ResourceBuilderWithMrtrHandler {
+            uri: self.uri,
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            mime_type: self.mime_type,
+            icons: self.icons,
+            size: self.size,
+            annotations: self.annotations,
+            handler,
+        }
+    }
+
     /// Create a static text resource (convenience method)
     pub fn text(self, content: impl Into<String>) -> Resource {
         let uri = self.uri.clone();
@@ -716,6 +822,46 @@ pub struct ResourceBuilderWithHandler<F> {
     size: Option<u64>,
     annotations: Option<ContentAnnotations>,
     handler: F,
+}
+
+#[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct ResourceBuilderWithMrtrHandler<F> {
+    uri: String,
+    name: Option<String>,
+    title: Option<String>,
+    description: Option<String>,
+    mime_type: Option<String>,
+    icons: Option<Vec<ToolIcon>>,
+    size: Option<u64>,
+    annotations: Option<ContentAnnotations>,
+    handler: F,
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> ResourceBuilderWithMrtrHandler<F>
+where
+    F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+{
+    /// Build the resource with an SEP-2322-aware handler.
+    pub fn build(self) -> Resource {
+        let name = self.name.unwrap_or_else(|| self.uri.clone());
+
+        Resource::from_mrtr_handler(
+            self.uri,
+            name,
+            self.title,
+            self.description,
+            self.mime_type,
+            self.icons,
+            self.size,
+            self.annotations,
+            MrtrContextHandler {
+                handler: self.handler,
+            },
+        )
+    }
 }
 
 impl<F, Fut> ResourceBuilderWithHandler<F>
@@ -838,7 +984,9 @@ where
             icons: self.icons,
             size: self.size,
             annotations: self.annotations,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 
@@ -968,7 +1116,9 @@ where
             icons: self.icons,
             size: self.size,
             annotations: self.annotations,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
         }
     }
 
@@ -1032,6 +1182,25 @@ where
 
     fn uses_context(&self) -> bool {
         true
+    }
+}
+
+#[cfg(feature = "stateless")]
+struct MrtrContextHandler<F> {
+    handler: F,
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> MrtrResourceHandler for MrtrContextHandler<F>
+where
+    F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+{
+    fn read(
+        &self,
+        ctx: RequestContext,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>> {
+        Box::pin((self.handler)(ctx))
     }
 }
 
@@ -1141,6 +1310,18 @@ pub trait ResourceTemplateHandler: Send + Sync {
     ) -> BoxFuture<'_, Result<ReadResourceResult>>;
 }
 
+/// Resource-template handler that may return an SEP-2322 continuation.
+#[cfg(feature = "stateless")]
+pub trait MrtrResourceTemplateHandler: Send + Sync {
+    /// Read a matched template resource with retry values in the context.
+    fn read(
+        &self,
+        ctx: RequestContext,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>>;
+}
+
 /// A parameterized resource template
 ///
 /// Resource templates use URI template syntax (RFC 6570) to match multiple URIs
@@ -1191,7 +1372,9 @@ pub struct ResourceTemplate {
     /// Variable names in order of appearance
     variables: Vec<String>,
     /// Handler for reading matched resources
-    handler: Arc<dyn ResourceTemplateHandler>,
+    handler: Option<Arc<dyn ResourceTemplateHandler>>,
+    #[cfg(feature = "stateless")]
+    mrtr_handler: Option<Arc<dyn MrtrResourceTemplateHandler>>,
 }
 
 impl Clone for ResourceTemplate {
@@ -1207,6 +1390,8 @@ impl Clone for ResourceTemplate {
             pattern: self.pattern.clone(),
             variables: self.variables.clone(),
             handler: self.handler.clone(),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: self.mrtr_handler.clone(),
         }
     }
 }
@@ -1274,7 +1459,45 @@ impl ResourceTemplate {
         uri: &str,
         variables: HashMap<String, String>,
     ) -> BoxFuture<'_, Result<ReadResourceResult>> {
-        self.handler.read(uri, variables)
+        match &self.handler {
+            Some(handler) => handler.read(uri, variables),
+            None => Box::pin(async {
+                Err(Error::invalid_params(
+                    "MRTR resource template requires read_outcome_with_context",
+                ))
+            }),
+        }
+    }
+
+    /// Read a matched resource while preserving an SEP-2322 continuation.
+    pub fn read_outcome_with_context(
+        &self,
+        ctx: RequestContext,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>> {
+        let _ = &ctx;
+        #[cfg(feature = "stateless")]
+        if let Some(handler) = &self.mrtr_handler {
+            return handler.read(ctx, uri, variables);
+        }
+        match &self.handler {
+            Some(handler) => {
+                let handler = handler.clone();
+                let uri = uri.to_string();
+                Box::pin(async move {
+                    handler
+                        .read(&uri, variables)
+                        .await
+                        .map(RequestOutcome::Complete)
+                })
+            }
+            None => Box::pin(async {
+                Err(Error::invalid_params(
+                    "resource template has neither a complete nor MRTR handler",
+                ))
+            }),
+        }
     }
 }
 
@@ -1446,7 +1669,53 @@ impl ResourceTemplateBuilder {
             annotations: self.annotations,
             pattern,
             variables,
-            handler: Arc::new(FnTemplateHandler { handler }),
+            handler: Some(Arc::new(FnTemplateHandler { handler })),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+        })
+    }
+
+    /// Set an SEP-2322-aware template handler that may require client input.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the URI template produces an invalid regex pattern. Use
+    /// [`try_mrtr_handler`](Self::try_mrtr_handler) for a fallible variant.
+    #[cfg(feature = "stateless")]
+    pub fn mrtr_handler<F, Fut>(self, handler: F) -> ResourceTemplate
+    where
+        F: Fn(RequestContext, String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+    {
+        self.try_mrtr_handler(handler)
+            .unwrap_or_else(|error| panic!("Invalid URI template: {error}"))
+    }
+
+    /// Fallible variant of [`mrtr_handler`](Self::mrtr_handler).
+    #[cfg(feature = "stateless")]
+    pub fn try_mrtr_handler<F, Fut>(
+        self,
+        handler: F,
+    ) -> std::result::Result<ResourceTemplate, Error>
+    where
+        F: Fn(RequestContext, String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+    {
+        let (pattern, variables) = compile_uri_template(&self.uri_template)?;
+        let name = self.name.unwrap_or_else(|| self.uri_template.clone());
+
+        Ok(ResourceTemplate {
+            uri_template: self.uri_template,
+            name,
+            title: self.title,
+            description: self.description,
+            mime_type: self.mime_type,
+            icons: self.icons,
+            annotations: self.annotations,
+            pattern,
+            variables,
+            handler: None,
+            mrtr_handler: Some(Arc::new(MrtrFnTemplateHandler { handler })),
         })
     }
 }
@@ -1468,6 +1737,27 @@ where
     ) -> BoxFuture<'_, Result<ReadResourceResult>> {
         let uri = uri.to_string();
         Box::pin((self.handler)(uri, variables))
+    }
+}
+
+#[cfg(feature = "stateless")]
+struct MrtrFnTemplateHandler<F> {
+    handler: F,
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> MrtrResourceTemplateHandler for MrtrFnTemplateHandler<F>
+where
+    F: Fn(RequestContext, String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+{
+    fn read(
+        &self,
+        ctx: RequestContext,
+        uri: &str,
+        variables: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>> {
+        Box::pin((self.handler)(ctx, uri.to_string(), variables))
     }
 }
 
@@ -1545,6 +1835,61 @@ mod tests {
         let result = resource.read().await;
         assert_eq!(result.contents.len(), 1);
         assert_eq!(result.contents[0].text.as_deref(), Some("Hello, World!"));
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn test_mrtr_builder_preserves_input_required_outcome() {
+        let resource = ResourceBuilder::new("test://continue")
+            .mrtr_handler(|_ctx| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("signed-state"),
+                ))
+            })
+            .build();
+
+        let outcome = resource
+            .read_outcome_with_context(RequestContext::new(crate::protocol::RequestId::Number(1)))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("signed-state")
+        );
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn test_mrtr_template_preserves_context_and_input_required_outcome() {
+        let template = ResourceTemplateBuilder::new("test://items/{id}").mrtr_handler(
+            |ctx, uri, variables| async move {
+                assert_eq!(ctx.request_state(), Some("prior-state"));
+                assert_eq!(uri, "test://items/42");
+                assert_eq!(variables.get("id").map(String::as_str), Some("42"));
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("next-state"),
+                ))
+            },
+        );
+        let variables = template.match_uri("test://items/42").unwrap();
+        let mut ctx = RequestContext::new(crate::protocol::RequestId::Number(1));
+        ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+            None,
+            Some("prior-state".into()),
+        ));
+
+        let outcome = template
+            .read_outcome_with_context(ctx, "test://items/42", variables)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("next-state")
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -86,9 +86,120 @@ fn json_value_contains(actual: &serde_json::Value, required: &serde_json::Value)
 #[cfg(feature = "stateless")]
 fn client_capabilities_satisfy(actual: &ClientCapabilities, required: &ClientCapabilities) -> bool {
     let actual = serde_json::to_value(actual).expect("ClientCapabilities is always serializable");
-    let required =
+    let mut required =
         serde_json::to_value(required).expect("ClientCapabilities is always serializable");
+    // `roots.listChanged: false` means the optional notification capability
+    // was not declared; it is not a requirement that the caller also set the
+    // flag to false. Normalize it away before doing the structural subset
+    // comparison so `{roots:{listChanged:true}}` satisfies plain `{roots:{}}`.
+    if required.pointer("/roots/listChanged") == Some(&serde_json::Value::Bool(false))
+        && let Some(roots) = required
+            .get_mut("roots")
+            .and_then(serde_json::Value::as_object_mut)
+    {
+        roots.remove("listChanged");
+    }
     json_value_contains(&actual, &required)
+}
+
+#[cfg(feature = "stateless")]
+fn validate_input_required_result(
+    extensions: &crate::context::Extensions,
+    result: &InputRequiredResult,
+) -> Result<()> {
+    result.validate().map_err(|message| {
+        Error::invalid_params(format!("invalid InputRequiredResult: {message}"))
+    })?;
+
+    let meta = extensions
+        .get::<crate::stateless::StatelessRequestMeta>()
+        .filter(|meta| {
+            meta.protocol_version.as_deref() == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        })
+        .ok_or_else(|| {
+            Error::invalid_params(
+                "InputRequiredResult is only supported by the 2026-07-28 request lifecycle",
+            )
+        })?;
+    let actual = meta.client_capabilities.as_ref().ok_or_else(|| {
+        Error::invalid_params("clientCapabilities is required for InputRequiredResult")
+    })?;
+
+    if let Some(requests) = &result.input_requests {
+        for request in requests.values() {
+            let (supported, required) = match request {
+                InputRequest::CreateMessage(params) => {
+                    let requires_tools = params.tools.is_some();
+                    let requires_context = params
+                        .include_context
+                        .is_some_and(|mode| mode != IncludeContext::None);
+                    let required_sampling = SamplingCapability {
+                        tools: requires_tools.then(SamplingToolsCapability::default),
+                        context: requires_context.then(SamplingContextCapability::default),
+                        ..SamplingCapability::default()
+                    };
+                    let supported = actual.sampling.as_ref().is_some_and(|sampling| {
+                        (!requires_tools || sampling.tools.is_some())
+                            && (!requires_context || sampling.context.is_some())
+                    });
+                    (
+                        supported,
+                        ClientCapabilities {
+                            sampling: Some(required_sampling),
+                            ..ClientCapabilities::default()
+                        },
+                    )
+                }
+                InputRequest::ListRoots(_) => (
+                    actual.roots.is_some(),
+                    ClientCapabilities {
+                        roots: Some(RootsCapability::default()),
+                        ..ClientCapabilities::default()
+                    },
+                ),
+                InputRequest::Elicit(ElicitRequestParams::Form(_)) => {
+                    let supported = actual.elicitation.as_ref().is_some_and(|elicitation| {
+                        elicitation.form.is_some()
+                            || (elicitation.form.is_none() && elicitation.url.is_none())
+                    });
+                    (
+                        supported,
+                        ClientCapabilities {
+                            elicitation: Some(ElicitationCapability {
+                                form: Some(ElicitationFormCapability::default()),
+                                ..ElicitationCapability::default()
+                            }),
+                            ..ClientCapabilities::default()
+                        },
+                    )
+                }
+                InputRequest::Elicit(ElicitRequestParams::Url(_)) => (
+                    actual
+                        .elicitation
+                        .as_ref()
+                        .is_some_and(|elicitation| elicitation.url.is_some()),
+                    ClientCapabilities {
+                        elicitation: Some(ElicitationCapability {
+                            url: Some(ElicitationUrlCapability::default()),
+                            ..ElicitationCapability::default()
+                        }),
+                        ..ClientCapabilities::default()
+                    },
+                ),
+                _ => {
+                    return Err(Error::invalid_params(
+                        "unsupported input request method in InputRequiredResult",
+                    ));
+                }
+            };
+            if !supported {
+                return Err(Error::JsonRpc(
+                    JsonRpcError::missing_required_client_capability(required),
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Apply pagination to a collected list of items.
@@ -588,6 +699,7 @@ impl McpRouter {
     /// router clones, so registering one sender per request would
     /// accumulate senders without bound.
     #[cfg(feature = "stateless")]
+    #[cfg(feature = "http")]
     pub(crate) fn with_request_notification_sender(mut self, tx: NotificationSender) -> Self {
         Arc::make_mut(&mut self.inner).notification_tx = Some(tx);
         self
@@ -2205,30 +2317,56 @@ impl McpRouter {
                         progress_token,
                         &extensions,
                     );
+                    #[cfg(feature = "stateless")]
+                    let ctx = {
+                        let mut ctx = ctx;
+                        ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                            params.input_responses,
+                            params.request_state,
+                        ));
+                        ctx
+                    };
 
                     let start = std::time::Instant::now();
-                    let result = tool.call_with_context(ctx, params.arguments).await;
+                    let outcome = tool
+                        .call_outcome_with_context(ctx, params.arguments)
+                        .await?;
                     let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
-                    if result.is_error {
-                        tracing::info!(
-                            target: "mcp::tools",
-                            tool = %params.name,
-                            duration_ms,
-                            status = "error",
-                            "tool call completed"
-                        );
-                    } else {
-                        tracing::info!(
-                            target: "mcp::tools",
-                            tool = %params.name,
-                            duration_ms,
-                            status = "success",
-                            "tool call completed"
-                        );
+                    match outcome {
+                        RequestOutcome::Complete(result) => {
+                            let status = if result.is_error { "error" } else { "success" };
+                            tracing::info!(
+                                target: "mcp::tools",
+                                tool = %params.name,
+                                duration_ms,
+                                status,
+                                "tool call completed"
+                            );
+                            Ok(McpResponse::CallTool(result))
+                        }
+                        RequestOutcome::InputRequired(result) => {
+                            #[cfg(feature = "stateless")]
+                            {
+                                validate_input_required_result(&extensions, &result)?;
+                                tracing::info!(
+                                    target: "mcp::tools",
+                                    tool = %params.name,
+                                    duration_ms,
+                                    status = "input_required",
+                                    "tool call requires client input"
+                                );
+                                Ok(McpResponse::InputRequired(result))
+                            }
+                            #[cfg(not(feature = "stateless"))]
+                            {
+                                let _ = result;
+                                Err(Error::invalid_params(
+                                    "InputRequiredResult support was not compiled",
+                                ))
+                            }
+                        }
                     }
-
-                    Ok(McpResponse::CallTool(result))
                 }
             }
 
@@ -2344,10 +2482,34 @@ impl McpRouter {
 
                     tracing::debug!(uri = %params.uri, "Reading static resource");
                     let ctx = self.create_context_with_extensions(request_id, None, &extensions);
-                    let result = resource.read_with_context(ctx).await;
-                    return Ok(McpResponse::ReadResource(
-                        self.apply_read_cache_hints(result),
-                    ));
+                    #[cfg(feature = "stateless")]
+                    let ctx = {
+                        let mut ctx = ctx;
+                        ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                            params.input_responses.clone(),
+                            params.request_state.clone(),
+                        ));
+                        ctx
+                    };
+                    return match resource.read_outcome_with_context(ctx).await? {
+                        RequestOutcome::Complete(result) => Ok(McpResponse::ReadResource(
+                            self.apply_read_cache_hints(result),
+                        )),
+                        RequestOutcome::InputRequired(result) => {
+                            #[cfg(feature = "stateless")]
+                            {
+                                validate_input_required_result(&extensions, &result)?;
+                                Ok(McpResponse::InputRequired(result))
+                            }
+                            #[cfg(not(feature = "stateless"))]
+                            {
+                                let _ = result;
+                                Err(Error::invalid_params(
+                                    "InputRequiredResult support was not compiled",
+                                ))
+                            }
+                        }
+                    };
                 }
 
                 // Try dynamic resources
@@ -2363,10 +2525,34 @@ impl McpRouter {
                         tracing::debug!(uri = %params.uri, "Reading dynamic resource");
                         let ctx =
                             self.create_context_with_extensions(request_id, None, &extensions);
-                        let result = resource.read_with_context(ctx).await;
-                        return Ok(McpResponse::ReadResource(
-                            self.apply_read_cache_hints(result),
-                        ));
+                        #[cfg(feature = "stateless")]
+                        let ctx = {
+                            let mut ctx = ctx;
+                            ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                                params.input_responses.clone(),
+                                params.request_state.clone(),
+                            ));
+                            ctx
+                        };
+                        return match resource.read_outcome_with_context(ctx).await? {
+                            RequestOutcome::Complete(result) => Ok(McpResponse::ReadResource(
+                                self.apply_read_cache_hints(result),
+                            )),
+                            RequestOutcome::InputRequired(result) => {
+                                #[cfg(feature = "stateless")]
+                                {
+                                    validate_input_required_result(&extensions, &result)?;
+                                    Ok(McpResponse::InputRequired(result))
+                                }
+                                #[cfg(not(feature = "stateless"))]
+                                {
+                                    let _ = result;
+                                    Err(Error::invalid_params(
+                                        "InputRequiredResult support was not compiled",
+                                    ))
+                                }
+                            }
+                        };
                     }
                 }
 
@@ -2378,10 +2564,39 @@ impl McpRouter {
                             template = %template.uri_template,
                             "Reading resource via template"
                         );
-                        let result = template.read(&params.uri, variables).await?;
-                        return Ok(McpResponse::ReadResource(
-                            self.apply_read_cache_hints(result),
-                        ));
+                        let ctx =
+                            self.create_context_with_extensions(request_id, None, &extensions);
+                        #[cfg(feature = "stateless")]
+                        let ctx = {
+                            let mut ctx = ctx;
+                            ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                                params.input_responses.clone(),
+                                params.request_state.clone(),
+                            ));
+                            ctx
+                        };
+                        return match template
+                            .read_outcome_with_context(ctx, &params.uri, variables)
+                            .await?
+                        {
+                            RequestOutcome::Complete(result) => Ok(McpResponse::ReadResource(
+                                self.apply_read_cache_hints(result),
+                            )),
+                            RequestOutcome::InputRequired(result) => {
+                                #[cfg(feature = "stateless")]
+                                {
+                                    validate_input_required_result(&extensions, &result)?;
+                                    Ok(McpResponse::InputRequired(result))
+                                }
+                                #[cfg(not(feature = "stateless"))]
+                                {
+                                    let _ = result;
+                                    Err(Error::invalid_params(
+                                        "InputRequiredResult support was not compiled",
+                                    ))
+                                }
+                            }
+                        };
                     }
                 }
 
@@ -2395,10 +2610,39 @@ impl McpRouter {
                             template = %template.uri_template,
                             "Reading resource via dynamic template"
                         );
-                        let result = template.read(&params.uri, variables).await?;
-                        return Ok(McpResponse::ReadResource(
-                            self.apply_read_cache_hints(result),
-                        ));
+                        let ctx =
+                            self.create_context_with_extensions(request_id, None, &extensions);
+                        #[cfg(feature = "stateless")]
+                        let ctx = {
+                            let mut ctx = ctx;
+                            ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                                params.input_responses.clone(),
+                                params.request_state.clone(),
+                            ));
+                            ctx
+                        };
+                        return match template
+                            .read_outcome_with_context(ctx, &params.uri, variables)
+                            .await?
+                        {
+                            RequestOutcome::Complete(result) => Ok(McpResponse::ReadResource(
+                                self.apply_read_cache_hints(result),
+                            )),
+                            RequestOutcome::InputRequired(result) => {
+                                #[cfg(feature = "stateless")]
+                                {
+                                    validate_input_required_result(&extensions, &result)?;
+                                    Ok(McpResponse::InputRequired(result))
+                                }
+                                #[cfg(not(feature = "stateless"))]
+                                {
+                                    let _ = result;
+                                    Err(Error::invalid_params(
+                                        "InputRequiredResult support was not compiled",
+                                    ))
+                                }
+                            }
+                        };
                     }
                 }
 
@@ -2522,9 +2766,36 @@ impl McpRouter {
 
                 tracing::debug!(name = %params.name, "Getting prompt");
                 let ctx = self.create_context_with_extensions(request_id, None, &extensions);
-                let result = prompt.get_with_context(ctx, params.arguments).await?;
+                #[cfg(feature = "stateless")]
+                let ctx = {
+                    let mut ctx = ctx;
+                    ctx.extensions_mut().insert(crate::mrtr::MrtrRequest::new(
+                        params.input_responses,
+                        params.request_state,
+                    ));
+                    ctx
+                };
+                let outcome = prompt
+                    .get_outcome_with_context(ctx, params.arguments)
+                    .await?;
 
-                Ok(McpResponse::GetPrompt(result))
+                match outcome {
+                    RequestOutcome::Complete(result) => Ok(McpResponse::GetPrompt(result)),
+                    RequestOutcome::InputRequired(result) => {
+                        #[cfg(feature = "stateless")]
+                        {
+                            validate_input_required_result(&extensions, &result)?;
+                            Ok(McpResponse::InputRequired(result))
+                        }
+                        #[cfg(not(feature = "stateless"))]
+                        {
+                            let _ = result;
+                            Err(Error::invalid_params(
+                                "InputRequiredResult support was not compiled",
+                            ))
+                        }
+                    }
+                }
             }
 
             McpRequest::Ping => Ok(McpResponse::Pong(EmptyResult {})),
@@ -2983,6 +3254,84 @@ mod tests {
     struct AddInput {
         a: i64,
         b: i64,
+    }
+
+    #[cfg(feature = "stateless")]
+    fn final_extensions(client_capabilities: ClientCapabilities) -> Extensions {
+        let mut extensions = Extensions::new();
+        extensions.insert(crate::stateless::StatelessRequestMeta {
+            protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            client_capabilities: Some(client_capabilities),
+            ..Default::default()
+        });
+        extensions
+    }
+
+    #[cfg(feature = "stateless")]
+    #[test]
+    fn input_required_capability_validation_uses_capability_semantics() {
+        let roots = InputRequiredResult::with_requests(
+            [(
+                "roots".to_string(),
+                InputRequest::ListRoots(ListRootsParams::default()),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let extensions = final_extensions(ClientCapabilities {
+            roots: Some(RootsCapability {
+                list_changed: true,
+                deprecated: None,
+            }),
+            ..Default::default()
+        });
+        validate_input_required_result(&extensions, &roots).unwrap();
+        assert!(client_capabilities_satisfy(
+            extensions
+                .get::<crate::stateless::StatelessRequestMeta>()
+                .and_then(|meta| meta.client_capabilities.as_ref())
+                .unwrap(),
+            &ClientCapabilities {
+                roots: Some(RootsCapability::default()),
+                ..Default::default()
+            }
+        ));
+
+        let sampling_with_tools = InputRequiredResult::with_requests(
+            [(
+                "sample".to_string(),
+                InputRequest::CreateMessage(CreateMessageParams {
+                    tools: Some(Vec::new()),
+                    ..CreateMessageParams::new(vec![SamplingMessage::user("hello")], 10)
+                }),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let extensions = final_extensions(ClientCapabilities {
+            sampling: Some(SamplingCapability::default()),
+            ..Default::default()
+        });
+        assert!(validate_input_required_result(&extensions, &sampling_with_tools).is_err());
+
+        let form = InputRequiredResult::with_requests(
+            [(
+                "form".to_string(),
+                InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                    mode: Some(ElicitMode::Form),
+                    message: "name".into(),
+                    requested_schema: ElicitFormSchema::new(),
+                    meta: None,
+                })),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let extensions = final_extensions(ClientCapabilities {
+            elicitation: Some(ElicitationCapability::default()),
+            ..Default::default()
+        });
+        validate_input_required_result(&extensions, &form).unwrap();
     }
 
     /// Helper to initialize a router for testing

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -50,8 +50,8 @@ use tower_service::Service;
 use crate::context::RequestContext;
 use crate::error::{Error, Result, ResultExt};
 use crate::protocol::{
-    CallToolResult, ClientCapabilities, TaskSupportMode, ToolAnnotations, ToolDefinition,
-    ToolExecution, ToolIcon,
+    CallToolResult, ClientCapabilities, RequestOutcome, TaskSupportMode, ToolAnnotations,
+    ToolDefinition, ToolExecution, ToolIcon,
 };
 
 // =============================================================================
@@ -426,6 +426,21 @@ pub trait ToolHandler: Send + Sync {
     fn input_schema(&self) -> Value;
 }
 
+/// Handler for a tool that can complete or return an SEP-2322
+/// [`RequestOutcome::InputRequired`] continuation.
+#[cfg(feature = "stateless")]
+pub trait MrtrToolHandler: Send + Sync {
+    /// Execute an MRTR-capable tool with request context and raw arguments.
+    fn call(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'_, Result<RequestOutcome<CallToolResult>>>;
+
+    /// Get the tool's input schema.
+    fn input_schema(&self) -> Value;
+}
+
 /// Adapts a `ToolHandler` to a Tower `Service<ToolRequest>`.
 ///
 /// This is an internal adapter that bridges the handler abstraction to the
@@ -493,7 +508,9 @@ pub struct Tool {
     /// per-request protocol.
     pub(crate) required_client_capabilities: Option<ClientCapabilities>,
     /// The boxed service that executes the tool
-    pub(crate) service: BoxToolService,
+    pub(crate) service: Option<BoxToolService>,
+    #[cfg(feature = "stateless")]
+    pub(crate) mrtr_handler: Option<Arc<dyn MrtrToolHandler>>,
     /// JSON Schema for the tool's input
     pub(crate) input_schema: Value,
 }
@@ -533,6 +550,8 @@ impl Clone for Tool {
             task_support: self.task_support,
             required_client_capabilities: self.required_client_capabilities.clone(),
             service: self.service.clone(),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: self.mrtr_handler.clone(),
             input_schema: self.input_schema.clone(),
         }
     }
@@ -589,12 +608,46 @@ impl Tool {
         ctx: RequestContext,
         args: Value,
     ) -> BoxFuture<'static, CallToolResult> {
-        use tower::ServiceExt;
-        let service = self.service.clone();
+        let tool = self.clone();
         Box::pin(async move {
-            // ServiceExt::oneshot properly handles poll_ready before call
-            // Service is Infallible, so unwrap is safe
-            service.oneshot(ToolRequest::new(ctx, args)).await.unwrap()
+            match tool.call_outcome_with_context(ctx, args).await {
+                Ok(RequestOutcome::Complete(result)) => result,
+                Ok(RequestOutcome::InputRequired(_)) => CallToolResult::error(
+                    "tool requires additional client input; use call_outcome_with_context",
+                ),
+                Err(error) => CallToolResult::error(error.to_string()),
+            }
+        })
+    }
+
+    /// Call the tool and preserve an SEP-2322 input-required outcome.
+    pub fn call_outcome(
+        &self,
+        args: Value,
+    ) -> BoxFuture<'static, Result<RequestOutcome<CallToolResult>>> {
+        let ctx = RequestContext::new(crate::protocol::RequestId::Number(0));
+        self.call_outcome_with_context(ctx, args)
+    }
+
+    /// Call the tool with context and preserve an SEP-2322 input-required
+    /// outcome or protocol-level handler error.
+    pub fn call_outcome_with_context(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'static, Result<RequestOutcome<CallToolResult>>> {
+        use tower::ServiceExt;
+        #[cfg(feature = "stateless")]
+        if let Some(handler) = self.mrtr_handler.clone() {
+            return Box::pin(async move { handler.call(ctx, args).await });
+        }
+        let service = self
+            .service
+            .clone()
+            .expect("tool must have a complete or MRTR handler");
+        Box::pin(async move {
+            let result = service.oneshot(ToolRequest::new(ctx, args)).await.unwrap();
+            Ok(RequestOutcome::Complete(result))
         })
     }
 
@@ -649,11 +702,13 @@ impl Tool {
     {
         let guarded = GuardService {
             guard,
-            inner: self.service,
+            inner: self
+                .service
+                .expect("with_guard is not supported on an MRTR tool"),
         };
         let caught = ToolCatchError::new(guarded);
         Tool {
-            service: BoxCloneService::new(caught),
+            service: Some(BoxCloneService::new(caught)),
             ..self
         }
     }
@@ -695,6 +750,8 @@ impl Tool {
             task_support: self.task_support,
             required_client_capabilities: self.required_client_capabilities.clone(),
             service: self.service.clone(),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: self.mrtr_handler.clone(),
             input_schema: self.input_schema.clone(),
         }
     }
@@ -727,7 +784,39 @@ impl Tool {
             annotations,
             task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+            input_schema,
+        }
+    }
+
+    #[cfg(feature = "stateless")]
+    #[allow(clippy::too_many_arguments)]
+    fn from_mrtr_handler<H: MrtrToolHandler + 'static>(
+        name: String,
+        title: Option<String>,
+        description: Option<String>,
+        output_schema: Option<Value>,
+        icons: Option<Vec<ToolIcon>>,
+        annotations: Option<ToolAnnotations>,
+        task_support: TaskSupportMode,
+        input_schema_override: Option<Value>,
+        handler: H,
+    ) -> Self {
+        let input_schema =
+            ensure_object_schema(input_schema_override.unwrap_or_else(|| handler.input_schema()));
+        Self {
+            name,
+            title,
+            description,
+            output_schema,
+            icons,
+            annotations,
+            task_support,
+            required_client_capabilities: None,
+            service: None,
+            mrtr_handler: Some(Arc::new(handler)),
             input_schema,
         }
     }
@@ -1093,6 +1182,33 @@ impl ToolBuilder {
         }
     }
 
+    /// Set an SEP-2322 handler that may return either a complete tool result
+    /// or an input-required continuation.
+    ///
+    /// The handler receives [`RequestContext`], where
+    /// [`RequestContext::input_responses`] and
+    /// [`RequestContext::request_state`] expose values from a retry.
+    #[cfg(feature = "stateless")]
+    pub fn mrtr_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithMrtrHandler<I, F>
+    where
+        I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+        F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+    {
+        ToolBuilderWithMrtrHandler {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema_override: self.input_schema_override,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: self.task_support,
+            handler,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
     /// Create a tool using the extractor pattern.
     ///
     /// This method provides an axum-inspired way to define handlers where state,
@@ -1316,6 +1432,22 @@ pub struct ToolBuilderWithHandler<I, F> {
     _phantom: std::marker::PhantomData<I>,
 }
 
+/// Builder state for an SEP-2322-capable tool handler.
+#[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct ToolBuilderWithMrtrHandler<I, F> {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    output_schema: Option<Value>,
+    input_schema_override: Option<Value>,
+    icons: Option<Vec<ToolIcon>>,
+    annotations: Option<ToolAnnotations>,
+    task_support: TaskSupportMode,
+    handler: F,
+    _phantom: std::marker::PhantomData<I>,
+}
+
 /// Builder state for tools with no parameters.
 ///
 /// Created by [`ToolBuilder::no_params_handler`].
@@ -1431,7 +1563,9 @@ where
             annotations: self.annotations,
             task_support: self.task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
             input_schema,
         }
     }
@@ -1548,6 +1682,32 @@ where
     }
 }
 
+#[cfg(feature = "stateless")]
+impl<I, F, Fut> ToolBuilderWithMrtrHandler<I, F>
+where
+    I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+    F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+{
+    /// Build the MRTR-capable tool.
+    pub fn build(self) -> Tool {
+        Tool::from_mrtr_handler(
+            self.name,
+            self.title,
+            self.description,
+            self.output_schema,
+            self.icons,
+            self.annotations,
+            self.task_support,
+            self.input_schema_override,
+            TypedMrtrHandler {
+                handler: self.handler,
+                _phantom: std::marker::PhantomData,
+            },
+        )
+    }
+}
+
 /// Builder state after a layer has been applied to the handler.
 ///
 /// This builder allows chaining additional layers and building the final tool.
@@ -1605,7 +1765,9 @@ where
             annotations: self.annotations,
             task_support: self.task_support,
             required_client_capabilities: None,
-            service,
+            service: Some(service),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
             input_schema,
         }
     }
@@ -1655,6 +1817,40 @@ where
 struct TypedHandler<I, F> {
     handler: F,
     _phantom: std::marker::PhantomData<I>,
+}
+
+#[cfg(feature = "stateless")]
+struct TypedMrtrHandler<I, F> {
+    handler: F,
+    _phantom: std::marker::PhantomData<I>,
+}
+
+#[cfg(feature = "stateless")]
+impl<I, F, Fut> MrtrToolHandler for TypedMrtrHandler<I, F>
+where
+    I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+    F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+{
+    fn call(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'_, Result<RequestOutcome<CallToolResult>>> {
+        Box::pin(async move {
+            let input: I = serde_json::from_value(args)
+                .map_err(|error| Error::invalid_params(format!("Invalid input: {error}")))?;
+            (self.handler)(ctx, input).await
+        })
+    }
+
+    fn input_schema(&self) -> Value {
+        let schema = schemars::schema_for!(I);
+        ensure_object_schema(
+            serde_json::to_value(schema)
+                .unwrap_or_else(|_| serde_json::json!({ "type": "object" })),
+        )
+    }
 }
 
 impl<I, F, Fut> ToolHandler for TypedHandler<I, F>
@@ -1831,6 +2027,26 @@ mod tests {
         let result = tool.call(serde_json::json!({"name": "World"})).await;
 
         assert!(!result.is_error);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn test_mrtr_builder_preserves_input_required_outcome() {
+        let tool = ToolBuilder::new("continue")
+            .mrtr_handler::<NoParams, _, _>(|_ctx, _input| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("signed-state"),
+                ))
+            })
+            .build();
+
+        let outcome = tool.call_outcome(serde_json::json!({})).await.unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("signed-state")
+        );
     }
 
     #[tokio::test]

--- a/examples/conformance-server/src/main.rs
+++ b/examples/conformance-server/src/main.rs
@@ -1,7 +1,7 @@
 //! MCP Conformance Test Server
 //!
 //! This server implements all MCP protocol features for conformance testing.
-//! It passes all 39 official MCP conformance tests.
+//! It passes all official 2025-11-25 and 2026-07-28 server checks.
 //!
 //! ## Running
 //!
@@ -32,7 +32,7 @@ mod tools;
 use clap::Parser;
 use tower_mcp::context::notification_channel;
 use tower_mcp::protocol::DeprecationInfo;
-use tower_mcp::{HttpTransport, McpRouter, StdioTransport};
+use tower_mcp::{HttpTransport, McpRouter, RequestStateCodec, StdioTransport};
 
 #[derive(Parser)]
 #[command(name = "conformance-server")]
@@ -64,7 +64,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .server_info("conformance-server", "0.1.0")
         .instructions(
             "MCP conformance test server implementing all spec features. \
-             This server passes all 39 official MCP conformance tests and \
+             This server passes all official MCP server conformance checks and \
              demonstrates tools, resources, prompts, progress notifications, \
              logging, sampling, and elicitation.",
         )
@@ -81,7 +81,11 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             remove_in: None,
             replacement: None,
         })
-        .with_notification_sender(tx);
+        .with_notification_sender(tx)
+        .with_extension(RequestStateCodec::new(
+            b"tower-mcp-conformance-state-key-2026-07-28",
+            std::time::Duration::from_secs(300),
+        )?);
 
     for tool in tools::build_tools() {
         router = router.tool(tool);

--- a/examples/conformance-server/src/prompts.rs
+++ b/examples/conformance-server/src/prompts.rs
@@ -1,5 +1,10 @@
-use tower_mcp::protocol::{Content, ResourceContent};
-use tower_mcp::{GetPromptResult, Prompt, PromptBuilder, PromptMessage, PromptRole};
+use tower_mcp::protocol::{
+    Content, ElicitRequestParams, InputRequest, InputRequiredResult, ResourceContent,
+};
+use tower_mcp::{
+    ElicitFormParams, ElicitFormSchema, ElicitMode, GetPromptResult, Prompt, PromptBuilder,
+    PromptMessage, PromptRole, RequestOutcome,
+};
 
 use crate::tools::red_pixel_base64;
 
@@ -10,8 +15,53 @@ pub fn build_prompts() -> Vec<Prompt> {
         build_prompt_with_arguments(),
         build_prompt_with_embedded_resource(),
         build_prompt_with_image(),
+        build_input_required_prompt(),
         build_exercise_conformance_prompt(),
     ]
+}
+
+fn build_input_required_prompt() -> Prompt {
+    PromptBuilder::new("test_input_required_result_prompt")
+        .description("SEP-2322 non-tool continuation fixture")
+        .mrtr_handler(|ctx, _args| async move {
+            if ctx
+                .input_responses()
+                .is_some_and(|responses| responses.contains_key("user_context"))
+            {
+                return Ok(RequestOutcome::Complete(GetPromptResult {
+                    description: Some("Prompt using client-provided context".into()),
+                    messages: vec![PromptMessage {
+                        role: PromptRole::User,
+                        content: Content::Text {
+                            text: "Use the supplied test context".into(),
+                            annotations: None,
+                            meta: None,
+                        },
+                        meta: None,
+                    }],
+                    meta: None,
+                }));
+            }
+
+            let request = InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                mode: Some(ElicitMode::Form),
+                message: "What context should the prompt use?".into(),
+                requested_schema: ElicitFormSchema::new().string_field(
+                    "context",
+                    Some("Context for the prompt"),
+                    true,
+                ),
+                meta: None,
+            }));
+            Ok(RequestOutcome::input_required(
+                InputRequiredResult::with_requests(
+                    [("user_context".to_string(), request)]
+                        .into_iter()
+                        .collect(),
+                ),
+            ))
+        })
+        .build()
 }
 
 /// A prompt that guides an agent to exercise all conformance server features.

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -1,10 +1,14 @@
 use base64::Engine;
+use serde::{Deserialize, Serialize};
 use tower_mcp::protocol::{
-    Content, CreateMessageParams, LogLevel, LoggingMessageParams, ResourceContent, SamplingMessage,
+    Content, CreateMessageParams, ElicitRequestParams, InputRequest, InputRequests,
+    InputRequiredResult, ListRootsParams, LogLevel, LoggingMessageParams, ResourceContent,
+    SamplingMessage,
 };
 use tower_mcp::{
-    CallToolResult, ClientCapabilities, ElicitFormParams, ElicitFormSchema, ElicitMode,
-    SamplingCapability, TaskSupportMode, Tool, ToolBuilder,
+    CallToolResult, ClientCapabilities, ElicitFormParams, ElicitFormSchema, ElicitMode, Error,
+    NoParams, RequestContext, RequestOutcome, SamplingCapability, TaskSupportMode, Tool,
+    ToolBuilder,
     extract::{Context, RawArgs},
 };
 
@@ -69,7 +73,334 @@ pub fn build_tools() -> Vec<Tool> {
         build_streaming_diagnostic(),
         build_trigger_tool_change(),
         build_trigger_prompt_change(),
+        build_input_required_elicitation(),
+        build_input_required_sampling(),
+        build_input_required_list_roots(),
+        build_input_required_request_state(),
+        build_input_required_multiple_inputs(),
+        build_input_required_multi_round(),
+        build_input_required_tampered_state(),
+        build_input_required_capabilities(),
     ]
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct ContinuationState {
+    flow: String,
+    round: u8,
+}
+
+fn elicitation_request(
+    message: impl Into<String>,
+    field: &str,
+    schema: serde_json::Value,
+) -> InputRequest {
+    InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+        mode: Some(ElicitMode::Form),
+        message: message.into(),
+        requested_schema: ElicitFormSchema::new().raw_field(field, schema, true),
+        meta: None,
+    }))
+}
+
+fn string_elicitation(message: impl Into<String>, field: &str) -> InputRequest {
+    elicitation_request(message, field, serde_json::json!({ "type": "string" }))
+}
+
+fn sampling_request(message: impl Into<String>, max_tokens: u32) -> InputRequest {
+    InputRequest::CreateMessage(CreateMessageParams::new(
+        vec![SamplingMessage::user(message)],
+        max_tokens,
+    ))
+}
+
+fn roots_request() -> InputRequest {
+    InputRequest::ListRoots(ListRootsParams::default())
+}
+
+fn input_required(
+    requests: impl IntoIterator<Item = (impl Into<String>, InputRequest)>,
+) -> RequestOutcome<CallToolResult> {
+    RequestOutcome::input_required(InputRequiredResult::with_requests(
+        requests
+            .into_iter()
+            .map(|(key, request)| (key.into(), request))
+            .collect(),
+    ))
+}
+
+fn signed_input_required(
+    ctx: &RequestContext,
+    requests: InputRequests,
+    state: ContinuationState,
+) -> Result<RequestOutcome<CallToolResult>, Error> {
+    let codec = ctx
+        .request_state_codec()
+        .ok_or_else(|| Error::internal("request-state codec is not configured"))?;
+    let token = codec
+        .encode(&state)
+        .map_err(|error| Error::internal(format!("failed to encode request state: {error}")))?;
+    Ok(RequestOutcome::input_required(
+        InputRequiredResult::with_requests(requests).with_request_state(token),
+    ))
+}
+
+fn decode_state(ctx: &RequestContext) -> Result<Option<ContinuationState>, Error> {
+    let Some(token) = ctx.request_state() else {
+        return Ok(None);
+    };
+    let codec = ctx
+        .request_state_codec()
+        .ok_or_else(|| Error::internal("request-state codec is not configured"))?;
+    codec
+        .decode(token)
+        .map(Some)
+        .map_err(|error| Error::invalid_params(format!("invalid requestState: {error}")))
+}
+
+fn build_input_required_elicitation() -> Tool {
+    ToolBuilder::new("test_input_required_result_elicitation")
+        .description("SEP-2322 elicitation continuation fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            if ctx
+                .input_responses()
+                .is_some_and(|responses| responses.contains_key("user_name"))
+            {
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "Hello, Alice!",
+                )));
+            }
+            Ok(input_required([(
+                "user_name",
+                string_elicitation("What is your name?", "name"),
+            )]))
+        })
+        .build()
+}
+
+fn build_input_required_sampling() -> Tool {
+    ToolBuilder::new("test_input_required_result_sampling")
+        .description("SEP-2322 sampling continuation fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            if ctx
+                .input_responses()
+                .is_some_and(|responses| responses.contains_key("capital_question"))
+            {
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "The capital of France is Paris.",
+                )));
+            }
+            Ok(input_required([(
+                "capital_question",
+                sampling_request("What is the capital of France?", 100),
+            )]))
+        })
+        .build()
+}
+
+fn build_input_required_list_roots() -> Tool {
+    ToolBuilder::new("test_input_required_result_list_roots")
+        .description("SEP-2322 roots continuation fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            if ctx
+                .input_responses()
+                .is_some_and(|responses| responses.contains_key("client_roots"))
+            {
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "Received client roots",
+                )));
+            }
+            Ok(input_required([("client_roots", roots_request())]))
+        })
+        .build()
+}
+
+fn build_input_required_request_state() -> Tool {
+    ToolBuilder::new("test_input_required_result_request_state")
+        .description("SEP-2322 integrity-protected requestState fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            let responses = ctx.input_responses();
+            if responses.is_some_and(|responses| responses.contains_key("confirm")) {
+                let state = decode_state(&ctx)?
+                    .ok_or_else(|| Error::invalid_params("requestState is required"))?;
+                if state.flow != "request-state" || state.round != 1 {
+                    return Err(Error::invalid_params(
+                        "requestState belongs to another flow",
+                    ));
+                }
+                return Ok(RequestOutcome::Complete(CallToolResult::text("state-ok")));
+            }
+
+            signed_input_required(
+                &ctx,
+                [(
+                    "confirm".to_string(),
+                    elicitation_request(
+                        "Please confirm",
+                        "ok",
+                        serde_json::json!({ "type": "boolean" }),
+                    ),
+                )]
+                .into_iter()
+                .collect(),
+                ContinuationState {
+                    flow: "request-state".into(),
+                    round: 1,
+                },
+            )
+        })
+        .build()
+}
+
+fn build_input_required_multiple_inputs() -> Tool {
+    ToolBuilder::new("test_input_required_result_multiple_inputs")
+        .description("SEP-2322 heterogeneous inputRequests fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            let complete = ctx.input_responses().is_some_and(|responses| {
+                ["user_name", "greeting", "client_roots"]
+                    .iter()
+                    .all(|key| responses.contains_key(*key))
+            });
+            if complete {
+                let state = decode_state(&ctx)?
+                    .ok_or_else(|| Error::invalid_params("requestState is required"))?;
+                if state.flow != "multiple-inputs" || state.round != 1 {
+                    return Err(Error::invalid_params(
+                        "requestState belongs to another flow",
+                    ));
+                }
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "All input received",
+                )));
+            }
+
+            signed_input_required(
+                &ctx,
+                [
+                    (
+                        "user_name".to_string(),
+                        string_elicitation("What is your name?", "name"),
+                    ),
+                    (
+                        "greeting".to_string(),
+                        sampling_request("Generate a greeting", 50),
+                    ),
+                    ("client_roots".to_string(), roots_request()),
+                ]
+                .into_iter()
+                .collect(),
+                ContinuationState {
+                    flow: "multiple-inputs".into(),
+                    round: 1,
+                },
+            )
+        })
+        .build()
+}
+
+fn build_input_required_multi_round() -> Tool {
+    ToolBuilder::new("test_input_required_result_multi_round")
+        .description("SEP-2322 evolving multi-round continuation fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            match decode_state(&ctx)? {
+                None => signed_input_required(
+                    &ctx,
+                    [(
+                        "step1".to_string(),
+                        string_elicitation("Step 1: What is your name?", "name"),
+                    )]
+                    .into_iter()
+                    .collect(),
+                    ContinuationState {
+                        flow: "multi-round".into(),
+                        round: 1,
+                    },
+                ),
+                Some(state) if state.flow == "multi-round" && state.round == 1 => {
+                    if !ctx
+                        .input_responses()
+                        .is_some_and(|responses| responses.contains_key("step1"))
+                    {
+                        return Err(Error::invalid_params("step1 response is required"));
+                    }
+                    signed_input_required(
+                        &ctx,
+                        [(
+                            "step2".to_string(),
+                            string_elicitation("Step 2: What is your favorite color?", "color"),
+                        )]
+                        .into_iter()
+                        .collect(),
+                        ContinuationState {
+                            flow: "multi-round".into(),
+                            round: 2,
+                        },
+                    )
+                }
+                Some(state) if state.flow == "multi-round" && state.round == 2 => {
+                    if !ctx
+                        .input_responses()
+                        .is_some_and(|responses| responses.contains_key("step2"))
+                    {
+                        return Err(Error::invalid_params("step2 response is required"));
+                    }
+                    Ok(RequestOutcome::Complete(CallToolResult::text(
+                        "Multi-round input complete",
+                    )))
+                }
+                Some(_) => Err(Error::invalid_params(
+                    "requestState belongs to another flow or round",
+                )),
+            }
+        })
+        .build()
+}
+
+fn build_input_required_tampered_state() -> Tool {
+    ToolBuilder::new("test_input_required_result_tampered_state")
+        .description("SEP-2322 tampered requestState rejection fixture")
+        .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
+            let Some(state) = decode_state(&ctx)? else {
+                return signed_input_required(
+                    &ctx,
+                    [(
+                        "confirm".to_string(),
+                        elicitation_request(
+                            "Please confirm",
+                            "ok",
+                            serde_json::json!({ "type": "boolean" }),
+                        ),
+                    )]
+                    .into_iter()
+                    .collect(),
+                    ContinuationState {
+                        flow: "tampered-state".into(),
+                        round: 1,
+                    },
+                );
+            };
+            if state.flow != "tampered-state" || state.round != 1 {
+                return Err(Error::invalid_params(
+                    "requestState belongs to another flow",
+                ));
+            }
+            Ok(RequestOutcome::Complete(CallToolResult::text(
+                "State validated",
+            )))
+        })
+        .build()
+}
+
+fn build_input_required_capabilities() -> Tool {
+    ToolBuilder::new("test_input_required_result_capabilities")
+        .description("SEP-2322 per-request capability filtering fixture")
+        .mrtr_handler::<NoParams, _, _>(|_ctx, _| async move {
+            Ok(input_required([(
+                "sampling_only",
+                sampling_request("Generate a capability-safe response", 50),
+            )]))
+        })
+        .build()
 }
 
 /// Diagnostic fixture for the final protocol's per-request capability gate.


### PR DESCRIPTION
## Summary

- add public complete/input-required result APIs and MRTR handlers for tools, prompts, static resources, and resource templates
- add a versioned HMAC-SHA256 request-state codec with TTL, size bounds, constant-time verification, multi-instance keys, and optional subject binding
- enforce final-protocol client capability declarations and MRTR result invariants in the router
- exercise multi-round, multiple-input, missing/extra input, capability, and tamper behavior in the official conformance server
- document the opt-in `protocol-2026-07-28` feature while retaining `stateless` as a compatibility alias

Advances #950 and #929. Client auto-driving and task-owned MRTR remain tracked in #953 and #951, so this does not close #950.

## Support policy

The 2026-07-28 specification is final, but tower-mcp's implementation remains explicitly experimental and non-default. Users opt in at compile time with `protocol-2026-07-28` and select the exact enabled versions at runtime with `ProtocolSupport`.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --workspace --all-features --no-fail-fast`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features`
- warning-clean compile matrices: no features, `stateless`, `protocol-2026-07-28`, and `http,protocol-2026-07-28`
- official conformance `server --spec-version 2026-07-28 --suite all`: **114/114**, empty expected-failures baseline