### PR TITLE
feat(stdio): support final subscriptions

### DIFF
--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -131,6 +131,27 @@ impl<S> JsonRpcService<S> {
         &self.protocol_support
     }
 
+    /// Validate the lifecycle metadata on a request without dispatching it.
+    ///
+    /// Long-lived transport-owned requests such as `subscriptions/listen`
+    /// need to be accepted by the binding before they reach the ordinary
+    /// request/response router. Keeping this validation here ensures those
+    /// transport paths honor the same runtime protocol allow-list and modern
+    /// metadata rules as [`Self::call_single`].
+    #[cfg(feature = "stateless")]
+    pub(crate) fn validate_request_protocol(
+        &self,
+        req: &JsonRpcRequest,
+    ) -> std::result::Result<Option<String>, JsonRpcError> {
+        req.validate()?;
+        let mut extensions = self.extensions.clone();
+        let protocol_support = extensions
+            .get::<ProtocolSupport>()
+            .cloned()
+            .unwrap_or_else(|| self.protocol_support.clone());
+        prepare_modern_request(req, &mut extensions, &protocol_support)
+    }
+
     /// Process a single JSON-RPC request
     pub async fn call_single(&mut self, req: JsonRpcRequest) -> Result<JsonRpcResponse>
     where

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -277,6 +277,10 @@ use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
     CatchError, InjectAnnotations, McpBoxService, ServiceFactory, identity_factory,
 };
+#[cfg(feature = "stateless")]
+use crate::transport::subscriptions::{
+    accepted_subscription_filter, subscription_matches, tagged_subscription_notification,
+};
 use crate::{ProtocolSupport, ProtocolSupportError};
 use tower::util::BoxCloneService;
 
@@ -1400,43 +1404,6 @@ impl Drop for ModernSubscriptionGuard {
             .unwrap()
             .remove(&self.key);
     }
-}
-
-#[cfg(feature = "stateless")]
-fn subscription_matches(notification: &ServerNotification, filter: &SubscriptionFilter) -> bool {
-    match notification {
-        ServerNotification::ToolsListChanged => filter.tools_list_changed == Some(true),
-        ServerNotification::PromptsListChanged => filter.prompts_list_changed == Some(true),
-        ServerNotification::ResourcesListChanged => filter.resources_list_changed == Some(true),
-        ServerNotification::ResourceUpdated { uri } => filter
-            .resource_subscriptions
-            .as_ref()
-            .is_some_and(|subscriptions| subscriptions.iter().any(|item| item == uri)),
-        _ => false,
-    }
-}
-
-#[cfg(feature = "stateless")]
-fn tagged_subscription_notification(
-    notification: &ServerNotification,
-    subscription_id: &RequestId,
-) -> Option<String> {
-    let json = crate::transport::stdio::serialize_notification(notification)?;
-    let mut value: serde_json::Value = serde_json::from_str(&json).ok()?;
-    let object = value.as_object_mut()?;
-    let params = object
-        .entry("params")
-        .or_insert_with(|| serde_json::json!({}))
-        .as_object_mut()?;
-    let meta = params
-        .entry("_meta")
-        .or_insert_with(|| serde_json::json!({}))
-        .as_object_mut()?;
-    meta.insert(
-        "io.modelcontextprotocol/subscriptionId".to_string(),
-        serde_json::to_value(subscription_id).ok()?,
-    );
-    serde_json::to_string(&value).ok()
 }
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
@@ -3712,16 +3679,6 @@ fn stateless_sse_with_notifications(
                 .text("ping"),
         )
         .into_response()
-}
-
-#[cfg(feature = "stateless")]
-fn accepted_subscription_filter(requested: SubscriptionFilter) -> SubscriptionFilter {
-    SubscriptionFilter {
-        tools_list_changed: requested.tools_list_changed.filter(|enabled| *enabled),
-        prompts_list_changed: requested.prompts_list_changed.filter(|enabled| *enabled),
-        resources_list_changed: requested.resources_list_changed.filter(|enabled| *enabled),
-        resource_subscriptions: requested.resource_subscriptions,
-    }
 }
 
 /// Serve the final, sessionless `subscriptions/listen` protocol over its

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -8,6 +8,9 @@
 
 pub mod stdio;
 
+#[cfg(feature = "stateless")]
+mod subscriptions;
+
 #[cfg(feature = "http")]
 pub mod http;
 
@@ -27,7 +30,8 @@ pub mod service;
 
 pub use service::{CatchError, InjectAnnotations};
 pub use stdio::{
-    BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, SyncStdioTransport,
+    BidirectionalStdioTransport, GenericStdioTransport, StdioTransport, StdioTransportHandle,
+    SyncStdioTransport,
 };
 
 #[cfg(feature = "http")]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -24,13 +24,17 @@
 //! [`StdioTransport`] and [`BidirectionalStdioTransport`] automatically set up
 //! notification channels and forward server notifications (progress, logging,
 //! resource/tool/prompt list changes) to stdout as JSON-RPC notifications.
