### PR TITLE
feat(client): complete OAuth conformance

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -225,10 +225,7 @@ jobs:
 
       - name: Run client conformance suite
         run: |
-          # Known gaps (new 0.1.16 offline-access scenarios, SHOULD-level
-          # warnings) are inventoried in conformance-baseline-client.yml and
-          # tracked in #953. The baseline makes the tool's exit code
-          # reliable: it fails on unexpected failures or stale entries.
+          # The empty baseline makes any regression fail immediately.
           npx @modelcontextprotocol/conformance@0.1.16 client \
             --suite all \
             --command "cargo run --manifest-path examples/conformance-client/Cargo.toml --" \
@@ -303,9 +300,7 @@ jobs:
           # The client half of the final-version suite (#1027): the other three jobs
           # cover stable client, stable server and final-version server, so this was
           # the least-visible coverage gap. Known gaps are inventoried in
-          # conformance-baseline-draft-client.yml, grouped by SEP and tracked
-          # in #953; the job fails on unexpected failures OR on stale baseline
-          # entries that started passing.
+          # The empty baseline makes any regression fail immediately.
           #
           # pipefail so the tee below cannot mask the tool's exit code (the
           # Actions default bash already sets it; stated here because the
@@ -321,8 +316,8 @@ jobs:
       - name: Publish suite summary
         if: always()
         run: |
