### PR TITLE
feat(transports): support final protocol across JSON-RPC bindings

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -73,18 +73,18 @@
 //!
 //! With the 2026-07-28 protocol, clients do not run an initialize handshake.
 //! Instead, every request carries the client's protocol version, identity, and
-//! capabilities in a `_meta` object. The HTTP transport extracts these fields
-//! and stashes them as a [`StatelessRequestMeta`](crate::stateless::StatelessRequestMeta)
+//! capabilities in a `_meta` object. JSON-RPC transports extract these fields
+//! and stash them as a [`StatelessRequestMeta`](crate::stateless::StatelessRequestMeta)
 //! extension on the [`RequestContext`], accessible via
 //! [`ctx.per_request_meta()`](RequestContext::per_request_meta).
 //!
 //! `per_request_meta()` returns `Some` when:
 //! - The `stateless` feature is compiled in, AND
-//! - The request was dispatched by the HTTP transport, AND
+//! - The request was dispatched by a JSON-RPC transport, AND
 //! - The request's `_meta` contained at least one recognized field.
 //!
-//! It returns `None` for stdio/WebSocket transports, for 2025-11-25 session-based
-//! requests, and when the request carried no `_meta`.
+//! It returns `None` for 2025-11-25 session-based requests and when the request
+//! carried no modern protocol metadata.
 //!
 //! The [`StatelessRequestMeta`](crate::stateless::StatelessRequestMeta) struct
 //! provides:
@@ -101,7 +101,7 @@
 //!
 //! async fn my_tool(ctx: RequestContext, input: MyInput) -> Result<CallToolResult> {
 //!     if let Some(meta) = ctx.per_request_meta() {
-//!         // Available for 2026-07-28+ clients on the HTTP transport
+//!         // Available for 2026-07-28 clients on JSON-RPC transports
 //!         if let Some(ref info) = meta.client_info {
 //!             tracing::info!(client = %info.name, version = %info.version, "request from");
 //!         }