+//! Once a final `subscriptions/listen` request is accepted, list and resource
+//! change notifications use final subscription filtering and ID tagging for
+//! the rest of that stream; they are not also broadcast in the legacy
+//! untagged form.
 
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
 use std::sync::Arc;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
 use crate::context::{
     ChannelClientRequester, ClientRequesterHandle, NotificationReceiver, OutgoingRequest,
@@ -44,13 +48,226 @@ use crate::protocol::{
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage,
     McpNotification, RequestId, notifications,
 };
+#[cfg(feature = "stateless")]
+use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{CatchError, InjectAnnotations};
+#[cfg(feature = "stateless")]
+use crate::transport::subscriptions::{
+    accepted_subscription_filter, subscription_acknowledgment, subscription_complete_response,
+    subscription_matches, tagged_subscription_notification,
+};
 use crate::{ProtocolSupport, ProtocolSupportError};
 
 // ============================================================================
 // Shared helpers
 // ============================================================================
+
+enum StdioControl {
+    #[cfg(feature = "stateless")]
+    CloseSubscription(RequestId),
+    Shutdown,
+}
+
+/// Cloneable control handle for an asynchronous stdio server.
+///
+/// The handle can gracefully finish one final-protocol subscription without
+/// closing the shared stdio channel, or gracefully finish every active
+/// subscription and stop the transport.
+#[derive(Clone)]
+pub struct StdioTransportHandle {
+    control_tx: mpsc::UnboundedSender<StdioControl>,
+}
+
+impl StdioTransportHandle {
+    /// Gracefully finish one active `subscriptions/listen` request.
+    ///
+    /// The transport writes a `SubscriptionsListenResult` for `request_id`.
+    /// Unknown or already-finished IDs are harmless.
+    #[cfg(feature = "stateless")]
+    pub fn close_subscription(&self, request_id: RequestId) -> Result<()> {
+        self.control_tx
+            .send(StdioControl::CloseSubscription(request_id))
+            .map_err(|_| Error::Transport("stdio transport is not running".to_string()))
+    }
+
+    /// Gracefully finish all subscriptions and stop the stdio transport.
+    pub fn shutdown(&self) -> Result<()> {
+        self.control_tx
+            .send(StdioControl::Shutdown)
+            .map_err(|_| Error::Transport("stdio transport is not running".to_string()))
+    }
+}
+
+fn stdio_control_channel() -> (
+    mpsc::UnboundedSender<StdioControl>,
+    mpsc::UnboundedReceiver<StdioControl>,
+) {
+    mpsc::unbounded_channel()
+}
+
+#[cfg(feature = "stateless")]
+#[derive(Default)]
+struct StdioSubscriptions {
+    active: HashMap<RequestId, SubscriptionFilter>,
+    modern_mode: bool,
+}
+
+#[cfg(feature = "stateless")]
+enum StdioSubscriptionInput {
+    NotHandled,
+    Handled(Vec<String>),
+}
+
+#[cfg(feature = "stateless")]
+impl StdioSubscriptions {
+    fn handle_input<S>(
+        &mut self,
+        service: &JsonRpcService<S>,
+        parsed: &serde_json::Value,
+    ) -> Result<StdioSubscriptionInput> {
+        let method = parsed.get("method").and_then(serde_json::Value::as_str);
+
+        if method == Some(notifications::CANCELLED) && parsed.get("id").is_none() {
+            let notification: JsonRpcNotification = match serde_json::from_value(parsed.clone()) {
+                Ok(notification) => notification,
+                Err(_) => return Ok(StdioSubscriptionInput::NotHandled),
+            };
+            let Ok(McpNotification::Cancelled(params)) =
+                McpNotification::from_jsonrpc(&notification)
+            else {
+                return Ok(StdioSubscriptionInput::NotHandled);
+            };
+            if let Some(request_id) = params.request_id
+                && self.active.remove(&request_id).is_some()
+            {
+                tracing::debug!(?request_id, "Cancelled stdio subscription");
+                return Ok(StdioSubscriptionInput::Handled(Vec::new()));
+            }
+            return Ok(StdioSubscriptionInput::NotHandled);
+        }
+
+        if method != Some("subscriptions/listen") || parsed.get("id").is_none() {
+            return Ok(StdioSubscriptionInput::NotHandled);
+        }
+
+        let claims_modern = parsed
+            .pointer("/params/_meta/io.modelcontextprotocol~1protocolVersion")
+            .is_some();
+        if !claims_modern {
+            return Ok(StdioSubscriptionInput::NotHandled);
+        }
+
+        let request: JsonRpcRequest = match serde_json::from_value(parsed.clone()) {
+            Ok(request) => request,
+            Err(error) => {
+                let response = parse_error_response(error.to_string());
+                return Ok(StdioSubscriptionInput::Handled(vec![
+                    serde_json::to_string(&response)?,
+                ]));
+            }
+        };
+        let request_id = request.id.clone();
+        if let Err(error) = service.validate_request_protocol(&request) {
+            let response = JsonRpcResponse::error(Some(request_id), error);
+            return Ok(StdioSubscriptionInput::Handled(vec![
+                serde_json::to_string(&response)?,
+            ]));
+        }
+
+        let params = request
+            .params
+            .clone()
+            .ok_or_else(|| {
+                crate::error::JsonRpcError::invalid_params("subscriptions/listen requires params")
+            })
+            .and_then(|value| {
+                serde_json::from_value::<SubscriptionsListenParams>(value)
+                    .map_err(|error| crate::error::JsonRpcError::invalid_params(error.to_string()))
+            });
+        let params = match params {
+            Ok(params) => params,
+            Err(error) => {
+                let response = JsonRpcResponse::error(Some(request_id), error);
+                return Ok(StdioSubscriptionInput::Handled(vec![
+                    serde_json::to_string(&response)?,
+                ]));
+            }
+        };
+        let Some(requested) = params.notifications else {
+            let response = JsonRpcResponse::error(
+                Some(request_id),
+                crate::error::JsonRpcError::invalid_params(
+                    "subscriptions/listen requires a notifications filter",
+                ),
+            );
+            return Ok(StdioSubscriptionInput::Handled(vec![
+                serde_json::to_string(&response)?,
+            ]));
+        };
+        if self.active.contains_key(&request_id) {
+            let response = JsonRpcResponse::error(
+                Some(request_id),
+                crate::error::JsonRpcError::invalid_request(
+                    "subscription request id is already active",
+                ),
+            );
+            return Ok(StdioSubscriptionInput::Handled(vec![
+                serde_json::to_string(&response)?,
+            ]));
+        }
+
+        let accepted = accepted_subscription_filter(requested);
+        let acknowledgment = subscription_acknowledgment(request_id.clone(), accepted.clone());
+        let acknowledgment = serde_json::to_string(&acknowledgment)?;
+        self.modern_mode = true;
+        self.active.insert(request_id, accepted);
+        Ok(StdioSubscriptionInput::Handled(vec![acknowledgment]))
+    }
+
+    /// Route a subscription-scoped notification and suppress its untagged
+    /// form whenever at least one final subscription is active.
+    fn route_notification(&self, notification: &ServerNotification) -> Option<Vec<String>> {
+        if !self.modern_mode
+            || !matches!(
+                notification,
+                ServerNotification::ResourceUpdated { .. }
+                    | ServerNotification::ResourcesListChanged
+                    | ServerNotification::ToolsListChanged
+                    | ServerNotification::PromptsListChanged
+            )
+        {
+            return None;
+        }
+
+        Some(
+            self.active
+                .iter()
+                .filter(|(_, filter)| subscription_matches(notification, filter))
+                .filter_map(|(id, _)| tagged_subscription_notification(notification, id))
+                .collect(),
+        )
+    }
+
+    fn close(&mut self, request_id: &RequestId) -> Result<Option<String>> {
+        if self.active.remove(request_id).is_none() {
+            return Ok(None);
+        }
+        Ok(Some(serde_json::to_string(
+            &subscription_complete_response(request_id.clone()),
+        )?))
+    }
+
+    fn close_all(&mut self) -> Result<Vec<String>> {
+        let ids: Vec<_> = self.active.keys().cloned().collect();
+        ids.into_iter()
+            .map(|id| {
+                self.close(&id)?
+                    .ok_or_else(|| Error::Internal("active subscription disappeared".to_string()))
+            })
+            .collect()
+    }
+}
 
 /// Strip an optional UTF-8 BOM, then trim whitespace.
 ///
@@ -191,18 +408,31 @@ pub struct StdioTransport {
     service: JsonRpcService<McpRouter>,
     router: McpRouter,
     notification_rx: NotificationReceiver,
+    control_tx: mpsc::UnboundedSender<StdioControl>,
+    control_rx: mpsc::UnboundedReceiver<StdioControl>,
 }
 
 impl StdioTransport {
     /// Create a new stdio transport wrapping an MCP router
     pub fn new(router: McpRouter) -> Self {
         let (notif_tx, notification_rx) = notification_channel(256);
+        let (control_tx, control_rx) = stdio_control_channel();
         let router = router.with_notification_sender(notif_tx);
         let service = JsonRpcService::new(router.clone());
         Self {
             service,
             router,
             notification_rx,
+            control_tx,
+            control_rx,
+        }
+    }
+
+    /// Return a cloneable handle for graceful subscription closure or server
+    /// shutdown while [`Self::run`] is active.
+    pub fn handle(&self) -> StdioTransportHandle {
+        StdioTransportHandle {
+            control_tx: self.control_tx.clone(),
         }
     }
 
@@ -273,8 +503,12 @@ impl StdioTransport {
         let annotations = self.router.tool_annotations_map();
         let wrapped = layer.layer(self.router);
         let service = InjectAnnotations::new(CatchError::new(wrapped), annotations);
-        GenericStdioTransport::with_notifications(service, self.notification_rx)
-            .protocol_support(protocol_support)
+        GenericStdioTransport {
+            service: JsonRpcService::new(service).protocol_support(protocol_support),
+            notification_rx: Some(self.notification_rx),
+            control_tx: self.control_tx,
+            control_rx: self.control_rx,
+        }
     }
 
     /// Run the transport, processing messages until EOF or error
@@ -301,6 +535,8 @@ impl StdioTransport {
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
         let mut reader = BufReader::new(reader);
+        #[cfg(feature = "stateless")]
+        let mut subscriptions = StdioSubscriptions::default();
 
         tracing::info!("Stdio transport started, waiting for input");
 
@@ -327,6 +563,22 @@ impl StdioTransport {
 
                     tracing::debug!(input = %trimmed, "Received message");
 
+                    #[cfg(feature = "stateless")]
+                    {
+                        let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
+                            Ok(parsed) => parsed,
+                            Err(_) => serde_json::Value::Null,
+                        };
+                        if let StdioSubscriptionInput::Handled(frames) =
+                            subscriptions.handle_input(&self.service, &parsed)?
+                        {
+                            for frame in frames {
+                                write_line_to_stdout(&mut writer, &frame).await?;
+                            }
+                            continue;
+                        }
+                    }
+
                     match process_line(&mut self.service, &self.router, trimmed).await {
                         Ok(Some(response)) => {
                             let response_json = serde_json::to_string(&response).map_err(|e| {
@@ -351,9 +603,35 @@ impl StdioTransport {
 
                 // Forward server notifications to stdout
                 Some(notification) = self.notification_rx.recv() => {
+                    #[cfg(feature = "stateless")]
+                    if let Some(frames) = subscriptions.route_notification(&notification) {
+                        for json in frames {
+                            tracing::debug!(output = %json, "Sending subscription notification");
+                            write_line_to_stdout(&mut writer, &json).await?;
+                        }
+                        continue;
+                    }
                     if let Some(json) = serialize_notification(&notification) {
                         tracing::debug!(output = %json, "Sending notification");
                         write_line_to_stdout(&mut writer, &json).await?;
+                    }
+                }
+
+                Some(control) = self.control_rx.recv() => {
+                    match control {
+                        #[cfg(feature = "stateless")]
+                        StdioControl::CloseSubscription(request_id) => {
+                            if let Some(json) = subscriptions.close(&request_id)? {
+                                write_line_to_stdout(&mut writer, &json).await?;
+                            }
+                        }
+                        StdioControl::Shutdown => {
+                            #[cfg(feature = "stateless")]
+                            for json in subscriptions.close_all()? {
+                                write_line_to_stdout(&mut writer, &json).await?;
+                            }
+                            break;
+                        }
                     }
                 }
             }
@@ -417,6 +695,8 @@ where
 {
     service: JsonRpcService<S>,
     notification_rx: Option<NotificationReceiver>,
+    control_tx: mpsc::UnboundedSender<StdioControl>,
+    control_rx: mpsc::UnboundedReceiver<StdioControl>,
 }
 
 impl<S> GenericStdioTransport<S>
@@ -436,9 +716,12 @@ where
     /// notifications (progress, logging, list changes) will not reach the client.
     /// Use [`GenericStdioTransport::with_notifications`] instead to enable them.
     pub fn new(service: S) -> Self {
+        let (control_tx, control_rx) = stdio_control_channel();
         Self {
             service: JsonRpcService::new(service),
             notification_rx: None,
+            control_tx,
+            control_rx,
         }
     }
 
@@ -450,9 +733,20 @@ where
     ///
     /// [`notification_channel()`]: crate::context::notification_channel
     pub fn with_notifications(service: S, notification_rx: NotificationReceiver) -> Self {
+        let (control_tx, control_rx) = stdio_control_channel();
         Self {
             service: JsonRpcService::new(service),
             notification_rx: Some(notification_rx),
+            control_tx,
+            control_rx,
+        }
+    }
+
+    /// Return a cloneable handle for graceful subscription closure or server
+    /// shutdown while [`Self::run`] is active.
+    pub fn handle(&self) -> StdioTransportHandle {
+        StdioTransportHandle {
+            control_tx: self.control_tx.clone(),
         }
     }
 
@@ -494,6 +788,8 @@ where
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
         let mut reader = BufReader::new(reader);
+        #[cfg(feature = "stateless")]
+        let mut subscriptions = StdioSubscriptions::default();
 
         tracing::info!("Generic stdio transport started, waiting for input");
 
@@ -513,28 +809,72 @@ where
                             break;
                         }
 
-                        Self::process_input(&mut self.service, &line, &mut writer).await?;
+                        Self::process_input(
+                            &mut self.service,
+                            &line,
+                            &mut writer,
+                            true,
+                            #[cfg(feature = "stateless")]
+                            &mut subscriptions,
+                        ).await?;
                     }
 
                     Some(notification) = notif_rx.recv() => {
+                        #[cfg(feature = "stateless")]
+                        if let Some(frames) = subscriptions.route_notification(&notification) {
+                            for json in frames {
+                                tracing::debug!(output = %json, "Sending subscription notification");
+                                write_line_to_stdout(&mut writer, &json).await?;
+                            }
+                            continue;
+                        }
                         if let Some(json) = serialize_notification(&notification) {
                             tracing::debug!(output = %json, "Sending notification");
                             write_line_to_stdout(&mut writer, &json).await?;
                         }
                     }
+
+                    Some(control) = self.control_rx.recv() => {
+                        if Self::handle_control(
+                            control,
+                            &mut writer,
+                            #[cfg(feature = "stateless")]
+                            &mut subscriptions,
+                        ).await? {
+                            break;
+                        }
+                    }
                 }
             } else {
-                let bytes_read = reader
-                    .read_line(&mut line)
-                    .await
-                    .map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
-
-                if bytes_read == 0 {
-                    tracing::info!("Stdin closed, shutting down");
-                    break;
+                tokio::select! {
+                    result = reader.read_line(&mut line) => {
+                        let bytes_read = result.map_err(|e| {
+                            Error::Transport(format!("Failed to read from stdin: {}", e))
+                        })?;
+                        if bytes_read == 0 {
+                            tracing::info!("Stdin closed, shutting down");
+                            break;
+                        }
+                        Self::process_input(
+                            &mut self.service,
+                            &line,
+                            &mut writer,
+                            false,
+                            #[cfg(feature = "stateless")]
+                            &mut subscriptions,
+                        ).await?;
+                    }
+                    Some(control) = self.control_rx.recv() => {
+                        if Self::handle_control(
+                            control,
+                            &mut writer,
+                            #[cfg(feature = "stateless")]
+                            &mut subscriptions,
+                        ).await? {
+                            break;
+                        }
+                    }
                 }
-
-                Self::process_input(&mut self.service, &line, &mut writer).await?;
             }
         }
 
@@ -545,6 +885,8 @@ where
         service: &mut JsonRpcService<S>,
         line: &str,
         writer: &mut W,
+        subscriptions_enabled: bool,
+        #[cfg(feature = "stateless")] subscriptions: &mut StdioSubscriptions,
     ) -> Result<()>
     where
         W: tokio::io::AsyncWrite + Unpin + Send,
@@ -564,6 +906,19 @@ where
                 return Ok(());
             }
         };
