### PR TITLE
feat(subscriptions): complete graceful server close

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -2032,20 +2032,33 @@ pub struct SubscriptionsListenParams {
 ///
 /// A server sends this empty complete result before it closes a subscription
 /// stream on its own initiative. An abrupt transport close has no result.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubscriptionsListenResult {
     /// Always [`ResultType::Complete`].
     #[serde(default)]
     pub result_type: ResultType,
-    /// Identifies the subscription that ended.
+    /// Required result metadata identifying the subscription that ended.
+    #[serde(rename = "_meta")]
+    pub meta: SubscriptionsListenResultMeta,
+}
+
+/// Result metadata for a gracefully closed `subscriptions/listen` request.
+///
+/// Unlike [`NotificationMeta`], the subscription ID is required because this
+/// metadata appears only on the terminal result of a known subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionsListenResultMeta {
+    /// The JSON-RPC ID of the `subscriptions/listen` request being closed.
+    #[serde(rename = "io.modelcontextprotocol/subscriptionId")]
+    pub subscription_id: RequestId,
+    /// Identifies the server software producing the response.
     #[serde(
-        rename = "_meta",
+        rename = "io.modelcontextprotocol/serverInfo",
         default,
-        skip_serializing_if = "Option::is_none",
-        with = "crate::protocol::meta_object_serde"
+        skip_serializing_if = "Option::is_none"
     )]
-    pub meta: Option<NotificationMeta>,
+    pub server_info: Option<Implementation>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -7383,9 +7396,18 @@ mod draft_2026_07_28_tests {
 
         let result = SubscriptionsListenResult {
             result_type: ResultType::Complete,
-            meta: Some(NotificationMeta {
-                subscription_id: Some(RequestId::Number(7)),
-            }),
+            meta: SubscriptionsListenResultMeta {
+                subscription_id: RequestId::Number(7),
+                server_info: Some(Implementation {
+                    name: "test-server".to_string(),
+                    version: "1.0.0".to_string(),
+                    title: None,
+                    description: None,
+                    icons: None,
+                    website_url: None,
+                    meta: None,
+                }),
+            },
         };
         let value = serde_json::to_value(&result).unwrap();
         assert_eq!(value["resultType"], json!("complete"));
@@ -7393,11 +7415,23 @@ mod draft_2026_07_28_tests {
             value["_meta"]["io.modelcontextprotocol/subscriptionId"],
             json!(7)
         );
+        assert_eq!(
+            value["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+            json!("test-server")
+        );
         let back: SubscriptionsListenResult = serde_json::from_value(value).unwrap();
         assert!(back.result_type.is_complete());
+        assert_eq!(back.meta.subscription_id, RequestId::Number(7));
         assert_eq!(
-            back.meta.and_then(|meta| meta.subscription_id),
-            Some(RequestId::Number(7))
+            back.meta.server_info.map(|info| info.name),
+            Some("test-server".to_string())
+        );
+        assert!(
+            serde_json::from_value::<SubscriptionsListenResult>(serde_json::json!({
+                "resultType": "complete"
+            }))
+            .is_err(),
+            "final subscription results require _meta and a subscription ID"
         );
     }
 

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -210,16 +210,7 @@ impl SubscriptionHandle {
                 result.result_type
             )));
         }
