### PR TITLE
feat(client): support final protocol subscriptions

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -237,6 +237,8 @@ pub mod notifications {
     pub const INITIALIZED: &str = "notifications/initialized";
     /// Sent when a request is cancelled
     pub const CANCELLED: &str = "notifications/cancelled";
+    /// Acknowledges a `subscriptions/listen` request and its accepted filter.
+    pub const SUBSCRIPTIONS_ACKNOWLEDGED: &str = "notifications/subscriptions/acknowledged";
     /// Progress updates for long-running operations
     pub const PROGRESS: &str = "notifications/progress";
     /// Tool list has changed
@@ -497,10 +499,7 @@ pub enum McpNotification {
 /// client-to-server only (`requestId` MUST reference a request the client
 /// issued); on stdio, the server may still send it, but solely to terminate
 /// a `subscriptions/listen` stream by referencing that request's id -- it
-/// MUST NOT use it to cancel any other request. This crate does not
-/// currently send `notifications/cancelled` from the server for any
-/// purpose, so no code changes; the `subscriptions/listen` termination case
-/// is part of #952.
+/// MUST NOT use it to cancel any other request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CancelledParams {
@@ -1726,16 +1725,19 @@ pub struct SubscriptionsListenParams {
     pub meta: Option<Value>,
 }
 
-/// Result of the `subscriptions/listen` RPC.
+/// Graceful final result of the `subscriptions/listen` RPC.
 ///
-/// In practice the HTTP transport opens an SSE stream and never serializes
-/// this type as a JSON-RPC result. It is provided for completeness and for
-/// transports that want a typed acknowledgement shape.
+/// A server sends this empty complete result before it closes a subscription
+/// stream on its own initiative. An abrupt transport close has no result.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubscriptionsListenResult {
-    /// Optional protocol-level metadata.
+    /// Always [`ResultType::Complete`].
+    #[serde(default)]
+    pub result_type: ResultType,
+    /// Identifies the subscription that ended.
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Value>,
+    pub meta: Option<NotificationMeta>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -4914,8 +4916,8 @@ impl<T> From<T> for RequestOutcome<T> {
     }
 }
 
-/// Notification meta (`_meta`) carried by notifications delivered on a
-/// `subscriptions/listen` stream (SEP-2575).
+/// Subscription meta (`_meta`) carried by messages delivered on a
+/// `subscriptions/listen` stream.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NotificationMeta {
     /// Identifies the subscription stream a notification was delivered on: the
@@ -4979,10 +4981,13 @@ pub struct SubscriptionFilter {
     pub resource_subscriptions: Option<Vec<String>>,
 }
 
-/// Parameters for a `notifications/subscriptions/acknowledged` notification
-/// (SEP-2575): the subset of requested notification types the server will honor.
+/// Parameters for a `notifications/subscriptions/acknowledged` notification:
+/// the subset of requested notification types the server will honor.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SubscriptionsAcknowledgedParams {
+    /// Identifies the `subscriptions/listen` request being acknowledged.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<NotificationMeta>,
     /// The notification types the server agreed to honor. Types the server does
     /// not support are omitted.
     pub notifications: SubscriptionFilter,
@@ -6737,11 +6742,31 @@ mod draft_2026_07_28_tests {
         assert!(v.get("promptsListChanged").is_none()); // None is omitted
 
         let ack = SubscriptionsAcknowledgedParams {
+            meta: None,
             notifications: filter,
         };
         let back: SubscriptionsAcknowledgedParams =
             serde_json::from_value(serde_json::to_value(&ack).unwrap()).unwrap();
         assert_eq!(back.notifications.tools_list_changed, Some(true));
+
+        let result = SubscriptionsListenResult {
+            result_type: ResultType::Complete,
+            meta: Some(NotificationMeta {
+                subscription_id: Some(RequestId::Number(7)),
+            }),
+        };
+        let value = serde_json::to_value(&result).unwrap();
+        assert_eq!(value["resultType"], json!("complete"));
+        assert_eq!(
+            value["_meta"]["io.modelcontextprotocol/subscriptionId"],
+            json!(7)
+        );
+        let back: SubscriptionsListenResult = serde_json::from_value(value).unwrap();
+        assert!(back.result_type.is_complete());
+        assert_eq!(
+            back.meta.and_then(|meta| meta.subscription_id),
+            Some(RequestId::Number(7))
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -223,7 +223,7 @@ required-features = ["http", "stateless"]
 [[example]]
 name = "stateless_http_client"
 path = "../../examples/stateless_http_client.rs"
-required-features = ["http", "stateless"]
+required-features = ["http", "http-client", "protocol-2026-07-28"]
 
 # --- Sampling and bidirectional ---
 [[example]]

--- a/crates/tower-mcp/src/client/handler.rs
+++ b/crates/tower-mcp/src/client/handler.rs
@@ -58,7 +58,7 @@ use async_trait::async_trait;
 
 use crate::protocol::{
     CreateMessageParams, CreateMessageResult, ElicitRequestParams, ElicitResult, ListRootsResult,
-    LogLevel, LoggingMessageParams, ProgressParams,
+    LogLevel, LoggingMessageParams, ProgressParams, RequestId, SubscriptionFilter,
 };
 use tower_mcp_types::JsonRpcError;
 
@@ -84,6 +84,27 @@ pub enum ServerNotification {
     ToolsListChanged,
     /// The list of available prompts has changed.
     PromptsListChanged,
+    /// The server acknowledged a `subscriptions/listen` stream.
+    SubscriptionAcknowledged {
+        /// JSON-RPC request ID that identifies the subscription.
+        subscription_id: RequestId,
+        /// Subset of the requested filter the server agreed to honor.
+        notifications: SubscriptionFilter,
+    },
+    /// A notification delivered on a `subscriptions/listen` stream.
+    Subscription {
+        /// JSON-RPC request ID that identifies the subscription.
+        subscription_id: RequestId,
+        /// The ordinary notification carried by this subscription.
+        notification: Box<ServerNotification>,
+    },
+    /// The server cancelled an active subscription.
+    SubscriptionCancelled {
+        /// JSON-RPC request ID that identified the subscription.
+        subscription_id: RequestId,
+        /// Optional diagnostic reason from the server.
+        reason: Option<String>,
+    },
     /// An unknown or unrecognized notification.
     Unknown {
         /// The notification method name.
@@ -275,30 +296,8 @@ impl NotificationHandler {
         self.on_prompts_changed = Some(Box::new(f));
         self
     }
-}
 
-impl Default for NotificationHandler {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl std::fmt::Debug for NotificationHandler {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("NotificationHandler")
-            .field("on_progress", &self.on_progress.is_some())
-            .field("on_log_message", &self.on_log_message.is_some())
-            .field("on_resource_updated", &self.on_resource_updated.is_some())
-            .field("on_resources_changed", &self.on_resources_changed.is_some())
-            .field("on_tools_changed", &self.on_tools_changed.is_some())
-            .field("on_prompts_changed", &self.on_prompts_changed.is_some())
-            .finish()
-    }
-}
-
-#[async_trait]
-impl ClientHandler for NotificationHandler {
-    async fn on_notification(&self, notification: ServerNotification) {
+    fn dispatch_notification(&self, notification: ServerNotification) {
         match notification {
             ServerNotification::Progress(params) => {
                 if let Some(cb) = &self.on_progress {
@@ -330,8 +329,42 @@ impl ClientHandler for NotificationHandler {
                     cb();
                 }
             }
-            ServerNotification::Unknown { .. } => {}
+            // Preserve the existing callback API for subscription-delivered
+            // events while custom ClientHandler implementations can inspect
+            // the wrapper and correlate concurrent streams.
+            ServerNotification::Subscription { notification, .. } => {
+                self.dispatch_notification(*notification);
+            }
+            ServerNotification::SubscriptionAcknowledged { .. }
+            | ServerNotification::SubscriptionCancelled { .. }
+            | ServerNotification::Unknown { .. } => {}
         }
+    }
+}
+
+impl Default for NotificationHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for NotificationHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NotificationHandler")
+            .field("on_progress", &self.on_progress.is_some())
+            .field("on_log_message", &self.on_log_message.is_some())
+            .field("on_resource_updated", &self.on_resource_updated.is_some())
+            .field("on_resources_changed", &self.on_resources_changed.is_some())
+            .field("on_tools_changed", &self.on_tools_changed.is_some())
+            .field("on_prompts_changed", &self.on_prompts_changed.is_some())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl ClientHandler for NotificationHandler {
+    async fn on_notification(&self, notification: ServerNotification) {
+        self.dispatch_notification(notification);
     }
 }
 

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -53,6 +53,7 @@ use tokio::task::JoinHandle;
 
 use super::transport::ClientTransport;
 use crate::error::{Error, Result};
+use crate::protocol::{RequestId, notifications};
 
 const MCP_METHOD_HEADER: &str = "mcp-method";
 const MCP_NAME_HEADER: &str = "mcp-name";
@@ -241,6 +242,12 @@ pub struct HttpClientTransport {
     incoming_tx: mpsc::Sender<String>,
     /// Handle to the SSE background task, if running.
     sse_task: Option<JoinHandle<()>>,
+    /// In-flight POST response streams, keyed by their JSON-RPC request ID.
+    ///
+    /// Final `subscriptions/listen` requests stay here until cancelled or the
+    /// server closes them. Other completed tasks are pruned on subsequent
+    /// sends.
+    request_tasks: HashMap<RequestId, JoinHandle<()>>,
     /// The last SSE event ID received, for stream resumption.
     last_event_id: Arc<RwLock<Option<String>>>,
     /// Server-requested retry delay from SSE `retry:` field.
@@ -299,6 +306,7 @@ impl HttpClientTransport {
             incoming_rx: rx,
             incoming_tx: tx,
             sse_task: None,
+            request_tasks: HashMap::new(),
             last_event_id: Arc::new(RwLock::new(None)),
             sse_retry_delay: Arc::new(RwLock::new(None)),
             sse_reconnect_signal: Arc::new(Notify::new()),
@@ -337,6 +345,7 @@ impl HttpClientTransport {
             incoming_rx: rx,
             incoming_tx: tx,
             sse_task: None,
+            request_tasks: HashMap::new(),
             last_event_id: Arc::new(RwLock::new(None)),
             sse_retry_delay: Arc::new(RwLock::new(None)),
             sse_reconnect_signal: Arc::new(Notify::new()),
@@ -798,8 +807,13 @@ impl ClientTransport for HttpClientTransport {
             .client
             .post(&self.url)
             .header("Content-Type", "application/json")
-            .header("Accept", "application/json, text/event-stream")
-            .timeout(timeout);
+            .header("Accept", "application/json, text/event-stream");
+        // A subscription is intentionally long-lived; its handle owns the
+        // timeout/cancellation decision. Every ordinary request remains
+        // bounded by the configured request timeout.
+        if method != Some("subscriptions/listen") {
+            request = request.timeout(timeout);
+        }
 
         if !is_modern_request && let Some(ref session_id) = self.session_id {
             request = request.header("mcp-session-id", session_id);
@@ -863,7 +877,7 @@ impl ClientTransport for HttpClientTransport {
         // This prevents a deadlock when the server blocks on a
         // bidirectional request (sampling/elicitation) that requires the
         // client to respond via the SSE channel.
-        if self.session_id.is_some() && !is_modern_request && !is_notification {
+        if !is_notification && (self.session_id.is_some() || is_modern_request) {
             let tx = self.incoming_tx.clone();
             // The caller is parked on this request id in the message loop's
             // correlation map. Every failure branch below delivers a frame
@@ -874,12 +888,17 @@ impl ClientTransport for HttpClientTransport {
                 .as_ref()
                 .and_then(|value| value.get("id"))
                 .cloned();
+            let request_id = req_id
+                .clone()
+                .and_then(|value| serde_json::from_value(value).ok());
+            let is_subscription = method == Some("subscriptions/listen");
             let connected = self.connected.clone();
             let last_event_id = self.last_event_id.clone();
             let sse_retry_delay = self.sse_retry_delay.clone();
             let sse_reconnect_signal = self.sse_reconnect_signal.clone();
             let max_sse_event_size = self.config.max_sse_event_size;
-            tokio::spawn(async move {
+            self.request_tasks.retain(|_, task| !task.is_finished());
+            let task = tokio::spawn(async move {
                 let response = match request.send().await {
                     Ok(r) => r,
                     Err(e) => {
@@ -915,7 +934,7 @@ impl ClientTransport for HttpClientTransport {
                     // this error instead of hanging.
                     if !body.is_empty()
                         && let Ok(mut v) = serde_json::from_str::<serde_json::Value>(&body)
-                        && v.get("error").is_some()
+                        && is_jsonrpc_error_response(&v)
                     {
                         let is_session_signal =
                             v.pointer("/error/code").and_then(|c| c.as_i64()) == Some(-32005);
@@ -955,6 +974,7 @@ impl ClientTransport for HttpClientTransport {
                     let mut parser = SseParser::with_limit(max_sse_event_size);
                     let mut had_retry = false;
                     let mut had_data = false;
+                    let mut subscription_acknowledged = false;
 
                     use futures::StreamExt;
                     while let Some(result) = stream.next().await {
@@ -985,7 +1005,119 @@ impl ClientTransport for HttpClientTransport {
                                     }
                                     if !event.data.is_empty() {
                                         had_data = true;
+                                        let value =
+                                            serde_json::from_str::<serde_json::Value>(&event.data);
+                                        let value = match value {
+                                            Ok(value) => value,
+                                            Err(error) if is_subscription => {
+                                                if let Some(id) = &req_id {
+                                                    let _ = tx
+                                                        .send(transport_error_frame(
+                                                            id,
+                                                            &format!(
+                                                                "subscription stream returned invalid JSON: {error}"
+                                                            ),
+                                                        ))
+                                                        .await;
+                                                }
+                                                return;
+                                            }
+                                            Err(_) => {
+                                                let _ = tx.send(event.data).await;
+                                                continue;
+                                            }
+                                        };
+                                        let is_terminal =
+                                            value.get("id").zip(req_id.as_ref()).is_some_and(
+                                                |(actual, expected)| {
+                                                    json_request_ids_match(actual, expected)
+                                                },
+                                            ) && (value.get("result").is_some()
+                                                || value.get("error").is_some());
+
+                                        if is_subscription {
+                                            let violation = if is_terminal {
+                                                if value.get("error").is_some() {
+                                                    None
+                                                } else if !subscription_acknowledged {
+                                                    Some(
+                                                        "subscriptions/listen completed before acknowledgment",
+                                                    )
+                                                } else if !value
+                                                    .pointer(
+                                                        "/result/_meta/io.modelcontextprotocol~1subscriptionId",
+                                                    )
+                                                    .zip(req_id.as_ref())
+                                                    .is_some_and(|(actual, expected)| {
+                                                        json_request_ids_match(actual, expected)
+                                                    })
+                                                {
+                                                    Some(
+                                                        "subscriptions/listen result carried a missing or mismatched subscription ID",
+                                                    )
+                                                } else {
+                                                    None
+                                                }
+                                            } else if value.get("method").is_some()
+                                                && value.get("id").is_none()
+                                            {
+                                                let correlated = value
+                                                    .pointer(
+                                                        "/params/_meta/io.modelcontextprotocol~1subscriptionId",
+                                                    )
+                                                    .zip(req_id.as_ref())
+                                                    .is_some_and(|(actual, expected)| {
+                                                        json_request_ids_match(actual, expected)
+                                                    });
+                                                let is_acknowledgment = value
+                                                    .get("method")
+                                                    .and_then(serde_json::Value::as_str)
+                                                    == Some(
+                                                        notifications::SUBSCRIPTIONS_ACKNOWLEDGED,
+                                                    );
+                                                if !correlated {
+                                                    Some(
+                                                        "subscription notification carried a missing or mismatched subscription ID",
+                                                    )
+                                                } else if !subscription_acknowledged
+                                                    && !is_acknowledgment
+                                                {
+                                                    Some(
+                                                        "subscription notification arrived before acknowledgment",
+                                                    )
+                                                } else if subscription_acknowledged
+                                                    && is_acknowledgment
+                                                {
+                                                    Some(
+                                                        "subscription stream sent a duplicate acknowledgment",
+                                                    )
+                                                } else {
+                                                    if is_acknowledgment {
+                                                        subscription_acknowledged = true;
+                                                    }
+                                                    None
+                                                }
+                                            } else {
+                                                Some(
+                                                    "subscription stream returned an unrelated JSON-RPC message",
+                                                )
+                                            };
+                                            if let Some(message) = violation {
+                                                if let Some(id) = &req_id {
+                                                    let _ = tx
+                                                        .send(transport_error_frame(id, message))
+                                                        .await;
+                                                }
+                                                return;
+                                            }
+                                        }
                                         let _ = tx.send(event.data).await;
+                                        if is_terminal {
+                                            // The request is complete. Close the response
+                                            // body ourselves even if a non-conforming server
+                                            // leaves the SSE stream open after its final reply.
+                                            return;
+                                        }
                                     }
                                 }
                             }
@@ -1000,19 +1132,20 @@ impl ClientTransport for HttpClientTransport {
                     // the server expects us to reconnect the GET notification stream.
                     // Signal the SSE loop to close its current stream and reconnect
                     // with the updated last_event_id and sse_retry_delay.
-                    if had_retry && !had_data {
+                    if !is_modern_request && had_retry && !had_data {
                         sse_reconnect_signal.notify_one();
-                    } else if !had_data {
+                    } else {
                         // The response stream closed without ever delivering a
-                        // data frame, so nothing correlated the request. Wake
-                        // the caller rather than leave it hanging.
+                        // terminal response. Acknowledgments and ordinary
+                        // notifications do not complete a request, so wake the
+                        // caller rather than leave it hanging.
                         if let Some(id) = &req_id {
-                            let _ = tx
-                                .send(transport_error_frame(
-                                    id,
-                                    "server closed the response stream without a reply",
-                                ))
-                                .await;
+                            let reason = if had_data {
+                                "server closed the response stream before the final reply"
+                            } else {
+                                "server closed the response stream without a reply"
+                            };
+                            let _ = tx.send(transport_error_frame(id, reason)).await;
                         }
                     }
                 } else {
@@ -1064,6 +1197,9 @@ impl ClientTransport for HttpClientTransport {
                     }
                 }
             });
+            if let Some(request_id) = request_id {
+                self.request_tasks.insert(request_id, task);
+            }
             return Ok(());
         }
 
@@ -1161,7 +1297,6 @@ impl ClientTransport for HttpClientTransport {
             .map_err(|e| Error::Transport(format!("Failed to read response: {}", e)))?;
 
         for msg in extract_json_messages(&body) {
-            let msg = self.normalize_incoming_message(msg);
             self.incoming_tx
                 .send(msg)
                 .await
@@ -1173,7 +1308,11 @@ impl ClientTransport for HttpClientTransport {
 
     async fn recv(&mut self) -> Result<Option<String>> {
         match self.incoming_rx.recv().await {
-            Some(msg) => Ok(Some(msg)),
+            // All response paths converge here, including background final
+            // POSTs. Normalize tools/list results on the transport-owning
+            // task so validated x-mcp-header mappings are available to the
+            // next tools/call without sharing mutable state across tasks.
+            Some(msg) => Ok(Some(self.normalize_incoming_message(msg))),
             None => {
                 self.connected.store(false, Ordering::Release);
                 Ok(None)
@@ -1187,6 +1326,10 @@ impl ClientTransport for HttpClientTransport {
 
     async fn close(&mut self) -> Result<()> {
         self.connected.store(false, Ordering::Release);
+
+        for (_, task) in self.request_tasks.drain() {
+            task.abort();
+        }
 
         // Abort SSE task
         if let Some(task) = self.sse_task.take() {
@@ -1223,6 +1366,10 @@ impl ClientTransport for HttpClientTransport {
     async fn reset_session(&mut self) {
         tracing::info!("Resetting session for re-initialization");
 
+        for (_, task) in self.request_tasks.drain() {
+            task.abort();
+        }
+
         // Abort SSE task
         if let Some(task) = self.sse_task.take() {
             task.abort();
@@ -1240,6 +1387,17 @@ impl ClientTransport for HttpClientTransport {
 
     fn supports_session_recovery(&self) -> bool {
         self.config.session_recovery
+    }
+
+    async fn cancel_request(&mut self, request_id: &RequestId) -> Result<()> {
+        if let Some(task) = self.request_tasks.remove(request_id) {
+            // Dropping reqwest's response byte stream closes this request's
+            // HTTP response body, which is the final protocol's cancellation
+            // signal. Other concurrent POST streams remain alive.
+            task.abort();
+            let _ = task.await;
+        }
+        Ok(())
     }
 }
 
@@ -1445,6 +1603,17 @@ fn transport_error_frame(id: &serde_json::Value, message: &str) -> String {
         "error": { "code": -32000, "message": message },
     })
     .to_string()
+}
+
+fn json_request_ids_match(left: &serde_json::Value, right: &serde_json::Value) -> bool {
+    left == right
+        || match (left, right) {
+            (serde_json::Value::Number(number), serde_json::Value::String(value))
+            | (serde_json::Value::String(value), serde_json::Value::Number(number)) => number
+                .as_i64()
+                .is_some_and(|number| value.parse::<i64>() == Ok(number)),
+            _ => false,
+        }
 }
 
 fn extract_json_messages(body: &str) -> Vec<String> {

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -68,16 +68,18 @@ use crate::error::{Error, ErrorCode, McpErrorCode, Result};
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
 use crate::protocol::DiscoverParams;
 use crate::protocol::{
-    CacheScope, CallToolParams, CallToolResult, CancelTaskParams, ClientCapabilities,
-    CompleteParams, CompleteResult, CompletionArgument, CompletionReference, CreateTaskResult,
-    DiscoverResult, ElicitationCapability, GetPromptParams, GetPromptResult, GetTaskInfoParams,
-    Implementation, InitializeParams, InitializeResult, InputRequest, InputRequests, InputResponse,
-    InputResponses, JsonRpcNotification, JsonRpcRequest, ListPromptsParams, ListPromptsResult,
-    ListResourceTemplatesParams, ListResourceTemplatesResult, ListResourcesParams,
-    ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult, PromptDefinition,
-    ReadResourceParams, ReadResourceResult, RequestId, RequestMeta, RequestOutcome,
-    ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability, SamplingCapability,
-    TaskObject, TaskRequestParams, ToolDefinition, notifications,
+    CacheScope, CallToolParams, CallToolResult, CancelTaskParams, CancelledParams,
+    ClientCapabilities, CompleteParams, CompleteResult, CompletionArgument, CompletionReference,
+    CreateTaskResult, DiscoverResult, ElicitationCapability, GetPromptParams, GetPromptResult,
+    GetTaskInfoParams, Implementation, InitializeParams, InitializeResult, InputRequest,
+    InputRequests, InputResponse, InputResponses, JsonRpcNotification, JsonRpcRequest,
+    ListPromptsParams, ListPromptsResult, ListResourceTemplatesParams, ListResourceTemplatesResult,
+    ListResourcesParams, ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult,
+    PromptDefinition, ReadResourceParams, ReadResourceResult, RequestId, RequestMeta,
+    RequestOutcome, ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability,
+    SamplingCapability, SubscriptionFilter, SubscriptionsAcknowledgedParams,
+    SubscriptionsListenParams, SubscriptionsListenResult, TaskObject, TaskRequestParams,
+    ToolDefinition, notifications,
 };
 use response_cache::{CacheLookup, ClientResponseCache};
 use tower_mcp_types::JsonRpcError;
@@ -122,6 +124,18 @@ enum LoopCommand {
         params: serde_json::Value,
         response_tx: oneshot::Sender<Result<serde_json::Value>>,
     },
+    /// Open a long-lived `subscriptions/listen` request and return its ID.
+    StartSubscription {
+        params: serde_json::Value,
+        id_tx: oneshot::Sender<RequestId>,
+        acknowledgment_tx: oneshot::Sender<SubscriptionFilter>,
+        response_tx: oneshot::Sender<Result<serde_json::Value>>,
+    },
+    /// Cancel one active subscription request.
+    CancelRequest {
+        request_id: RequestId,
+        done_tx: Option<oneshot::Sender<Result<()>>>,
+    },
     /// Send a JSON-RPC notification (no response expected).
     Notify {
         method: String,
@@ -136,6 +150,110 @@ enum LoopCommand {
     },
     /// Graceful shutdown.
     Shutdown,
+}
+
+/// An active `subscriptions/listen` request.
+///
+/// The handle exposes the JSON-RPC request ID used as the subscription ID,
+/// the server's acknowledged filter, graceful server completion, and explicit
+/// cancellation. Dropping an active handle requests cancellation on a
+/// best-effort basis; callers that need confirmation should call
+/// [`cancel()`](Self::cancel).
+#[must_use = "dropping the handle cancels the active subscription"]
+pub struct SubscriptionHandle {
+    request_id: RequestId,
+    command_tx: mpsc::Sender<LoopCommand>,
+    acknowledgment_rx: Option<oneshot::Receiver<SubscriptionFilter>>,
+    response_rx: Option<oneshot::Receiver<Result<serde_json::Value>>>,
+    active: bool,
+}
+
+impl SubscriptionHandle {
+    /// The JSON-RPC request ID that identifies this subscription.
+    pub fn id(&self) -> &RequestId {
+        &self.request_id
+    }
+
+    /// Wait for the server's mandatory first-message acknowledgment.
+    ///
+    /// The returned filter is the subset the server agreed to honor.
+    pub async fn acknowledged(&mut self) -> Result<SubscriptionFilter> {
+        let receiver = self.acknowledgment_rx.take().ok_or_else(|| {
+            Error::Transport("subscription acknowledgment was already consumed".to_string())
+        })?;
+        receiver
+            .await
+            .map_err(|_| Error::Transport("subscription ended before acknowledgment".to_string()))
+    }
+
+    /// Wait for the server to end the subscription gracefully.
+    ///
+    /// An HTTP disconnect without a terminal response is reported as a
+    /// transport error. Dropping this future drops the handle and cancels the
+    /// subscription.
+    pub async fn wait(mut self) -> Result<SubscriptionsListenResult> {
+        let receiver = self.response_rx.take().ok_or_else(|| {
+            Error::Transport("subscription result was already consumed".to_string())
+        })?;
+        let value = receiver
+            .await
+            .map_err(|_| Error::Transport("connection closed".to_string()))??;
+        self.active = false;
+        let result: SubscriptionsListenResult = serde_json::from_value(value).map_err(|error| {
+            Error::Transport(format!(
+                "failed to deserialize subscriptions/listen response: {error}"
+            ))
+        })?;
+        if !result.result_type.is_complete() {
+            return Err(Error::Transport(format!(
+                "subscriptions/listen ended with unexpected result type {:?}",
+                result.result_type
+            )));
+        }
+        let response_id = result
+            .meta
+            .as_ref()
+            .and_then(|meta| meta.subscription_id.as_ref())
+            .ok_or_else(|| {
+                Error::Transport(
+                    "subscriptions/listen result omitted its subscription ID".to_string(),
+                )
+            })?;
+        if !request_ids_match(response_id, &self.request_id) {
+            return Err(Error::Transport(
+                "subscriptions/listen result carried the wrong subscription ID".to_string(),
+            ));
+        }
+        Ok(result)
+    }
+
+    /// Cancel the subscription and wait until its transport stream is closed.
+    pub async fn cancel(mut self) -> Result<()> {
+        let (done_tx, done_rx) = oneshot::channel();
+        self.command_tx
+            .send(LoopCommand::CancelRequest {
+                request_id: self.request_id.clone(),
+                done_tx: Some(done_tx),
+            })
+            .await
+            .map_err(|_| Error::Transport("connection closed".to_string()))?;
+        let result = done_rx
+            .await
+            .map_err(|_| Error::Transport("connection closed".to_string()))?;
+        self.active = false;
+        result
+    }
+}
+
+impl Drop for SubscriptionHandle {
+    fn drop(&mut self) {
+        if self.active {
+            let _ = self.command_tx.try_send(LoopCommand::CancelRequest {
+                request_id: self.request_id.clone(),
+                done_tx: None,
+            });
+        }
+    }
 }
 
 /// MCP client with a background message loop.
@@ -899,6 +1017,61 @@ impl McpClient {
             meta: None,
         };
         self.send_request("resources/read", &params).await
+    }
+
+    /// Open a final-protocol `subscriptions/listen` notification stream.
+    ///
+    /// The returned handle owns the long-lived request. Use
+    /// [`SubscriptionHandle::acknowledged`] to inspect the subset accepted by
+    /// the server, [`SubscriptionHandle::wait`] to observe graceful server
+    /// closure, or [`SubscriptionHandle::cancel`] to close the stream.
+    /// Notifications continue to flow through the configured
+    /// [`ClientHandler`] and carry their subscription ID in
+    /// [`ServerNotification::Subscription`].
+    pub async fn listen_subscriptions(
+        &self,
+        notifications: SubscriptionFilter,
+    ) -> Result<SubscriptionHandle> {
+        self.ensure_initialized()?;
+        if !self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "subscriptions/listen requires the 2026-07-28 protocol".to_string(),
+            ));
+        }
+
+        let params = SubscriptionsListenParams {
+            notifications: Some(notifications),
+            meta: None,
+        };
+        let params = serde_json::to_value(params).map_err(|error| {
+            Error::Transport(format!(
+                "failed to serialize subscriptions/listen params: {error}"
+            ))
+        })?;
+        let params = self.with_final_request_meta(params).await?;
+        let (id_tx, id_rx) = oneshot::channel();
+        let (acknowledgment_tx, acknowledgment_rx) = oneshot::channel();
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(LoopCommand::StartSubscription {
+                params,
+                id_tx,
+                acknowledgment_tx,
+                response_tx,
+            })
+            .await
+            .map_err(|_| Error::Transport("connection closed".to_string()))?;
+        let request_id = id_rx
+            .await
+            .map_err(|_| Error::Transport("connection closed".to_string()))?;
+
+        Ok(SubscriptionHandle {
+            request_id,
+            command_tx: self.command_tx.clone(),
+            acknowledgment_rx: Some(acknowledgment_rx),
+            response_rx: Some(response_rx),
+            active: true,
+        })
     }
 
     /// Subscribe to `notifications/resources/updated` for one resource
@@ -1678,7 +1851,9 @@ impl Drop for McpClient {
 
 /// A pending request waiting for a response from the server.
 struct PendingRequest {
+    method: String,
     response_tx: oneshot::Sender<Result<serde_json::Value>>,
+    acknowledgment_tx: Option<oneshot::Sender<SubscriptionFilter>>,
 }
 
 /// Background message loop that multiplexes incoming/outgoing messages.
@@ -1715,12 +1890,76 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
                         };
 
                         tracing::debug!(method = %method, id = ?id, "Sending request");
-                        pending_requests.insert(id, PendingRequest { response_tx });
+                        pending_requests.insert(id, PendingRequest {
+                            method,
+                            response_tx,
+                            acknowledgment_tx: None,
+                        });
 
                         if let Err(e) = transport.send(&json).await {
                             tracing::error!(error = %e, "Transport send error");
                             fail_all_pending(&mut pending_requests, &format!("Transport error: {}", e));
                             break;
+                        }
+                    }
+                    Some(LoopCommand::StartSubscription {
+                        params,
+                        id_tx,
+                        acknowledgment_tx,
+                        response_tx,
+                    }) => {
+                        let id = RequestId::Number(next_id.fetch_add(1, Ordering::Relaxed));
+                        let request = JsonRpcRequest::new(id.clone(), "subscriptions/listen")
+                            .with_params(params);
+                        let json = match serde_json::to_string(&request) {
+                            Ok(json) => json,
+                            Err(error) => {
+                                let _ = response_tx.send(Err(Error::Transport(
+                                    format!("Serialization failed: {error}")
+                                )));
+                                continue;
+                            }
+                        };
+
+                        tracing::debug!(id = ?id, "Opening subscription");
+                        pending_requests.insert(id.clone(), PendingRequest {
+                            method: "subscriptions/listen".to_string(),
+                            response_tx,
+                            acknowledgment_tx: Some(acknowledgment_tx),
+                        });
+                        let _ = id_tx.send(id);
+
+                        if let Err(error) = transport.send(&json).await {
+                            tracing::error!(%error, "Subscription transport send error");
+                            fail_all_pending(
+                                &mut pending_requests,
+                                &format!("Transport error: {error}"),
+                            );
+                            break;
+                        }
+                    }
+                    Some(LoopCommand::CancelRequest {
+                        request_id,
+                        done_tx,
+                    }) => {
+                        let result = if pending_requests
+                            .get(&request_id)
+                            .is_some_and(|pending| pending.method == "subscriptions/listen")
+                        {
+                            let result = transport.cancel_request(&request_id).await;
+                            if result.is_ok()
+                                && let Some(pending) = pending_requests.remove(&request_id)
+                            {
+                                let _ = pending.response_tx.send(Err(Error::Transport(
+                                    "subscription cancelled".to_string(),
+                                )));
+                            }
+                            result
+                        } else {
+                            Ok(())
+                        };
+                        if let Some(done_tx) = done_tx {
+                            let _ = done_tx.send(result);
                         }
                     }
                     Some(LoopCommand::Notify { method, params }) => {
@@ -1912,8 +2151,112 @@ async fn handle_incoming<T: ClientTransport, H: ClientHandler>(
         let params = parsed.get("params").cloned();
         invalidate_response_cache(response_cache, method, params.as_ref()).await;
         let notification = parse_server_notification(method, params);
-        handler.on_notification(notification).await;
+        let should_dispatch = match &notification {
+            ServerNotification::SubscriptionAcknowledged {
+                subscription_id,
+                notifications,
+            } => {
+                let Some(key) = matching_subscription_id(pending_requests, subscription_id) else {
+                    tracing::warn!(
+                        id = ?subscription_id,
+                        "Ignoring acknowledgment for unknown subscription"
+                    );
+                    return;
+                };
+                if let Some(sender) = pending_requests
+                    .get_mut(&key)
+                    .and_then(|pending| pending.acknowledgment_tx.take())
+                {
+                    let _ = sender.send(notifications.clone());
+                    true
+                } else {
+                    tracing::warn!(
+                        id = ?subscription_id,
+                        "Ignoring duplicate subscription acknowledgment"
+                    );
+                    false
+                }
+            }
+            ServerNotification::Subscription {
+                subscription_id, ..
+            } => {
+                let Some(key) = matching_subscription_id(pending_requests, subscription_id) else {
+                    tracing::warn!(
+                        id = ?subscription_id,
+                        "Ignoring notification for unknown subscription"
+                    );
+                    return;
+                };
+                let before_acknowledgment = pending_requests
+                    .get(&key)
+                    .is_some_and(|pending| pending.acknowledgment_tx.is_some());
+                if before_acknowledgment {
+                    tracing::warn!(
+                        id = ?subscription_id,
+                        "Ending subscription that received a notification before acknowledgment"
+                    );
+                    if let Some(pending) = pending_requests.remove(&key) {
+                        let _ = pending.response_tx.send(Err(Error::Transport(
+                            "subscription notification arrived before acknowledgment".to_string(),
+                        )));
+                    }
+                    false
+                } else {
+                    true
+                }
+            }
+            ServerNotification::SubscriptionCancelled {
+                subscription_id,
+                reason,
+            } => {
+                let Some(key) = matching_subscription_id(pending_requests, subscription_id) else {
+                    tracing::warn!(
+                        id = ?subscription_id,
+                        "Ignoring cancellation for unknown or non-subscription request"
+                    );
+                    return;
+                };
+                if let Some(pending) = pending_requests.remove(&key) {
+                    let message = reason.as_deref().map_or_else(
+                        || "subscription cancelled by server".to_string(),
+                        |reason| format!("subscription cancelled by server: {reason}"),
+                    );
+                    let _ = pending.response_tx.send(Err(Error::Transport(message)));
+                }
+                true
+            }
+            _ => true,
+        };
+        if should_dispatch {
+            handler.on_notification(notification).await;
+        }
     }
+}
+
+fn matching_subscription_id(
+    pending_requests: &HashMap<RequestId, PendingRequest>,
+    id: &RequestId,
+) -> Option<RequestId> {
+    if pending_requests
+        .get(id)
+        .is_some_and(|pending| pending.method == "subscriptions/listen")
+    {
+        return Some(id.clone());
+    }
+    pending_requests.iter().find_map(|(candidate, pending)| {
+        (pending.method == "subscriptions/listen" && request_ids_match(candidate, id))
+            .then(|| candidate.clone())
+    })
+}
+
+fn request_ids_match(left: &RequestId, right: &RequestId) -> bool {
+    left == right
+        || matches!(
+            (left, right),
+            (RequestId::Number(number), RequestId::String(value))
+                | (RequestId::String(value), RequestId::Number(number))
+                if value.parse::<i64>() == Ok(*number)
+        )
 }
 
 async fn invalidate_response_cache(
@@ -2009,6 +2352,12 @@ fn handle_response(
             .response_tx
             .send(Err(Error::JsonRpc(json_rpc_error)));
     } else if let Some(result) = parsed.get("result") {
+        if pending.method == "subscriptions/listen" && pending.acknowledgment_tx.is_some() {
+            let _ = pending.response_tx.send(Err(Error::Transport(
+                "subscriptions/listen completed before acknowledgment".to_string(),
+            )));
+            return;
+        }
         let _ = pending.response_tx.send(Ok(result.clone()));
     } else {
         let _ = pending
@@ -2074,40 +2423,79 @@ fn parse_server_notification(
     method: &str,
     params: Option<serde_json::Value>,
 ) -> ServerNotification {
-    match method {
+    if method == notifications::SUBSCRIPTIONS_ACKNOWLEDGED {
+        if let Some(params) = &params
+            && let Ok(acknowledgment) =
+                serde_json::from_value::<SubscriptionsAcknowledgedParams>(params.clone())
+            && let Some(subscription_id) = acknowledgment.meta.and_then(|meta| meta.subscription_id)
+        {
+            return ServerNotification::SubscriptionAcknowledged {
+                subscription_id,
+                notifications: acknowledgment.notifications,
+            };
+        }
+        return ServerNotification::Unknown {
+            method: method.to_string(),
+            params,
+        };
+    }
+    if method == notifications::CANCELLED {
+        if let Some(params) = &params
+            && let Ok(cancelled) = serde_json::from_value::<CancelledParams>(params.clone())
+            && let Some(subscription_id) = cancelled.request_id
+        {
+            return ServerNotification::SubscriptionCancelled {
+                subscription_id,
+                reason: cancelled.reason,
+            };
+        }
+        return ServerNotification::Unknown {
+            method: method.to_string(),
+            params,
+        };
+    }
+
+    let subscription_id = params
+        .as_ref()
+        .and_then(|params| params.pointer("/_meta/io.modelcontextprotocol~1subscriptionId"))
+        .and_then(|id| serde_json::from_value::<RequestId>(id.clone()).ok());
+    let notification = match method {
         notifications::PROGRESS => {
-            if let Some(params) = params
+            if let Some(params) = params.clone()
                 && let Ok(p) = serde_json::from_value(params)
             {
-                return ServerNotification::Progress(p);
-            }
-            ServerNotification::Unknown {
-                method: method.to_string(),
-                params: None,
+                ServerNotification::Progress(p)
+            } else {
+                ServerNotification::Unknown {
+                    method: method.to_string(),
+                    params: None,
+                }
             }
         }
         notifications::MESSAGE => {
-            if let Some(params) = params
+            if let Some(params) = params.clone()
                 && let Ok(p) = serde_json::from_value(params)
             {
-                return ServerNotification::LogMessage(p);
-            }
-            ServerNotification::Unknown {
-                method: method.to_string(),
-                params: None,
+                ServerNotification::LogMessage(p)
+            } else {
+                ServerNotification::Unknown {
+                    method: method.to_string(),
+                    params: None,
+                }
             }
         }
         notifications::RESOURCE_UPDATED => {
             if let Some(params) = &params
                 && let Some(uri) = params.get("uri").and_then(|u| u.as_str())
             {
-                return ServerNotification::ResourceUpdated {
+                ServerNotification::ResourceUpdated {
                     uri: uri.to_string(),
-                };
-            }
-            ServerNotification::Unknown {
-                method: method.to_string(),
-                params,
+                }
+            } else {
+                ServerNotification::Unknown {
+                    method: method.to_string(),
+                    params: params.clone(),
+                }
             }
         }
         notifications::RESOURCES_LIST_CHANGED => ServerNotification::ResourcesListChanged,
@@ -2115,8 +2503,16 @@ fn parse_server_notification(
         notifications::PROMPTS_LIST_CHANGED => ServerNotification::PromptsListChanged,
         _ => ServerNotification::Unknown {
             method: method.to_string(),
-            params,
+            params: params.clone(),
         },
+    };
+    if let Some(subscription_id) = subscription_id {
+        ServerNotification::Subscription {
+            subscription_id,
+            notification: Box::new(notification),
+        }
+    } else {
+        notification
     }
 }
 
@@ -2365,6 +2761,324 @@ mod tests {
             "ttlMs": 0,
             "cacheScope": "private"
         })
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    struct SubscriptionTestTransport {
+        incoming_tx: mpsc::Sender<String>,
+        incoming_rx: mpsc::Receiver<String>,
+        outgoing: Arc<Mutex<Vec<String>>>,
+        connected: Arc<AtomicBool>,
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    impl SubscriptionTestTransport {
+        fn new() -> Self {
+            let (incoming_tx, incoming_rx) = mpsc::channel(32);
+            Self {
+                incoming_tx,
+                incoming_rx,
+                outgoing: Arc::new(Mutex::new(Vec::new())),
+                connected: Arc::new(AtomicBool::new(true)),
+            }
+        }
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[async_trait]
+    impl ClientTransport for SubscriptionTestTransport {
+        async fn send(&mut self, message: &str) -> Result<()> {
+            self.outgoing.lock().unwrap().push(message.to_string());
+            let value: serde_json::Value = serde_json::from_str(message)
+                .map_err(|error| Error::Transport(error.to_string()))?;
+            let Some(id) = value.get("id").cloned() else {
+                return Ok(());
+            };
+            match value
+                .get("method")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+            {
+                "server/discover" => {
+                    self.incoming_tx
+                        .send(
+                            serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "id": id,
+                                "result": final_discover_result()
+                            })
+                            .to_string(),
+                        )
+                        .await
+                        .map_err(|_| Error::Transport("test channel closed".to_string()))?;
+                }
+                "subscriptions/listen" => {
+                    let notifications = value["params"]["notifications"].clone();
+                    self.incoming_tx
+                        .send(
+                            serde_json::json!({
+                                "jsonrpc": "2.0",
+                                "method": notifications::SUBSCRIPTIONS_ACKNOWLEDGED,
+                                "params": {
+                                    "_meta": {
+                                        "io.modelcontextprotocol/subscriptionId": id
+                                    },
+                                    "notifications": notifications
+                                }
+                            })
+                            .to_string(),
+                        )
+                        .await
+                        .map_err(|_| Error::Transport("test channel closed".to_string()))?;
+
+                    if value["params"]["notifications"]["promptsListChanged"]
+                        == serde_json::Value::Bool(true)
+                    {
+                        self.incoming_tx
+                            .send(
+                                serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": id,
+                                    "result": {
+                                        "resultType": "complete",
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": id
+                                        }
+                                    }
+                                })
+                                .to_string(),
+                            )
+                            .await
+                            .map_err(|_| Error::Transport("test channel closed".to_string()))?;
+                    } else {
+                        self.incoming_tx
+                            .send(
+                                serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "method": notifications::TOOLS_LIST_CHANGED,
+                                    "params": {
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": id
+                                        }
+                                    }
+                                })
+                                .to_string(),
+                            )
+                            .await
+                            .map_err(|_| Error::Transport("test channel closed".to_string()))?;
+                    }
+                }
+                _ => {}
+            }
+            Ok(())
+        }
+
+        async fn recv(&mut self) -> Result<Option<String>> {
+            Ok(self.incoming_rx.recv().await)
+        }
+
+        fn is_connected(&self) -> bool {
+            self.connected.load(Ordering::Acquire)
+        }
+
+        async fn close(&mut self) -> Result<()> {
+            self.connected.store(false, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_subscriptions_correlate_and_cancel_over_message_transport() {
+        let transport = SubscriptionTestTransport::new();
+        let outgoing = transport.outgoing.clone();
+        let incoming = transport.incoming_tx.clone();
+        let received = Arc::new(Mutex::new(Vec::new()));
+
+        struct RecordingHandler(Arc<Mutex<Vec<ServerNotification>>>);
+
+        #[async_trait]
+        impl ClientHandler for RecordingHandler {
+            async fn on_notification(&self, notification: ServerNotification) {
+                self.0.lock().unwrap().push(notification);
+            }
+        }
+
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect(transport, RecordingHandler(received.clone()))
+            .await
+            .unwrap();
+        client.discover("test-client", "1.0.0").await.unwrap();
+
+        let requested = SubscriptionFilter {
+            tools_list_changed: Some(true),
+            ..Default::default()
+        };
+        let mut first = client
+            .listen_subscriptions(requested.clone())
+            .await
+            .unwrap();
+        let mut second = client.listen_subscriptions(requested).await.unwrap();
+        assert_ne!(first.id(), second.id());
+        assert_eq!(
+            first.acknowledged().await.unwrap().tools_list_changed,
+            Some(true)
+        );
+        assert_eq!(
+            second.acknowledged().await.unwrap().tools_list_changed,
+            Some(true)
+        );
+
+        for _ in 0..100 {
+            if received
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|notification| {
+                    matches!(
+                        notification,
+                        ServerNotification::Subscription {
+                            notification,
+                            ..
+                        } if matches!(notification.as_ref(), ServerNotification::ToolsListChanged)
+                    )
+                })
+                .count()
+                == 2
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        let subscription_ids: Vec<RequestId> = received
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|notification| match notification {
+                ServerNotification::Subscription {
+                    subscription_id,
+                    notification,
+                } if matches!(notification.as_ref(), ServerNotification::ToolsListChanged) => {
+                    Some(subscription_id.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(subscription_ids, [first.id().clone(), second.id().clone()]);
+
+        incoming
+            .send(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": notifications::CANCELLED,
+                    "params": {
+                        "requestId": 999,
+                        "reason": "not a subscription"
+                    }
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap();
+        tokio::task::yield_now().await;
+        assert!(
+            !received.lock().unwrap().iter().any(|notification| matches!(
+                notification,
+                ServerNotification::SubscriptionCancelled { subscription_id, .. }
+                    if subscription_id == &RequestId::Number(999)
+            ))
+        );
+
+        let first_id = first.id().clone();
+        let second_id = second.id().clone();
+        first.cancel().await.unwrap();
+        second.cancel().await.unwrap();
+        let cancellation_ids: Vec<RequestId> = outgoing
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|message| {
+                let value: serde_json::Value = serde_json::from_str(message).unwrap();
+                (value["method"] == notifications::CANCELLED)
+                    .then(|| serde_json::from_value(value["params"]["requestId"].clone()).unwrap())
+            })
+            .collect();
+        assert_eq!(cancellation_ids, [first_id, second_id]);
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_subscription_observes_graceful_completion() {
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect_simple(SubscriptionTestTransport::new())
+            .await
+            .unwrap();
+        client.discover("test-client", "1.0.0").await.unwrap();
+
+        let mut handle = client
+            .listen_subscriptions(SubscriptionFilter {
+                prompts_list_changed: Some(true),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            handle.acknowledged().await.unwrap().prompts_list_changed,
+            Some(true)
+        );
+        let expected_id = handle.id().clone();
+        let result = handle.wait().await.unwrap();
+        assert!(result.result_type.is_complete());
+        assert_eq!(
+            result.meta.and_then(|meta| meta.subscription_id),
+            Some(expected_id)
+        );
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_subscription_accepts_server_cancellation_only_for_active_listen() {
+        let transport = SubscriptionTestTransport::new();
+        let incoming = transport.incoming_tx.clone();
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect_simple(transport)
+            .await
+            .unwrap();
+        client.discover("test-client", "1.0.0").await.unwrap();
+
+        let mut handle = client
+            .listen_subscriptions(SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        handle.acknowledged().await.unwrap();
+        let id = handle.id().clone();
+        incoming
+            .send(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": notifications::CANCELLED,
+                    "params": {
+                        "requestId": id,
+                        "reason": "server shutdown"
+                    }
+                })
+                .to_string(),
+            )
+            .await
+            .unwrap();
+
+        let error = handle.wait().await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("subscription cancelled by server: server shutdown")
+        );
     }
 
     #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
@@ -3158,6 +3872,57 @@ mod tests {
             }
             _ => panic!("Expected Unknown"),
         }
+
+        let notification = parse_server_notification(
+            notifications::SUBSCRIPTIONS_ACKNOWLEDGED,
+            Some(serde_json::json!({
+                "_meta": {
+                    "io.modelcontextprotocol/subscriptionId": 7
+                },
+                "notifications": {
+                    "toolsListChanged": true
+                }
+            })),
+        );
+        assert!(matches!(
+            notification,
+            ServerNotification::SubscriptionAcknowledged {
+                subscription_id: RequestId::Number(7),
+                ..
+            }
+        ));
+
+        let notification = parse_server_notification(
+            notifications::TOOLS_LIST_CHANGED,
+            Some(serde_json::json!({
+                "_meta": {
+                    "io.modelcontextprotocol/subscriptionId": "stream-a"
+                }
+            })),
+        );
+        assert!(matches!(
+            notification,
+            ServerNotification::Subscription {
+                subscription_id: RequestId::String(id),
+                notification,
+            } if id == "stream-a"
+                && matches!(notification.as_ref(), ServerNotification::ToolsListChanged)
+        ));
+
+        let notification = parse_server_notification(
+            notifications::CANCELLED,
+            Some(serde_json::json!({
+                "requestId": 7,
+                "reason": "done"
+            })),
+        );
+        assert!(matches!(
+            notification,
+            ServerNotification::SubscriptionCancelled {
+                subscription_id: RequestId::Number(7),
+                reason: Some(reason),
+            } if reason == "done"
+        ));
     }
 
     // =========================================================================
@@ -3174,7 +3939,14 @@ mod tests {
         let mut rxs = Vec::new();
         for id in ids {
             let (tx, rx) = oneshot::channel();
-            map.insert(id.clone(), PendingRequest { response_tx: tx });
+            map.insert(
+                id.clone(),
+                PendingRequest {
+                    method: "test".to_string(),
+                    response_tx: tx,
+                    acknowledgment_tx: None,
+                },
+            );
             rxs.push(rx);
         }
         (map, rxs)

--- a/crates/tower-mcp/src/client/transport.rs
+++ b/crates/tower-mcp/src/client/transport.rs
@@ -10,6 +10,7 @@
 use async_trait::async_trait;
 
 use crate::error::Result;
+use crate::protocol::RequestId;
 
 /// Low-level transport for sending and receiving raw JSON-RPC messages.
 ///
@@ -75,6 +76,25 @@ pub trait ClientTransport: Send + 'static {
     /// The default implementation is a no-op (for transports like stdio
     /// that don't have sessions).
     async fn reset_session(&mut self) {}
+
+    /// Cancel one in-flight request.
+    ///
+    /// Message-oriented transports such as stdio use the protocol's
+    /// `notifications/cancelled` notification. HTTP overrides this method to
+    /// close only the response stream belonging to the request.
+    async fn cancel_request(&mut self, request_id: &RequestId) -> Result<()> {
+        self.send(
+            &serde_json::json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/cancelled",
+                "params": {
+                    "requestId": request_id,
+                }
+            })
+            .to_string(),
+        )
+        .await
+    }
 
     /// Whether this transport supports automatic session recovery.
     ///

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -143,6 +143,8 @@
 //! - [`RequestStateCodec`] - Expiring, integrity-protected continuation state
 //! - `McpClient::discover` - Sessionless client discovery with per-request metadata,
 //!   runtime version selection, SEP-2243 headers, and bounded MRTR auto-driving
+//! - `McpClient::listen_subscriptions` - Long-lived, correlated notification streams with
+//!   typed acknowledgments and transport-specific cancellation
 //!
 //! ## Feature Flags
 //!
@@ -351,7 +353,9 @@
 //! - **`subscriptions/listen`** -- client-initiated SSE subscription. A POST of a
 //!   `subscriptions/listen` request with `MCP-Protocol-Version: 2026-07-28` opens a
 //!   server-push stream that is not tied to any session, allowing stateless clients to
-//!   receive notifications.
+//!   receive notifications. [`McpClient::listen_subscriptions`] returns a handle that
+//!   exposes the accepted filter and subscription ID; dropping or cancelling the handle
+//!   closes only that request's response stream.
 //!
 //! Per-request client identity and capabilities ride in each request's `_meta` object via
 //! [`stateless::StatelessRequestMeta`] rather than being negotiated once at session open.
@@ -561,19 +565,20 @@ pub use protocol::{
     ListResourcesParams, ListResourcesResult, ListRootsParams, ListRootsResult, ListTasksParams,
     ListTasksResult, ListToolsParams, ListToolsResult, LogLevel, LoggingCapability,
     LoggingMessageParams, McpNotification, McpRequest, McpResponse, ModelHint, ModelPreferences,
-    MultiSelectEnumItems, MultiSelectEnumSchema, NumberSchema, PrimitiveSchemaDefinition,
-    ProgressParams, ProgressToken, PromptArgument, PromptDefinition, PromptMessage,
-    PromptReference, PromptRole, PromptsCapability, ReadResourceParams, ReadResourceResult,
-    RequestId, RequestMeta, RequestOutcome, ResourceContent, ResourceDefinition, ResourceReference,
-    ResourceTemplateDefinition, ResourcesCapability, ResultType, Root, RootsCapability,
-    SamplingCapability, SamplingContent, SamplingContentOrArray, SamplingContextCapability,
-    SamplingMessage, SamplingTool, SamplingToolsCapability, ServerCapabilities, SetLogLevelParams,
-    SingleSelectEnumSchema, StringSchema, SubscribeResourceParams, TaskInfo, TaskObject,
-    TaskRequestParams, TaskStatus, TaskStatusChangedParams, TaskStatusParams, TaskSupportMode,
-    TasksCancelCapability, TasksCapability, TasksListCapability, TasksRequestsCapability,
-    TasksToolsCallCapability, TasksToolsRequestsCapability, ToolAnnotations, ToolChoice,
-    ToolDefinition, ToolExecution, ToolIcon, ToolsCapability, UnsubscribeResourceParams,
-    UpdateTaskParams,
+    MultiSelectEnumItems, MultiSelectEnumSchema, NotificationMeta, NumberSchema,
+    PrimitiveSchemaDefinition, ProgressParams, ProgressToken, PromptArgument, PromptDefinition,
+    PromptMessage, PromptReference, PromptRole, PromptsCapability, ReadResourceParams,
+    ReadResourceResult, RequestId, RequestMeta, RequestOutcome, ResourceContent,
+    ResourceDefinition, ResourceReference, ResourceTemplateDefinition, ResourcesCapability,
+    ResultType, Root, RootsCapability, SamplingCapability, SamplingContent, SamplingContentOrArray,
+    SamplingContextCapability, SamplingMessage, SamplingTool, SamplingToolsCapability,
+    ServerCapabilities, SetLogLevelParams, SingleSelectEnumSchema, StringSchema,
+    SubscribeResourceParams, SubscriptionFilter, SubscriptionsAcknowledgedParams,
+    SubscriptionsListenParams, SubscriptionsListenResult, TaskInfo, TaskObject, TaskRequestParams,
+    TaskStatus, TaskStatusChangedParams, TaskStatusParams, TaskSupportMode, TasksCancelCapability,
+    TasksCapability, TasksListCapability, TasksRequestsCapability, TasksToolsCallCapability,
+    TasksToolsRequestsCapability, ToolAnnotations, ToolChoice, ToolDefinition, ToolExecution,
+    ToolIcon, ToolsCapability, UnsubscribeResourceParams, UpdateTaskParams,
 };
 pub use protocol::{RESULT_TYPE_TASK, TASKS_EXTENSION_ID};
 #[cfg(feature = "dynamic-tools")]

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -17,7 +17,7 @@ use tower_mcp::{
     ElicitResult, GetPromptResult, HttpTransport, LogLevel, LoggingMessageParams, McpClientBuilder,
     McpRouter, NoParams, NotificationHandler, PromptBuilder, PromptMessage, PromptRole,
     ReadResourceResult, ResourceBuilder, ResourceContent, ResourceTemplateBuilder, Root,
-    SamplingContent, SamplingContentOrArray, SamplingMessage, ToolBuilder,
+    SamplingContent, SamplingContentOrArray, SamplingMessage, SubscriptionFilter, ToolBuilder,
     client::{HttpClientConfig, HttpClientTransport, McpClient},
     extract::{Context, RawArgs},
     transport::http::SessionConfig,
@@ -2253,9 +2253,11 @@ mod stateless_tests {
     use super::*;
     use axum::extract::State;
     use axum::http::{HeaderMap, StatusCode};
+    use axum::response::sse::{Event, Sse};
     use axum::response::{IntoResponse, Response};
     use axum::routing::post;
     use axum::{Json, Router};
+    use std::convert::Infallible;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower_mcp::stateless::StatelessConfig;
 
@@ -2390,6 +2392,353 @@ mod stateless_tests {
             )
                 .into_response(),
         }
+    }
+
+    #[derive(Clone, Default)]
+    struct SubscriptionClientState {
+        active_streams: Arc<AtomicUsize>,
+        dropped_streams: Arc<AtomicUsize>,
+        tools_list_calls: Arc<AtomicUsize>,
+        cancellation_posts: Arc<AtomicUsize>,
+    }
+
+    enum SubscriptionStreamMode {
+        LongLived,
+        Graceful,
+        Abrupt,
+        BeforeAcknowledgment,
+        MismatchedId,
+    }
+
+    struct SubscriptionStream {
+        phase: u8,
+        id: serde_json::Value,
+        notifications: serde_json::Value,
+        mode: SubscriptionStreamMode,
+        state: SubscriptionClientState,
+    }
+
+    impl Drop for SubscriptionStream {
+        fn drop(&mut self) {
+            self.state.active_streams.fetch_sub(1, Ordering::SeqCst);
+            self.state.dropped_streams.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn subscription_client_endpoint(
+        State(state): State<SubscriptionClientState>,
+        headers: HeaderMap,
+        Json(body): Json<serde_json::Value>,
+    ) -> Response {
+        let id = body.get("id").cloned().unwrap_or(serde_json::Value::Null);
+        let method = body
+            .get("method")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default();
+        match method {
+            "server/discover" => (
+                StatusCode::OK,
+                Json(serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "resultType": "complete",
+                        "supportedVersions": ["2026-07-28"],
+                        "capabilities": {},
+                        "ttlMs": 0,
+                        "cacheScope": "private"
+                    }
+                })),
+            )
+                .into_response(),
+            "tools/list" => {
+                state.tools_list_calls.fetch_add(1, Ordering::SeqCst);
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": {
+                            "resultType": "complete",
+                            "tools": [],
+                            "ttlMs": 0,
+                            "cacheScope": "private"
+                        }
+                    })),
+                )
+                    .into_response()
+            }
+            "subscriptions/listen" => {
+                if headers
+                    .get("mcp-protocol-version")
+                    .and_then(|value| value.to_str().ok())
+                    != Some("2026-07-28")
+                    || headers
+                        .get("mcp-method")
+                        .and_then(|value| value.to_str().ok())
+                        != Some("subscriptions/listen")
+                    || body.pointer("/params/_meta/io.modelcontextprotocol~1protocolVersion")
+                        != Some(&serde_json::json!("2026-07-28"))
+                {
+                    return StatusCode::BAD_REQUEST.into_response();
+                }
+
+                let notifications = body["params"]["notifications"].clone();
+                let mode = if notifications["resourcesListChanged"] == serde_json::Value::Bool(true)
+                {
+                    SubscriptionStreamMode::Graceful
+                } else if notifications["promptsListChanged"] == serde_json::Value::Bool(true) {
+                    SubscriptionStreamMode::Abrupt
+                } else if notifications["resourceSubscriptions"][0]
+                    == serde_json::json!("before-ack")
+                {
+                    SubscriptionStreamMode::BeforeAcknowledgment
+                } else if notifications["resourceSubscriptions"][0] == serde_json::json!("wrong-id")
+                {
+                    SubscriptionStreamMode::MismatchedId
+                } else {
+                    SubscriptionStreamMode::LongLived
+                };
+                state.active_streams.fetch_add(1, Ordering::SeqCst);
+                let stream = futures::stream::unfold(
+                    SubscriptionStream {
+                        phase: 0,
+                        id,
+                        notifications,
+                        mode,
+                        state,
+                    },
+                    |mut stream| async move {
+                        let message = match stream.phase {
+                            0 => match stream.mode {
+                                SubscriptionStreamMode::BeforeAcknowledgment => {
+                                    serde_json::json!({
+                                        "jsonrpc": "2.0",
+                                        "method": "notifications/tools/list_changed",
+                                        "params": {
+                                            "_meta": {
+                                                "io.modelcontextprotocol/subscriptionId": stream.id
+                                            }
+                                        }
+                                    })
+                                }
+                                SubscriptionStreamMode::MismatchedId => serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "method": "notifications/subscriptions/acknowledged",
+                                    "params": {
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": 999
+                                        },
+                                        "notifications": stream.notifications
+                                    }
+                                }),
+                                _ => serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "method": "notifications/subscriptions/acknowledged",
+                                    "params": {
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": stream.id
+                                        },
+                                        "notifications": stream.notifications
+                                    }
+                                }),
+                            },
+                            1 => match stream.mode {
+                                SubscriptionStreamMode::LongLived => serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "method": "notifications/tools/list_changed",
+                                    "params": {
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": stream.id
+                                        }
+                                    }
+                                }),
+                                SubscriptionStreamMode::Graceful => serde_json::json!({
+                                    "jsonrpc": "2.0",
+                                    "id": stream.id,
+                                    "result": {
+                                        "resultType": "complete",
+                                        "_meta": {
+                                            "io.modelcontextprotocol/subscriptionId": stream.id
+                                        }
+                                    }
+                                }),
+                                SubscriptionStreamMode::Abrupt => return None,
+                                SubscriptionStreamMode::BeforeAcknowledgment
+                                | SubscriptionStreamMode::MismatchedId => {
+                                    std::future::pending::<()>().await;
+                                    unreachable!()
+                                }
+                            },
+                            _ => match stream.mode {
+                                SubscriptionStreamMode::LongLived => {
+                                    std::future::pending::<()>().await;
+                                    unreachable!()
+                                }
+                                SubscriptionStreamMode::Graceful
+                                | SubscriptionStreamMode::Abrupt => return None,
+                                SubscriptionStreamMode::BeforeAcknowledgment
+                                | SubscriptionStreamMode::MismatchedId => unreachable!(),
+                            },
+                        };
+                        stream.phase += 1;
+                        Some((
+                            Ok::<_, Infallible>(Event::default().data(message.to_string())),
+                            stream,
+                        ))
+                    },
+                );
+                Sse::new(stream).into_response()
+            }
+            "notifications/cancelled" => {
+                state.cancellation_posts.fetch_add(1, Ordering::SeqCst);
+                StatusCode::ACCEPTED.into_response()
+            }
+            _ => StatusCode::NOT_FOUND.into_response(),
+        }
+    }
+
+    async fn wait_for_counter(counter: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while counter.load(Ordering::SeqCst) != expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn final_http_client_manages_concurrent_subscription_streams() {
+        let state = SubscriptionClientState::default();
+        let app = Router::new()
+            .route("/", post(subscription_client_endpoint))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let tools_changed = Arc::new(AtomicUsize::new(0));
+        let handler = NotificationHandler::new().on_tools_changed({
+            let tools_changed = tools_changed.clone();
+            move || {
+                tools_changed.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        let config = HttpClientConfig {
+            request_timeout: Duration::from_millis(100),
+            sse_reconnect: false,
+            ..Default::default()
+        };
+        let client = McpClient::builder()
+            .protocol_support(tower_mcp::ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect(HttpClientTransport::with_config(url, config), handler)
+            .await
+            .unwrap();
+        client.discover("test-client", "1.0.0").await.unwrap();
+
+        let filter = SubscriptionFilter {
+            tools_list_changed: Some(true),
+            ..Default::default()
+        };
+        let mut first = client.listen_subscriptions(filter.clone()).await.unwrap();
+        let mut second = client.listen_subscriptions(filter).await.unwrap();
+        assert_ne!(first.id(), second.id());
+        assert_eq!(
+            first.acknowledged().await.unwrap().tools_list_changed,
+            Some(true)
+        );
+        assert_eq!(
+            second.acknowledged().await.unwrap().tools_list_changed,
+            Some(true)
+        );
+        wait_for_counter(&state.active_streams, 2).await;
+        wait_for_counter(&tools_changed, 2).await;
+
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        assert_eq!(state.dropped_streams.load(Ordering::SeqCst), 0);
+        client.list_tools().await.unwrap();
+
+        first.cancel().await.unwrap();
+        wait_for_counter(&state.active_streams, 1).await;
+        client.list_tools().await.unwrap();
+        second.cancel().await.unwrap();
+        wait_for_counter(&state.active_streams, 0).await;
+        assert_eq!(state.dropped_streams.load(Ordering::SeqCst), 2);
+        assert_eq!(state.tools_list_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(state.cancellation_posts.load(Ordering::SeqCst), 0);
+
+        let mut graceful = client
+            .listen_subscriptions(SubscriptionFilter {
+                resources_list_changed: Some(true),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            graceful
+                .acknowledged()
+                .await
+                .unwrap()
+                .resources_list_changed,
+            Some(true)
+        );
+        let graceful_id = graceful.id().clone();
+        let result = graceful.wait().await.unwrap();
+        assert_eq!(
+            result.meta.and_then(|meta| meta.subscription_id),
+            Some(graceful_id)
+        );
+
+        let mut abrupt = client
+            .listen_subscriptions(SubscriptionFilter {
+                prompts_list_changed: Some(true),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(
+            abrupt.acknowledged().await.unwrap().prompts_list_changed,
+            Some(true)
+        );
+        let error = tokio::time::timeout(Duration::from_secs(2), abrupt.wait())
+            .await
+            .expect("abrupt close should not leave the subscription pending")
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("closed the response stream before the final reply")
+        );
+
+        for (resource, expected) in [
+            (
+                "before-ack",
+                "subscription notification arrived before acknowledgment",
+            ),
+            (
+                "wrong-id",
+                "subscription notification carried a missing or mismatched subscription ID",
+            ),
+        ] {
+            let invalid = client
+                .listen_subscriptions(SubscriptionFilter {
+                    resource_subscriptions: Some(vec![resource.to_string()]),
+                    ..Default::default()
+                })
+                .await
+                .unwrap();
+            let error = tokio::time::timeout(Duration::from_secs(2), invalid.wait())
+                .await
+                .expect("protocol violation should end the subscription")
+                .unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+        }
+
+        client.shutdown().await.unwrap();
+        server.abort();
     }
 
     #[tokio::test]

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,7 +28,7 @@ cargo run --example websocket_server --features websocket
 # Clients (start http_server first, or run stateless_http_client standalone)
 cargo run --example http_client --features http-client
 cargo run --example http_sse_client --features http
-cargo run --example stateless_http_client --features "http,stateless"
+cargo run --example stateless_http_client --features "http,http-client,protocol-2026-07-28"
 
 # Dynamic capabilities
 cargo run --example dynamic_capabilities --features dynamic-tools

--- a/examples/stateless_http_client.rs
+++ b/examples/stateless_http_client.rs
@@ -18,22 +18,22 @@
 //! # Running
 //!
 //! ```bash
-//! cargo run --example stateless_http_client --features "http,stateless"
+//! cargo run --example stateless_http_client \
+//!   --features "http,http-client,protocol-2026-07-28"
 //! ```
 //!
 //! No separate server process is needed -- the server is started in-process.
-//! The `stateless` feature is required for the server to route 2026-07-28
-//! requests without a session.
+//! The `protocol-2026-07-28` feature is required for the server and client to
+//! compile this experimental final-protocol implementation.
 
 use std::time::Duration;
 
-use futures::StreamExt;
-use reqwest::Client;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
-
-const PROTOCOL_VERSION: &str = "2026-07-28";
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, ProtocolSupport, SubscriptionFilter, ToolBuilder,
+    client::{HttpClientTransport, McpClient},
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct AddInput {
@@ -87,7 +87,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Give the server a moment to start.
     tokio::time::sleep(Duration::from_millis(50)).await;
 
-    let client = Client::new();
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"])?)
+        .connect_simple(HttpClientTransport::new(&base_url))
+        .await?;
 
     // -----------------------------------------------------------------------
     // Step 1: server/discover
@@ -97,39 +100,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the server supports.
     // -----------------------------------------------------------------------
     println!("=== Step 1: server/discover ===");
-    println!("POST {} (no session, no initialize)", base_url);
-
-    let discover_response = client
-        .post(&base_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json")
-        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
-        .header("Mcp-Method", "server/discover")
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "server/discover"
-        }))
-        .send()
-        .await?;
-
-    // Stateless: no MCP-Session-Id must be present.
-    assert!(
-        discover_response.headers().get("mcp-session-id").is_none(),
-        "server returned an unexpected MCP-Session-Id in stateless mode"
-    );
-    println!("Confirmed: no session ID returned (stateless)");
-
-    let discover_body: serde_json::Value = discover_response.json().await?;
-    let result = &discover_body["result"];
-    println!(
-        "Server: {}",
-        result["serverInfo"]["name"].as_str().unwrap_or("(unknown)")
-    );
-    if let Some(versions) = result["supportedVersions"].as_array() {
-        let version_list: Vec<&str> = versions.iter().filter_map(|v| v.as_str()).collect();
-        println!("Supported protocol versions: {}", version_list.join(", "));
+    let discovery = client.discover("stateless-example-client", "1.0.0").await?;
+    if let Some(server_info) = discovery.meta.and_then(|meta| meta.server_info) {
+        println!("Server: {}", server_info.name);
     }
+    println!(
+        "Supported protocol versions: {}",
+        discovery.supported_versions.join(", ")
+    );
+    println!("Selected protocol: 2026-07-28 (no session ID)");
     println!();
 
     // -----------------------------------------------------------------------
@@ -140,31 +119,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -----------------------------------------------------------------------
     println!("=== Step 2: tools/list ===");
 
-    let list_response = client
-        .post(&base_url)
-        .header("Content-Type", "application/json")
-        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
-        .header("Mcp-Method", "tools/list")
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 2,
-            "method": "tools/list"
-        }))
-        .send()
-        .await?;
-
-    let list_body: serde_json::Value = list_response.json().await?;
-    let tools = list_body["result"]["tools"]
-        .as_array()
-        .map(|a| a.as_slice())
-        .unwrap_or_default();
-
-    println!("Available tools ({}):", tools.len());
-    for tool in tools {
+    let tools = client.list_tools().await?;
+    println!("Available tools ({}):", tools.tools.len());
+    for tool in tools.tools {
         println!(
             "  - {} : {}",
-            tool["name"].as_str().unwrap_or("(unnamed)"),
-            tool["description"].as_str().unwrap_or("(no description)")
+            tool.name,
+            tool.description.unwrap_or_default()
         );
     }
     println!();
@@ -177,104 +138,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -----------------------------------------------------------------------
     println!("=== Step 3: tools/call (add, a=10, b=32) ===");
 
-    let call_response = client
-        .post(&base_url)
-        .header("Content-Type", "application/json")
-        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
-        .header("Mcp-Method", "tools/call")
-        .header("Mcp-Name", "add")
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 3,
-            "method": "tools/call",
-            "params": {
-                "name": "add",
-                "arguments": { "a": 10, "b": 32 }
-            }
-        }))
-        .send()
+    let result = client
+        .call_tool("add", serde_json::json!({ "a": 10, "b": 32 }))
         .await?;
-
-    let call_body: serde_json::Value = call_response.json().await?;
-    if let Some(content) = call_body["result"]["content"].as_array() {
-        for item in content {
-            if item["type"] == "text" {
-                println!("Result: {}", item["text"].as_str().unwrap_or("(empty)"));
-            }
-        }
-    }
+    println!("Result: {}", result.first_text().unwrap_or("(empty)"));
     println!();
 
     // -----------------------------------------------------------------------
     // Step 4: subscriptions/listen
     //
     // Opens a server-push SSE stream. In the 2026-07-28 protocol this is a
-    // POST (not a GET) with Accept: text/event-stream. The server delivers
-    // notifications for any in-flight requests that carry a progressToken.
-    // We read for a short window and then disconnect.
+    // POST (not a GET) with Accept: text/event-stream. The client validates
+    // the server's mandatory first-message acknowledgment, keeps the stream
+    // open for a short window, and cancels it by closing this response stream.
     // -----------------------------------------------------------------------
     println!("=== Step 4: subscriptions/listen (SSE stream, 1-second window) ===");
 
-    let listen_response = client
-        .post(&base_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "text/event-stream")
-        .header("MCP-Protocol-Version", PROTOCOL_VERSION)
-        .header("Mcp-Method", "subscriptions/listen")
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 4,
-            "method": "subscriptions/listen",
-            "params": {}
-        }))
-        .send()
+    let mut subscription = client
+        .listen_subscriptions(SubscriptionFilter {
+            tools_list_changed: Some(true),
+            ..Default::default()
+        })
         .await?;
-
-    let content_type = listen_response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    println!("Response Content-Type: {}", content_type);
-
-    let mut stream = listen_response.bytes_stream();
-    let deadline = tokio::time::sleep(Duration::from_secs(1));
-    tokio::pin!(deadline);
-
-    let mut event_count = 0usize;
-    loop {
-        tokio::select! {
-            chunk = stream.next() => {
-                match chunk {
-                    Some(Ok(bytes)) => {
-                        let text = String::from_utf8_lossy(&bytes);
-                        // Print non-empty, non-comment SSE lines for visibility.
-                        for line in text.lines() {
-                            if !line.is_empty() && !line.starts_with(':') {
-                                println!("  SSE: {}", line);
-                            }
-                        }
-                        event_count += 1;
-                    }
-                    Some(Err(e)) => {
-                        println!("  Stream error: {}", e);
-                        break;
-                    }
-                    None => {
-                        println!("  Stream closed by server");
-                        break;
-                    }
-                }
-            }
-            _ = &mut deadline => {
-                println!("  Disconnecting after 1-second window ({} chunk(s) received)", event_count);
-                break;
-            }
-        }
-    }
+    let accepted = subscription.acknowledged().await?;
+    println!(
+        "Subscription {:?} acknowledged: toolsListChanged={:?}",
+        subscription.id(),
+        accepted.tools_list_changed
+    );
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    subscription.cancel().await?;
+    println!("Subscription cancelled by closing its HTTP response stream");
 
     println!();
     println!("Done. All four stateless 2026-07-28 requests completed.");
+    client.shutdown().await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- add `McpClient::listen_subscriptions` and a cancellable `SubscriptionHandle` with request/subscription ID, accepted-filter acknowledgment, and typed graceful completion
- process final POST SSE response streams concurrently, correlate subscription messages, and distinguish graceful completion from abrupt disconnects
- cancel HTTP by closing only the owning response stream and message transports with `notifications/cancelled`; accept server cancellation only for an active listen request
- validate acknowledgment ordering and per-message subscription IDs, preserve callback behavior, and support multiple concurrent subscriptions
- update final subscription protocol types/re-exports and convert the stateless HTTP client example to the public client API

Part of #953.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (834 + 149 tests)
- `cargo test --test '*' --all-features` (all integration suites; HTTP client 63/63)
- `cargo test --doc --all-features` (267 passed, 75 ignored)
- `cargo check -p tower-mcp --no-default-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p tower-mcp --all-features --no-deps`
- `cargo run -p tower-mcp --example stateless_http_client --features 'http,http-client,protocol-2026-07-28'`