### PR TITLE
feat(client): support final MCP lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 suites (114/114 server and 171/213 client checks at 0.2.0-alpha.10, client gaps baselined in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 suites (114/114 server; 210 passing client checks with the remaining auth scenarios baselined at 0.2.0-alpha.10) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -589,7 +589,7 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 - **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
 - **Client (2025-11-25):** 264/266 checks (`conformance@0.1.16`; the two gaps are new offline-access scenarios, baselined in `conformance-baseline-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953))
 - **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
-- **Client (2026-07-28):** 171/213 checks (`conformance@0.2.0-alpha.10`, `--suite all`); gaps are baselined in `conformance-baseline-draft-client.yml`, grouped by SEP and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)
+- **Client (2026-07-28):** 210 passing checks and 9/32 scenarios fully green (`conformance@0.2.0-alpha.10`, `--suite all`); the 23 remaining auth scenarios are baselined in `conformance-baseline-draft-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)
 
 Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. CI fails when a baselined scenario regresses further or starts passing (stale baseline), so the baselines cannot silently rot.
 
@@ -599,6 +599,30 @@ The `protocol-2026-07-28` feature enables the experimental implementation of the
 `_meta` capabilities, and SEP-2322 Multi Round-Trip Requests. It is not enabled by default and is
 not yet included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
 runtime enablement are reported separately.
+
+Clients opt in independently at runtime, then use the discover-based lifecycle.
+Every later request receives the required `_meta`, HTTP headers are generated
+from the JSON-RPC frame, and MRTR results are followed through the configured
+client handler with a bounded round count:
+
+```rust,no_run
+use tower_mcp::{HttpClientTransport, ProtocolSupport};
+use tower_mcp::client::McpClient;
+
+# async fn connect() -> Result<(), tower_mcp::BoxError> {
+let support = ProtocolSupport::try_new(["2026-07-28"])?;
+let transport = HttpClientTransport::new("https://example.com/mcp");
+let client = McpClient::builder()
+    .protocol_support(support)
+    .max_mrtr_rounds(8)
+    .connect_simple(transport)
+    .await?;
+
+let discovery = client.discover("my-client", "1.0.0").await?;
+println!("server versions: {:?}", discovery.supported_versions);
+# Ok(())
+# }
+```
 
 MRTR-aware tool, prompt, resource, and resource-template handlers return
 `RequestOutcome<T>`. Retry values are exposed on `RequestContext`, while

--- a/conformance-baseline-draft-client.yml
+++ b/conformance-baseline-draft-client.yml
@@ -7,38 +7,15 @@
 # as the gaps close; CI fails when a baselined scenario starts passing (stale
 # entry) or a non-baselined scenario fails.
 #
-# Status at 0.2.0-alpha.10 (2026-07-29, re-baselined after the 2026-07-28
-# protocol finalization): 171/213 checks pass; 3/32 scenarios fully green
-# (auth/pre-registration, auth/resource-mismatch, json-schema-ref-no-deref),
-# 29 baselined. Identical scenario set to alpha.9; no regressions or new
-# passes from finalization.
+# Status at 0.2.0-alpha.10 after the final client lifecycle/header/MRTR work:
+# 210 checks pass; 9/32 scenarios are fully green and 23 auth scenarios remain
+# baselined. The exact total includes scenario-specific header assertions that
+# were previously skipped because those methods were never exercised.
 #
 # Format (0.2.x suite): plain scenario-name strings under the `client:` key;
 # reasons live in these comments.
 
 client:
-  # SEP-2575: the client does not send `MCP-Protocol-Version` on the
-  # initialize POST (it only sets the header once initialize has returned a
-  # version), and does not populate the required per-request `_meta` fields.
-  # The harness answers a header-less POST with HTTP 400 / -32020, so
-  # every scenario that gets past auth and then makes an MCP call stops there.
-  # This one gap accounts for most of the entries below. Client work in #953.
-  - request-metadata
-  - tools_call
-
-  # SEP-2322 MRTR is not implemented client-side (#950 for the protocol work,
-  # #953 for the client surface): no request-state echo, no input-required
-  # result handling.
-  - sep-2322-client-request-state
-
-  # SEP-2243 custom/standard HTTP headers, client half (#952 server side,
-  # #953 client side): no `Mcp-Method` header on outgoing POSTs, no mirroring
-  # of x-mcp-header-annotated tool arguments into `Mcp-Param-*` headers, and no
-  # schema-aware exclusion of tools carrying invalid header annotations.
-  - http-standard-headers
-  - http-custom-headers
-  - http-invalid-tool-headers
-
   # SEP-837: Dynamic Client Registration omits `application_type`. One missing
   # field, but it is a MUST, so it fails every scenario that registers.
   - auth/metadata-default

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -1646,10 +1646,14 @@ pub struct InitializeResult {
 /// session or going through the initialize handshake. It is the stateless
 /// replacement for `initialize` in the 2026-07-28 protocol.
 ///
-/// The request takes no parameters today; the empty struct is reserved
-/// so future SEPs can add optional fields without breaking callers.
+/// The final lifecycle carries the same required per-request metadata on
+/// discovery that it carries on every subsequent request.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct DiscoverParams {}
+pub struct DiscoverParams {
+    /// Required per-request metadata for the final protocol.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<RequestMeta>,
+}
 
 /// Result of the `server/discover` RPC (SEP-2575).
 ///

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -47,11 +47,24 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use base64::Engine;
 use tokio::sync::{Notify, RwLock, mpsc};
 use tokio::task::JoinHandle;
 
 use super::transport::ClientTransport;
 use crate::error::{Error, Result};
+
+const MCP_METHOD_HEADER: &str = "mcp-method";
+const MCP_NAME_HEADER: &str = "mcp-name";
+const MCP_PARAM_HEADER_PREFIX: &str = "mcp-param-";
+const BASE64_SENTINEL_PREFIX: &str = "=?base64?";
+const BASE64_SENTINEL_SUFFIX: &str = "?=";
+
+#[derive(Debug, Clone)]
+struct CustomHeaderMapping {
+    suffix: String,
+    property_path: Vec<String>,
+}
 
 #[cfg(feature = "oauth-client")]
 use super::oauth::TokenProvider;
@@ -219,6 +232,8 @@ pub struct HttpClientTransport {
     session_id: Option<String>,
     /// Negotiated protocol version.
     protocol_version: Option<String>,
+    /// Validated custom-header mappings learned from the latest tools/list.
+    tool_header_mappings: HashMap<String, Vec<CustomHeaderMapping>>,
     /// Channel receiver for incoming messages (POST responses + SSE events).
     incoming_rx: mpsc::Receiver<String>,
     /// Channel sender used by `send()` to queue POST response bodies
@@ -280,6 +295,7 @@ impl HttpClientTransport {
             client: reqwest::Client::new(),
             session_id: None,
             protocol_version: None,
+            tool_header_mappings: HashMap::new(),
             incoming_rx: rx,
             incoming_tx: tx,
             sse_task: None,
@@ -317,6 +333,7 @@ impl HttpClientTransport {
             client,
             session_id: None,
             protocol_version: None,
+            tool_header_mappings: HashMap::new(),
             incoming_rx: rx,
             incoming_tx: tx,
             sse_task: None,
@@ -473,6 +490,76 @@ impl HttpClientTransport {
         self
     }
 
+    fn outgoing_custom_headers(&self, parsed: &serde_json::Value) -> Vec<(String, String)> {
+        if parsed.get("method").and_then(serde_json::Value::as_str) != Some("tools/call") {
+            return Vec::new();
+        }
+        let Some(params) = parsed.get("params") else {
+            return Vec::new();
+        };
+        let Some(name) = params.get("name").and_then(serde_json::Value::as_str) else {
+            return Vec::new();
+        };
+        let Some(mappings) = self.tool_header_mappings.get(name) else {
+            return Vec::new();
+        };
+        let arguments = params.get("arguments").unwrap_or(&serde_json::Value::Null);
+
+        mappings
+            .iter()
+            .filter_map(|mapping| {
+                let value = value_at_property_path(arguments, &mapping.property_path)?;
+                if value.is_null() {
+                    return None;
+                }
+                let rendered = json_value_to_header_string(value)?;
+                Some((
+                    format!("{MCP_PARAM_HEADER_PREFIX}{}", mapping.suffix),
+                    encode_header_value(&rendered),
+                ))
+            })
+            .collect()
+    }
+
+    fn normalize_incoming_message(&mut self, message: String) -> String {
+        if self.protocol_version.as_deref() != Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        {
+            return message;
+        }
+        let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(&message) else {
+            return message;
+        };
+        let Some(tools) = parsed
+            .get_mut("result")
+            .and_then(|result| result.get_mut("tools"))
+            .and_then(serde_json::Value::as_array_mut)
+        else {
+            return message;
+        };
+
+        self.tool_header_mappings.clear();
+        tools.retain(|tool| {
+            let Some(name) = tool.get("name").and_then(serde_json::Value::as_str) else {
+                return false;
+            };
+            let Some(schema) = tool.get("inputSchema") else {
+                return false;
+            };
+            match custom_header_mappings(schema) {
+                Ok(mappings) => {
+                    self.tool_header_mappings.insert(name.to_string(), mappings);
+                    true
+                }
+                Err(error) => {
+                    tracing::warn!(tool = %name, %error, "Excluding tool with invalid x-mcp-header annotations");
+                    false
+                }
+            }
+        });
+
+        parsed.to_string()
+    }
+
     /// Start the SSE background stream after session is established.
     fn start_sse_stream(&mut self) {
         let url = self.url.clone();
@@ -508,6 +595,153 @@ impl HttpClientTransport {
     }
 }
 
+fn custom_header_mappings(
+    schema: &serde_json::Value,
+) -> std::result::Result<Vec<CustomHeaderMapping>, String> {
+    fn annotation_count(value: &serde_json::Value) -> usize {
+        match value {
+            serde_json::Value::Object(object) => {
+                usize::from(object.contains_key("x-mcp-header"))
+                    + object.values().map(annotation_count).sum::<usize>()
+            }
+            serde_json::Value::Array(values) => values.iter().map(annotation_count).sum::<usize>(),
+            _ => 0,
+        }
+    }
+
+    fn is_tchar(byte: u8) -> bool {
+        byte.is_ascii_alphanumeric()
+            || matches!(
+                byte,
+                b'!' | b'#'
+                    | b'$'
+                    | b'%'
+                    | b'&'
+                    | b'\''
+                    | b'*'
+                    | b'+'
+                    | b'-'
+                    | b'.'
+                    | b'^'
+                    | b'_'
+                    | b'`'
+                    | b'|'
+                    | b'~'
+            )
+    }
+
+    fn primitive_header_type(schema: &serde_json::Value) -> bool {
+        match schema.get("type") {
+            Some(serde_json::Value::String(kind)) => {
+                matches!(kind.as_str(), "string" | "number" | "integer" | "boolean")
+            }
+            Some(serde_json::Value::Array(kinds)) => {
+                let mut primitive = false;
+                for kind in kinds {
+                    match kind.as_str() {
+                        Some("string" | "number" | "integer" | "boolean") if !primitive => {
+                            primitive = true;
+                        }
+                        Some("null") => {}
+                        _ => return false,
+                    }
+                }
+                primitive
+            }
+            _ => false,
+        }
+    }
+
+    fn walk(
+        schema: &serde_json::Value,
+        path: &mut Vec<String>,
+        seen: &mut std::collections::HashSet<String>,
+        mappings: &mut Vec<CustomHeaderMapping>,
+    ) -> std::result::Result<(), String> {
+        let Some(properties) = schema
+            .get("properties")
+            .and_then(serde_json::Value::as_object)
+        else {
+            return Ok(());
+        };
+        for (property_name, property_schema) in properties {
+            path.push(property_name.clone());
+            if let Some(annotation) = property_schema.get("x-mcp-header") {
+                let suffix = annotation
+                    .as_str()
+                    .ok_or_else(|| format!("annotation at {} is not a string", path.join(".")))?;
+                if suffix.is_empty() || !suffix.bytes().all(is_tchar) {
+                    return Err(format!(
+                        "invalid header suffix {suffix:?} at {}",
+                        path.join(".")
+                    ));
+                }
+                if !primitive_header_type(property_schema) {
+                    return Err(format!(
+                        "annotation at {} is not on a primitive property",
+                        path.join(".")
+                    ));
+                }
+                if !seen.insert(suffix.to_ascii_lowercase()) {
+                    return Err(format!("duplicate header suffix {suffix:?}"));
+                }
+                mappings.push(CustomHeaderMapping {
+                    suffix: suffix.to_string(),
+                    property_path: path.clone(),
+                });
+            }
+            walk(property_schema, path, seen, mappings)?;
+            path.pop();
+        }
+        Ok(())
+    }
+
+    let mut mappings = Vec::new();
+    walk(
+        schema,
+        &mut Vec::new(),
+        &mut std::collections::HashSet::new(),
+        &mut mappings,
+    )?;
+    if annotation_count(schema) != mappings.len() {
+        return Err(
+            "x-mcp-header annotation is not statically reachable through properties".to_string(),
+        );
+    }
+    Ok(mappings)
+}
+
+fn value_at_property_path<'a>(
+    root: &'a serde_json::Value,
+    path: &[String],
+) -> Option<&'a serde_json::Value> {
+    path.iter().try_fold(root, |value, key| value.get(key))
+}
+
+fn json_value_to_header_string(value: &serde_json::Value) -> Option<String> {
+    match value {
+        serde_json::Value::String(value) => Some(value.clone()),
+        serde_json::Value::Number(value) => Some(value.to_string()),
+        serde_json::Value::Bool(value) => Some(value.to_string()),
+        serde_json::Value::Null | serde_json::Value::Array(_) | serde_json::Value::Object(_) => {
+            None
+        }
+    }
+}
+
+fn encode_header_value(value: &str) -> String {
+    let unsafe_for_header =
+        value.trim() != value || value.bytes().any(|byte| !(0x20..=0x7e).contains(&byte));
+    if unsafe_for_header {
+        format!(
+            "{BASE64_SENTINEL_PREFIX}{}{BASE64_SENTINEL_SUFFIX}",
+            base64::engine::general_purpose::STANDARD.encode(value)
+        )
+    } else {
+        value.to_string()
+    }
+}
+
 #[async_trait]
 impl ClientTransport for HttpClientTransport {
     async fn send(&mut self, message: &str) -> Result<()> {
@@ -526,6 +760,25 @@ impl ClientTransport for HttpClientTransport {
             .as_ref()
             .map(|v| v.get("id").is_none())
             .unwrap_or(false);
+        let method = parsed_message
+            .as_ref()
+            .and_then(|value| value.get("method"))
+            .and_then(serde_json::Value::as_str);
+        let outbound_version = parsed_message
+            .as_ref()
+            .and_then(|value| {
+                value.pointer("/params/_meta/io.modelcontextprotocol~1protocolVersion")
+            })
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string);
+        let is_modern_request =
+            outbound_version.as_deref() == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION);
+        if is_modern_request {
+            self.protocol_version = outbound_version.clone();
+            // Final requests are sessionless even when a transitional peer
+            // incorrectly returns a legacy session header from discovery.
+            self.session_id = None;
+        }
         let timeout = if is_notification {
             self.config
                 .notification_timeout
@@ -542,12 +795,40 @@ impl ClientTransport for HttpClientTransport {
             .header("Accept", "application/json, text/event-stream")
             .timeout(timeout);
 
-        if let Some(ref session_id) = self.session_id {
+        if !is_modern_request && let Some(ref session_id) = self.session_id {
             request = request.header("mcp-session-id", session_id);
         }
 
-        if let Some(ref version) = self.protocol_version {
+        if let Some(version) = outbound_version.as_ref().or(self.protocol_version.as_ref()) {
             request = request.header("mcp-protocol-version", version);
+        }
+
+        if let Some(method) = method {
+            request = request.header(MCP_METHOD_HEADER, method);
+            let name = match method {
+                "tools/call" | "prompts/get" => parsed_message
+                    .as_ref()
+                    .and_then(|value| value.pointer("/params/name"))
+                    .and_then(serde_json::Value::as_str),
+                "resources/read" => parsed_message
+                    .as_ref()
+                    .and_then(|value| value.pointer("/params/uri"))
+                    .and_then(serde_json::Value::as_str),
+                "tasks/get" | "tasks/update" | "tasks/cancel" => parsed_message
+                    .as_ref()
+                    .and_then(|value| value.pointer("/params/taskId"))
+                    .and_then(serde_json::Value::as_str),
+                _ => None,
+            };
+            if let Some(name) = name {
+                request = request.header(MCP_NAME_HEADER, name);
+            }
+        }
+
+        if let Some(parsed) = parsed_message.as_ref() {
+            for (name, value) in self.outgoing_custom_headers(parsed) {
+                request = request.header(name, value);
+            }
         }
 
         for (key, value) in &self.config.headers {
@@ -576,14 +857,17 @@ impl ClientTransport for HttpClientTransport {
         // This prevents a deadlock when the server blocks on a
         // bidirectional request (sampling/elicitation) that requires the
         // client to respond via the SSE channel.
-        if self.session_id.is_some() && !is_notification {
+        if self.session_id.is_some() && !is_modern_request && !is_notification {
             let tx = self.incoming_tx.clone();
             // The caller is parked on this request id in the message loop's
             // correlation map. Every failure branch below delivers a frame
             // carrying it, so a background POST that dies (network error,
             // timeout, HTTP error, empty body, response stream closed early)
             // wakes the caller with an error instead of hanging it forever.
-            let req_id = parsed_message.and_then(|v| v.get("id").cloned());
+            let req_id = parsed_message
+                .as_ref()
+                .and_then(|value| value.get("id"))
+                .cloned();
             let connected = self.connected.clone();
             let last_event_id = self.last_event_id.clone();
             let sse_retry_delay = self.sse_retry_delay.clone();
@@ -802,7 +1086,7 @@ impl ClientTransport for HttpClientTransport {
         // 202 Accepted = notification acknowledged, no body
         if status == reqwest::StatusCode::ACCEPTED {
             // Still update session state if headers present
-            if let Some(sid) = new_session_id {
+            if !is_modern_request && let Some(sid) = new_session_id {
                 self.session_id = Some(sid);
             }
             if let Some(pv) = new_protocol_version {
@@ -812,6 +1096,22 @@ impl ClientTransport for HttpClientTransport {
         }
 
         if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            if is_modern_request
+                && let Ok(mut error) = serde_json::from_str::<serde_json::Value>(&body)
+                && error.get("error").is_some()
+            {
+                if error.get("id").is_none_or(serde_json::Value::is_null)
+                    && let Some(id) = parsed_message.as_ref().and_then(|value| value.get("id"))
+                {
+                    error["id"] = id.clone();
+                }
+                self.incoming_tx
+                    .send(error.to_string())
+                    .await
+                    .map_err(|_| Error::Transport("Internal channel closed".to_string()))?;
+                return Ok(());
+            }
             // 404 only signals an expired session once a session exists.
             // Before that (the initial `initialize`), a 404 means the URL is
             // wrong, and reporting it as "Session expired" sends users
@@ -829,7 +1129,6 @@ impl ClientTransport for HttpClientTransport {
                     self.url
                 )));
             }
-            let body = response.text().await.unwrap_or_default();
             return Err(Error::Transport(format!(
                 "HTTP {} from server: {}",
                 status, body
@@ -837,7 +1136,7 @@ impl ClientTransport for HttpClientTransport {
         }
 
         // Update session state
-        if let Some(sid) = new_session_id {
+        if !is_modern_request && let Some(sid) = new_session_id {
             let is_new_session = self.session_id.is_none();
             self.session_id = Some(sid);
 
@@ -856,6 +1155,7 @@ impl ClientTransport for HttpClientTransport {
             .map_err(|e| Error::Transport(format!("Failed to read response: {}", e)))?;
 
         for msg in extract_json_messages(&body) {
+            let msg = self.normalize_incoming_message(msg);
             self.incoming_tx
                 .send(msg)
                 .await
@@ -1580,5 +1880,90 @@ mod tests {
         let config = HttpClientConfig::default().basic_auth("user", "pw");
         let header = config.headers.get("Authorization").unwrap();
         assert!(header.starts_with("Basic "));
+    }
+
+    #[test]
+    fn sep_2243_encodes_only_unsafe_values() {
+        assert_eq!(encode_header_value("us west 1"), "us west 1");
+        assert_eq!(encode_header_value(""), "");
+        assert_eq!(encode_header_value(" padded "), "=?base64?IHBhZGRlZCA=?=");
+        assert_eq!(
+            encode_header_value("Hello, 世界"),
+            "=?base64?SGVsbG8sIOS4lueVjA==?="
+        );
+    }
+
+    #[test]
+    fn sep_2243_validates_custom_header_annotations() {
+        let mappings = custom_header_mappings(&serde_json::json!({
+            "type": "object",
+            "properties": {
+                "region": {"type": "string", "x-mcp-header": "Region"},
+                "priority": {"type": "integer", "x-mcp-header": "Priority"},
+                "ratio": {"type": "number", "x-mcp-header": "Ratio"}
+            }
+        }))
+        .unwrap();
+        assert_eq!(mappings.len(), 3);
+
+        for invalid in [
+            serde_json::json!({
+                "type": "object",
+                "properties": {"value": {"type": "object", "x-mcp-header": "Value"}}
+            }),
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "a": {"type": "string", "x-mcp-header": "Region"},
+                    "b": {"type": "string", "x-mcp-header": "region"}
+                }
+            }),
+            serde_json::json!({
+                "type": "object",
+                "properties": {"value": {"type": "string", "x-mcp-header": "Bad Header"}}
+            }),
+        ] {
+            assert!(custom_header_mappings(&invalid).is_err());
+        }
+    }
+
+    #[test]
+    fn sep_2243_filters_invalid_tools_and_caches_valid_mappings() {
+        let mut transport = HttpClientTransport::new("http://localhost:3000");
+        transport.protocol_version =
+            Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string());
+        let normalized = transport.normalize_incoming_message(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "tools": [
+                        {
+                            "name": "valid",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "region": {"type": "string", "x-mcp-header": "Region"}
+                                }
+                            }
+                        },
+                        {
+                            "name": "invalid",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "value": {"type": "array", "x-mcp-header": "Value"}
+                                }
+                            }
+                        }
+                    ]
+                }
+            })
+            .to_string(),
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+        assert_eq!(parsed["result"]["tools"].as_array().unwrap().len(), 1);
+        assert!(transport.tool_header_mappings.contains_key("valid"));
+        assert!(!transport.tool_header_mappings.contains_key("invalid"));
     }
 }

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -61,17 +61,21 @@ use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 use tokio::sync::{Mutex, RwLock, mpsc, oneshot};
 use tokio::task::JoinHandle;
 
+use crate::ProtocolSupport;
 use crate::error::{Error, Result};
+#[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+use crate::protocol::DiscoverParams;
 use crate::protocol::{
     CallToolParams, CallToolResult, CancelTaskParams, ClientCapabilities, CompleteParams,
-    CompleteResult, CompletionArgument, CompletionReference, CreateTaskResult,
+    CompleteResult, CompletionArgument, CompletionReference, CreateTaskResult, DiscoverResult,
     ElicitationCapability, GetPromptParams, GetPromptResult, GetTaskInfoParams, Implementation,
-    InitializeParams, InitializeResult, JsonRpcNotification, JsonRpcRequest, ListPromptsParams,
-    ListPromptsResult, ListResourceTemplatesParams, ListResourceTemplatesResult,
-    ListResourcesParams, ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult,
-    PromptDefinition, ReadResourceParams, ReadResourceResult, RequestId, ResourceDefinition,
-    ResourceTemplateDefinition, Root, RootsCapability, SamplingCapability, TaskObject,
-    TaskRequestParams, ToolDefinition, notifications,
+    InitializeParams, InitializeResult, InputRequest, InputRequests, InputResponse, InputResponses,
+    JsonRpcNotification, JsonRpcRequest, ListPromptsParams, ListPromptsResult,
+    ListResourceTemplatesParams, ListResourceTemplatesResult, ListResourcesParams,
+    ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult, PromptDefinition,
+    ReadResourceParams, ReadResourceResult, RequestId, RequestMeta, RequestOutcome,
+    ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability, SamplingCapability,
+    TaskObject, TaskRequestParams, ToolDefinition, notifications,
 };
 use tower_mcp_types::JsonRpcError;
 
@@ -90,6 +94,11 @@ enum LoopCommand {
     },
     /// Reset the transport's session state for re-initialization.
     ResetSession { done_tx: oneshot::Sender<()> },
+    /// Fulfil embedded MRTR requests through the configured client handler.
+    ResolveInputs {
+        requests: InputRequests,
+        response_tx: oneshot::Sender<Result<InputResponses>>,
+    },
     /// Graceful shutdown.
     Shutdown,
 }
@@ -134,6 +143,14 @@ pub struct McpClient {
     server_info: RwLock<Option<InitializeResult>>,
     /// Client capabilities declared during initialization.
     capabilities: ClientCapabilities,
+    /// Exact ordered set of protocol implementations enabled for this client.
+    protocol_support: ProtocolSupport,
+    /// Protocol selected by the discover-based final lifecycle.
+    selected_protocol_version: RwLock<Option<String>>,
+    /// Client identity repeated in final-protocol request metadata.
+    client_info: RwLock<Option<Implementation>>,
+    /// Server discovery result, when the final lifecycle is active.
+    discovery: RwLock<Option<DiscoverResult>>,
     /// Current roots (shared with the loop for roots/list responses).
     roots: Arc<RwLock<Vec<Root>>>,
     /// Whether the transport is still connected.
@@ -144,6 +161,8 @@ pub struct McpClient {
     init_params: RwLock<Option<(String, String)>>,
     /// Lock to prevent concurrent session recovery attempts.
     recovery_lock: Mutex<()>,
+    /// Maximum number of input-required rounds auto-driven per operation.
+    max_mrtr_rounds: usize,
 }
 
 /// Builder for configuring and connecting an [`McpClient`].
@@ -168,6 +187,8 @@ pub struct McpClient {
 pub struct McpClientBuilder {
     capabilities: ClientCapabilities,
     roots: Vec<Root>,
+    protocol_support: ProtocolSupport,
+    max_mrtr_rounds: usize,
 }
 
 impl McpClientBuilder {
@@ -176,6 +197,10 @@ impl McpClientBuilder {
         Self {
             capabilities: ClientCapabilities::default(),
             roots: Vec::new(),
+            // Merely compiling an experimental implementation must not move an
+            // existing client off the established initialize/session path.
+            protocol_support: ProtocolSupport::stable(),
+            max_mrtr_rounds: 8,
         }
     }
 
@@ -195,6 +220,24 @@ impl McpClientBuilder {
     /// Configure custom capabilities for this client.
     pub fn with_capabilities(mut self, capabilities: ClientCapabilities) -> Self {
         self.capabilities = capabilities;
+        self
+    }
+
+    /// Set the exact ordered protocol versions enabled for this client.
+    ///
+    /// The default is [`ProtocolSupport::stable`], even when the experimental
+    /// final-protocol implementation was compiled. Applications opt into
+    /// 2026-07-28 explicitly and then call `McpClient::discover`.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.protocol_support = support;
+        self
+    }
+
+    /// Bound the number of MRTR rounds automatically followed for one request.
+    ///
+    /// Zero is normalized to one. The default is eight rounds.
+    pub fn max_mrtr_rounds(mut self, rounds: usize) -> Self {
+        self.max_mrtr_rounds = rounds.max(1);
         self
     }
 
@@ -229,7 +272,15 @@ impl McpClientBuilder {
         T: ClientTransport,
         H: ClientHandler,
     {
-        McpClient::connect_inner(transport, handler, self.capabilities, self.roots).await
+        McpClient::connect_inner(
+            transport,
+            handler,
+            self.capabilities,
+            self.roots,
+            self.protocol_support,
+            self.max_mrtr_rounds,
+        )
+        .await
     }
 
     /// Connect to a server without a handler.
@@ -274,6 +325,8 @@ impl McpClient {
         handler: H,
         capabilities: ClientCapabilities,
         roots: Vec<Root>,
+        protocol_support: ProtocolSupport,
+        max_mrtr_rounds: usize,
     ) -> Result<Self>
     where
         T: ClientTransport,
@@ -297,11 +350,16 @@ impl McpClient {
             initialized: AtomicBool::new(false),
             server_info: RwLock::new(None),
             capabilities,
+            protocol_support,
+            selected_protocol_version: RwLock::new(None),
+            client_info: RwLock::new(None),
+            discovery: RwLock::new(None),
             roots,
             connected,
             supports_session_recovery,
             init_params: RwLock::new(None),
             recovery_lock: Mutex::new(()),
+            max_mrtr_rounds,
         })
     }
 
@@ -318,6 +376,21 @@ impl McpClient {
     /// Get the server info (available after initialization).
     pub async fn server_info(&self) -> Option<InitializeResult> {
         self.server_info.read().await.clone()
+    }
+
+    /// Return the exact ordered protocol implementations enabled for this client.
+    pub fn protocol_support(&self) -> &ProtocolSupport {
+        &self.protocol_support
+    }
+
+    /// Get the server discovery result after the final lifecycle is active.
+    pub async fn discovery(&self) -> Option<DiscoverResult> {
+        self.discovery.read().await.clone()
+    }
+
+    /// Get the protocol version selected for the discover-based lifecycle.
+    pub async fn selected_protocol_version(&self) -> Option<String> {
+        self.selected_protocol_version.read().await.clone()
     }
 
     /// Get the server info synchronously (best-effort, non-blocking).
@@ -364,6 +437,99 @@ impl McpClient {
         Ok(result)
     }
 
+    /// Start the sessionless 2026-07-28 lifecycle with `server/discover`.
+    ///
+    /// This path is available only when the final implementation was compiled.
+    /// The client sends required per-request metadata from the first request,
+    /// retries one `Unsupported protocol version` response using the server's
+    /// advertised intersection, and then repeats the selected version,
+    /// capabilities, and client identity on every subsequent request.
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    pub async fn discover(
+        &self,
+        client_name: &str,
+        client_version: &str,
+    ) -> Result<DiscoverResult> {
+        use crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+
+        let client_info = Implementation {
+            name: client_name.to_string(),
+            version: client_version.to_string(),
+            ..Default::default()
+        };
+        *self.client_info.write().await = Some(client_info.clone());
+
+        let mut candidate = self
+            .protocol_support
+            .versions()
+            .iter()
+            .find(|version| version.as_str() == EXPERIMENTAL_PROTOCOL_VERSION)
+            .cloned()
+            .ok_or_else(|| {
+                Error::Transport(
+                    "2026-07-28 is not enabled for this client; configure ProtocolSupport"
+                        .to_string(),
+                )
+            })?;
+        let mut retried_unsupported = false;
+
+        loop {
+            let params = DiscoverParams {
+                meta: Some(self.request_meta_for(&candidate, &client_info)),
+            };
+            match self
+                .send_request_once::<_, DiscoverResult>("server/discover", &params)
+                .await
+            {
+                Ok(result) => {
+                    let selected = self
+                        .protocol_support
+                        .versions()
+                        .iter()
+                        .find(|version| {
+                            result
+                                .supported_versions
+                                .iter()
+                                .any(|supported| supported == *version)
+                        })
+                        .cloned()
+                        .ok_or_else(|| {
+                            Error::Transport(format!(
+                                "server and client have no protocol version in common; server: {:?}, client: {:?}",
+                                result.supported_versions,
+                                self.protocol_support.versions()
+                            ))
+                        })?;
+                    *self.selected_protocol_version.write().await = Some(selected);
+                    *self.discovery.write().await = Some(result.clone());
+                    self.initialized.store(true, Ordering::Release);
+                    return Ok(result);
+                }
+                Err(Error::JsonRpc(error)) if error.code == -32022 && !retried_unsupported => {
+                    let supported = error
+                        .data
+                        .as_ref()
+                        .and_then(|data| data.get("supported"))
+                        .and_then(serde_json::Value::as_array)
+                        .ok_or_else(|| Error::JsonRpc(error.clone()))?;
+                    candidate = self
+                        .protocol_support
+                        .versions()
+                        .iter()
+                        .find(|version| {
+                            supported
+                                .iter()
+                                .any(|item| item.as_str() == Some(version.as_str()))
+                        })
+                        .cloned()
+                        .ok_or_else(|| Error::JsonRpc(error.clone()))?;
+                    retried_unsupported = true;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
     /// List available tools.
     pub async fn list_tools(&self) -> Result<ListToolsResult> {
         self.ensure_initialized()?;
@@ -383,12 +549,54 @@ impl McpClient {
         name: &str,
         arguments: serde_json::Value,
     ) -> Result<CallToolResult> {
+        let mut input_responses = None;
+        let mut request_state = None;
+        for round in 0..=self.max_mrtr_rounds {
+            match self
+                .call_tool_once(
+                    name,
+                    arguments.clone(),
+                    input_responses.take(),
+                    request_state.take(),
+                )
+                .await?
+            {
+                RequestOutcome::Complete(result) => return Ok(result),
+                RequestOutcome::InputRequired(required) => {
+                    if round == self.max_mrtr_rounds {
+                        return Err(Error::Transport(format!(
+                            "MRTR round limit ({}) exceeded for tools/call",
+                            self.max_mrtr_rounds
+                        )));
+                    }
+                    let requests = required.input_requests.ok_or_else(|| {
+                        Error::Transport(
+                            "input_required result has no requests the client can fulfil"
+                                .to_string(),
+                        )
+                    })?;
+                    input_responses = Some(self.resolve_input_requests(requests).await?);
+                    request_state = required.request_state;
+                }
+            }
+        }
+        unreachable!("MRTR loop either completes or returns at the configured bound")
+    }
+
+    /// Send one tools/call attempt without automatically following MRTR input.
+    pub async fn call_tool_once(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+        input_responses: Option<InputResponses>,
+        request_state: Option<String>,
+    ) -> Result<RequestOutcome<CallToolResult>> {
         self.ensure_initialized()?;
         let params = CallToolParams {
             name: name.to_string(),
             arguments,
-            input_responses: None,
-            request_state: None,
+            input_responses,
+            request_state,
             meta: None,
             task: None,
         };
@@ -491,11 +699,47 @@ impl McpClient {
 
     /// Read a resource.
     pub async fn read_resource(&self, uri: &str) -> Result<ReadResourceResult> {
+        let mut input_responses = None;
+        let mut request_state = None;
+        for round in 0..=self.max_mrtr_rounds {
+            match self
+                .read_resource_once(uri, input_responses.take(), request_state.take())
+                .await?
+            {
+                RequestOutcome::Complete(result) => return Ok(result),
+                RequestOutcome::InputRequired(required) => {
+                    if round == self.max_mrtr_rounds {
+                        return Err(Error::Transport(format!(
+                            "MRTR round limit ({}) exceeded for resources/read",
+                            self.max_mrtr_rounds
+                        )));
+                    }
+                    let requests = required.input_requests.ok_or_else(|| {
+                        Error::Transport(
+                            "input_required result has no requests the client can fulfil"
+                                .to_string(),
+                        )
+                    })?;
+                    input_responses = Some(self.resolve_input_requests(requests).await?);
+                    request_state = required.request_state;
+                }
+            }
+        }
+        unreachable!("MRTR loop either completes or returns at the configured bound")
+    }
+
+    /// Send one resources/read attempt without automatically following MRTR.
+    pub async fn read_resource_once(
+        &self,
+        uri: &str,
+        input_responses: Option<InputResponses>,
+        request_state: Option<String>,
+    ) -> Result<RequestOutcome<ReadResourceResult>> {
         self.ensure_initialized()?;
         let params = ReadResourceParams {
             uri: uri.to_string(),
-            input_responses: None,
-            request_state: None,
+            input_responses,
+            request_state,
             meta: None,
         };
         self.send_request("resources/read", &params).await
@@ -511,6 +755,12 @@ impl McpClient {
     /// capabilities; one that does not will reject the request.
     pub async fn subscribe_resource(&self, uri: &str) -> Result<()> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "resources/subscribe was removed in 2026-07-28; use subscriptions/listen"
+                    .to_string(),
+            ));
+        }
         let _: serde_json::Value = self
             .send_request("resources/subscribe", &serde_json::json!({ "uri": uri }))
             .await?;
@@ -520,6 +770,12 @@ impl McpClient {
     /// Stop receiving updates for a resource (`resources/unsubscribe`).
     pub async fn unsubscribe_resource(&self, uri: &str) -> Result<()> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "resources/unsubscribe was removed in 2026-07-28; use subscriptions/listen"
+                    .to_string(),
+            ));
+        }
         let _: serde_json::Value = self
             .send_request("resources/unsubscribe", &serde_json::json!({ "uri": uri }))
             .await?;
@@ -676,12 +932,55 @@ impl McpClient {
         name: &str,
         arguments: Option<std::collections::HashMap<String, String>>,
     ) -> Result<GetPromptResult> {
+        let arguments = arguments.unwrap_or_default();
+        let mut input_responses = None;
+        let mut request_state = None;
+        for round in 0..=self.max_mrtr_rounds {
+            match self
+                .get_prompt_once(
+                    name,
+                    arguments.clone(),
+                    input_responses.take(),
+                    request_state.take(),
+                )
+                .await?
+            {
+                RequestOutcome::Complete(result) => return Ok(result),
+                RequestOutcome::InputRequired(required) => {
+                    if round == self.max_mrtr_rounds {
+                        return Err(Error::Transport(format!(
+                            "MRTR round limit ({}) exceeded for prompts/get",
+                            self.max_mrtr_rounds
+                        )));
+                    }
+                    let requests = required.input_requests.ok_or_else(|| {
+                        Error::Transport(
+                            "input_required result has no requests the client can fulfil"
+                                .to_string(),
+                        )
+                    })?;
+                    input_responses = Some(self.resolve_input_requests(requests).await?);
+                    request_state = required.request_state;
+                }
+            }
+        }
+        unreachable!("MRTR loop either completes or returns at the configured bound")
+    }
+
+    /// Send one prompts/get attempt without automatically following MRTR.
+    pub async fn get_prompt_once(
+        &self,
+        name: &str,
+        arguments: std::collections::HashMap<String, String>,
+        input_responses: Option<InputResponses>,
+        request_state: Option<String>,
+    ) -> Result<RequestOutcome<GetPromptResult>> {
         self.ensure_initialized()?;
         let params = GetPromptParams {
             name: name.to_string(),
-            arguments: arguments.unwrap_or_default(),
-            input_responses: None,
-            request_state: None,
+            arguments,
+            input_responses,
+            request_state,
             meta: None,
         };
         self.send_request("prompts/get", &params).await
@@ -689,6 +988,11 @@ impl McpClient {
 
     /// Ping the server.
     pub async fn ping(&self) -> Result<()> {
+        if self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "ping was removed from the 2026-07-28 core protocol".to_string(),
+            ));
+        }
         let _: serde_json::Value = self.send_request("ping", &serde_json::json!({})).await?;
         Ok(())
     }
@@ -762,7 +1066,7 @@ impl McpClient {
     /// Set roots and notify the server if initialized.
     pub async fn set_roots(&self, roots: Vec<Root>) -> Result<()> {
         *self.roots.write().await = roots;
-        if self.is_initialized() {
+        if self.is_initialized() && !self.uses_final_protocol().await {
             self.send_notification(notifications::ROOTS_LIST_CHANGED, &serde_json::json!({}))
                 .await?;
         }
@@ -772,7 +1076,7 @@ impl McpClient {
     /// Add a root and notify the server if initialized.
     pub async fn add_root(&self, root: Root) -> Result<()> {
         self.roots.write().await.push(root);
-        if self.is_initialized() {
+        if self.is_initialized() && !self.uses_final_protocol().await {
             self.send_notification(notifications::ROOTS_LIST_CHANGED, &serde_json::json!({}))
                 .await?;
         }
@@ -787,7 +1091,7 @@ impl McpClient {
         let removed = roots.len() < initial_len;
         drop(roots);
 
-        if removed && self.is_initialized() {
+        if removed && self.is_initialized() && !self.uses_final_protocol().await {
             self.send_notification(notifications::ROOTS_LIST_CHANGED, &serde_json::json!({}))
                 .await?;
         }
@@ -818,9 +1122,10 @@ impl McpClient {
         method: &str,
         params: &P,
     ) -> Result<R> {
+        let final_protocol = self.uses_final_protocol().await;
         match self.send_request_once(method, params).await {
             Err(Error::SessionExpired)
-                if self.supports_session_recovery && method != "initialize" =>
+                if self.supports_session_recovery && !final_protocol && method != "initialize" =>
             {
                 tracing::info!(method = %method, "Session expired, attempting recovery");
                 self.recover_session().await?;
@@ -838,6 +1143,7 @@ impl McpClient {
         self.ensure_connected()?;
         let params_value = serde_json::to_value(params)
             .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
+        let params_value = self.with_final_request_meta(params_value).await?;
 
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
@@ -915,6 +1221,7 @@ impl McpClient {
         self.ensure_connected()?;
         let params_value = serde_json::to_value(params)
             .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
+        let params_value = self.with_final_request_meta(params_value).await?;
 
         self.command_tx
             .send(LoopCommand::Notify {
@@ -925,6 +1232,96 @@ impl McpClient {
             .map_err(|_| Error::Transport("Connection closed".to_string()))?;
 
         Ok(())
+    }
+
+    async fn resolve_input_requests(&self, requests: InputRequests) -> Result<InputResponses> {
+        if !self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "input_required results require the 2026-07-28 client lifecycle".to_string(),
+            ));
+        }
+        for request in requests.values() {
+            let declared = match request {
+                InputRequest::CreateMessage(_) => self.capabilities.sampling.is_some(),
+                InputRequest::ListRoots(_) => self.capabilities.roots.is_some(),
+                InputRequest::Elicit(_) => self.capabilities.elicitation.is_some(),
+                _ => false,
+            };
+            if !declared {
+                return Err(Error::Transport(format!(
+                    "server requested undeclared MRTR input capability: {}",
+                    request.method_name()
+                )));
+            }
+        }
+
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(LoopCommand::ResolveInputs {
+                requests,
+                response_tx,
+            })
+            .await
+            .map_err(|_| Error::Transport("Connection closed".to_string()))?;
+        response_rx
+            .await
+            .map_err(|_| Error::Transport("Connection closed".to_string()))?
+    }
+
+    async fn uses_final_protocol(&self) -> bool {
+        self.selected_protocol_version.read().await.as_deref()
+            == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+    }
+
+    fn request_meta_for(&self, version: &str, client_info: &Implementation) -> RequestMeta {
+        RequestMeta {
+            progress_token: None,
+            protocol_version: Some(version.to_string()),
+            client_info: Some(client_info.clone()),
+            client_capabilities: Some(self.capabilities.clone()),
+            log_level: None,
+        }
+    }
+
+    async fn with_final_request_meta(
+        &self,
+        mut params: serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        let Some(version) = self.selected_protocol_version.read().await.clone() else {
+            return Ok(params);
+        };
+        if version != crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+            return Ok(params);
+        }
+        let client_info = self.client_info.read().await.clone().ok_or_else(|| {
+            Error::Transport("final protocol selected without client identity".to_string())
+        })?;
+        let required = serde_json::to_value(self.request_meta_for(&version, &client_info))
+            .map_err(|e| Error::Transport(format!("Failed to serialize request metadata: {e}")))?;
+        let required = required
+            .as_object()
+            .expect("RequestMeta serializes as an object");
+
+        if !params.is_object() {
+            params = serde_json::json!({});
+        }
+        let params_object = params
+            .as_object_mut()
+            .expect("params was normalized to object");
+        let meta = params_object
+            .entry("_meta")
+            .or_insert_with(|| serde_json::json!({}));
+        if !meta.is_object() {
+            *meta = serde_json::json!({});
+        }
+        let meta = meta
+            .as_object_mut()
+            .expect("metadata was normalized to object");
+        for (key, value) in required {
+            meta.insert(key.clone(), value.clone());
+        }
+
+        Ok(params)
     }
 
     fn ensure_connected(&self) -> Result<()> {
@@ -1008,6 +1405,10 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
                             let _ = transport.send(&json).await;
                         }
                     }
+                    Some(LoopCommand::ResolveInputs { requests, response_tx }) => {
+                        let result = resolve_inputs_with_handler(&handler, &roots, requests).await;
+                        let _ = response_tx.send(result);
+                    }
                     Some(LoopCommand::ResetSession { done_tx }) => {
                         tracing::info!("Resetting transport session for re-initialization");
                         transport.reset_session().await;
@@ -1053,6 +1454,49 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
     connected.store(false, Ordering::Release);
     fail_all_pending(&mut pending_requests, "Connection closed");
     let _ = transport.close().await;
+}
+
+async fn resolve_inputs_with_handler<H: ClientHandler>(
+    handler: &Arc<H>,
+    roots: &Arc<RwLock<Vec<Root>>>,
+    requests: InputRequests,
+) -> Result<InputResponses> {
+    let mut responses = InputResponses::new();
+    for (key, request) in requests {
+        let response = match request {
+            InputRequest::CreateMessage(params) => InputResponse::CreateMessage(
+                handler
+                    .handle_create_message(params)
+                    .await
+                    .map_err(Error::JsonRpc)?,
+            ),
+            InputRequest::ListRoots(_) => {
+                let configured = roots.read().await.clone();
+                let result = if configured.is_empty() {
+                    handler.handle_list_roots().await.map_err(Error::JsonRpc)?
+                } else {
+                    ListRootsResult {
+                        roots: configured,
+                        meta: None,
+                    }
+                };
+                InputResponse::ListRoots(result)
+            }
+            InputRequest::Elicit(params) => InputResponse::Elicit(
+                handler
+                    .handle_elicit(params)
+                    .await
+                    .map_err(Error::JsonRpc)?,
+            ),
+            _ => {
+                return Err(Error::Transport(
+                    "unsupported MRTR input request method".to_string(),
+                ));
+            }
+        };
+        responses.insert(key, response);
+    }
+    Ok(responses)
 }
 
 /// Handle a single incoming message from the server.
@@ -1471,6 +1915,60 @@ mod tests {
 
         let server_info = client.server_info().await.unwrap();
         assert_eq!(server_info.server_info.name, "test-server");
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_discover_injects_metadata_on_every_request() {
+        let transport = MockTransport::with_responses(vec![
+            serde_json::json!({
+                "resultType": "complete",
+                "supportedVersions": ["2026-07-28"],
+                "capabilities": {}
+            }),
+            serde_json::json!({
+                "resultType": "complete",
+                "tools": [],
+                "ttlMs": 0,
+                "cacheScope": "private"
+            }),
+        ]);
+        let outgoing = transport.outgoing.clone();
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .with_elicitation()
+            .connect_simple(transport)
+            .await
+            .unwrap();
+
+        client.discover("test-client", "1.0.0").await.unwrap();
+        client.list_tools().await.unwrap();
+        assert_eq!(
+            client.selected_protocol_version().await.as_deref(),
+            Some("2026-07-28")
+        );
+
+        let messages: Vec<serde_json::Value> = outgoing
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|message| serde_json::from_str(message).unwrap())
+            .collect();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["method"], "server/discover");
+        assert_eq!(messages[1]["method"], "tools/list");
+        for message in messages {
+            let meta = &message["params"]["_meta"];
+            assert_eq!(
+                meta["io.modelcontextprotocol/protocolVersion"],
+                "2026-07-28"
+            );
+            assert_eq!(
+                meta["io.modelcontextprotocol/clientInfo"]["name"],
+                "test-client"
+            );
+            assert!(meta["io.modelcontextprotocol/clientCapabilities"].is_object());
+        }
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -141,6 +141,8 @@
 //!   client identity, and client capabilities for sessionless 2026-07-28 requests
 //! - [`RequestOutcome`] and [`InputRequiredResult`] - SEP-2322 Multi Round-Trip Request results
 //! - [`RequestStateCodec`] - Expiring, integrity-protected continuation state
+//! - `McpClient::discover` - Sessionless client discovery with per-request metadata,
+//!   runtime version selection, SEP-2243 headers, and bounded MRTR auto-driving
 //!
 //! ## Feature Flags
 //!
@@ -161,7 +163,8 @@
 //! - `protocol-2026-07-28` - Compile the experimental implementation of the released final
 //!   protocol. Use [`ProtocolSupport`] to select enabled versions at runtime. Enables
 //!   version-gated sessionless dispatch, `server/discover` RPC, per-request `_meta` via
-//!   [`stateless::StatelessRequestMeta`], `subscriptions/listen`, and SEP-2322 MRTR handlers.
+//!   [`stateless::StatelessRequestMeta`], `subscriptions/listen`, SEP-2322 MRTR handlers,
+//!   and the discover-based [`McpClient`] path.
 //! - `stateless` - Compatibility alias for the former 2026 protocol feature name.
 //!
 //! ## Middleware Placement Guide

--- a/examples/conformance-client/Cargo.toml
+++ b/examples/conformance-client/Cargo.toml
@@ -12,7 +12,7 @@ name = "conformance-client"
 path = "src/main.rs"
 
 [dependencies]
-tower-mcp = { workspace = true, features = ["http-client", "oauth-client"] }
+tower-mcp = { workspace = true, features = ["http-client", "oauth-client", "protocol-2026-07-28"] }
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/examples/conformance-client/src/core_scenarios.rs
+++ b/examples/conformance-client/src/core_scenarios.rs
@@ -1,19 +1,42 @@
 //! Core conformance scenarios (non-auth).
 
 use anyhow::Result;
-use tower_mcp::HttpClientTransport;
-use tower_mcp::client::McpClient;
+use tower_mcp::client::{McpClient, McpClientBuilder};
+use tower_mcp::{HttpClientTransport, ProtocolSupport};
 
 use crate::handlers;
+
+fn requested_protocol_version() -> String {
+    std::env::var("MCP_CONFORMANCE_PROTOCOL_VERSION")
+        .unwrap_or_else(|_| tower_mcp::protocol::LATEST_PROTOCOL_VERSION.to_string())
+}
+
+fn client_builder() -> Result<McpClientBuilder> {
+    let version = requested_protocol_version();
+    let mut builder = McpClient::builder();
+    if version == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+        builder = builder.protocol_support(ProtocolSupport::try_new([version])?);
+    }
+    Ok(builder)
+}
+
+async fn activate(client: &McpClient) -> Result<()> {
+    if requested_protocol_version() == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+        client.discover("conformance-client", "0.1.0").await?;
+    } else {
+        client.initialize("conformance-client", "0.1.0").await?;
+    }
+    Ok(())
+}
 
 /// `initialize` -- Connect, list tools, disconnect.
 pub async fn initialize(server_url: &str) -> Result<()> {
     let transport = HttpClientTransport::new(server_url);
-    let client = McpClient::builder()
+    let client = client_builder()?
         .connect(transport, handlers::BasicHandler)
         .await?;
 
-    client.initialize("conformance-client", "0.1.0").await?;
+    activate(&client).await?;
     let tools = client.list_tools().await?;
     tracing::info!("Listed {} tools", tools.tools.len());
 
@@ -24,13 +47,13 @@ pub async fn initialize(server_url: &str) -> Result<()> {
 /// `tools_call` -- Connect with full handler, list and call all tools.
 pub async fn tools_call(server_url: &str) -> Result<()> {
     let transport = HttpClientTransport::new(server_url);
-    let client = McpClient::builder()
+    let client = client_builder()?
         .with_sampling()
         .with_elicitation()
         .connect(transport, handlers::FullHandler)
         .await?;
 
-    client.initialize("conformance-client", "0.1.0").await?;
+    activate(&client).await?;
     let tools = client.list_tools().await?;
     tracing::info!("Listed {} tools", tools.tools.len());
 
@@ -47,6 +70,114 @@ pub async fn tools_call(server_url: &str) -> Result<()> {
                 tracing::warn!(tool = %tool.name, error = %e, "Tool call failed");
             }
         }
+    }
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// Exercise all named and unnamed request headers required by SEP-2243.
+pub async fn http_standard_headers(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = client_builder()?
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+    activate(&client).await?;
+
+    let tools = client.list_tools().await?;
+    if let Some(tool) = tools.tools.first() {
+        client
+            .call_tool(&tool.name, build_tool_arguments(&tool.input_schema))
+            .await?;
+    }
+    let resources = client.list_resources().await?;
+    if let Some(resource) = resources.resources.first() {
+        client.read_resource(&resource.uri).await?;
+    }
+    let prompts = client.list_prompts().await?;
+    if let Some(prompt) = prompts.prompts.first() {
+        client.get_prompt(&prompt.name, None).await?;
+    }
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// Mirror every schema-designated tool argument into its MCP parameter header.
+pub async fn http_custom_headers(
+    server_url: &str,
+    context: &Option<serde_json::Value>,
+) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = client_builder()?
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+    activate(&client).await?;
+    client.list_tools().await?;
+
+    let calls = context
+        .as_ref()
+        .and_then(|value| value.get("toolCalls"))
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| anyhow::anyhow!("conformance context did not include toolCalls"))?;
+    for call in calls {
+        let name = call
+            .get("name")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("tool call is missing name"))?;
+        let arguments = call
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+        client.call_tool(name, arguments).await?;
+    }
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// Confirm invalid header annotations are excluded without hiding valid tools.
+pub async fn http_invalid_tool_headers(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = client_builder()?
+        .connect(transport, handlers::BasicHandler)
+        .await?;
+    activate(&client).await?;
+    let tools = client.list_tools().await?;
+    let valid = tools
+        .tools
+        .iter()
+        .find(|tool| tool.name == "valid_tool")
+        .ok_or_else(|| anyhow::anyhow!("valid_tool was filtered from tools/list"))?;
+    client
+        .call_tool(&valid.name, serde_json::json!({ "region": "us-west1" }))
+        .await?;
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+/// Exercise request-state echo, omission, request-id freshness, and isolation.
+pub async fn mrtr_request_state(server_url: &str) -> Result<()> {
+    let transport = HttpClientTransport::new(server_url);
+    let client = client_builder()?
+        .with_elicitation()
+        .connect(transport, handlers::FullHandler)
+        .await?;
+    activate(&client).await?;
+    let tools = client.list_tools().await?;
+
+    for name in [
+        "test_mrtr_unrelated",
+        "test_mrtr_echo_state",
+        "test_mrtr_no_state",
+        "test_mrtr_no_result_type",
+    ] {
+        anyhow::ensure!(
+            tools.tools.iter().any(|tool| tool.name == name),
+            "MRTR fixture tool {name} was not listed"
+        );
+        client.call_tool(name, serde_json::json!({})).await?;
     }
 
     client.shutdown().await?;

--- a/examples/conformance-client/src/main.rs
+++ b/examples/conformance-client/src/main.rs
@@ -40,6 +40,11 @@ async fn main() {
         // Core scenarios
         "initialize" => core_scenarios::initialize(&server_url).await,
         "tools_call" => core_scenarios::tools_call(&server_url).await,
+        "request-metadata" => core_scenarios::initialize(&server_url).await,
+        "http-standard-headers" => core_scenarios::http_standard_headers(&server_url).await,
+        "http-custom-headers" => core_scenarios::http_custom_headers(&server_url, &context).await,
+        "http-invalid-tool-headers" => core_scenarios::http_invalid_tool_headers(&server_url).await,
+        "sep-2322-client-request-state" => core_scenarios::mrtr_request_state(&server_url).await,
         "sse-retry" => core_scenarios::sse_retry(&server_url).await,
         "elicitation-sep1034-client-defaults" | "elicitation-defaults" => {
             core_scenarios::elicitation_defaults(&server_url).await


### PR DESCRIPTION
## Summary

- add explicit runtime `ProtocolSupport` selection to `McpClient` while preserving the stable initialize/session lifecycle by default
- implement the 2026-07-28 `server/discover` lifecycle, required per-request `_meta`, sessionless HTTP behavior, and one bounded unsupported-version retry
- emit SEP-2243 standard and schema-defined request headers, validate/filter invalid `x-mcp-header` tool schemas, and preserve legacy HTTP behavior
- add single-shot and bounded auto-driven SEP-2322 MRTR client APIs with opaque request-state echo and capability-checked handler dispatch
- remove the completed non-auth scenarios from the final client conformance baseline and document the experimental opt-in path

## Conformance

Official `conformance@0.2.0-alpha.10` 2026-07-28 client suite:

- 210 checks pass
- 9/32 scenarios fully green
- all 23 remaining baselined scenarios are authentication-only
- newly green: final tools/call lifecycle, request metadata, SEP-2322 client request state, standard headers, custom headers, invalid-tool-header filtering

The exact `conformance@0.1.16` 2025-11-25 client suite remains unchanged at 264 passing checks with its existing two-scenario baseline.

## Verification

- `cargo test --workspace --all-features --no-fail-fast`
- `RUSTFLAGS=-Dwarnings cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --all-features`
- minimal, HTTP-only, and HTTP + `protocol-2026-07-28` feature checks
- `cargo fmt --all -- --check`
- `git diff --check`
- official final and stable client conformance suites with strict baselines

Refs #953
Refs #950
Refs #929