-        let response_id = result
-            .meta
-            .as_ref()
-            .and_then(|meta| meta.subscription_id.as_ref())
-            .ok_or_else(|| {
-                Error::Transport(
-                    "subscriptions/listen result omitted its subscription ID".to_string(),
-                )
-            })?;
-        if !request_ids_match(response_id, &self.request_id) {
+        if !request_ids_match(&result.meta.subscription_id, &self.request_id) {
             return Err(Error::Transport(
                 "subscriptions/listen result carried the wrong subscription ID".to_string(),
             ));
@@ -3031,10 +3022,7 @@ mod tests {
         let expected_id = handle.id().clone();
         let result = handle.wait().await.unwrap();
         assert!(result.result_type.is_complete());
-        assert_eq!(
-            result.meta.and_then(|meta| meta.subscription_id),
-            Some(expected_id)
-        );
+        assert_eq!(result.meta.subscription_id, expected_id);
     }
 
     #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -574,11 +574,12 @@ pub use protocol::{
     SamplingContextCapability, SamplingMessage, SamplingTool, SamplingToolsCapability,
     ServerCapabilities, SetLogLevelParams, SingleSelectEnumSchema, StringSchema,
     SubscribeResourceParams, SubscriptionFilter, SubscriptionsAcknowledgedParams,
-    SubscriptionsListenParams, SubscriptionsListenResult, TaskInfo, TaskObject, TaskRequestParams,
-    TaskStatus, TaskStatusChangedParams, TaskStatusParams, TaskSupportMode, TasksCancelCapability,
-    TasksCapability, TasksListCapability, TasksRequestsCapability, TasksToolsCallCapability,
-    TasksToolsRequestsCapability, ToolAnnotations, ToolChoice, ToolDefinition, ToolExecution,
-    ToolIcon, ToolsCapability, UnsubscribeResourceParams, UpdateTaskParams,
+    SubscriptionsListenParams, SubscriptionsListenResult, SubscriptionsListenResultMeta, TaskInfo,
+    TaskObject, TaskRequestParams, TaskStatus, TaskStatusChangedParams, TaskStatusParams,
+    TaskSupportMode, TasksCancelCapability, TasksCapability, TasksListCapability,
+    TasksRequestsCapability, TasksToolsCallCapability, TasksToolsRequestsCapability,
+    ToolAnnotations, ToolChoice, ToolDefinition, ToolExecution, ToolIcon, ToolsCapability,
+    UnsubscribeResourceParams, UpdateTaskParams,
 };
 pub use protocol::{RESULT_TYPE_TASK, TASKS_EXTENSION_ID};
 #[cfg(feature = "dynamic-tools")]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -302,6 +302,9 @@ struct AutoInstructionsConfig {
     suffix: Option<String>,
 }
 