@@ -480,12 +480,11 @@ impl RequestContext {
     /// SEP-2575 per-request `_meta` (protocol version, client info, client
     /// capabilities, log level) if the transport extracted it.
     ///
-    /// Returns `Some` for 2026-07-28+ clients on the HTTP transport when the
+    /// Returns `Some` for 2026-07-28 clients on JSON-RPC transports when the
     /// request carried a `_meta` object with recognized fields. Returns `None`
     /// when:
     /// - The request had no `_meta` field, or
-    /// - The transport does not stash per-request metadata (only the HTTP
-    ///   transport currently does this), or
+    /// - The transport does not use [`crate::jsonrpc::JsonRpcService`], or
     /// - The `stateless` feature is not compiled in.
     ///
     /// # Example

--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -20,9 +20,10 @@ use tower_service::Service;
 
 use crate::error::{Error, JsonRpcError, Result};
 use crate::protocol::{
-    JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage, McpRequest,
+    JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage, McpRequest, ResultType,
 };
 use crate::router::{Extensions, RouterRequest, RouterResponse};
+use crate::{ProtocolSupport, ProtocolSupportError};
 
 /// Tower layer that adds JSON-RPC 2.0 framing to an MCP service.
 ///
@@ -81,6 +82,7 @@ impl<S> Layer<S> for JsonRpcLayer {
 pub struct JsonRpcService<S> {
     inner: S,
     extensions: Extensions,
+    protocol_support: ProtocolSupport,
 }
 
 impl<S> JsonRpcService<S> {
@@ -89,6 +91,7 @@ impl<S> JsonRpcService<S> {
         Self {
             inner,
             extensions: Extensions::new(),
+            protocol_support: ProtocolSupport::default(),
         }
     }
 
@@ -101,6 +104,33 @@ impl<S> JsonRpcService<S> {
         self
     }
 
+    /// Set the exact protocol versions this service accepts and advertises.
+    ///
+    /// The default enables every protocol implementation compiled into
+    /// `tower-mcp`. Transports expose the same policy so applications can
+    /// narrow support per server instance.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.protocol_support = support;
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.protocol_support = ProtocolSupport::try_new(versions)?;
+        Ok(self)
+    }
+
+    pub(crate) fn configured_protocol_support(&self) -> &ProtocolSupport {
+        &self.protocol_support
+    }
+
     /// Process a single JSON-RPC request
     pub async fn call_single(&mut self, req: JsonRpcRequest) -> Result<JsonRpcResponse>
     where
@@ -110,7 +140,13 @@ impl<S> JsonRpcService<S> {
             + 'static,
         S::Future: Send,
     {
-        process_single_request(self.inner.clone(), req, self.extensions.clone()).await
+        process_single_request(
+            self.inner.clone(),
+            req,
+            self.extensions.clone(),
+            self.protocol_support.clone(),
+        )
+        .await
     }
 
     /// Process a batch of JSON-RPC requests concurrently
@@ -137,9 +173,10 @@ impl<S> JsonRpcService<S> {
             .map(|req| {
                 let inner = self.inner.clone();
                 let extensions = self.extensions.clone();
+                let protocol_support = self.protocol_support.clone();
                 let req_id = req.id.clone();
                 async move {
-                    match process_single_request(inner, req, extensions).await {
+                    match process_single_request(inner, req, extensions, protocol_support).await {
                         Ok(resp) => resp,
                         Err(e) => {
                             // Convert errors to error responses instead of dropping
@@ -193,6 +230,7 @@ where
         Self {
             inner: self.inner.clone(),
             extensions: self.extensions.clone(),
+            protocol_support: self.protocol_support.clone(),
         }
     }
 }
@@ -217,23 +255,13 @@ where
     fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
         let inner = self.inner.clone();
         let extensions = self.extensions.clone();
-        Box::pin(async move {
-            // Parse the MCP request from JSON-RPC
-            let mcp_request = McpRequest::from_jsonrpc(&req)?;
-
-            // Create router request
-            let router_req = RouterRequest {
-                id: req.id,
-                inner: mcp_request,
-                extensions,
-            };
-
-            // Call the inner service (oneshot handles poll_ready)
-            let response = inner.oneshot(router_req).await.unwrap(); // Infallible
-
-            // Convert to JSON-RPC response
-            Ok(response.into_jsonrpc())
-        })
+        let protocol_support = self.protocol_support.clone();
+        Box::pin(process_single_request(
+            inner,
+            req,
+            extensions,
+            protocol_support,
+        ))
     }
 }
 
@@ -258,10 +286,12 @@ where
     fn call(&mut self, msg: JsonRpcMessage) -> Self::Future {
         let inner = self.inner.clone();
         let extensions = self.extensions.clone();
+        let protocol_support = self.protocol_support.clone();
         Box::pin(async move {
             match msg {
                 JsonRpcMessage::Single(req) => {
-                    let response = process_single_request(inner, req, extensions).await?;
+                    let response =
+                        process_single_request(inner, req, extensions, protocol_support).await?;
                     Ok(JsonRpcResponseMessage::Single(response))
                 }
                 JsonRpcMessage::Batch(requests) => {
@@ -279,9 +309,17 @@ where
                         .map(|req| {
                             let inner = inner.clone();
                             let extensions = extensions.clone();
+                            let protocol_support = protocol_support.clone();
                             let req_id = req.id.clone();
                             async move {
-                                match process_single_request(inner, req, extensions).await {
+                                match process_single_request(
+                                    inner,
+                                    req,
+                                    extensions,
+                                    protocol_support,
+                                )
+                                .await
+                                {
                                     Ok(resp) => resp,
                                     Err(e) => {
                                         // Convert errors to error responses instead of dropping
@@ -320,7 +358,8 @@ where
 async fn process_single_request<S>(
     inner: S,
     req: JsonRpcRequest,
-    extensions: Extensions,
+    mut extensions: Extensions,
+    configured_protocol_support: ProtocolSupport,
 ) -> std::result::Result<JsonRpcResponse, Error>
 where
     S: Service<RouterRequest, Response = RouterResponse, Error = std::convert::Infallible>
@@ -332,6 +371,23 @@ where
     if let Err(e) = req.validate() {
         return Ok(JsonRpcResponse::error(Some(req.id), e));
     }
+
+    let method = req.method.clone();
+    #[cfg(feature = "stateless")]
+    let request_id = req.id.clone();
+    let protocol_support = extensions
+        .get::<ProtocolSupport>()
+        .cloned()
+        .unwrap_or(configured_protocol_support);
+    extensions.insert(protocol_support.clone());
+
+    #[cfg(feature = "stateless")]
+    let protocol_version = match prepare_modern_request(&req, &mut extensions, &protocol_support) {
+        Ok(version) => version,
+        Err(error) => return Ok(JsonRpcResponse::error(Some(request_id), error)),
+    };
+    #[cfg(not(feature = "stateless"))]
+    let protocol_version: Option<String> = None;
 
     // Parse the MCP request from JSON-RPC
     let mcp_request = match McpRequest::from_jsonrpc(&req) {
@@ -355,7 +411,140 @@ where
     let response = inner.oneshot(router_req).await.unwrap(); // Infallible
 
     // Convert to JSON-RPC response
-    Ok(response.into_jsonrpc())
+    let mut response = response.into_jsonrpc();
+    if let Some(version) = protocol_version.as_deref() {
+        apply_protocol_result_fields(&mut response, &method, version);
+    }
+    Ok(response)
+}
+
+/// Validate a request using the final per-request metadata lifecycle.
+///
+/// The protocol-version key is the era discriminator on transports without
+/// headers (stdio and custom bindings). Legacy initialize traffic can coexist
+/// on the same connection because requests without that key retain the
+/// sessionful path.
+#[cfg(feature = "stateless")]
+fn prepare_modern_request(
+    req: &JsonRpcRequest,
+    extensions: &mut Extensions,
+    protocol_support: &ProtocolSupport,
+) -> std::result::Result<Option<String>, JsonRpcError> {
+    let Some(params) = req.params.as_ref() else {
+        return Ok(None);
+    };
+    let Some(meta_value) = params.as_object().and_then(|params| params.get("_meta")) else {
+        return Ok(None);
+    };
+    let claims_modern = meta_value
+        .as_object()
+        .is_some_and(|meta| meta.contains_key("io.modelcontextprotocol/protocolVersion"));
+    if !claims_modern {
+        return Ok(None);
+    }
+
+    crate::protocol::validate_meta_object(meta_value)
+        .map_err(|error| JsonRpcError::invalid_params(error.to_string()))?;
+    let meta_object = meta_value
+        .as_object()
+        .expect("validate_meta_object accepted a JSON object");
+    let protocol_version = meta_object
+        .get("io.modelcontextprotocol/protocolVersion")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| {
+            JsonRpcError::invalid_params(
+                "Missing or invalid _meta.io.modelcontextprotocol/protocolVersion",
+            )
+        })?;
+    let client_capabilities = meta_object
+        .get("io.modelcontextprotocol/clientCapabilities")
+        .ok_or_else(|| {
+            JsonRpcError::invalid_params("Missing _meta.io.modelcontextprotocol/clientCapabilities")
+        })?;
+    if !client_capabilities.is_object()
+        || serde_json::from_value::<crate::protocol::ClientCapabilities>(
+            client_capabilities.clone(),
+        )
+        .is_err()
+    {
+        return Err(JsonRpcError::invalid_params(
+            "Invalid _meta.io.modelcontextprotocol/clientCapabilities",
+        ));
+    }
+    if !protocol_support.contains(protocol_version) {
+        return Err(JsonRpcError::unsupported_protocol_version(
+            protocol_version,
+            protocol_support.versions().iter().map(String::as_str),
+        ));
+    }
+    if protocol_version == crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+        && is_removed_modern_method(&req.method)
+    {
+        return Err(JsonRpcError::method_not_found(&req.method));
+    }
+
+    let meta: crate::stateless::StatelessRequestMeta =
+        serde_json::from_value(meta_value.clone())
+            .map_err(|error| JsonRpcError::invalid_params(error.to_string()))?;
+    extensions.insert(meta);
+    Ok(Some(protocol_version.to_string()))
+}
+
+/// Methods present in legacy protocol unions but removed from the final core.
+#[cfg(feature = "stateless")]
+fn is_removed_modern_method(method: &str) -> bool {
+    matches!(
+        method,
+        "initialize"
+            | "notifications/initialized"
+            | "ping"
+            | "logging/setLevel"
+            | "resources/subscribe"
+            | "resources/unsubscribe"
+            | "notifications/roots/list_changed"
+    )
+}
+
+/// Fill the required 2026-07-28 result envelope immediately before it reaches
+/// a JSON-RPC transport, while preserving legacy public result types.
+pub(crate) fn apply_protocol_result_fields(
+    response: &mut JsonRpcResponse,
+    method: &str,
+    protocol_version: &str,
+) {
+    if protocol_version != crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+        return;
+    }
+
+    let JsonRpcResponse::Result(result) = response else {
+        return;
+    };
+    ResultType::Complete.stamp_into(&mut result.result, protocol_version);
+
+    if !is_cacheable_result_method(method) {
+        return;
+    }
+    let Some(object) = result.result.as_object_mut() else {
+        return;
+    };
+    object
+        .entry("ttlMs")
+        .or_insert_with(|| serde_json::Value::Number(0.into()));
+    object
+        .entry("cacheScope")
+        .or_insert_with(|| serde_json::Value::String("private".to_string()));
+}
+
+fn is_cacheable_result_method(method: &str) -> bool {
+    matches!(
+        method,
+        "server/discover"
+            | "tools/list"
+            | "prompts/list"
+            | "resources/list"
+            | "resources/read"
+            | "resources/templates/list"
+    )
 }
 
 #[cfg(test)]
@@ -444,6 +633,80 @@ mod tests {
 
         let responses = service.call_batch(requests).await.unwrap();
         assert_eq!(responses.len(), 2);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn modern_batch_metadata_is_isolated_per_request() {
+        let router = create_test_router();
+        let mut service = JsonRpcService::new(router);
+        let final_request = JsonRpcRequest::new(1, "tools/list").with_params(serde_json::json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion":
+                    crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION,
+                "io.modelcontextprotocol/clientCapabilities": {}
+            }
+        }));
+        let legacy_request =
+            JsonRpcRequest::new(2, "tools/list").with_params(serde_json::json!({}));
+
+        let responses = service
+            .call_batch(vec![final_request, legacy_request])
+            .await
+            .unwrap();
+        let JsonRpcResponse::Result(final_response) = &responses[0] else {
+            panic!("final request should bypass legacy session state");
+        };
+        assert_eq!(final_response.result["resultType"], "complete");
+
+        let JsonRpcResponse::Error(legacy_response) = &responses[1] else {
+            panic!("legacy request must not inherit final request metadata");
+        };
+        assert_eq!(legacy_response.error.code, -32600);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn modern_request_requires_client_capabilities() {
+        let router = create_test_router();
+        let mut service = JsonRpcService::new(router);
+        let request = JsonRpcRequest::new(1, "server/discover").with_params(serde_json::json!({
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion":
+                    crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+            }
+        }));
+
+        let response = service.call_single(request).await.unwrap();
+        let JsonRpcResponse::Error(response) = response else {
+            panic!("missing clientCapabilities must be rejected");
+        };
+        assert_eq!(response.error.code, -32602);
+        assert!(response.error.message.contains("clientCapabilities"));
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn final_only_policy_never_negotiates_final_via_initialize() {
+        let router = create_test_router();
+        let mut service = JsonRpcService::new(router).protocol_support(
+            ProtocolSupport::try_new([crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION]).unwrap(),
+        );
+        let request = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "legacy-client", "version": "1.0.0"}
+        }));
+
+        let response = service.call_single(request).await.unwrap();
+        let JsonRpcResponse::Error(response) = response else {
+            panic!("final-only policy must reject the removed initialize lifecycle");
+        };
+        assert_eq!(response.error.code, -32022);
+        assert_eq!(
+            response.error.data.unwrap()["supported"],
+            serde_json::json!([crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION])
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -868,8 +868,12 @@ impl McpRouter {
             ctx
         };
 
-        // Set up client requester if configured (for sampling support)
-        let ctx = if let Some(requester) = &self.inner.client_requester {
+        // The final protocol does not permit servers to initiate JSON-RPC
+        // requests. Keep legacy sampling/elicitation available on sessionful
+        // requests, but do not expose the requester to final handlers.
+        let ctx = if !is_final_protocol_request(per_request)
+            && let Some(requester) = &self.inner.client_requester
+        {
             ctx.with_client_requester(requester.clone())
         } else {
             ctx
@@ -2040,7 +2044,7 @@ impl McpRouter {
     ) -> Result<McpResponse> {
         // Enforce session state - reject requests before initialization
         let method = request.method_name();
-        if !self.session.is_request_allowed(method) {
+        if !is_final_protocol_request(&extensions) && !self.session.is_request_allowed(method) {
             tracing::warn!(
                 method = %method,
                 phase = ?self.session.phase(),
@@ -2064,20 +2068,31 @@ impl McpRouter {
                 // runtime allow-list. Direct router use retains the stable
                 // default policy.
                 let protocol_support = extensions.get::<crate::ProtocolSupport>();
-                let requested_is_supported = protocol_support.map_or_else(
-                    || {
-                        crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
-                            .contains(&params.protocol_version.as_str())
-                    },
-                    |support| support.contains(&params.protocol_version),
-                );
+                let requested_is_legacy = crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                    .contains(&params.protocol_version.as_str());
+                let requested_is_supported = requested_is_legacy
+                    && protocol_support
+                        .is_none_or(|support| support.contains(&params.protocol_version));
                 let protocol_version = if requested_is_supported {
                     params.protocol_version
                 } else {
-                    protocol_support.map_or_else(
-                        || crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
-                        |support| support.preferred().to_string(),
-                    )
+                    match protocol_support {
+                        None => crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
+                        Some(support) => support
+                            .versions()
+                            .iter()
+                            .find(|version| {
+                                crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                                    .contains(&version.as_str())
+                            })
+                            .cloned()
+                            .ok_or_else(|| {
+                                Error::JsonRpc(JsonRpcError::unsupported_protocol_version(
+                                    params.protocol_version,
+                                    support.versions().iter().map(String::as_str),
+                                ))
+                            })?,
+                    }
                 };
 
                 // Transition session state to Initializing

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -6,13 +6,14 @@
 //!
 //! ## Two stateless paths
 //!
-//! ### Automatic version-gated path (2026-07-28+)
+//! ### Automatic version-gated path (2026-07-28)
 //!
-//! When the `stateless` feature is compiled in, the HTTP transport automatically
-//! dispatches any request carrying `MCP-Protocol-Version: 2026-07-28` (or later)
-//! statelessly -- no session is created or looked up, and no initialize handshake
-//! is required. Client identity and capabilities flow through per-request `_meta`
-//! (see [`StatelessRequestMeta`]).
+//! When the `stateless` feature is compiled in, JSON-RPC transports
+//! automatically dispatch requests whose per-request `_meta` selects the exact
+//! 2026-07-28 protocol without an initialize handshake. HTTP additionally
+//! requires a matching `MCP-Protocol-Version` header. Client identity and
+//! capabilities flow through per-request `_meta` (see
+//! [`StatelessRequestMeta`]).
 //!
 //! **This path is always active when the feature is compiled in, regardless of
 //! whether [`StatelessConfig`] was provided to the transport.** Adding
@@ -86,8 +87,10 @@ pub struct StatelessRequestMeta {
 
     /// The MCP protocol version this request targets.
     ///
-    /// For HTTP transport this MUST match the `MCP-Protocol-Version` header
-    /// (see SEP-2243). Spec key: `io.modelcontextprotocol/protocolVersion`.
+    /// For HTTP this MUST match the `MCP-Protocol-Version` header. On stdio
+    /// and custom JSON-RPC bindings, this field independently selects the
+    /// request lifecycle. Spec key:
+    /// `io.modelcontextprotocol/protocolVersion`.
     #[serde(
         rename = "io.modelcontextprotocol/protocolVersion",
         skip_serializing_if = "Option::is_none"

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -266,11 +266,10 @@ use crate::context::{
 use crate::error::{Error, JsonRpcError, Result};
 #[cfg(feature = "stateless")]
 use crate::error::{ErrorCode, McpErrorCode};
-use crate::jsonrpc::JsonRpcService;
+use crate::jsonrpc::{JsonRpcService, apply_protocol_result_fields};
 use crate::protocol::{
     ClientCapabilities, EXPERIMENTAL_PROTOCOL_VERSION, Implementation, JsonRpcNotification,
     JsonRpcRequest, JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, RequestId,
-    ResultType,
 };
 #[cfg(feature = "stateless")]
 use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
@@ -3497,53 +3496,6 @@ fn version_supports_subscriptions_listen(
 #[cfg(feature = "stateless")]
 fn is_stateless_protocol_version(version: &str) -> bool {
     version == EXPERIMENTAL_PROTOCOL_VERSION
-}
-
-/// Fill the required 2026-07-28 result envelope immediately before it reaches
-/// the wire, while preserving the legacy serde representation of public result
-/// types.
-///
-/// Every successful result gets `resultType: "complete"` unless it already
-/// owns a discriminator such as `input_required` or `task`. Cacheable methods
-/// also receive conservative defaults for fields omitted by a handler/router.
-fn apply_protocol_result_fields(
-    response: &mut JsonRpcResponse,
-    method: &str,
-    protocol_version: &str,
-) {
-    if protocol_version != EXPERIMENTAL_PROTOCOL_VERSION {
-        return;
-    }
-
-    let JsonRpcResponse::Result(result) = response else {
-        return;
-    };
-    ResultType::Complete.stamp_into(&mut result.result, protocol_version);
-
-    if !is_cacheable_result_method(method) {
-        return;
-    }
-    let Some(object) = result.result.as_object_mut() else {
-        return;
-    };
-    object
-        .entry("ttlMs")
-        .or_insert_with(|| serde_json::Value::Number(0.into()));
-    object
-        .entry("cacheScope")
-        .or_insert_with(|| serde_json::Value::String("private".to_string()));
-}
-
-fn is_cacheable_result_method(method: &str) -> bool {
-    matches!(
-        method,
-        "server/discover"
-            | "tools/list"
-            | "prompts/list"
-            | "resources/list"
-            | "resources/read"
-            | "resources/templates/list"
-    )
 }
 
 /// Stamp `_meta["io.modelcontextprotocol/serverInfo"]` onto a successful

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -3,11 +3,21 @@
 //! Reads JSON-RPC messages from stdin and writes responses to stdout.
 //! Uses line-delimited JSON format.
 //!
+//! # Protocol lifecycles
+//!
+//! Final 2026-07-28 requests carry protocol version and client capabilities
+//! inline in each request's `_meta` and can begin with a `server/discover`
+//! probe. Requests without that metadata retain the legacy initialize
+//! lifecycle, so both eras can coexist on one stdio stream. Use
+//! [`StdioTransport::protocol_support`] to set the exact runtime allow-list.
+//!
 //! # Bidirectional Support
 //!
-//! The [`BidirectionalStdioTransport`] enables server-to-client requests like
-//! sampling (LLM requests). It multiplexes the stdio streams to handle both
-//! incoming requests and outgoing requests/responses.
+//! For legacy protocols, [`BidirectionalStdioTransport`] enables
+//! server-to-client requests like sampling (LLM requests). It multiplexes the
+//! stdio streams to handle both incoming requests and outgoing
+//! requests/responses. Final 2026-07-28 handlers do not receive a client
+//! requester because that protocol does not permit server-initiated requests.
 //!
 //! # Server Notifications
 //!
@@ -36,6 +46,7 @@ use crate::protocol::{
 };
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{CatchError, InjectAnnotations};
+use crate::{ProtocolSupport, ProtocolSupportError};
 
 // ============================================================================
 // Shared helpers
@@ -195,6 +206,30 @@ impl StdioTransport {
         }
     }
 
+    /// Set the exact protocol versions this transport accepts and advertises.
+    ///
+    /// By default every implementation compiled into `tower-mcp` is enabled.
+    /// Final 2026-07-28 requests carry their version and capabilities in each
+    /// request's `_meta`; legacy initialize traffic may coexist on the same
+    /// stdio stream.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.service = self.service.protocol_support(support);
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.service = self.service.protocol_versions(versions)?;
+        Ok(self)
+    }
+
     /// Apply a tower middleware layer to this transport.
     ///
     /// This converts the `StdioTransport` into a [`GenericStdioTransport`] with
@@ -234,10 +269,12 @@ impl StdioTransport {
         <L::Service as Service<RouterRequest>>::Error: std::fmt::Display + Send,
         <L::Service as Service<RouterRequest>>::Future: Send,
     {
+        let protocol_support = self.service.configured_protocol_support().clone();
         let annotations = self.router.tool_annotations_map();
         let wrapped = layer.layer(self.router);
         let service = InjectAnnotations::new(CatchError::new(wrapped), annotations);
         GenericStdioTransport::with_notifications(service, self.notification_rx)
+            .protocol_support(protocol_support)
     }
 
     /// Run the transport, processing messages until EOF or error
@@ -419,6 +456,25 @@ where
         }
     }
 
+    /// Set the exact protocol versions this transport accepts and advertises.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.service = self.service.protocol_support(support);
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.service = self.service.protocol_versions(versions)?;
+        Ok(self)
+    }
+
     /// Run the transport, processing messages until EOF or error.
     ///
     /// Thin wrapper around [`Self::run_with_streams`] that wires up
@@ -588,6 +644,25 @@ impl SyncStdioTransport {
         Self { service, router }
     }
 
+    /// Set the exact protocol versions this transport accepts and advertises.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.service = self.service.protocol_support(support);
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.service = self.service.protocol_versions(versions)?;
+        Ok(self)
+    }
+
     /// Run the transport synchronously using a tokio runtime
     pub fn run_blocking(&mut self) -> Result<()> {
         let rt = tokio::runtime::Runtime::new()
@@ -656,9 +731,10 @@ struct PendingRequest {
 
 /// Bidirectional stdio transport with sampling support
 ///
-/// This transport supports both incoming requests from clients and outgoing
-/// requests to clients (for sampling/LLM requests). It multiplexes stdin/stdout
-/// to handle the bidirectional communication.
+/// For legacy protocol requests, this transport supports both incoming
+/// requests from clients and outgoing requests to clients (for sampling/LLM
+/// requests). It multiplexes stdin/stdout to handle the bidirectional
+/// communication. Final 2026-07-28 handlers cannot initiate requests.
 ///
 /// Server notifications (progress, logging, resource/tool/prompt list changes)
 /// are automatically forwarded to stdout as JSON-RPC notifications.
@@ -732,12 +808,35 @@ impl BidirectionalStdioTransport {
         }
     }
 
+    /// Set the exact protocol versions this transport accepts and advertises.
+    ///
+    /// Final handlers never receive the legacy client requester, because the
+    /// 2026-07-28 protocol forbids servers from initiating JSON-RPC requests.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.service = self.service.protocol_support(support);
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.service = self.service.protocol_versions(versions)?;
+        Ok(self)
+    }
+
     /// Get the client requester handle
     ///
     /// The requester is already wired into the router's request context by
-    /// [`Self::new`], so handlers can elicit and sample without further setup.
-    /// This getter exposes the same handle for advanced callers that want to
-    /// issue server-to-client requests directly.
+    /// [`Self::new`], so legacy handlers can elicit and sample without further
+    /// setup. Final 2026-07-28 handlers do not receive it. This getter exposes
+    /// the same handle for advanced callers that want to issue
+    /// server-to-client requests directly on legacy connections.
     pub fn client_requester(&self) -> ClientRequesterHandle {
         self.client_requester.clone()
     }

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -27,6 +27,7 @@ use std::path::{Path, PathBuf};
 use crate::error::Error;
 use crate::router::McpRouter;
 use crate::transport::http::{HttpTransport, SessionConfig, SessionHandle};
+use crate::{ProtocolSupport, ProtocolSupportError};
 
 /// A transport that serves the MCP Streamable HTTP protocol over a Unix
 /// domain socket.
@@ -86,6 +87,25 @@ impl UnixSocketTransport {
     pub fn require_sessions(mut self) -> Self {
         self.inner = self.inner.require_sessions();
         self
+    }
+
+    /// Set the exact protocol versions accepted by the delegated HTTP binding.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.inner = self.inner.protocol_support(support);
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.inner = self.inner.protocol_versions(versions)?;
+        Ok(self)
     }
 
     /// Set session configuration (TTL, max sessions, cleanup interval).
@@ -254,5 +274,68 @@ fn cleanup_socket(path: &PathBuf) {
                 e
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn delegates_runtime_protocol_configuration_to_http() {
+        let transport =
+            UnixSocketTransport::new(McpRouter::new().server_info("unix-protocol-test", "0.0.0"))
+                .protocol_support(ProtocolSupport::stable())
+                .protocol_versions(["2025-11-25"])
+                .unwrap();
+
+        // Building the router exercises the delegated HTTP configuration;
+        // UnixSocketTransport only replaces the listener.
+        let _router = transport.into_router();
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn delegated_http_binding_enforces_protocol_selection() {
+        use axum::body::Body;
+        use axum::http::Request;
+        use tower::ServiceExt;
+
+        let app =
+            UnixSocketTransport::new(McpRouter::new().server_info("unix-protocol-test", "0.0.0"))
+                .protocol_support(ProtocolSupport::stable())
+                .disable_origin_validation()
+                .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .header("mcp-protocol-version", "2026-07-28")
+            .header("mcp-method", "server/discover")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "server/discover",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["error"]["code"], -32022);
+        assert_eq!(body["error"]["data"]["requested"], "2026-07-28");
     }
 }

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -96,6 +96,7 @@ use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
     CatchError, InjectAnnotations, McpBoxService, ServiceFactory, identity_factory,
 };
+use crate::{ProtocolSupport, ProtocolSupportError};
 
 /// Session state for WebSocket transport
 struct Session {
@@ -207,6 +208,7 @@ struct AppState {
     router_template: McpRouter,
     service_factory: ServiceFactory,
     sessions: SessionStore,
+    protocol_support: ProtocolSupport,
     /// Whether sampling is enabled
     sampling_enabled: bool,
 }
@@ -214,10 +216,24 @@ struct AppState {
 /// WebSocket transport for MCP servers
 ///
 /// Provides full-duplex communication over WebSocket.
+///
+/// WebSocket is a tower-mcp custom transport binding, not a standard
+/// 2026-07-28 MCP transport. JSON-RPC request bodies remain the source of
+/// truth for final per-request metadata. The optional `mcp.version.*`
+/// subprotocol is an upgrade-time compatibility hint constrained by this
+/// transport's exact [`ProtocolSupport`] allow-list.
+///
+/// Connection and cancellation semantics remain those of this custom binding:
+/// a WebSocket close terminates the connection, and reconnecting a stored
+/// session closes the older socket. It does not currently cancel an in-flight
+/// handler. `notifications/cancelled` is processed between requests, so it
+/// cannot interrupt a handler that is already executing. Final
+/// `subscriptions/listen` multiplexing is not implemented on this binding.
 pub struct WebSocketTransport {
     router: McpRouter,
     sampling_enabled: bool,
     service_factory: ServiceFactory,
+    protocol_support: ProtocolSupport,
     #[cfg(feature = "oauth")]
     oauth_config: Option<crate::oauth::ProtectedResourceMetadata>,
 }
@@ -229,6 +245,7 @@ impl WebSocketTransport {
             router,
             sampling_enabled: false,
             service_factory: identity_factory(),
+            protocol_support: ProtocolSupport::default(),
             #[cfg(feature = "oauth")]
             oauth_config: None,
         }
@@ -241,6 +258,25 @@ impl WebSocketTransport {
     pub fn with_sampling(mut self) -> Self {
         self.sampling_enabled = true;
         self
+    }
+
+    /// Set the exact protocol versions this custom binding accepts.
+    pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
+        self.protocol_support = support;
+        self
+    }
+
+    /// Construct and set an exact runtime protocol-version allow-list.
+    pub fn protocol_versions<I, V>(
+        mut self,
+        versions: I,
+    ) -> std::result::Result<Self, ProtocolSupportError>
+    where
+        I: IntoIterator<Item = V>,
+        V: Into<String>,
+    {
+        self.protocol_support = ProtocolSupport::try_new(versions)?;
+        Ok(self)
     }
 
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
@@ -325,6 +361,7 @@ impl WebSocketTransport {
             router_template: self.router,
             service_factory: self.service_factory,
             sessions: SessionStore::new(),
+            protocol_support: self.protocol_support,
             sampling_enabled: self.sampling_enabled,
         });
 
@@ -347,6 +384,7 @@ impl WebSocketTransport {
             router_template: self.router,
             service_factory: self.service_factory,
             sessions: SessionStore::new(),
+            protocol_support: self.protocol_support,
             sampling_enabled: self.sampling_enabled,
         });
 
@@ -426,9 +464,10 @@ struct McpSubprotocols {
 /// Parse MCP subprotocols from the `Sec-WebSocket-Protocol` header.
 ///
 /// Returns the parsed subprotocols and the negotiated protocol version (if valid).
-fn parse_mcp_subprotocols(headers: &axum::http::HeaderMap) -> McpSubprotocols {
-    use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
-
+fn parse_mcp_subprotocols(
+    headers: &axum::http::HeaderMap,
+    protocol_support: &ProtocolSupport,
+) -> McpSubprotocols {
     let mut result = McpSubprotocols::default();
 
     let Some(header) = headers.get("sec-websocket-protocol") else {
@@ -445,7 +484,7 @@ fn parse_mcp_subprotocols(headers: &axum::http::HeaderMap) -> McpSubprotocols {
                 result.selected.push(protocol.to_string());
             }
         } else if let Some(version) = protocol.strip_prefix("mcp.version.") {
-            if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) {
+            if protocol_support.contains(version) {
                 result.protocol_version = Some(version.to_string());
                 result.selected.push(protocol.to_string());
             } else {
@@ -472,7 +511,7 @@ async fn handle_websocket(
     let (mut parts, _body) = request.into_parts();
 
     // Parse MCP subprotocols (mcp.auth.*, mcp.version.*) from Sec-WebSocket-Protocol
-    let subprotocols = parse_mcp_subprotocols(&parts.headers);
+    let subprotocols = parse_mcp_subprotocols(&parts.headers, &state.protocol_support);
     if let Some(ref version) = subprotocols.protocol_version {
         tracing::debug!(version = %version, "Client requested MCP protocol version via subprotocol");
     }
@@ -530,13 +569,30 @@ async fn handle_socket(
         )
         .await;
     let session_id = session.id.clone();
+    let protocol_support = state.protocol_support.clone();
 
     tracing::info!(session_id = %session_id, "WebSocket connection established");
 
     if state.sampling_enabled {
-        handle_socket_bidirectional(socket, session, &session_id, mcp_extensions, cancel_rx).await;
+        handle_socket_bidirectional(
+            socket,
+            session,
+            &session_id,
+            mcp_extensions,
+            protocol_support,
+            cancel_rx,
+        )
+        .await;
     } else {
-        handle_socket_simple(socket, session, &session_id, mcp_extensions, cancel_rx).await;
+        handle_socket_simple(
+            socket,
+            session,
+            &session_id,
+            mcp_extensions,
+            protocol_support,
+            cancel_rx,
+        )
+        .await;
     }
 
     // Cleanup session
@@ -550,9 +606,12 @@ async fn handle_socket_simple(
     session: Arc<Session>,
     session_id: &str,
     mcp_extensions: crate::router::Extensions,
+    protocol_support: ProtocolSupport,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
-    let mut service = JsonRpcService::new(session.make_service()).with_extensions(mcp_extensions);
+    let mut service = JsonRpcService::new(session.make_service())
+        .with_extensions(mcp_extensions)
+        .protocol_support(protocol_support);
     let (mut sender, mut receiver) = socket.split();
 
     // Process incoming messages, also watching for cancellation (zombie prevention)
@@ -651,6 +710,7 @@ async fn handle_socket_bidirectional(
     session: Arc<Session>,
     session_id: &str,
     _mcp_extensions: crate::router::Extensions,
+    protocol_support: ProtocolSupport,
     mut cancel_rx: watch::Receiver<bool>,
 ) {
     // Create channels for outgoing requests
@@ -666,7 +726,8 @@ async fn handle_socket_bidirectional(
         .clone()
         .with_client_requester(client_requester);
     let mut service = JsonRpcService::new((session.service_factory)(router.clone()))
-        .with_extensions(_mcp_extensions);
+        .with_extensions(_mcp_extensions)
+        .protocol_support(protocol_support);
 
     // Track pending outgoing requests
     let pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>> =
@@ -993,7 +1054,7 @@ mod tests {
     #[test]
     fn test_parse_mcp_subprotocols_empty() {
         let headers = axum::http::HeaderMap::new();
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert!(result.auth_token.is_none());
         assert!(result.protocol_version.is_none());
         assert!(result.selected.is_empty());
@@ -1008,7 +1069,7 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert_eq!(result.auth_token.as_deref(), Some("my-secret-token"));
         assert_eq!(result.protocol_version.as_deref(), Some("2025-11-25"));
         assert_eq!(result.selected.len(), 2);
@@ -1021,7 +1082,7 @@ mod tests {
             "sec-websocket-protocol",
             "mcp.version.1999-01-01".parse().unwrap(),
         );
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert!(result.protocol_version.is_none());
         assert!(result.selected.is_empty());
     }
@@ -1033,7 +1094,7 @@ mod tests {
             "sec-websocket-protocol",
             "mcp.version.2025-03-26".parse().unwrap(),
         );
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert_eq!(result.protocol_version.as_deref(), Some("2025-03-26"));
         assert_eq!(result.selected.len(), 1);
     }
@@ -1045,7 +1106,7 @@ mod tests {
             "sec-websocket-protocol",
             "mcp.auth.bearer-xyz123".parse().unwrap(),
         );
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert_eq!(result.auth_token.as_deref(), Some("bearer-xyz123"));
         assert!(result.protocol_version.is_none());
     }
@@ -1059,11 +1120,65 @@ mod tests {
                 .parse()
                 .unwrap(),
         );
-        let result = parse_mcp_subprotocols(&headers);
+        let result = parse_mcp_subprotocols(&headers, &ProtocolSupport::default());
         assert_eq!(result.auth_token.as_deref(), Some("token"));
         assert_eq!(result.protocol_version.as_deref(), Some("2025-11-25"));
         // Only MCP subprotocols are selected
         assert_eq!(result.selected.len(), 2);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[test]
+    fn websocket_subprotocol_uses_exact_runtime_allow_list() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "sec-websocket-protocol",
+            "mcp.version.2026-07-28, mcp.version.2025-11-25"
+                .parse()
+                .unwrap(),
+        );
+
+        let stable = parse_mcp_subprotocols(&headers, &ProtocolSupport::stable());
+        assert_eq!(stable.protocol_version.as_deref(), Some("2025-11-25"));
+        assert_eq!(stable.selected, vec!["mcp.version.2025-11-25"]);
+
+        let final_only = ProtocolSupport::try_new(["2026-07-28"]).unwrap();
+        let final_selected = parse_mcp_subprotocols(&headers, &final_only);
+        assert_eq!(
+            final_selected.protocol_version.as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(final_selected.selected, vec!["mcp.version.2026-07-28"]);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn websocket_request_body_selects_final_lifecycle() {
+        let router = create_test_router();
+        let service = identity_factory()(router.clone());
+        let mut service = JsonRpcService::new(service)
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap());
+        let request = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
+        });
+
+        let response = process_message(&mut service, &router, &request.to_string())
+            .await
+            .unwrap()
+            .expect("request response");
+        let response = serde_json::to_value(response).unwrap();
+        assert_eq!(response["result"]["resultType"], "complete");
+        assert_eq!(response["result"]["ttlMs"], 0);
+        assert_eq!(response["result"]["cacheScope"], "private");
+        assert_eq!(response["result"]["supportedVersions"][0], "2026-07-28");
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -6,10 +6,12 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::collections::HashMap;
+#[cfg(feature = "oauth")]
+use tower_mcp::Extensions;
 use tower_mcp::{
-    CallToolResult, Extensions, GetPromptResult, JsonRpcRequest, JsonRpcResponse, JsonRpcService,
-    McpRouter, PromptBuilder, PromptMessage, PromptRole, ReadResourceResult, ResourceBuilder,
-    ResourceContent, TaskSupportMode, ToolBuilder,
+    CallToolResult, GetPromptResult, JsonRpcRequest, JsonRpcResponse, JsonRpcService, McpRouter,
+    PromptBuilder, PromptMessage, PromptRole, ReadResourceResult, ResourceBuilder, ResourceContent,
+    TaskSupportMode, ToolBuilder,
 };
 
 // =============================================================================

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -14,6 +14,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::time::{Duration, timeout};
+#[cfg(feature = "stateless")]
+use tower_mcp::ProtocolSupport;
+#[cfg(feature = "stateless")]
+use tower_mcp::extract::RawArgs;
 use tower_mcp::extract::{Context, Json};
 use tower_mcp::protocol::{ElicitAction, ElicitFormParams, ElicitFormSchema};
 use tower_mcp::transport::stdio::BidirectionalStdioTransport;
@@ -183,6 +187,223 @@ async fn stdio_transport_eof_returns_ok() {
         result.is_ok(),
         "run_with_streams must return Ok on EOF, got: {result:?}"
     );
+}
+
+#[cfg(feature = "stateless")]
+fn modern_router() -> McpRouter {
+    let inspect = ToolBuilder::new("inspect_meta")
+        .description("Report final request metadata visible to the handler")
+        .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
+            let version = ctx
+                .per_request_meta()
+                .and_then(|meta| meta.protocol_version.as_deref())
+                .unwrap_or("absent");
+            Ok(CallToolResult::text(format!(
+                "{version}|can_elicit={}",
+                ctx.can_elicit()
+            )))
+        })
+        .build();
+    McpRouter::new()
+        .server_info("stdio-modern-test", "0.0.0")
+        .tool(inspect)
+}
+
+#[cfg(feature = "stateless")]
+fn final_meta(version: &str) -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": version,
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "stdio-loop-client",
+            "version": "1.0.0"
+        },
+        "io.modelcontextprotocol/clientCapabilities": {}
+    })
+}
+
+/// The final stdio lifecycle is selected independently on every request.
+/// A modern discovery probe and ordinary calls work before initialize, then
+/// legacy initialize traffic can continue on the same byte stream.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_supports_final_and_legacy_lifecycles_on_one_stream() {
+    let mut transport = StdioTransport::new(modern_router());
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(32 * 1024);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(32 * 1024);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let final_version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+    let requests = vec![
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+            "params": {"_meta": final_meta(final_version)}
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/list",
+            "params": {"_meta": final_meta(final_version)}
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+            "params": {
+                "name": "inspect_meta",
+                "arguments": {},
+                "_meta": final_meta(final_version)
+            }
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 4, "method": "ping",
+            "params": {"_meta": final_meta(final_version)}
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 5, "method": "server/discover",
+            "params": {"_meta": final_meta("2099-01-01")}
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 6, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "legacy-client", "version": "1.0.0"}
+            }
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "method": "notifications/initialized"
+        }),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/list", "params": {}
+        }),
+    ];
+    let mut stdin_writer = server_stdin_writer;
+    for request in requests {
+        stdin_writer
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .unwrap();
+    }
+    stdin_writer.flush().await.unwrap();
+    drop(stdin_writer);
+
+    let frames = read_n_frames(BufReader::new(server_stdout_reader), 7).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(frames.len(), 7, "unexpected frames: {frames:#?}");
+
+    assert_eq!(frames[0]["result"]["resultType"], "complete");
+    assert_eq!(frames[0]["result"]["ttlMs"], 0);
+    assert_eq!(frames[0]["result"]["cacheScope"], "private");
+    assert_eq!(frames[1]["result"]["resultType"], "complete");
+    assert_eq!(frames[1]["result"]["ttlMs"], 0);
+    assert_eq!(
+        frames[2]["result"]["content"][0]["text"],
+        format!("{final_version}|can_elicit=false")
+    );
+    assert_eq!(frames[2]["result"]["resultType"], "complete");
+    assert!(frames[2]["result"].get("ttlMs").is_none());
+    assert_eq!(frames[3]["error"]["code"], -32601);
+    assert_eq!(frames[4]["error"]["code"], -32022);
+    assert_eq!(frames[4]["error"]["data"]["requested"], "2099-01-01");
+
+    // Legacy responses retain their established wire shape.
+    assert!(frames[5]["result"].get("resultType").is_none());
+    assert!(frames[6]["result"].get("resultType").is_none());
+    assert_eq!(frames[6]["result"]["tools"].as_array().unwrap().len(), 1);
+}
+
+/// Runtime support can be narrowed even when the final implementation is
+/// present in the binary.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_runtime_protocol_allow_list_is_exact() {
+    let mut transport =
+        StdioTransport::new(modern_router()).protocol_support(ProtocolSupport::stable());
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+        "params": {
+            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        }
+    });
+    let mut stdin_writer = server_stdin_writer;
+    stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(stdin_writer);
+
+    let frames = read_n_frames(BufReader::new(server_stdout_reader), 1).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(frames[0]["error"]["code"], -32022);
+    assert_eq!(
+        frames[0]["error"]["data"]["requested"],
+        tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+    );
+    assert!(
+        frames[0]["error"]["data"]["supported"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|version| version != tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn bidi_final_handlers_cannot_initiate_client_requests() {
+    let mut transport = BidirectionalStdioTransport::new(modern_router());
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {
+            "name": "inspect_meta",
+            "arguments": {},
+            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        }
+    });
+    let mut stdin_writer = server_stdin_writer;
+    stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+
+    let mut reader = BufReader::new(server_stdout_reader);
+    let frame = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("final tool response");
+    assert_eq!(
+        frame["result"]["content"][0]["text"],
+        "2026-07-28|can_elicit=false"
+    );
+    assert_eq!(frame["result"]["resultType"], "complete");
+
+    drop(stdin_writer);
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- make `JsonRpcService` own an exact runtime `ProtocolSupport` policy and enforce final per-request `_meta` on every JSON-RPC binding
- allow final stdio discovery/tool traffic before initialize while preserving legacy initialize traffic on the same stream
- stamp final result/cache envelopes outside HTTP and isolate metadata across concurrent batch requests
- reject final-removed methods and unsupported versions consistently, and never expose legacy client-request capabilities to final handlers
- add runtime protocol configuration to all stdio variants, WebSocket, and Unix-over-HTTP
- make WebSocket `mcp.version.*` negotiation use the runtime allow-list while keeping request-body `_meta` authoritative
- document the custom WebSocket cancellation/termination limitations and the Unix transport's delegated HTTP lifecycle
- prevent legacy `initialize` negotiation from ever selecting the final version (including final-only runtime policies)

This is the transport-neutral lifecycle slice of #952. It deliberately does **not** claim final `subscriptions/listen` multiplexing/cancellation on stdio, a graceful listen result, or 2025-era associated-request routing; those remain tracked in #952.

## Tests

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo check -p tower-mcp --no-default-features --all-targets`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- official stable server conformance: 39/39
- official final server conformance: 114/114
- official stable client conformance: 295/295
- official final client conformance: 382/382

Refs #952
Refs #929