-          # The baselined exit code answers "did anything regress"; the
-          # absolute counts answer "how far along is the client". Both come
+          # The exit code answers "did anything regress"; the absolute counts
+          # record the current suite size. Both come
           # from the single run above, so this step only reformats its output.
           log=/tmp/conformance-draft-client.log
           if [ ! -s "$log" ]; then

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/crates/l/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp#license)
 [![MSRV](https://img.shields.io/crates/msrv/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp)
 [![MCP](https://img.shields.io/badge/MCP-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
-[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_264%2F266_client-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
+[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_295_client_checks-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
 
 Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
 
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks and 264/266 client checks (2025-11-25 suites, conformance@0.1.16) plus the official 2026-07-28 suites (114/114 server; 210 passing client checks with the remaining auth scenarios baselined at 0.2.0-alpha.10) run in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 39/39 server checks and all 26 client scenarios (295 checks) for 2025-11-25 (`conformance@0.1.16`), plus 114/114 server checks and all 32 client scenarios (382 checks) for 2026-07-28 (`conformance@0.2.0-alpha.10`), run with empty baselines in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -587,11 +587,11 @@ let router = McpRouter::new()
 tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
 - **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
-- **Client (2025-11-25):** 264/266 checks (`conformance@0.1.16`; the two gaps are new offline-access scenarios, baselined in `conformance-baseline-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953))
+- **Client (2025-11-25):** all 26 scenarios green, 295 checks (`conformance@0.1.16`); the client baseline is empty
 - **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
-- **Client (2026-07-28):** 210 passing checks and 9/32 scenarios fully green (`conformance@0.2.0-alpha.10`, `--suite all`); the 23 remaining auth scenarios are baselined in `conformance-baseline-draft-client.yml` and tracked in [#953](https://github.com/joshrotenberg/tower-mcp/issues/953)
+- **Client (2026-07-28):** all 32 scenarios green, 382 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
 
-Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. CI fails when a baselined scenario regresses further or starts passing (stale baseline), so the baselines cannot silently rot.
+Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 
 The `protocol-2026-07-28` feature enables the experimental implementation of the released
 2026-07-28 protocol (version-gated, behind

--- a/conformance-baseline-client.yml
+++ b/conformance-baseline-client.yml
@@ -1,22 +1,9 @@
 # MCP Conformance Suite -- Expected Failures Baseline (client, 2025-11-25)
 #
 # Applies to `@modelcontextprotocol/conformance@0.1.16 client --suite all`.
-# The baseline checker counts SHOULD-level warnings the same as failures,
-# so warning-carrying scenarios are listed too. CI fails when a baselined
-# scenario starts passing cleanly (stale entry) or a non-baselined scenario
-# fails.
+# CI fails if any scenario regresses.
 #
-# Status at 0.1.16 (2026-07-23): 264/266 checks pass, 4 warnings.
+# Status at 0.1.16 after the authorization work: all 26 scenarios are green
+# (295 checks, zero failures or warnings).
 
-client:
-  # New scenarios in 0.1.16 that the conformance-client harness does not
-  # implement yet ("Unknown scenario"): offline_access scope handling.
-  # Client-side work tracked in #953 (phase 6).
-  - auth/offline-access-scope
-  - auth/offline-access-not-supported
-
-  # SHOULD-level warnings (passing checks, warning flags). Inventoried for
-  # #953; each needs a look at whether the SHOULD is worth implementing.
-  - auth/basic-cimd
-  - auth/scope-from-scopes-supported
-  - auth/scope-step-up
+client: []

--- a/conformance-baseline-draft-client.yml
+++ b/conformance-baseline-draft-client.yml
@@ -7,52 +7,10 @@
 # as the gaps close; CI fails when a baselined scenario starts passing (stale
 # entry) or a non-baselined scenario fails.
 #
-# Status at 0.2.0-alpha.10 after the final client lifecycle/header/MRTR work:
-# 210 checks pass; 9/32 scenarios are fully green and 23 auth scenarios remain
-# baselined. The exact total includes scenario-specific header assertions that
-# were previously skipped because those methods were never exercised.
+# Status at 0.2.0-alpha.10 after the final client lifecycle and authorization
+# work: all 32 scenarios are green (382 checks, zero failures or warnings).
 #
 # Format (0.2.x suite): plain scenario-name strings under the `client:` key;
 # reasons live in these comments.
 
-client:
-  # SEP-837: Dynamic Client Registration omits `application_type`. One missing
-  # field, but it is a MUST, so it fails every scenario that registers.
-  - auth/metadata-default
-  - auth/metadata-var1
-  - auth/metadata-var2
-  - auth/metadata-var3
-  - auth/basic-cimd
-  - auth/scope-from-www-authenticate
-  - auth/scope-from-scopes-supported
-  - auth/scope-omitted-when-undefined
-  - auth/scope-retry-limit
-  - auth/token-endpoint-auth-basic
-  - auth/token-endpoint-auth-post
-  - auth/token-endpoint-auth-none
-
-  # SEP-2468 `iss` handling in the authorization response is not implemented:
-  # no comparison against the recorded issuer, no rejection on mismatch or on
-  # a missing iss when the server advertised support, and no validation of the
-  # metadata document's issuer against the well-known URL.
-  - auth/iss-supported
-  - auth/iss-supported-missing
-  - auth/iss-not-advertised
-  - auth/iss-unexpected
-  - auth/iss-wrong-issuer
-  - auth/iss-normalized
-  - auth/metadata-issuer-mismatch
-
-  # SEP-2350 scope escalation: the client does not re-authorize with the
-  # union of old and new scopes after a step-up challenge. Also carries the
-  # SEP-837 failure above and a SHOULD-level warning about using the
-  # WWW-Authenticate scope on the initial request.
-  - auth/scope-step-up
-
-  # SEP-2352: no re-registration when PRM `authorization_servers` changes.
-  - auth/authorization-server-migration
-
-  # SEP-2207 offline_access: the harness cannot observe the scope decision
-  # because the client does not complete these flows.
-  - auth/offline-access-scope
-  - auth/offline-access-not-supported
+client: []

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -742,6 +742,12 @@ fn encode_header_value(value: &str) -> String {
     }
 }
 
+fn is_jsonrpc_error_response(value: &serde_json::Value) -> bool {
+    value.get("error").is_some_and(serde_json::Value::is_object)
+        && value.pointer("/error/code").is_some()
+        && value.pointer("/error/message").is_some()
+}
+
 #[async_trait]
 impl ClientTransport for HttpClientTransport {
     async fn send(&mut self, message: &str) -> Result<()> {
@@ -1099,7 +1105,7 @@ impl ClientTransport for HttpClientTransport {
             let body = response.text().await.unwrap_or_default();
             if is_modern_request
                 && let Ok(mut error) = serde_json::from_str::<serde_json::Value>(&body)
-                && error.get("error").is_some()
+                && is_jsonrpc_error_response(&error)
             {
                 if error.get("id").is_none_or(serde_json::Value::is_null)
                     && let Some(id) = parsed_message.as_ref().and_then(|value| value.get("id"))
@@ -1891,6 +1897,22 @@ mod tests {
             encode_header_value("Hello, 世界"),
             "=?base64?SGVsbG8sIOS4lueVjA==?="
         );
+    }
+
+    #[test]
+    fn oauth_error_body_is_not_misclassified_as_jsonrpc() {
+        assert!(!is_jsonrpc_error_response(&serde_json::json!({
+            "error": "insufficient_scope",
+            "error_description": "Token has insufficient scope"
+        })));
+        assert!(is_jsonrpc_error_response(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32022,
+                "message": "Unsupported protocol version"
+            }
+        })));
     }
 
     #[test]

--- a/crates/tower-mcp/src/client/oauth_authcode.rs
+++ b/crates/tower-mcp/src/client/oauth_authcode.rs
@@ -78,11 +78,8 @@ fn generate_state() -> String {
 /// OAuth authorization server metadata (subset of RFC 8414).
 #[derive(Debug, serde::Deserialize)]
 struct AuthorizationServerMetadata {
-    /// AS issuer identifier (RFC 8414 §2). Required by the spec but
-    /// modelled as `Option` so deserialization tolerates AS metadata
-    /// documents that omit it (we then can't enforce SEP-2468).
-    #[serde(default)]
-    issuer: Option<String>,
+    /// AS issuer identifier (RFC 8414 §2).
+    issuer: String,
     authorization_endpoint: String,
     token_endpoint: String,
     #[allow(dead_code)]
@@ -103,34 +100,48 @@ async fn discover_auth_server(
     let base = server_url.trim_end_matches('/');
 
     // Try Protected Resource Metadata first (RFC 9728)
-    if let Some(metadata) = try_discover_via_prm(base, client).await {
+    if let Some(metadata) = try_discover_via_prm(base, client).await? {
         return Ok(metadata);
     }
 
     // Fallback: try well-known directly on the server URL
     let meta_url = format!("{}/.well-known/oauth-authorization-server", base);
-    client
+    let metadata = client
         .get(&meta_url)
         .send()
         .await
         .map_err(|e| OAuthClientError::Discovery(e.to_string()))?
+        .error_for_status()
+        .map_err(|e| OAuthClientError::Discovery(e.to_string()))?
         .json()
         .await
-        .map_err(|e| OAuthClientError::Discovery(e.to_string()))
+        .map_err(|e| OAuthClientError::Discovery(e.to_string()))?;
+    validate_metadata_issuer(&metadata, base)?;
+    Ok(metadata)
 }
 
 /// Try to discover auth server via Protected Resource Metadata (RFC 9728).
 async fn try_discover_via_prm(
     base: &str,
     client: &reqwest::Client,
-) -> Option<AuthorizationServerMetadata> {
+) -> Result<Option<AuthorizationServerMetadata>, OAuthClientError> {
     let prm_url = format!("{}/.well-known/oauth-protected-resource", base);
-    let resp = client.get(&prm_url).send().await.ok()?;
+    let Ok(resp) = client.get(&prm_url).send().await else {
+        return Ok(None);
+    };
     if !resp.status().is_success() {
-        return None;
+        return Ok(None);
     }
-    let prm: serde_json::Value = resp.json().await.ok()?;
-    let auth_server = prm["authorization_servers"].as_array()?.first()?.as_str()?;
+    let Ok(prm) = resp.json::<serde_json::Value>().await else {
+        return Ok(None);
+    };
+    let Some(auth_server) = prm["authorization_servers"]
+        .as_array()
+        .and_then(|servers| servers.first())
+        .and_then(serde_json::Value::as_str)
+    else {
+        return Ok(None);
+    };
     let meta_url = format!(
         "{}/.well-known/oauth-authorization-server",
         auth_server.trim_end_matches('/')
@@ -139,10 +150,34 @@ async fn try_discover_via_prm(
         .get(&meta_url)
         .send()
         .await
-        .ok()?
+        .map_err(|e| OAuthClientError::Discovery(e.to_string()))?
         .error_for_status()
-        .ok()?;
-    meta.json().await.ok()
+        .map_err(|e| OAuthClientError::Discovery(e.to_string()))?;
+    let metadata = meta
+        .json()
+        .await
+        .map_err(|e| OAuthClientError::Discovery(e.to_string()))?;
+    validate_metadata_issuer(&metadata, auth_server)?;
+    Ok(Some(metadata))
+}
+
+/// Validate the metadata issuer against the authorization-server identifier
+/// used to construct its well-known URL.
+///
+/// MCP requires exact string equality here. In particular, trailing slashes
+/// are significant and must not be normalized before comparison.
+fn validate_metadata_issuer(
+    metadata: &AuthorizationServerMetadata,
+    expected: &str,
+) -> Result<(), OAuthClientError> {
+    if metadata.issuer == expected {
+        Ok(())
+    } else {
+        Err(OAuthClientError::Discovery(format!(
+            "authorization server metadata issuer mismatch: expected `{expected}`, got `{}`",
+            metadata.issuer
+        )))
+    }
 }
 
 // =============================================================================
@@ -322,7 +357,7 @@ impl OAuthAuthorizationCode {
                 cache: RwLock::new(None),
                 callback_rx: Mutex::new(Some(callback_rx)),
                 _callback_task: callback_task,
-                expected_issuer: metadata.issuer,
+                expected_issuer: Some(metadata.issuer),
                 iss_required: metadata.authorization_response_iss_parameter_supported,
             }),
         })
@@ -864,6 +899,29 @@ mod tests {
         // Accept rather than fail-open, but the AS metadata is non-compliant.
         assert!(validate_iss(Some("https://auth.example.com"), None, false).is_ok());
         assert!(validate_iss(None, None, false).is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_issuer_accepts_exact_match() {
+        let metadata = authorization_server_metadata("https://auth.example.com");
+        assert!(validate_metadata_issuer(&metadata, "https://auth.example.com").is_ok());
+    }
+
+    #[test]
+    fn validate_metadata_issuer_rejects_trailing_slash_mismatch() {
+        let metadata = authorization_server_metadata("https://auth.example.com/");
+        let err = validate_metadata_issuer(&metadata, "https://auth.example.com").unwrap_err();
+        assert!(err.to_string().contains("issuer mismatch"), "got: {err}");
+    }
+
+    fn authorization_server_metadata(issuer: &str) -> AuthorizationServerMetadata {
+        AuthorizationServerMetadata {
+            issuer: issuer.to_string(),
+            authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+            token_endpoint: "https://auth.example.com/token".to_string(),
+            registration_endpoint: None,
+            authorization_response_iss_parameter_supported: false,
+        }
     }
 
     #[test]

--- a/examples/conformance-client/src/auth_scenarios.rs
+++ b/examples/conformance-client/src/auth_scenarios.rs
@@ -5,30 +5,51 @@
 //! with the authorization code, enabling headless OAuth flows.
 
 use anyhow::{Context, Result};
-use tower_mcp::client::McpClient;
 use tower_mcp::{HttpClientConfig, HttpClientTransport};
 
 use crate::handlers;
+
+struct OAuthFlowResult {
+    access_token: String,
+    requested_scope: Option<String>,
+}
 
 /// Standard OAuth authorization-code flow.
 ///
 /// Used by most auth scenarios: metadata discovery variants, CIMD, scope handling,
 /// token endpoint auth methods, and backcompat scenarios.
 pub async fn standard_auth(server_url: &str, context: &Option<serde_json::Value>) -> Result<()> {
-    let access_token = perform_oauth_flow(server_url, context, None).await?;
-    run_authed_client(server_url, &access_token).await
+    let flow = perform_oauth_flow(server_url, context, None).await?;
+    run_authed_client(server_url, &flow.access_token).await
+}
+
+/// Re-discover and re-register when protected-resource metadata changes issuer.
+pub async fn authorization_server_migration(
+    server_url: &str,
+    context: &Option<serde_json::Value>,
+) -> Result<()> {
+    let first = perform_oauth_flow(server_url, context, None).await?;
+    let first_result = run_authed_client(server_url, &first.access_token).await;
+    anyhow::ensure!(
+        first_result.is_err(),
+        "authorization-server migration scenario did not reject the first issuer's token"
+    );
+
+    let second = perform_oauth_flow(server_url, context, None).await?;
+    run_authed_client(server_url, &second.access_token).await
 }
 
 /// Scope step-up: connect, try tools, re-auth on failure, retry.
 pub async fn scope_step_up(server_url: &str, context: &Option<serde_json::Value>) -> Result<()> {
-    let access_token = perform_oauth_flow(server_url, context, None).await?;
+    let initial_flow = perform_oauth_flow(server_url, context, None).await?;
+    let access_token = &initial_flow.access_token;
 
-    let transport = HttpClientTransport::new(server_url).bearer_token(&access_token);
-    let client = McpClient::builder()
+    let transport = HttpClientTransport::new(server_url).bearer_token(access_token);
+    let client = crate::core_scenarios::client_builder()?
         .connect(transport, handlers::BasicHandler)
         .await?;
 
-    client.initialize("conformance-client", "0.1.0").await?;
+    crate::core_scenarios::activate(&client).await?;
 
     // Try listing/calling tools -- may fail with 403 at any point
     let mut needs_reauth = false;
@@ -73,17 +94,21 @@ pub async fn scope_step_up(server_url: &str, context: &Option<serde_json::Value>
 
     if needs_reauth {
         // Probe the server with the old token to get the required scope from 403 WWW-Authenticate
-        let escalated_scope = probe_for_scope(server_url, &access_token).await;
+        let escalated_scope = probe_for_scope(server_url, access_token).await;
         tracing::info!(scope = ?escalated_scope, "Escalated scope from 403 probe");
 
         // Re-authenticate with escalated scope
-        let new_token = perform_oauth_flow(server_url, context, escalated_scope.as_deref()).await?;
-        let transport = HttpClientTransport::new(server_url).bearer_token(&new_token);
-        let client = McpClient::builder()
+        let union_scope = union_scopes(
+            initial_flow.requested_scope.as_deref(),
+            escalated_scope.as_deref(),
+        );
+        let new_flow = perform_oauth_flow(server_url, context, union_scope.as_deref()).await?;
+        let transport = HttpClientTransport::new(server_url).bearer_token(&new_flow.access_token);
+        let client = crate::core_scenarios::client_builder()?
             .connect(transport, handlers::BasicHandler)
             .await?;
 
-        client.initialize("conformance-client", "0.1.0").await?;
+        crate::core_scenarios::activate(&client).await?;
 
         // Second attempt -- may still fail with 403 if server requires further escalation
         match client.list_tools().await {
@@ -115,13 +140,13 @@ pub async fn scope_retry_limit(
 ) -> Result<()> {
     for attempt in 0..3 {
         tracing::info!(attempt, "Auth attempt");
-        let access_token = perform_oauth_flow(server_url, context, None).await?;
-        let transport = HttpClientTransport::new(server_url).bearer_token(&access_token);
-        let client = McpClient::builder()
+        let flow = perform_oauth_flow(server_url, context, None).await?;
+        let transport = HttpClientTransport::new(server_url).bearer_token(&flow.access_token);
+        let client = crate::core_scenarios::client_builder()?
             .connect(transport, handlers::BasicHandler)
             .await?;
 
-        client.initialize("conformance-client", "0.1.0").await?;
+        crate::core_scenarios::activate(&client).await?;
         let tools = client.list_tools().await?;
 
         let mut success = true;
@@ -158,9 +183,9 @@ pub async fn resource_mismatch(
 ) -> Result<()> {
     // Try the standard flow -- expect it to fail due to resource mismatch
     match perform_oauth_flow(server_url, context, None).await {
-        Ok(token) => {
+        Ok(flow) => {
             // If we got a token, try using it -- should fail
-            let result = run_authed_client(server_url, &token).await;
+            let result = run_authed_client(server_url, &flow.access_token).await;
             if result.is_err() {
                 return Ok(());
             }
@@ -432,6 +457,67 @@ pub async fn cross_app_access(server_url: &str, context: &Option<serde_json::Val
 // Internal helpers
 // ============================================================================
 
+async fn send_initial_mcp_probe(
+    http: &reqwest::Client,
+    server_url: &str,
+) -> Result<reqwest::Response> {
+    let mut request = http
+        .post(server_url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+
+    if crate::core_scenarios::uses_final_protocol() {
+        request = request
+            .header("MCP-Protocol-Version", "2026-07-28")
+            .header("Mcp-Method", "server/discover")
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "server/discover",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                        "io.modelcontextprotocol/clientCapabilities": {},
+                        "io.modelcontextprotocol/clientInfo": {
+                            "name": "conformance-client",
+                            "version": "0.1.0"
+                        }
+                    }
+                }
+            }));
+    } else {
+        request = request.json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {
+                    "name": "conformance-client",
+                    "version": "0.1.0"
+                }
+            }
+        }));
+    }
+
+    Ok(request.send().await?)
+}
+
+fn union_scopes(left: Option<&str>, right: Option<&str>) -> Option<String> {
+    let mut scopes = Vec::new();
+    for scope in left
+        .into_iter()
+        .chain(right)
+        .flat_map(str::split_whitespace)
+    {
+        if !scopes.contains(&scope) {
+            scopes.push(scope);
+        }
+    }
+    (!scopes.is_empty()).then(|| scopes.join(" "))
+}
+
 /// Result of probing the server for auth requirements.
 struct ProbeResult {
     #[allow(dead_code)]
@@ -445,13 +531,7 @@ async fn probe_server(server_url: &str) -> Result<ProbeResult> {
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
 
-    let initial_resp = http
-        .post(server_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"conformance-client","version":"0.1.0"}}}"#)
-        .send()
-        .await?;
+    let initial_resp = send_initial_mcp_probe(&http, server_url).await?;
 
     let status = initial_resp.status();
     tracing::info!(status = %status, "Initial MCP request status");
@@ -519,13 +599,7 @@ async fn discover_metadata_via_probe(server_url: &str) -> Result<serde_json::Val
         .build()?;
 
     // Step 1: Try MCP endpoint for 401 with resource_metadata
-    let initial_resp = http
-        .post(server_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"conformance-client","version":"0.1.0"}}}"#)
-        .send()
-        .await?;
+    let initial_resp = send_initial_mcp_probe(&http, server_url).await?;
 
     let www_auth = initial_resp
         .headers()
@@ -593,19 +667,13 @@ async fn perform_oauth_flow(
     server_url: &str,
     _context: &Option<serde_json::Value>,
     scope_override: Option<&str>,
-) -> Result<String> {
+) -> Result<OAuthFlowResult> {
     let http = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()?;
 
     // Step 1: Try MCP endpoint, expect 401 with resource metadata URL
-    let initial_resp = http
-        .post(server_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"conformance-client","version":"0.1.0"}}}"#)
-        .send()
-        .await?;
+    let initial_resp = send_initial_mcp_probe(&http, server_url).await?;
 
     let status = initial_resp.status();
     tracing::info!(status = %status, "Initial MCP request status");
@@ -682,50 +750,69 @@ async fn perform_oauth_flow(
     let registration_endpoint = metadata
         .get("registration_endpoint")
         .and_then(|v| v.as_str());
+    let expected_issuer = metadata.get("issuer").and_then(|v| v.as_str());
+    let iss_required = metadata
+        .get("authorization_response_iss_parameter_supported")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let refresh_supported = metadata
+        .get("grant_types_supported")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|values| values.iter().any(|value| value == "refresh_token"));
+    let offline_access_supported = metadata
+        .get("scopes_supported")
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|values| values.iter().any(|value| value == "offline_access"));
 
     // Determine token endpoint auth method from metadata
     let auth_method = get_token_auth_method(&metadata);
 
-    // Determine scope for authorization request.
-    // If re-authing after 403 (scope_override), combine escalated scope with all supported scopes.
-    // Otherwise, use scope from WWW-Authenticate or scopes_supported (for initial auth).
-    let scope: Option<String> = if let Some(s) = scope_override {
-        // Combine escalated scope with all supported scopes from PRM/metadata
-        let mut all_scopes: Vec<String> = Vec::new();
-        for part in s.split_whitespace() {
-            if !all_scopes.contains(&part.to_string()) {
-                all_scopes.push(part.to_string());
-            }
-        }
-        let supported = metadata
-            .get("scopes_supported")
-            .or_else(|| prm.as_ref().and_then(|p| p.get("scopes_supported")))
-            .and_then(|v| v.as_array());
-        if let Some(arr) = supported {
-            for v in arr {
-                if let Some(s) = v.as_str()
-                    && !all_scopes.contains(&s.to_string())
-                {
-                    all_scopes.push(s.to_string());
-                }
-            }
-        }
-        Some(all_scopes.join(" "))
-    } else {
-        // Initial auth: only use scope from WWW-Authenticate header.
-        // Don't use scopes_supported from metadata/PRM here to avoid requesting
-        // more scope than needed (which would prevent step-up auth from working).
-        scope
-    };
+    // Scope precedence is: an explicit re-authorization union, then the
+    // challenge, then the protected-resource/authorization-server metadata.
+    let supported_scope = prm
+        .as_ref()
+        .and_then(|value| value.get("scopes_supported"))
+        .or_else(|| metadata.get("scopes_supported"))
+        .and_then(serde_json::Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .filter(|value| !value.is_empty());
+    let mut selected_scope = scope_override
+        .map(str::to_string)
+        .or(scope)
+        .or(supported_scope);
+    if refresh_supported && offline_access_supported {
+        selected_scope = union_scopes(selected_scope.as_deref(), Some("offline_access"));
+    }
 
     // Step 4: Dynamic client registration (if available)
-    let (client_id, client_secret) = if let Some(reg_endpoint) = registration_endpoint {
+    let use_cimd = metadata
+        .get("client_id_metadata_document_supported")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let (client_id, client_secret) = if use_cimd {
+        (
+            "https://conformance-test.local/client-metadata.json".to_string(),
+            None,
+        )
+    } else if let Some(reg_endpoint) = registration_endpoint {
+        let grant_types = if refresh_supported {
+            serde_json::json!(["authorization_code", "refresh_token"])
+        } else {
+            serde_json::json!(["authorization_code"])
+        };
         let reg_resp = http_plain
             .post(reg_endpoint)
             .json(&serde_json::json!({
                 "client_name": "conformance-client",
+                "application_type": "native",
                 "redirect_uris": ["http://localhost:23456/callback"],
-                "grant_types": ["authorization_code"],
+                "grant_types": grant_types,
                 "response_types": ["code"],
                 "token_endpoint_auth_method": auth_method
             }))
@@ -765,7 +852,7 @@ async fn perform_oauth_flow(
         urlencoded(&code_challenge),
     );
 
-    if let Some(ref s) = scope {
+    if let Some(ref s) = selected_scope {
         auth_url.push_str(&format!("&scope={}", urlencoded(s)));
     }
 
@@ -786,6 +873,26 @@ async fn perform_oauth_flow(
     // Extract code from redirect URL
     let redirect_url = url::Url::parse(&location)
         .or_else(|_| url::Url::parse(&format!("http://localhost:23456{}", location)))?;
+    let response_issuer = redirect_url
+        .query_pairs()
+        .find(|(key, _)| key == "iss")
+        .map(|(_, value)| value.to_string());
+    match (response_issuer.as_deref(), expected_issuer) {
+        (Some(actual), Some(expected)) if actual != expected => {
+            anyhow::bail!(
+                "authorization response issuer mismatch: expected {expected:?}, got {actual:?}"
+            );
+        }
+        (Some(_), None) => {
+            anyhow::bail!("authorization response included iss but metadata omitted issuer");
+        }
+        (None, _) if iss_required => {
+            anyhow::bail!(
+                "authorization server advertised iss response support but omitted the parameter"
+            );
+        }
+        _ => {}
+    }
     let code = redirect_url
         .query_pairs()
         .find(|(k, _)| k == "code")
@@ -826,7 +933,10 @@ async fn perform_oauth_flow(
         .context("No access_token in token response")?;
 
     tracing::info!("OAuth flow completed successfully");
-    Ok(access_token.to_string())
+    Ok(OAuthFlowResult {
+        access_token: access_token.to_string(),
+        requested_scope: selected_scope,
+    })
 }
 
 /// OAuth flow with pre-registered credentials (no DCR).
@@ -841,13 +951,7 @@ async fn perform_oauth_flow_with_credentials(
         .build()?;
 
     // Try MCP endpoint first to get metadata hints
-    let initial_resp = http
-        .post(server_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .body(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"conformance-client","version":"0.1.0"}}}"#)
-        .send()
-        .await?;
+    let initial_resp = send_initial_mcp_probe(&http, server_url).await?;
 
     let www_auth = initial_resp
         .headers()
@@ -975,11 +1079,11 @@ async fn run_authed_client(server_url: &str, access_token: &str) -> Result<()> {
         ..Default::default()
     };
     let transport = HttpClientTransport::with_config(server_url, config).bearer_token(access_token);
-    let client = McpClient::builder()
+    let client = crate::core_scenarios::client_builder()?
         .connect(transport, handlers::BasicHandler)
         .await?;
 
-    client.initialize("conformance-client", "0.1.0").await?;
+    crate::core_scenarios::activate(&client).await?;
     let tools = client.list_tools().await?;
     tracing::info!("Listed {} tools with auth", tools.tools.len());
 
@@ -1081,6 +1185,14 @@ async fn discover_oauth_metadata_from_issuer(issuer_url: &str) -> Result<serde_j
         match http.get(url).send().await {
             Ok(resp) if resp.status().is_success() => {
                 let metadata: serde_json::Value = resp.json().await?;
+                let metadata_issuer = metadata
+                    .get("issuer")
+                    .and_then(serde_json::Value::as_str)
+                    .context("Authorization server metadata omitted issuer")?;
+                anyhow::ensure!(
+                    metadata_issuer == issuer_url,
+                    "Authorization server metadata issuer mismatch: expected {issuer_url:?}, got {metadata_issuer:?}"
+                );
                 tracing::info!(url = %url, "Discovered OAuth metadata from issuer");
                 return Ok(metadata);
             }
@@ -1243,12 +1355,35 @@ async fn probe_for_scope(server_url: &str, token: &str) -> Option<String> {
         .build()
         .ok()?;
 
-    let resp = http
+    let mut request = http
         .post(server_url)
         .header("Content-Type", "application/json")
         .header("Accept", "application/json, text/event-stream")
         .header("Authorization", format!("Bearer {}", token))
-        .body(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}"#)
+        .header("Mcp-Method", "tools/call")
+        .header("Mcp-Name", "test-tool");
+    let mut params = serde_json::json!({
+        "name": "test-tool",
+        "arguments": {}
+    });
+    if crate::core_scenarios::uses_final_protocol() {
+        request = request.header("MCP-Protocol-Version", "2026-07-28");
+        params["_meta"] = serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": {},
+            "io.modelcontextprotocol/clientInfo": {
+                "name": "conformance-client",
+                "version": "0.1.0"
+            }
+        });
+    }
+    let resp = request
+        .json(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": params
+        }))
         .send()
         .await
         .ok()?;
@@ -1265,15 +1400,10 @@ async fn probe_for_scope(server_url: &str, token: &str) -> Option<String> {
 /// Extract a parameter value from a WWW-Authenticate header.
 /// Handles: `param="value"` in comma-or-space-separated list.
 fn extract_www_auth_param(header: &str, param: &str) -> Option<String> {
-    let prefix = format!("{}=\"", param);
-    // Try splitting by comma first, then by space
-    for part in header.split(',').chain(header.split_whitespace()) {
-        let trimmed = part.trim().trim_end_matches(',');
-        if let Some(rest) = trimmed.strip_prefix(&prefix) {
-            return rest.strip_suffix('"').map(|s| s.to_string());
-        }
-    }
-    None
+    let prefix = format!("{param}=\"");
+    let start = header.find(&prefix)? + prefix.len();
+    let end = header[start..].find('"')? + start;
+    Some(header[start..end].to_string())
 }
 
 // ============================================================================

--- a/examples/conformance-client/src/core_scenarios.rs
+++ b/examples/conformance-client/src/core_scenarios.rs
@@ -11,17 +11,21 @@ fn requested_protocol_version() -> String {
         .unwrap_or_else(|_| tower_mcp::protocol::LATEST_PROTOCOL_VERSION.to_string())
 }
 
-fn client_builder() -> Result<McpClientBuilder> {
+pub(crate) fn uses_final_protocol() -> bool {
+    requested_protocol_version() == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+}
+
+pub(crate) fn client_builder() -> Result<McpClientBuilder> {
     let version = requested_protocol_version();
     let mut builder = McpClient::builder();
-    if version == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+    if uses_final_protocol() {
         builder = builder.protocol_support(ProtocolSupport::try_new([version])?);
     }
     Ok(builder)
 }
 
-async fn activate(client: &McpClient) -> Result<()> {
-    if requested_protocol_version() == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+pub(crate) async fn activate(client: &McpClient) -> Result<()> {
+    if uses_final_protocol() {
         client.discover("conformance-client", "0.1.0").await?;
     } else {
         client.initialize("conformance-client", "0.1.0").await?;

--- a/examples/conformance-client/src/main.rs
+++ b/examples/conformance-client/src/main.rs
@@ -84,6 +84,22 @@ async fn main() {
             auth_scenarios::standard_auth(&server_url, &context).await
         }
 
+        // Final authorization additions
+        "auth/offline-access-scope"
+        | "auth/offline-access-not-supported"
+        | "auth/iss-supported"
+        | "auth/iss-supported-missing"
+        | "auth/iss-not-advertised"
+        | "auth/iss-unexpected"
+        | "auth/iss-wrong-issuer"
+        | "auth/iss-normalized"
+        | "auth/metadata-issuer-mismatch" => {
+            auth_scenarios::standard_auth(&server_url, &context).await
+        }
+        "auth/authorization-server-migration" => {
+            auth_scenarios::authorization_server_migration(&server_url, &context).await
+        }
+
         // Auth scenarios - resource mismatch
         "auth/resource-mismatch" => auth_scenarios::resource_mismatch(&server_url, &context).await,
 


### PR DESCRIPTION
## Summary

- complete the final 2026-07-28 client authentication scenarios, including exact SEP-2468/RFC 9207 issuer checks, authorization-server migration, scope escalation, offline access, CIMD/DCR selection, and token endpoint auth modes
- make the conformance client use the selected stable or final lifecycle and send final request metadata consistently
- harden the reusable authorization-code helper by requiring an exact RFC 8414 metadata issuer match
- avoid misclassifying OAuth `{"error":"insufficient_scope"}` bodies as JSON-RPC errors
- remove both client expected-failure baselines and update the CI/readme counts

Part of #953 and #929.

## Verification

- `RUSTFLAGS='-D warnings' cargo check --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features --no-fail-fast`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --all-features`
- minimal, OAuth-client + 2026-07-28, and types-only feature checks
- stable official client suite: all 26 scenarios, 295 checks, 0 failures/warnings, empty baseline
- 2026-07-28 official client suite: all 32 scenarios, 382 checks, 0 failures/warnings, empty baseline