### PR TITLE
feat(mrtr): compose handler middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,26 @@ let tool = ToolBuilder::new("workspace_summary")
     .build();
 ```
 
+Each MRTR retry is an independent MCP request. Router/transport middleware
+therefore runs once per round, and MRTR tool, prompt, and static-resource
+builders support the same per-handler `.layer()` composition as complete
+handlers. Tool `.guard()` checks also run on every round. Resource templates
+use router/transport middleware for both complete and MRTR handlers because
+they do not have a separate per-template Tower service.
+
+The server does not own a continuation loop, so there is no server-global
+round counter to configure. Clients bound automatic retries with
+`McpClientBuilder::max_mrtr_rounds`; a server workflow that needs its own cap
+should encode and verify a round counter inside `requestState`.
+
+`RequestStateCodec` intentionally leaves authenticated-principal binding under
+application control: HTTP/custom-service authentication can place any
+application-defined identity in request extensions. If continuation state can
+affect authorization, resource access, or business logic, use `encode_for` and
+`decode_for` with that stable principal identifier on every round. This keeps
+the codec transport-neutral while following the final specification's replay
+and cross-principal protections.
+
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
 
 - [x] [JSON-RPC 2.0 message format](https://modelcontextprotocol.io/specification/2025-11-25/basic#messages)

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -840,10 +840,10 @@ impl RequestContext {
     ///
     /// **Protocol note:** `ElicitUrlParams::elicitation_id` and the callback
     /// notification it correlates with are a 2025-11-25-and-earlier pattern.
-    /// The final 2026-07-28 schema removes both in favor of MRTR (SEP-2322,
-    /// not yet implemented -- see #950), where the client learns the outcome
-    /// by retrying the original request instead of receiving a completion
-    /// notification.
+    /// The final 2026-07-28 schema removes both in favor of MRTR (SEP-2322).
+    /// Use an MRTR-capable tool, prompt, or resource handler there; the client
+    /// learns the outcome by retrying the original request instead of receiving
+    /// a completion notification.
     ///
     /// # Example
     ///

--- a/crates/tower-mcp/src/mrtr.rs
+++ b/crates/tower-mcp/src/mrtr.rs
@@ -113,7 +113,9 @@ struct StateEnvelope<T> {
 /// that may receive a retry. Use [`encode_for`](Self::encode_for) and
 /// [`decode_for`](Self::decode_for) when an authenticated subject is
 /// available; subject binding prevents one user from replaying another user's
-/// continuation token.
+/// continuation token. Binding is intentionally explicit: authentication
+/// middleware may place any application-defined principal type in request
+/// extensions, so the transport-neutral codec cannot safely infer one.
 #[derive(Clone)]
 pub struct RequestStateCodec {
     key: std::sync::Arc<[u8]>,

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -105,6 +105,10 @@ impl PromptRequest {
 /// handler can consume it without knowing the concrete middleware stack.
 pub type BoxPromptService = BoxCloneService<PromptRequest, GetPromptResult, Infallible>;
 
+#[cfg(feature = "stateless")]
+type BoxMrtrPromptService =
+    BoxCloneService<PromptRequest, RequestOutcome<GetPromptResult>, Infallible>;
+
 /// A service wrapper that catches errors from middleware and converts them
 /// into prompt errors, maintaining the `Error = Infallible` contract.
 ///
@@ -198,6 +202,61 @@ where
     }
 }
 
+#[cfg(feature = "stateless")]
+#[derive(Clone)]
+struct MrtrPromptCatchError<S> {
+    inner: S,
+}
+
+#[cfg(feature = "stateless")]
+impl<S> MrtrPromptCatchError<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<S> Service<PromptRequest> for MrtrPromptCatchError<S>
+where
+    S: Service<PromptRequest, Response = RequestOutcome<GetPromptResult>> + Clone + Send + 'static,
+    S::Error: fmt::Display + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = RequestOutcome<GetPromptResult>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, req: PromptRequest) -> Self::Future {
+        let future = self.inner.call(req);
+        Box::pin(async move {
+            Ok(match future.await {
+                Ok(outcome) => outcome,
+                Err(error) => RequestOutcome::Complete(GetPromptResult {
+                    description: Some(format!("Prompt error: {error}")),
+                    messages: vec![PromptMessage {
+                        role: PromptRole::Assistant,
+                        content: Content::Text {
+                            text: format!("Error generating prompt: {error}"),
+                            annotations: None,
+                            meta: None,
+                        },
+                        meta: None,
+                    }],
+                    meta: None,
+                }),
+            })
+        })
+    }
+}
+
 /// Adapts a prompt handler function into a `Service<PromptRequest>`.
 ///
 /// This allows the handler to be wrapped with tower middleware layers.
@@ -243,6 +302,42 @@ where
 #[doc(hidden)]
 pub struct PromptContextHandlerService<F> {
     handler: F,
+}
+
+#[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct MrtrPromptHandlerService<F> {
+    handler: F,
+}
+
+#[cfg(feature = "stateless")]
+impl<F: Clone> Clone for MrtrPromptHandlerService<F> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<F, Fut> Service<PromptRequest> for MrtrPromptHandlerService<F>
+where
+    F: Fn(RequestContext, HashMap<String, String>) -> Fut + Clone + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<GetPromptResult>>> + Send + 'static,
+{
+    type Response = RequestOutcome<GetPromptResult>;
+    type Error = Error;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: PromptRequest) -> Self::Future {
+        let handler = self.handler.clone();
+        Box::pin(async move { handler(req.context, req.arguments).await })
+    }
 }
 
 impl<F> Clone for PromptContextHandlerService<F>
@@ -827,6 +922,41 @@ where
             })),
         }
     }
+
+    /// Apply a Tower layer to every attempt at this MRTR-capable prompt.
+    ///
+    /// Each retry is an independent request, so the layer runs once per
+    /// round. Middleware failures become complete prompt error results,
+    /// matching non-MRTR prompt middleware.
+    #[allow(private_bounds)]
+    pub fn layer<L>(self, layer: L) -> Prompt
+    where
+        L: Layer<MrtrPromptHandlerService<F>> + Send + Sync + 'static,
+        L::Service: Service<PromptRequest, Response = RequestOutcome<GetPromptResult>>
+            + Clone
+            + Send
+            + 'static,
+        <L::Service as Service<PromptRequest>>::Error: fmt::Display + Send + 'static,
+        <L::Service as Service<PromptRequest>>::Future: Send + 'static,
+    {
+        let service = MrtrPromptHandlerService {
+            handler: self.handler,
+        };
+        let service = layer.layer(service);
+        let service = BoxCloneService::new(MrtrPromptCatchError::new(service));
+
+        Prompt {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            icons: self.icons,
+            arguments: self.arguments,
+            handler: None,
+            mrtr_handler: Some(Arc::new(ServiceMrtrPromptHandler {
+                service: Mutex::new(service),
+            })),
+        }
+    }
 }
 
 /// Builder state after context-aware handler is specified
@@ -917,6 +1047,33 @@ struct ContextAwareHandler<F> {
 #[cfg(feature = "stateless")]
 struct MrtrContextHandler<F> {
     handler: F,
+}
+
+#[cfg(feature = "stateless")]
+struct ServiceMrtrPromptHandler {
+    service: Mutex<BoxMrtrPromptService>,
+}
+
+#[cfg(feature = "stateless")]
+impl MrtrPromptHandler for ServiceMrtrPromptHandler {
+    fn get(
+        &self,
+        ctx: RequestContext,
+        arguments: HashMap<String, String>,
+    ) -> BoxFuture<'_, Result<RequestOutcome<GetPromptResult>>> {
+        Box::pin(async move {
+            let request = PromptRequest::new(ctx, arguments);
+            let mut service = self.service.lock().await.clone();
+            let outcome = service
+                .ready()
+                .await
+                .expect("MRTR prompt service is infallible")
+                .call(request)
+                .await
+                .expect("MRTR prompt service is infallible");
+            Ok(outcome)
+        })
+    }
 }
 
 #[cfg(feature = "stateless")]
@@ -1494,6 +1651,32 @@ mod tests {
                 .as_input_required()
                 .and_then(|result| result.request_state.as_deref()),
             Some("signed-state")
+        );
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn mrtr_prompt_composes_middleware() {
+        use std::time::Duration;
+        use tower::timeout::TimeoutLayer;
+
+        let prompt = PromptBuilder::new("layered_continue")
+            .mrtr_handler(|_ctx, _args| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("layered-state"),
+                ))
+            })
+            .layer(TimeoutLayer::new(Duration::from_secs(1)));
+
+        let outcome = prompt
+            .get_outcome_with_context(RequestContext::new(RequestId::Number(2)), HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("layered-state")
         );
     }
 

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -78,8 +78,13 @@ use std::task::{Context, Poll};
 
 use pin_project_lite::pin_project;
 
+#[cfg(feature = "stateless")]
+use tower::ServiceExt;
 use tower::util::BoxCloneService;
 use tower_service::Service;
+
+#[cfg(feature = "stateless")]
+use tokio::sync::Mutex;
 
 use crate::context::RequestContext;
 use crate::error::{Error, Result};
@@ -116,6 +121,10 @@ impl ResourceRequest {
 /// This is the internal service type that resources use. Middleware errors are
 /// caught and converted to error results, so the service never fails at the Tower level.
 pub type BoxResourceService = BoxCloneService<ResourceRequest, ReadResourceResult, Infallible>;
+
+#[cfg(feature = "stateless")]
+type BoxMrtrResourceService =
+    BoxCloneService<ResourceRequest, RequestOutcome<ReadResourceResult>, Infallible>;
 
 /// Catches errors from the inner service and converts them to error results.
 ///
@@ -220,6 +229,63 @@ where
     }
 }
 
+#[cfg(feature = "stateless")]
+#[derive(Clone)]
+struct MrtrResourceCatchError<S> {
+    inner: S,
+}
+
+#[cfg(feature = "stateless")]
+impl<S> MrtrResourceCatchError<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<S> Service<ResourceRequest> for MrtrResourceCatchError<S>
+where
+    S: Service<ResourceRequest, Response = RequestOutcome<ReadResourceResult>>
+        + Clone
+        + Send
+        + 'static,
+    S::Error: fmt::Display + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = RequestOutcome<ReadResourceResult>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, req: ResourceRequest) -> Self::Future {
+        let uri = req.uri.clone();
+        let future = self.inner.call(req);
+        Box::pin(async move {
+            Ok(match future.await {
+                Ok(outcome) => outcome,
+                Err(error) => RequestOutcome::Complete(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri,
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some(format!("Error reading resource: {error}")),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                    ..Default::default()
+                }),
+            })
+        })
+    }
+}
+
 /// A boxed future for resource handlers
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
@@ -250,6 +316,76 @@ pub trait MrtrResourceHandler: Send + Sync {
         &self,
         ctx: RequestContext,
     ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>>;
+}
+
+#[cfg(feature = "stateless")]
+struct MrtrResourceHandlerService<H> {
+    handler: Arc<H>,
+}
+
+#[cfg(feature = "stateless")]
+impl<H> MrtrResourceHandlerService<H> {
+    fn new(handler: H) -> Self {
+        Self {
+            handler: Arc::new(handler),
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<H> Clone for MrtrResourceHandlerService<H> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<H> Service<ResourceRequest> for MrtrResourceHandlerService<H>
+where
+    H: MrtrResourceHandler + 'static,
+{
+    type Response = RequestOutcome<ReadResourceResult>;
+    type Error = Error;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: ResourceRequest) -> Self::Future {
+        let handler = self.handler.clone();
+        Box::pin(async move { handler.read(req.ctx).await })
+    }
+}
+
+#[cfg(feature = "stateless")]
+struct ServiceMrtrResourceHandler {
+    service: Mutex<BoxMrtrResourceService>,
+    uri: String,
+}
+
+#[cfg(feature = "stateless")]
+impl MrtrResourceHandler for ServiceMrtrResourceHandler {
+    fn read(
+        &self,
+        ctx: RequestContext,
+    ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>> {
+        Box::pin(async move {
+            let request = ResourceRequest::new(ctx, self.uri.clone());
+            let mut service = self.service.lock().await.clone();
+            let outcome = service
+                .ready()
+                .await
+                .expect("MRTR resource service is infallible")
+                .call(request)
+                .await
+                .expect("MRTR resource service is infallible");
+            Ok(outcome)
+        })
+    }
 }
 
 /// Adapts a `ResourceHandler` to a Tower `Service<ResourceRequest>`.
@@ -839,6 +975,21 @@ pub struct ResourceBuilderWithMrtrHandler<F> {
 }
 
 #[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct ResourceBuilderWithMrtrLayer<F, L> {
+    uri: String,
+    name: Option<String>,
+    title: Option<String>,
+    description: Option<String>,
+    mime_type: Option<String>,
+    icons: Option<Vec<ToolIcon>>,
+    size: Option<u64>,
+    annotations: Option<ContentAnnotations>,
+    handler: F,
+    layer: L,
+}
+
+#[cfg(feature = "stateless")]
 impl<F, Fut> ResourceBuilderWithMrtrHandler<F>
 where
     F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
@@ -861,6 +1012,91 @@ where
                 handler: self.handler,
             },
         )
+    }
+
+    /// Apply a Tower layer to every attempt at this MRTR-capable resource.
+    ///
+    /// Each retry is an independent request, so the layer runs once per
+    /// round. Middleware failures become complete resource error results,
+    /// matching non-MRTR resource middleware.
+    pub fn layer<L>(self, layer: L) -> ResourceBuilderWithMrtrLayer<F, L> {
+        ResourceBuilderWithMrtrLayer {
+            uri: self.uri,
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            mime_type: self.mime_type,
+            icons: self.icons,
+            size: self.size,
+            annotations: self.annotations,
+            handler: self.handler,
+            layer,
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+#[allow(private_bounds)]
+impl<F, Fut, L> ResourceBuilderWithMrtrLayer<F, L>
+where
+    F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<ReadResourceResult>>> + Send + 'static,
+    L: tower::Layer<MrtrResourceHandlerService<MrtrContextHandler<F>>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    L::Service: Service<ResourceRequest, Response = RequestOutcome<ReadResourceResult>>
+        + Clone
+        + Send
+        + 'static,
+    <L::Service as Service<ResourceRequest>>::Error: fmt::Display + Send + 'static,
+    <L::Service as Service<ResourceRequest>>::Future: Send + 'static,
+{
+    /// Build the MRTR resource with the applied layer(s).
+    pub fn build(self) -> Resource {
+        let name = self.name.unwrap_or_else(|| self.uri.clone());
+        let handler = MrtrContextHandler {
+            handler: self.handler,
+        };
+        let service = MrtrResourceHandlerService::new(handler);
+        let service = self.layer.layer(service);
+        let service = BoxCloneService::new(MrtrResourceCatchError::new(service));
+
+        Resource {
+            uri: self.uri.clone(),
+            name,
+            title: self.title,
+            description: self.description,
+            mime_type: self.mime_type,
+            icons: self.icons,
+            size: self.size,
+            annotations: self.annotations,
+            service: None,
+            mrtr_handler: Some(Arc::new(ServiceMrtrResourceHandler {
+                service: Mutex::new(service),
+                uri: self.uri,
+            })),
+        }
+    }
+
+    /// Apply an additional Tower layer.
+    pub fn layer<L2>(
+        self,
+        layer: L2,
+    ) -> ResourceBuilderWithMrtrLayer<F, tower::layer::util::Stack<L2, L>> {
+        ResourceBuilderWithMrtrLayer {
+            uri: self.uri,
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            mime_type: self.mime_type,
+            icons: self.icons,
+            size: self.size,
+            annotations: self.annotations,
+            handler: self.handler,
+            layer: tower::layer::util::Stack::new(layer, self.layer),
+        }
     }
 }
 
@@ -1857,6 +2093,30 @@ mod tests {
                 .as_input_required()
                 .and_then(|result| result.request_state.as_deref()),
             Some("signed-state")
+        );
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn mrtr_resource_composes_middleware() {
+        let resource = ResourceBuilder::new("test://layered-continue")
+            .mrtr_handler(|_ctx| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("layered-state"),
+                ))
+            })
+            .layer(TimeoutLayer::new(Duration::from_secs(1)))
+            .build();
+
+        let outcome = resource
+            .read_outcome_with_context(RequestContext::new(crate::protocol::RequestId::Number(2)))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("layered-state")
         );
     }
 

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -44,8 +44,13 @@ use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
+#[cfg(feature = "stateless")]
+use tower::ServiceExt;
 use tower::util::BoxCloneService;
 use tower_service::Service;
+
+#[cfg(feature = "stateless")]
+use tokio::sync::Mutex;
 
 use crate::context::RequestContext;
 use crate::error::{Error, Result, ResultExt};
@@ -83,6 +88,10 @@ impl ToolRequest {
 /// caught and converted to `CallToolResult::error()` responses, so the
 /// service never fails at the Tower level.
 pub type BoxToolService = BoxCloneService<ToolRequest, CallToolResult, Infallible>;
+
+/// A boxed MRTR-capable tool service.
+#[cfg(feature = "stateless")]
+type BoxMrtrToolService = BoxCloneService<ToolRequest, RequestOutcome<CallToolResult>, Infallible>;
 
 /// Catches errors from the inner service and converts them to `CallToolResult::error()`.
 ///
@@ -168,6 +177,54 @@ where
     }
 }
 
+/// Catches errors from an MRTR-capable tool service.
+///
+/// Per-tool middleware has the same error semantics for complete and MRTR
+/// handlers: middleware and handler failures become complete tool error
+/// results, while input-required outcomes pass through unchanged.
+#[cfg(feature = "stateless")]
+#[derive(Clone)]
+struct MrtrToolCatchError<S> {
+    inner: S,
+}
+
+#[cfg(feature = "stateless")]
+impl<S> MrtrToolCatchError<S> {
+    fn new(inner: S) -> Self {
+        Self { inner }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<S> Service<ToolRequest> for MrtrToolCatchError<S>
+where
+    S: Service<ToolRequest, Response = RequestOutcome<CallToolResult>> + Clone + Send + 'static,
+    S::Error: fmt::Display + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = RequestOutcome<CallToolResult>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) | Poll::Ready(Err(_)) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn call(&mut self, req: ToolRequest) -> Self::Future {
+        let future = self.inner.call(req);
+        Box::pin(async move {
+            Ok(match future.await {
+                Ok(outcome) => outcome,
+                Err(error) => RequestOutcome::Complete(CallToolResult::error(error.to_string())),
+            })
+        })
+    }
+}
+
 /// A tower [`Layer`](tower::Layer) that applies a guard function before the inner service.
 ///
 /// Guards run before the tool handler and can short-circuit with an error message.
@@ -237,16 +294,17 @@ pub struct GuardService<G, S> {
     inner: S,
 }
 
-impl<G, S> Service<ToolRequest> for GuardService<G, S>
+impl<G, S, R> Service<ToolRequest> for GuardService<G, S>
 where
     G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
-    S: Service<ToolRequest, Response = CallToolResult> + Clone + Send + 'static,
+    S: Service<ToolRequest, Response = R> + Clone + Send + 'static,
     S::Error: Into<Error> + Send,
     S::Future: Send,
+    R: Send + 'static,
 {
-    type Response = CallToolResult;
+    type Response = R;
     type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = std::result::Result<CallToolResult, Error>> + Send>>;
+    type Future = Pin<Box<dyn Future<Output = std::result::Result<R, Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         self.inner.poll_ready(cx).map_err(Into::into)
@@ -439,6 +497,114 @@ pub trait MrtrToolHandler: Send + Sync {
 
     /// Get the tool's input schema.
     fn input_schema(&self) -> Value;
+}
+
+/// Adapts an MRTR handler to Tower's service abstraction.
+#[cfg(feature = "stateless")]
+struct MrtrToolHandlerService<H> {
+    handler: Arc<H>,
+}
+
+#[cfg(feature = "stateless")]
+impl<H> MrtrToolHandlerService<H> {
+    fn new(handler: H) -> Self {
+        Self {
+            handler: Arc::new(handler),
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<H> Clone for MrtrToolHandlerService<H> {
+    fn clone(&self) -> Self {
+        Self {
+            handler: self.handler.clone(),
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl<H> Service<ToolRequest> for MrtrToolHandlerService<H>
+where
+    H: MrtrToolHandler + 'static,
+{
+    type Response = RequestOutcome<CallToolResult>;
+    type Error = Error;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: ToolRequest) -> Self::Future {
+        let handler = self.handler.clone();
+        Box::pin(async move { handler.call(req.ctx, req.args).await })
+    }
+}
+
+/// Runs an erased MRTR Tower service as an MRTR handler.
+#[cfg(feature = "stateless")]
+struct ServiceMrtrToolHandler {
+    service: Mutex<BoxMrtrToolService>,
+    input_schema: Value,
+}
+
+#[cfg(feature = "stateless")]
+struct GuardedMrtrToolHandler<G> {
+    guard: G,
+    inner: Arc<dyn MrtrToolHandler>,
+}
+
+#[cfg(feature = "stateless")]
+impl<G> MrtrToolHandler for GuardedMrtrToolHandler<G>
+where
+    G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
+{
+    fn call(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'_, Result<RequestOutcome<CallToolResult>>> {
+        let request = ToolRequest::new(ctx, args);
+        match (self.guard)(&request) {
+            Ok(()) => self.inner.call(request.ctx, request.args),
+            Err(message) => {
+                Box::pin(
+                    async move { Ok(RequestOutcome::Complete(CallToolResult::error(message))) },
+                )
+            }
+        }
+    }
+
+    fn input_schema(&self) -> Value {
+        self.inner.input_schema()
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl MrtrToolHandler for ServiceMrtrToolHandler {
+    fn call(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'_, Result<RequestOutcome<CallToolResult>>> {
+        Box::pin(async move {
+            let mut service = self.service.lock().await.clone();
+            let outcome = service
+                .ready()
+                .await
+                .expect("MRTR tool service is infallible")
+                .call(ToolRequest::new(ctx, args))
+                .await
+                .expect("MRTR tool service is infallible");
+            Ok(outcome)
+        })
+    }
+
+    fn input_schema(&self) -> Value {
+        self.input_schema.clone()
+    }
 }
 
 /// Adapts a `ToolHandler` to a Tower `Service<ToolRequest>`.
@@ -700,11 +866,19 @@ impl Tool {
     where
         G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
     {
+        #[cfg(feature = "stateless")]
+        if let Some(inner) = self.mrtr_handler.clone() {
+            return Tool {
+                mrtr_handler: Some(Arc::new(GuardedMrtrToolHandler { guard, inner })),
+                ..self
+            };
+        }
+
         let guarded = GuardService {
             guard,
             inner: self
                 .service
-                .expect("with_guard is not supported on an MRTR tool"),
+                .expect("tool must have a complete or MRTR handler"),
         };
         let caught = ToolCatchError::new(guarded);
         Tool {
@@ -1448,6 +1622,23 @@ pub struct ToolBuilderWithMrtrHandler<I, F> {
     _phantom: std::marker::PhantomData<I>,
 }
 
+/// Builder state after a layer has been applied to an MRTR handler.
+#[cfg(feature = "stateless")]
+#[doc(hidden)]
+pub struct ToolBuilderWithMrtrLayer<I, F, L> {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    output_schema: Option<Value>,
+    input_schema_override: Option<Value>,
+    icons: Option<Vec<ToolIcon>>,
+    annotations: Option<ToolAnnotations>,
+    task_support: TaskSupportMode,
+    handler: F,
+    layer: L,
+    _phantom: std::marker::PhantomData<I>,
+}
+
 /// Builder state for tools with no parameters.
 ///
 /// Created by [`ToolBuilder::no_params_handler`].
@@ -1705,6 +1896,112 @@ where
                 _phantom: std::marker::PhantomData,
             },
         )
+    }
+
+    /// Apply a Tower layer to every attempt at this MRTR-capable tool.
+    ///
+    /// Each MRTR retry is an independent request, so the layer runs once per
+    /// round. Middleware failures become complete tool error results, matching
+    /// the behavior of layers on non-MRTR tools.
+    pub fn layer<L>(self, layer: L) -> ToolBuilderWithMrtrLayer<I, F, L> {
+        ToolBuilderWithMrtrLayer {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema_override: self.input_schema_override,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: self.task_support,
+            handler: self.handler,
+            layer,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Apply a guard to every attempt at this MRTR-capable tool.
+    pub fn guard<G>(self, guard: G) -> ToolBuilderWithMrtrLayer<I, F, GuardLayer<G>>
+    where
+        G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
+    {
+        self.layer(GuardLayer::new(guard))
+    }
+}
+
+#[cfg(feature = "stateless")]
+#[allow(private_bounds)]
+impl<I, F, Fut, L> ToolBuilderWithMrtrLayer<I, F, L>
+where
+    I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+    F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+    L: tower::Layer<MrtrToolHandlerService<TypedMrtrHandler<I, F>>> + Clone + Send + Sync + 'static,
+    L::Service:
+        Service<ToolRequest, Response = RequestOutcome<CallToolResult>> + Clone + Send + 'static,
+    <L::Service as Service<ToolRequest>>::Error: fmt::Display + Send + 'static,
+    <L::Service as Service<ToolRequest>>::Future: Send + 'static,
+{
+    /// Build the MRTR-capable tool with the applied layer(s).
+    pub fn build(self) -> Tool {
+        let input_schema = self.input_schema_override.unwrap_or_else(|| {
+            let schema = schemars::schema_for!(I);
+            serde_json::to_value(schema).unwrap_or_else(|_| serde_json::json!({ "type": "object" }))
+        });
+        let input_schema = ensure_object_schema(input_schema);
+        let service = MrtrToolHandlerService::new(TypedMrtrHandler {
+            handler: self.handler,
+            _phantom: std::marker::PhantomData,
+        });
+        let service = self.layer.layer(service);
+        let service = BoxCloneService::new(MrtrToolCatchError::new(service));
+
+        Tool {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: self.task_support,
+            required_client_capabilities: None,
+            service: None,
+            mrtr_handler: Some(Arc::new(ServiceMrtrToolHandler {
+                service: Mutex::new(service),
+                input_schema: input_schema.clone(),
+            })),
+            input_schema,
+        }
+    }
+
+    /// Apply an additional Tower layer.
+    pub fn layer<L2>(
+        self,
+        layer: L2,
+    ) -> ToolBuilderWithMrtrLayer<I, F, tower::layer::util::Stack<L2, L>> {
+        ToolBuilderWithMrtrLayer {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema_override: self.input_schema_override,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: self.task_support,
+            handler: self.handler,
+            layer: tower::layer::util::Stack::new(layer, self.layer),
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Apply an additional guard.
+    pub fn guard<G>(
+        self,
+        guard: G,
+    ) -> ToolBuilderWithMrtrLayer<I, F, tower::layer::util::Stack<GuardLayer<G>, L>>
+    where
+        G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
+    {
+        self.layer(GuardLayer::new(guard))
     }
 }
 
@@ -2047,6 +2344,60 @@ mod tests {
                 .and_then(|result| result.request_state.as_deref()),
             Some("signed-state")
         );
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn mrtr_builder_composes_guards_and_layers() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::time::Duration;
+        use tower::timeout::TimeoutLayer;
+
+        let rounds = Arc::new(AtomicUsize::new(0));
+        let observed = rounds.clone();
+        let tool = ToolBuilder::new("guarded_continue")
+            .mrtr_handler::<NoParams, _, _>(|_ctx, _input| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("continue"),
+                ))
+            })
+            .layer(TimeoutLayer::new(Duration::from_secs(1)))
+            .guard(move |_request| {
+                observed.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            })
+            .build();
+
+        for _ in 0..2 {
+            assert!(
+                tool.call_outcome(serde_json::json!({}))
+                    .await
+                    .unwrap()
+                    .as_input_required()
+                    .is_some()
+            );
+        }
+        assert_eq!(rounds.load(Ordering::SeqCst), 2);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn built_mrtr_tool_accepts_a_guard() {
+        let tool = ToolBuilder::new("denied_continue")
+            .mrtr_handler::<NoParams, _, _>(|_ctx, _input| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("unreachable"),
+                ))
+            })
+            .build()
+            .with_guard(|_request| Err("MRTR access denied".to_string()));
+
+        let outcome = tool.call_outcome(serde_json::json!({})).await.unwrap();
+        let result = outcome
+            .as_complete()
+            .expect("guard rejection is a complete tool error");
+        assert!(result.is_error);
+        assert_eq!(result.first_text(), Some("MRTR access denied"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Completes the remaining MRTR server policy/composition work owned by #950.

## What changed

- add Tower `.layer()` composition to MRTR-capable tool, prompt, and static-resource handlers
- add `.guard()` support to MRTR tool builders and `Tool::with_guard()` for already-built MRTR tools
- run per-handler middleware and guards independently on every MRTR retry round
- preserve the established complete-handler behavior by converting middleware failures into complete error results while passing `input_required` outcomes through unchanged
- document that the server owns no continuation loop: client auto-driving uses `max_mrtr_rounds`, while server workflows that need a cap encode a counter in integrity-protected `requestState`
- document the decision to keep authenticated-principal binding explicit through `RequestStateCodec::encode_for` / `decode_for`, since auth middleware may expose application-defined identity types
- remove stale documentation that described MRTR as unimplemented

## Why

The final 2026-07-28 MRTR pattern treats every retry as an independent request. Middleware therefore needs round-local semantics, and a process-global server round counter would conflict with the stateless model. Explicit request-state and principal binding preserve multi-instance routing and keep the codec transport-neutral.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p tower-mcp --no-default-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc -p tower-mcp --all-features --no-deps`
- `cargo test --workspace --all-features`
- `git diff --check`