+#[cfg(all(feature = "http", feature = "stateless"))]
+type ModernNotificationSink = Arc<dyn Fn(&ServerNotification) -> bool + Send + Sync + 'static>;
+
 /// Inner configuration that is shared across clones
 #[derive(Clone)]
 struct McpRouterInner {
@@ -326,6 +329,12 @@ struct McpRouterInner {
     in_flight: Arc<RwLock<HashMap<RequestId, CancellationToken>>>,
     /// Channel for sending notifications to connected clients
     notification_tx: Option<NotificationSender>,
+    /// Transport-lifetime sink for final HTTP subscription notifications.
+    ///
+    /// The lock is shared across router clones so an application-owned clone
+    /// can publish after the transport attaches its subscription registry.
+    #[cfg(all(feature = "http", feature = "stateless"))]
+    modern_notification_sink: Arc<RwLock<Option<ModernNotificationSink>>>,
     /// Handle for sending requests to the client (for sampling, etc.)
     client_requester: Option<ClientRequesterHandle>,
     /// Task store for async operations
@@ -484,6 +493,8 @@ impl McpRouter {
                 prompts: HashMap::new(),
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 notification_tx: None,
+                #[cfg(all(feature = "http", feature = "stateless"))]
+                modern_notification_sink: Arc::new(RwLock::new(None)),
                 client_requester: None,
                 task_store: Arc::new(MemoryTaskStore::new()),
                 subscriptions: Arc::new(RwLock::new(HashSet::new())),
@@ -748,6 +759,14 @@ impl McpRouter {
         }
         inner.notification_tx = Some(tx);
         self
+    }
+
+    /// Attach the transport-lifetime final subscription notification path.
+    #[cfg(all(feature = "http", feature = "stateless"))]
+    pub(crate) fn attach_modern_notification_sink(&self, sink: ModernNotificationSink) {
+        if let Ok(mut active) = self.inner.modern_notification_sink.write() {
+            *active = Some(sink);
+        }
     }
 
     /// Get the notification sender (if configured)
@@ -1731,21 +1750,30 @@ impl McpRouter {
 
     /// Notify clients that a subscribed resource has been updated
     ///
-    /// Only sends the notification if the resource is currently subscribed.
+    /// Legacy sessions receive the notification only after
+    /// `resources/subscribe`. Final HTTP listeners are filtered by their
+    /// `subscriptions/listen` registration.
     /// Returns `true` if the notification was sent.
     pub fn notify_resource_updated(&self, uri: &str) -> bool {
-        // Only notify if the resource is subscribed
-        if !self.is_subscribed(uri) {
-            return false;
+        let notification = ServerNotification::ResourceUpdated {
+            uri: uri.to_string(),
+        };
+        let mut sent = false;
+
+        if self.is_subscribed(uri)
+            && let Some(tx) = &self.inner.notification_tx
+        {
+            sent |= tx.try_send(notification.clone()).is_ok();
         }
 
-        let Some(tx) = &self.inner.notification_tx else {
-            return false;
-        };
-        tx.try_send(ServerNotification::ResourceUpdated {
-            uri: uri.to_string(),
-        })
-        .is_ok()
+        #[cfg(all(feature = "http", feature = "stateless"))]
+        if let Ok(active) = self.inner.modern_notification_sink.read()
+            && let Some(sink) = active.as_ref()
+        {
+            sent |= sink(&notification);
+        }
+
+        sent
     }
 
     /// Notify clients that the list of available resources has changed

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -285,7 +285,8 @@ use crate::transport::service::{
 };
 #[cfg(feature = "stateless")]
 use crate::transport::subscriptions::{
-    accepted_subscription_filter, subscription_matches, tagged_subscription_notification,
+    accepted_subscription_filter, subscription_complete_response, subscription_matches,
+    tagged_subscription_notification,
 };
 use crate::{ProtocolSupport, ProtocolSupportError};
 use tower::util::BoxCloneService;
@@ -1225,7 +1226,7 @@ pub struct SessionInfo {
     pub last_activity: Duration,
 }
 
-/// A handle for querying and managing HTTP transport sessions.
+/// A handle for managing HTTP transport sessions and final subscription streams.
 ///
 /// Obtained from [`HttpTransport::into_router_with_handle()`] or
 /// [`HttpTransport::into_router_at_with_handle()`]. The handle is cheap to
@@ -1245,10 +1246,15 @@ pub struct SessionInfo {
 ///     println!("{}: created {:?} ago", info.id, info.created_at);
 /// }
 /// handle.terminate_session("session-id").await;
+///
+/// // During graceful server shutdown (with the `stateless` feature):
+/// handle.close_subscriptions();
 /// ```
 #[derive(Clone)]
 pub struct SessionHandle {
     store: Arc<SessionRegistry>,
+    #[cfg(feature = "stateless")]
+    modern_subscriptions: Arc<ModernSubscriptionRegistry>,
 }
 
 impl SessionHandle {
@@ -1275,6 +1281,21 @@ impl SessionHandle {
     /// Terminates a session by ID, returning `true` if the session existed.
     pub async fn terminate_session(&self, id: &str) -> bool {
         self.store.remove(id).await
+    }
+
+    /// Returns the number of active final-protocol subscription streams.
+    #[cfg(feature = "stateless")]
+    pub fn subscription_count(&self) -> usize {
+        self.modern_subscriptions.len()
+    }
+
+    /// Gracefully finish every active final-protocol subscription stream.
+    ///
+    /// Each stream receives its terminal `SubscriptionsListenResult` before
+    /// closing. Returns the number of streams that were drained.
+    #[cfg(feature = "stateless")]
+    pub fn close_subscriptions(&self) -> usize {
+        self.modern_subscriptions.close_all()
     }
 }
 
@@ -1340,14 +1361,22 @@ struct ModernSubscription {
 /// The 2026-07-28 transport deliberately has no session or replay state.
 /// Each listen POST owns one sender, removed when its response stream drops.
 #[cfg(feature = "stateless")]
-#[derive(Default)]
 struct ModernSubscriptionRegistry {
     next_key: AtomicU64,
     subscriptions: std::sync::Mutex<HashMap<u64, ModernSubscription>>,
+    server_info: Option<Implementation>,
 }
 
 #[cfg(feature = "stateless")]
 impl ModernSubscriptionRegistry {
+    fn new(server_info: Option<Implementation>) -> Self {
+        Self {
+            next_key: AtomicU64::new(0),
+            subscriptions: std::sync::Mutex::new(HashMap::new()),
+            server_info,
+        }
+    }
+
     fn register(
         self: &Arc<Self>,
         subscription_id: RequestId,
@@ -1402,6 +1431,39 @@ impl ModernSubscriptionRegistry {
             !subscription.tx.is_closed()
         });
         true
+    }
+
+    fn len(&self) -> usize {
+        self.subscriptions.lock().unwrap().len()
+    }
+
+    /// Gracefully finish every active HTTP listen stream.
+    fn close_all(&self) -> usize {
+        let subscriptions = {
+            let mut active = self.subscriptions.lock().unwrap();
+            active
+                .drain()
+                .map(|(_, subscription)| subscription)
+                .collect::<Vec<_>>()
+        };
+        let count = subscriptions.len();
+        for subscription in subscriptions {
+            let response = subscription_complete_response(
+                subscription.subscription_id,
+                self.server_info.clone(),
+            );
+            if let Ok(json) = serde_json::to_string(&response) {
+                let _ = subscription.tx.send(json);
+            }
+        }
+        count
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl Default for ModernSubscriptionRegistry {
+    fn default() -> Self {
+        Self::new(None)
     }
 }
 
@@ -2098,7 +2160,14 @@ impl HttpTransport {
 
     fn build_state(&self) -> Arc<AppState> {
         #[cfg(feature = "stateless")]
-        let modern_subscriptions = Arc::new(ModernSubscriptionRegistry::default());
+        let modern_subscriptions = Arc::new(ModernSubscriptionRegistry::new(
+            match &self.service_source {
+                ServiceSource::Router { router, .. } if self.stamp_server_info => {
+                    Some(router.implementation())
+                }
+                _ => None,
+            },
+        ));
 
         // Keep one transport-lifetime notification sender registered with
         // dynamic registries. Per-request senders intentionally are not
@@ -2108,6 +2177,10 @@ impl HttpTransport {
         let service_source = match &self.service_source {
             ServiceSource::Router { router, factory } => {
                 let (tx, mut rx) = notification_channel(256);
+                let direct_subscriptions = modern_subscriptions.clone();
+                router.attach_modern_notification_sink(Arc::new(move |notification| {
+                    direct_subscriptions.publish(notification)
+                }));
                 let subscriptions = modern_subscriptions.clone();
                 tokio::spawn(async move {
                     while let Some(notification) = rx.recv().await {
@@ -2170,8 +2243,8 @@ impl HttpTransport {
         router
     }
 
-    /// Build the axum router and return a [`SessionHandle`] for querying
-    /// session metrics (e.g., active session count).
+    /// Build the axum router and return a [`SessionHandle`] for managing
+    /// sessions and final subscription streams.
     ///
     /// # Example
     ///
@@ -2187,6 +2260,8 @@ impl HttpTransport {
         let state = self.build_state();
         let handle = SessionHandle {
             store: state.sessions.clone(),
+            #[cfg(feature = "stateless")]
+            modern_subscriptions: state.modern_subscriptions.clone(),
         };
 
         spawn_external_notification_fanout(
@@ -2216,12 +2291,14 @@ impl HttpTransport {
     }
 
     /// Build an axum router mounted at a specific path and return a
-    /// [`SessionHandle`] for querying session metrics.
+    /// [`SessionHandle`] for managing sessions and final subscription streams.
     pub fn into_router_at_with_handle(mut self, path: &str) -> (Router, SessionHandle) {
         let external_rx = self.external_notifications.take();
         let state = self.build_state();
         let handle = SessionHandle {
             store: state.sessions.clone(),
+            #[cfg(feature = "stateless")]
+            modern_subscriptions: state.modern_subscriptions.clone(),
         };
 
         spawn_external_notification_fanout(

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -44,12 +44,12 @@ use tower_service::Service;
 
 use crate::error::{Error, Result};
 use crate::jsonrpc::JsonRpcService;
+#[cfg(feature = "stateless")]
+use crate::protocol::{Implementation, SubscriptionFilter, SubscriptionsListenParams};
 use crate::protocol::{
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage,
     McpNotification, RequestId, notifications,
 };
-#[cfg(feature = "stateless")]
-use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{CatchError, InjectAnnotations};
 #[cfg(feature = "stateless")]
@@ -111,6 +111,7 @@ fn stdio_control_channel() -> (
 struct StdioSubscriptions {
     active: HashMap<RequestId, SubscriptionFilter>,
     modern_mode: bool,
+    server_info: Option<Implementation>,
 }
 
 #[cfg(feature = "stateless")]
@@ -254,7 +255,7 @@ impl StdioSubscriptions {
             return Ok(None);
         }
         Ok(Some(serde_json::to_string(
-            &subscription_complete_response(request_id.clone()),
+            &subscription_complete_response(request_id.clone(), self.server_info.clone()),
         )?))
     }
 
@@ -536,7 +537,10 @@ impl StdioTransport {
     {
         let mut reader = BufReader::new(reader);
         #[cfg(feature = "stateless")]
-        let mut subscriptions = StdioSubscriptions::default();
+        let mut subscriptions = StdioSubscriptions {
+            server_info: Some(self.router.implementation()),
+            ..StdioSubscriptions::default()
+        };
 
         tracing::info!("Stdio transport started, waiting for input");
 
@@ -1261,7 +1265,10 @@ impl BidirectionalStdioTransport {
         let writer = Arc::new(Mutex::new(writer));
         let mut reader = BufReader::new(reader);
         #[cfg(feature = "stateless")]
-        let mut subscriptions = StdioSubscriptions::default();
+        let mut subscriptions = StdioSubscriptions {
+            server_info: Some(self.router.implementation()),
+            ..StdioSubscriptions::default()
+        };
 
         tracing::info!("Bidirectional stdio transport started, waiting for input");
 

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -2,8 +2,9 @@
 
 use crate::context::ServerNotification;
 use crate::protocol::{
-    JsonRpcNotification, JsonRpcResponse, NotificationMeta, RequestId, ResultType,
-    SubscriptionFilter, SubscriptionsAcknowledgedParams, SubscriptionsListenResult, notifications,
+    Implementation, JsonRpcNotification, JsonRpcResponse, NotificationMeta, RequestId, ResultType,
+    SubscriptionFilter, SubscriptionsAcknowledgedParams, SubscriptionsListenResult,
+    SubscriptionsListenResultMeta, notifications,
 };
 
 pub(crate) fn accepted_subscription_filter(requested: SubscriptionFilter) -> SubscriptionFilter {
@@ -68,12 +69,16 @@ pub(crate) fn subscription_acknowledgment(
     )
 }
 
-pub(crate) fn subscription_complete_response(subscription_id: RequestId) -> JsonRpcResponse {
+pub(crate) fn subscription_complete_response(
+    subscription_id: RequestId,
+    server_info: Option<Implementation>,
+) -> JsonRpcResponse {
     let result = SubscriptionsListenResult {
         result_type: ResultType::Complete,
-        meta: Some(NotificationMeta {
-            subscription_id: Some(subscription_id.clone()),
-        }),
+        meta: SubscriptionsListenResultMeta {
+            subscription_id: subscription_id.clone(),
+            server_info,
+        },
     };
     JsonRpcResponse::result(
         subscription_id,

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -2772,10 +2772,7 @@ mod stateless_tests {
         );
         let graceful_id = graceful.id().clone();
         let result = graceful.wait().await.unwrap();
-        assert_eq!(
-            result.meta.and_then(|meta| meta.subscription_id),
-            Some(graceful_id)
-        );
+        assert_eq!(result.meta.subscription_id, graceful_id);
 
         let mut abrupt = client
             .listen_subscriptions(SubscriptionFilter {

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -563,6 +563,10 @@ async fn stdio_multiplexes_and_gracefully_closes_final_subscriptions() {
         complete["result"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
         22
     );
+    assert_eq!(
+        complete["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "stdio-subscription-test"
+    );
 
     let list = serde_json::json!({
         "jsonrpc": "2.0",
@@ -760,6 +764,12 @@ async fn middleware_wrapped_stdio_preserves_subscription_routing() {
         .expect("layered graceful result");
     assert_eq!(complete["id"], "layered");
     assert_eq!(complete["result"]["resultType"], "complete");
+    assert!(
+        complete["result"]["_meta"]
+            .get("io.modelcontextprotocol/serverInfo")
+            .is_none(),
+        "generic services do not expose server identity to the transport"
+    );
     control.shutdown().unwrap();
     task.await
         .expect("transport task join")
@@ -809,6 +819,10 @@ async fn bidi_stdio_preserves_subscription_routing() {
         .expect("bidirectional graceful result");
     assert_eq!(complete["id"], 71);
     assert_eq!(complete["result"]["resultType"], "complete");
+    assert_eq!(
+        complete["result"]["_meta"]["io.modelcontextprotocol/serverInfo"]["name"],
+        "stdio-subscription-test"
+    );
     control.shutdown().unwrap();
     task.await
         .expect("transport task join")

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -212,6 +212,55 @@ async fn subscriptions_listen_requires_notification_filter() {
     assert_eq!(body["error"]["code"], -32602);
 }
 
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn server_gracefully_drains_http_subscription_streams() {
+    let router = router();
+    let publisher = router.clone();
+    let (app, handle) = HttpTransport::new(router)
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_router_with_handle();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", "subscriptions/listen")
+        .body(Body::from(
+            r#"{"jsonrpc":"2.0","id":"graceful-http","method":"subscriptions/listen","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28","io.modelcontextprotocol/clientCapabilities":{}},"notifications":{"resourceSubscriptions":["file:///wanted"]}}}"#,
+        ))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(handle.subscription_count(), 1);
+    assert!(publisher.notify_resource_updated("file:///ignored"));
+    assert!(publisher.notify_resource_updated("file:///wanted"));
+    assert_eq!(handle.close_subscriptions(), 1);
+    assert_eq!(handle.subscription_count(), 0);
+
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body = String::from_utf8(bytes.to_vec()).unwrap();
+    let acknowledgment = body
+        .find("notifications/subscriptions/acknowledged")
+        .expect("stream must begin with an acknowledgment");
+    let completion = body
+        .find("\"resultType\":\"complete\"")
+        .expect("stream must end with a graceful result");
+    assert!(acknowledgment < completion);
+    assert!(body.contains("\"id\":\"graceful-http\""));
+    assert!(body.contains("\"io.modelcontextprotocol/subscriptionId\":\"graceful-http\""));
+    assert!(body.contains("\"io.modelcontextprotocol/serverInfo\""));
+    assert!(body.contains("\"name\":\"listen-test-server\""));
+    assert!(body.contains("notifications/resources/updated"));
+    assert!(body.contains("file:///wanted"));
+    assert!(!body.contains("file:///ignored"));
+}
+
 /// Exercise the pure session-fallback branch (no header, session carries version).
 ///
 /// Without final-protocol support compiled in, the legacy routing behavior


### PR DESCRIPTION
Completes the remaining `subscriptions/listen` work tracked in #952.

## What changed

- align `SubscriptionsListenResult` with the 2026-07-28 schema by requiring `_meta.io.modelcontextprotocol/subscriptionId` and supporting `_meta.io.modelcontextprotocol/serverInfo`
- stamp server identity on graceful STDIO and router-backed HTTP completion results
- add `SessionHandle::subscription_count()` and `SessionHandle::close_subscriptions()` so HTTP servers can drain all active final-protocol listen streams during shutdown
- make application-owned `McpRouter` clones publish resource updates directly into final subscription registries while preserving legacy `resources/subscribe` behavior
- guarantee that an accepted external update reaches the registry before an immediate graceful drain, avoiding update/close reordering
- update client and transport coverage for required metadata, server identity, filtering, external publication, and graceful HTTP/STDIO completion

## Impact

Final-protocol servers can now explicitly and cleanly terminate both STDIO and HTTP subscriptions. Clients receive the required correlated terminal result, and applications can use their retained router clone to publish resource updates to final subscription listeners.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tower-mcp --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `git diff --check`