+
+        #[cfg(feature = "stateless")]
+        if subscriptions_enabled
+            && let StdioSubscriptionInput::Handled(frames) =
+                subscriptions.handle_input(service, &parsed)?
+        {
+            for frame in frames {
+                write_line_to_stdout(writer, &frame).await?;
+            }
+            return Ok(());
+        }
+        #[cfg(not(feature = "stateless"))]
+        let _ = subscriptions_enabled;
 
         if parsed.get("id").is_none() {
             // Notification - log and ignore since we don't have router access
@@ -597,6 +952,34 @@ where
             }
         }
         Ok(())
+    }
+
+    async fn handle_control<W>(
+        control: StdioControl,
+        writer: &mut W,
+        #[cfg(feature = "stateless")] subscriptions: &mut StdioSubscriptions,
+    ) -> Result<bool>
+    where
+        W: tokio::io::AsyncWrite + Unpin + Send,
+    {
+        #[cfg(not(feature = "stateless"))]
+        let _ = &mut *writer;
+        match control {
+            #[cfg(feature = "stateless")]
+            StdioControl::CloseSubscription(request_id) => {
+                if let Some(json) = subscriptions.close(&request_id)? {
+                    write_line_to_stdout(writer, &json).await?;
+                }
+                Ok(false)
+            }
+            StdioControl::Shutdown => {
+                #[cfg(feature = "stateless")]
+                for json in subscriptions.close_all()? {
+                    write_line_to_stdout(writer, &json).await?;
+                }
+                Ok(true)
+            }
+        }
     }
 
     async fn write_error<W>(
@@ -782,6 +1165,8 @@ pub struct BidirectionalStdioTransport {
     pending_requests: Arc<Mutex<HashMap<RequestId, PendingRequest>>>,
     /// Channel for receiving server notifications to forward to the client
     notification_rx: NotificationReceiver,
+    control_tx: mpsc::UnboundedSender<StdioControl>,
+    control_rx: mpsc::UnboundedReceiver<StdioControl>,
 }
 
 impl BidirectionalStdioTransport {
@@ -792,6 +1177,7 @@ impl BidirectionalStdioTransport {
             Arc::new(ChannelClientRequester::new(request_tx));
 
         let (notif_tx, notification_rx) = notification_channel(256);
+        let (control_tx, control_rx) = stdio_control_channel();
         let router = router
             .with_notification_sender(notif_tx)
             .with_client_requester(client_requester.clone());
@@ -805,6 +1191,16 @@ impl BidirectionalStdioTransport {
             client_requester,
             pending_requests: Arc::new(Mutex::new(HashMap::new())),
             notification_rx,
+            control_tx,
+            control_rx,
+        }
+    }
+
+    /// Return a cloneable handle for graceful subscription closure or server
+    /// shutdown while [`Self::run`] is active.
+    pub fn handle(&self) -> StdioTransportHandle {
+        StdioTransportHandle {
+            control_tx: self.control_tx.clone(),
         }
     }
 
@@ -864,6 +1260,8 @@ impl BidirectionalStdioTransport {
     {
         let writer = Arc::new(Mutex::new(writer));
         let mut reader = BufReader::new(reader);
+        #[cfg(feature = "stateless")]
+        let mut subscriptions = StdioSubscriptions::default();
 
         tracing::info!("Bidirectional stdio transport started, waiting for input");
 
@@ -887,7 +1285,12 @@ impl BidirectionalStdioTransport {
                         continue;
                     }
 
-                    self.handle_incoming_message(trimmed, writer.clone()).await?;
+                    self.handle_incoming_message(
+                        trimmed,
+                        writer.clone(),
+                        #[cfg(feature = "stateless")]
+                        &mut subscriptions,
+                    ).await?;
                 }
 
                 // Handle outgoing requests to send to the client
@@ -897,9 +1300,35 @@ impl BidirectionalStdioTransport {
 
                 // Forward server notifications to the client
                 Some(notification) = self.notification_rx.recv() => {
+                    #[cfg(feature = "stateless")]
+                    if let Some(frames) = subscriptions.route_notification(&notification) {
+                        for json in frames {
+                            tracing::debug!(output = %json, "Sending subscription notification");
+                            self.write_line(&json, writer.clone()).await?;
+                        }
+                        continue;
+                    }
                     if let Some(json) = serialize_notification(&notification) {
                         tracing::debug!(output = %json, "Sending notification");
                         self.write_line(&json, writer.clone()).await?;
+                    }
+                }
+
+                Some(control) = self.control_rx.recv() => {
+                    match control {
+                        #[cfg(feature = "stateless")]
+                        StdioControl::CloseSubscription(request_id) => {
+                            if let Some(json) = subscriptions.close(&request_id)? {
+                                self.write_line(&json, writer.clone()).await?;
+                            }
+                        }
+                        StdioControl::Shutdown => {
+                            #[cfg(feature = "stateless")]
+                            for json in subscriptions.close_all()? {
+                                self.write_line(&json, writer.clone()).await?;
+                            }
+                            break;
+                        }
                     }
                 }
             }
@@ -909,7 +1338,12 @@ impl BidirectionalStdioTransport {
     }
 
     /// Handle an incoming message from stdin
-    async fn handle_incoming_message<W>(&mut self, line: &str, writer: Arc<Mutex<W>>) -> Result<()>
+    async fn handle_incoming_message<W>(
+        &mut self,
+        line: &str,
+        writer: Arc<Mutex<W>>,
+        #[cfg(feature = "stateless")] subscriptions: &mut StdioSubscriptions,
+    ) -> Result<()>
     where
         W: tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
@@ -931,6 +1365,16 @@ impl BidirectionalStdioTransport {
             && (parsed.get("result").is_some() || parsed.get("error").is_some())
         {
             return self.handle_response(&parsed).await;
+        }
+
+        #[cfg(feature = "stateless")]
+        if let StdioSubscriptionInput::Handled(frames) =
+            subscriptions.handle_input(&self.service, &parsed)?
+        {
+            for frame in frames {
+                self.write_line(&frame, writer.clone()).await?;
+            }
+            return Ok(());
         }
 
         // Check if it's a notification (no id field)

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -1,0 +1,82 @@
+//! Shared transport helpers for final-protocol subscriptions.
+
+use crate::context::ServerNotification;
+use crate::protocol::{
+    JsonRpcNotification, JsonRpcResponse, NotificationMeta, RequestId, ResultType,
+    SubscriptionFilter, SubscriptionsAcknowledgedParams, SubscriptionsListenResult, notifications,
+};
+
+pub(crate) fn accepted_subscription_filter(requested: SubscriptionFilter) -> SubscriptionFilter {
+    SubscriptionFilter {
+        tools_list_changed: requested.tools_list_changed.filter(|enabled| *enabled),
+        prompts_list_changed: requested.prompts_list_changed.filter(|enabled| *enabled),
+        resources_list_changed: requested.resources_list_changed.filter(|enabled| *enabled),
+        resource_subscriptions: requested.resource_subscriptions,
+    }
+}
+
+pub(crate) fn subscription_matches(
+    notification: &ServerNotification,
+    filter: &SubscriptionFilter,
+) -> bool {
+    match notification {
+        ServerNotification::ToolsListChanged => filter.tools_list_changed == Some(true),
+        ServerNotification::PromptsListChanged => filter.prompts_list_changed == Some(true),
+        ServerNotification::ResourcesListChanged => filter.resources_list_changed == Some(true),
+        ServerNotification::ResourceUpdated { uri } => filter
+            .resource_subscriptions
+            .as_ref()
+            .is_some_and(|subscriptions| subscriptions.iter().any(|item| item == uri)),
+        _ => false,
+    }
+}
+
+pub(crate) fn tagged_subscription_notification(
+    notification: &ServerNotification,
+    subscription_id: &RequestId,
+) -> Option<String> {
+    let json = crate::transport::stdio::serialize_notification(notification)?;
+    let mut value: serde_json::Value = serde_json::from_str(&json).ok()?;
+    let object = value.as_object_mut()?;
+    let params = object
+        .entry("params")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()?;
+    let meta = params
+        .entry("_meta")
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()?;
+    meta.insert(
+        "io.modelcontextprotocol/subscriptionId".to_string(),
+        serde_json::to_value(subscription_id).ok()?,
+    );
+    serde_json::to_string(&value).ok()
+}
+
+pub(crate) fn subscription_acknowledgment(
+    subscription_id: RequestId,
+    notifications: SubscriptionFilter,
+) -> JsonRpcNotification {
+    JsonRpcNotification::new(notifications::SUBSCRIPTIONS_ACKNOWLEDGED).with_params(
+        serde_json::to_value(SubscriptionsAcknowledgedParams {
+            meta: Some(NotificationMeta {
+                subscription_id: Some(subscription_id),
+            }),
+            notifications,
+        })
+        .expect("subscription acknowledgment is serializable"),
+    )
+}
+
+pub(crate) fn subscription_complete_response(subscription_id: RequestId) -> JsonRpcResponse {
+    let result = SubscriptionsListenResult {
+        result_type: ResultType::Complete,
+        meta: Some(NotificationMeta {
+            subscription_id: Some(subscription_id.clone()),
+        }),
+    };
+    JsonRpcResponse::result(
+        subscription_id,
+        serde_json::to_value(result).expect("subscription result is serializable"),
+    )
+}

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -363,6 +363,459 @@ async fn stdio_runtime_protocol_allow_list_is_exact() {
 }
 
 #[cfg(feature = "stateless")]
+fn subscription_router() -> McpRouter {
+    let emit = ToolBuilder::new("emit_changes")
+        .description("Emit every core subscription-scoped notification")
+        .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
+            ctx.notify_tools_list_changed();
+            ctx.notify_prompts_list_changed();
+            ctx.notify_resources_list_changed();
+            ctx.notify_resource_updated("file:///watched");
+            Ok(CallToolResult::text("emitted"))
+        })
+        .build();
+    McpRouter::new()
+        .server_info("stdio-subscription-test", "0.0.0")
+        .tool(emit)
+}
+
+/// Final subscriptions share stdout, preserve numeric/string IDs verbatim,
+/// filter every delivered notification, and distinguish silent client
+/// cancellation from graceful server closure.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_multiplexes_and_gracefully_closes_final_subscriptions() {
+    let mut transport = StdioTransport::new(subscription_router());
+    let control = transport.handle();
+    let (server_stdin_writer, server_stdin) = tokio::io::duplex(32 * 1024);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(32 * 1024);
+    let transport_task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let mut writer = server_stdin_writer;
+    let mut reader = BufReader::new(server_stdout_reader);
+    let version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+
+    let tools_listen = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "tools-sub",
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(version),
+            "notifications": {
+                "toolsListChanged": true,
+                "promptsListChanged": false
+            }
+        }
+    });
+    writer
+        .write_all(format!("{tools_listen}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+    let tools_ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("tools subscription acknowledgment");
+    assert_eq!(
+        tools_ack["method"],
+        "notifications/subscriptions/acknowledged"
+    );
+    assert_eq!(
+        tools_ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        "tools-sub"
+    );
+    assert_eq!(
+        tools_ack["params"]["notifications"]["toolsListChanged"],
+        true
+    );
+    assert!(
+        tools_ack["params"]["notifications"]
+            .get("promptsListChanged")
+            .is_none(),
+        "false filters must be omitted from the honored filter: {tools_ack}"
+    );
+
+    let resources_listen = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 22,
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(version),
+            "notifications": {
+                "promptsListChanged": true,
+                "resourcesListChanged": true,
+                "resourceSubscriptions": ["file:///watched"]
+            }
+        }
+    });
+    writer
+        .write_all(format!("{resources_listen}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+    let resources_ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("resources subscription acknowledgment");
+    assert_eq!(
+        resources_ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        22
+    );
+
+    let emit = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "emit_changes",
+            "arguments": {},
+            "_meta": final_meta(version)
+        }
+    });
+    writer
+        .write_all(format!("{emit}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+
+    let mut first_delivery = Vec::new();
+    for _ in 0..5 {
+        first_delivery.push(
+            timeout(Duration::from_secs(2), read_frame(&mut reader))
+                .await
+                .expect("first subscription delivery"),
+        );
+    }
+    assert!(first_delivery.iter().any(|frame| frame["id"] == 3));
+    let delivered: Vec<_> = first_delivery
+        .iter()
+        .filter(|frame| frame.get("method").is_some())
+        .collect();
+    assert_eq!(
+        delivered.len(),
+        4,
+        "unexpected delivery: {first_delivery:#?}"
+    );
+    for frame in delivered {
+        let method = frame["method"].as_str().unwrap();
+        let id = &frame["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"];
+        match method {
+            "notifications/tools/list_changed" => assert_eq!(id, "tools-sub"),
+            "notifications/prompts/list_changed"
+            | "notifications/resources/list_changed"
+            | "notifications/resources/updated" => assert_eq!(id, 22),
+            _ => panic!("unexpected subscription notification: {frame}"),
+        }
+    }
+
+    // Client cancellation is silent and removes only the named subscription.
+    let cancel = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/cancelled",
+        "params": {"requestId": "tools-sub"}
+    });
+    let emit_again = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "emit_changes",
+            "arguments": {},
+            "_meta": final_meta(version)
+        }
+    });
+    writer
+        .write_all(format!("{cancel}\n{emit_again}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+
+    let mut after_cancel = Vec::new();
+    for _ in 0..4 {
+        after_cancel.push(
+            timeout(Duration::from_secs(2), read_frame(&mut reader))
+                .await
+                .expect("delivery after cancellation"),
+        );
+    }
+    assert!(after_cancel.iter().any(|frame| frame["id"] == 4));
+    assert!(
+        after_cancel
+            .iter()
+            .filter(|frame| frame.get("method").is_some())
+            .all(|frame| {
+                frame["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"]
+                    == serde_json::json!(22)
+            })
+    );
+
+    // Server closure returns the complete result but leaves stdout usable.
+    control
+        .close_subscription(tower_mcp::RequestId::Number(22))
+        .unwrap();
+    let complete = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("graceful subscription result");
+    assert_eq!(complete["id"], 22);
+    assert_eq!(complete["result"]["resultType"], "complete");
+    assert_eq!(
+        complete["result"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        22
+    );
+
+    let list = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 5,
+        "method": "tools/list",
+        "params": {"_meta": final_meta(version)}
+    });
+    writer
+        .write_all(format!("{list}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+    let list_response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("shared channel remains usable");
+    assert_eq!(list_response["id"], 5);
+
+    // Whole-server shutdown drains every remaining subscription result.
+    let shutdown_listen = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "shutdown-sub",
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(version),
+            "notifications": {"toolsListChanged": true}
+        }
+    });
+    writer
+        .write_all(format!("{shutdown_listen}\n").as_bytes())
+        .await
+        .unwrap();
+    writer.flush().await.unwrap();
+    let shutdown_ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("shutdown subscription acknowledgment");
+    assert_eq!(
+        shutdown_ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        "shutdown-sub"
+    );
+    control.shutdown().unwrap();
+    let shutdown_result = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("shutdown drains subscription result");
+    assert_eq!(shutdown_result["id"], "shutdown-sub");
+    assert_eq!(shutdown_result["result"]["resultType"], "complete");
+
+    transport_task
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_subscription_validation_uses_runtime_protocol_policy() {
+    let mut transport =
+        StdioTransport::new(subscription_router()).protocol_support(ProtocolSupport::stable());
+    let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 9,
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "notifications": {"toolsListChanged": true}
+        }
+    });
+    server_stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(server_stdin_writer);
+
+    let frames = read_n_frames(BufReader::new(server_stdout_reader), 1).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(frames[0]["id"], 9);
+    assert_eq!(frames[0]["error"]["code"], -32022);
+    assert_eq!(
+        frames[0]["error"]["data"]["requested"],
+        tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_subscription_requires_final_metadata_and_filter() {
+    let mut transport = StdioTransport::new(subscription_router());
+    let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+    let missing_filter = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "subscriptions/listen",
+        "params": {"_meta": final_meta(version)}
+    });
+    let missing_capabilities = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": version
+            },
+            "notifications": {"toolsListChanged": true}
+        }
+    });
+    let legacy_shape = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 12,
+        "method": "subscriptions/listen",
+        "params": {"notifications": {"toolsListChanged": true}}
+    });
+    server_stdin_writer
+        .write_all(format!("{missing_filter}\n{missing_capabilities}\n{legacy_shape}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(server_stdin_writer);
+
+    let frames = read_n_frames(BufReader::new(server_stdout_reader), 3).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(frames[0]["id"], 10);
+    assert_eq!(frames[0]["error"]["code"], -32602);
+    assert_eq!(frames[1]["id"], 11);
+    assert_eq!(frames[1]["error"]["code"], -32602);
+    assert_eq!(frames[2]["id"], 12);
+    assert_eq!(
+        frames[2]["error"]["code"], -32600,
+        "claimless listen must remain on the legacy lifecycle and fail before initialize"
+    );
+    assert!(
+        frames.iter().all(|frame| frame.get("method").is_none()),
+        "invalid listens must not be acknowledged: {frames:#?}"
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn middleware_wrapped_stdio_preserves_subscription_routing() {
+    let mut transport =
+        StdioTransport::new(subscription_router()).layer(tower::layer::util::Identity::new());
+    let control = transport.handle();
+    let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "layered",
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "notifications": {"toolsListChanged": true}
+        }
+    });
+    server_stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    server_stdin_writer.flush().await.unwrap();
+    let mut reader = BufReader::new(server_stdout_reader);
+    let ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layered subscription acknowledgment");
+    assert_eq!(
+        ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        "layered"
+    );
+
+    control
+        .close_subscription(tower_mcp::RequestId::String("layered".to_string()))
+        .unwrap();
+    let complete = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layered graceful result");
+    assert_eq!(complete["id"], "layered");
+    assert_eq!(complete["result"]["resultType"], "complete");
+    control.shutdown().unwrap();
+    task.await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn bidi_stdio_preserves_subscription_routing() {
+    let mut transport = BidirectionalStdioTransport::new(subscription_router());
+    let control = transport.handle();
+    let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 71,
+        "method": "subscriptions/listen",
+        "params": {
+            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "notifications": {"toolsListChanged": true}
+        }
+    });
+    server_stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    server_stdin_writer.flush().await.unwrap();
+    let mut reader = BufReader::new(server_stdout_reader);
+    let ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("bidirectional subscription acknowledgment");
+    assert_eq!(
+        ack["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        71
+    );
+
+    control
+        .close_subscription(tower_mcp::RequestId::Number(71))
+        .unwrap();
+    let complete = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("bidirectional graceful result");
+    assert_eq!(complete["id"], 71);
+    assert_eq!(complete["result"]["resultType"], "complete");
+    control.shutdown().unwrap();
+    task.await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+}
+
+#[cfg(feature = "stateless")]
 #[tokio::test]
 async fn bidi_final_handlers_cannot_initiate_client_requests() {
     let mut transport = BidirectionalStdioTransport::new(modern_router());


### PR DESCRIPTION
Closes the STDIO cancellation and multiplexing gaps in #952.

## What changed

- intercept final `subscriptions/listen` requests at the STDIO binding and validate them with the same per-request metadata and exact runtime `ProtocolSupport` policy as ordinary JSON-RPC dispatch
- acknowledge each numeric or string subscription ID before delivery, retain multiple concurrent filters, and fan list/resource changes out as per-subscription tagged notifications on the shared output channel
- consume client `notifications/cancelled` silently for active listen IDs while preserving ordinary request cancellation
- add `StdioTransportHandle` so servers can gracefully finish one logical subscription with `SubscriptionsListenResult`, or drain all active subscriptions before shutting down
- preserve the behavior through middleware-wrapped and bidirectional STDIO transports
- share filter/tagging helpers with the HTTP subscription registry

Once a final subscription has been accepted, subscription-scoped server notifications remain on the final filtered/tagged path for the lifetime of that STDIO stream; they are not duplicated as legacy untagged notifications.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo check -p tower-mcp --no-default-features`

The tests cover concurrent string/numeric IDs, ack ordering, filter-specific delivery, silent client cancellation, single-listen graceful closure without closing stdout, whole-server drain, invalid final metadata/filter handling, runtime protocol rejection, middleware preservation, and bidirectional STDIO.