### PR TITLE
feat(client): add bounded OAuth scope escalation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks and all 26 client scenarios (295 checks) for 2025-11-25 (`conformance@0.1.16`), plus 114/114 server checks and all 32 client scenarios (382 checks) for 2026-07-28 (`conformance@0.2.0-alpha.10`), run with empty baselines in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 39/39 server checks and all 26 client scenarios (311 checks) for 2025-11-25 (`conformance@0.1.16`), plus 114/114 server checks and all 32 client scenarios (399 checks) for 2026-07-28 (`conformance@0.2.0-alpha.10`), run with empty baselines in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -587,9 +587,9 @@ let router = McpRouter::new()
 tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
 - **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
-- **Client (2025-11-25):** all 26 scenarios green, 295 checks (`conformance@0.1.16`); the client baseline is empty
+- **Client (2025-11-25):** all 26 scenarios green, 311 checks (`conformance@0.1.16`); the client baseline is empty
 - **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
-- **Client (2026-07-28):** all 32 scenarios green, 382 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
+- **Client (2026-07-28):** all 32 scenarios green, 399 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
 
 Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -68,7 +68,93 @@ struct CustomHeaderMapping {
 }
 
 #[cfg(feature = "oauth-client")]
-use super::oauth::TokenProvider;
+#[derive(Clone)]
+struct ScopeEscalationRuntime {
+    handler: Arc<dyn OAuthScopeEscalationHandler>,
+    state: Arc<tokio::sync::Mutex<ScopeEscalationState>>,
+    max_attempts: usize,
+}
+
+#[cfg(feature = "oauth-client")]
+struct ScopeEscalationState {
+    scopes: Vec<String>,
+    revision: usize,
+}
+
+#[cfg(feature = "oauth-client")]
+impl ScopeEscalationRuntime {
+    fn new<P>(handler: Arc<P>, config: OAuthScopeEscalationConfig) -> Self
+    where
+        P: OAuthScopeEscalationHandler,
+    {
+        Self {
+            handler,
+            state: Arc::new(tokio::sync::Mutex::new(ScopeEscalationState {
+                scopes: config.initial_scopes().to_vec(),
+                revision: 0,
+            })),
+            max_attempts: config.maximum_attempts(),
+        }
+    }
+
+    async fn respond_to_challenge(
+        &self,
+        challenge: OAuthScopeChallenge,
+        resource: &str,
+        operation: &str,
+        attempt: usize,
+        observed_revision: usize,
+    ) -> std::result::Result<ScopeEscalationDecision, OAuthClientError> {
+        // Serialize the complete reauthorization flow. A second operation
+        // challenged by the same scope can reuse the token produced by the
+        // first rather than opening a duplicate browser/headless flow.
+        let mut state = self.state.lock().await;
+        let previous_scopes = state.scopes.clone();
+        let mut requested_scopes = previous_scopes.clone();
+        for scope in &challenge.required_scopes {
+            if !requested_scopes.contains(scope) {
+                requested_scopes.push(scope.clone());
+            }
+        }
+
+        if requested_scopes == previous_scopes && state.revision > observed_revision {
+            return Ok(ScopeEscalationDecision {
+                revision: state.revision,
+            });
+        }
+        // The scope may have been requested previously without being granted,
+        // or the token may otherwise be stale. Reauthorize the same union
+        // again, but only within the caller's hard attempt limit.
+
+        self.handler
+            .reauthorize(OAuthScopeEscalationRequest {
+                resource: resource.to_string(),
+                operation: operation.to_string(),
+                challenge,
+                previous_scopes,
+                requested_scopes: requested_scopes.clone(),
+                attempt,
+            })
+            .await?;
+
+        state.scopes = requested_scopes;
+        state.revision += 1;
+        Ok(ScopeEscalationDecision {
+            revision: state.revision,
+        })
+    }
+}
+
+#[cfg(feature = "oauth-client")]
+struct ScopeEscalationDecision {
+    revision: usize,
+}
+
+#[cfg(feature = "oauth-client")]
+use super::oauth::{
+    OAuthClientError, OAuthScopeChallenge, OAuthScopeEscalationConfig, OAuthScopeEscalationHandler,
+    OAuthScopeEscalationRequest, TokenProvider,
+};
 
 /// Configuration for [`HttpClientTransport`].
 ///
@@ -263,6 +349,9 @@ pub struct HttpClientTransport {
     /// Dynamic token provider for OAuth or other token-based auth.
     #[cfg(feature = "oauth-client")]
     token_provider: Option<Arc<dyn TokenProvider>>,
+    /// Runtime policy for insufficient-scope challenges.
+    #[cfg(feature = "oauth-client")]
+    scope_escalation: Option<ScopeEscalationRuntime>,
 }
 
 impl HttpClientTransport {
@@ -316,6 +405,8 @@ impl HttpClientTransport {
             config,
             #[cfg(feature = "oauth-client")]
             token_provider: None,
+            #[cfg(feature = "oauth-client")]
+            scope_escalation: None,
         }
     }
 
@@ -355,6 +446,8 @@ impl HttpClientTransport {
             config,
             #[cfg(feature = "oauth-client")]
             token_provider: None,
+            #[cfg(feature = "oauth-client")]
+            scope_escalation: None,
         }
     }
 
@@ -498,6 +591,34 @@ impl HttpClientTransport {
     #[cfg(feature = "oauth-client")]
     pub fn with_token_provider(mut self, provider: impl TokenProvider) -> Self {
         self.token_provider = Some(Arc::new(provider));
+        self.scope_escalation = None;
+        self
+    }
+
+    /// Set a token provider with bounded runtime scope escalation.
+    ///
+    /// When an MCP operation receives an HTTP 403 Bearer challenge with
+    /// `error="insufficient_scope"`, the transport unions the challenged
+    /// scopes with the scopes already tracked by `config`, invokes
+    /// [`OAuthScopeEscalationHandler::reauthorize`], asks the provider for a
+    /// fresh token, and retries the same operation. Reauthorization is
+    /// serialized across concurrent requests, and each operation is bounded
+    /// by [`OAuthScopeEscalationConfig::maximum_attempts`].
+    ///
+    /// The provider and handler are the same value so the handler can update
+    /// the token returned by [`TokenProvider::get_token`].
+    #[cfg(feature = "oauth-client")]
+    pub fn with_scope_aware_token_provider<P>(
+        mut self,
+        provider: P,
+        config: OAuthScopeEscalationConfig,
+    ) -> Self
+    where
+        P: TokenProvider + OAuthScopeEscalationHandler,
+    {
+        let provider = Arc::new(provider);
+        self.token_provider = Some(provider.clone());
+        self.scope_escalation = Some(ScopeEscalationRuntime::new(provider, config));
         self
     }
 
@@ -753,10 +874,165 @@ fn encode_header_value(value: &str) -> String {
     }
 }
 
+#[cfg(feature = "oauth-client")]
+fn bearer_headers(token: &str) -> std::result::Result<reqwest::header::HeaderMap, String> {
+    let value = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+        .map_err(|_| "token provider returned an invalid bearer token".to_string())?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(reqwest::header::AUTHORIZATION, value);
+    // RequestBuilder::header appends, which can leave a stale Authorization
+    // value in front of the fresh token. Supplying a HeaderMap replaces the
+    // existing value instead.
+    Ok(headers)
+}
+
 fn is_jsonrpc_error_response(value: &serde_json::Value) -> bool {
     value.get("error").is_some_and(serde_json::Value::is_object)
         && value.pointer("/error/code").is_some()
         && value.pointer("/error/message").is_some()
+}
+
+struct HttpRequestSendError {
+    message: String,
+    connection_failed: bool,
+}
+
+impl HttpRequestSendError {
+    fn request(error: reqwest::Error) -> Self {
+        Self {
+            message: format!("HTTP request failed: {error}"),
+            connection_failed: true,
+        }
+    }
+
+    #[cfg(feature = "oauth-client")]
+    fn oauth(error: OAuthClientError) -> Self {
+        Self {
+            message: error.to_string(),
+            connection_failed: false,
+        }
+    }
+}
+
+async fn send_http_request(
+    mut request: reqwest::RequestBuilder,
+    resource: &str,
+    operation: &str,
+    #[cfg(feature = "oauth-client")] token_provider: Option<Arc<dyn TokenProvider>>,
+    #[cfg(feature = "oauth-client")] scope_escalation: Option<ScopeEscalationRuntime>,
+    #[cfg(feature = "oauth-client")] initial_scope_revision: usize,
+) -> std::result::Result<reqwest::Response, HttpRequestSendError> {
+    #[cfg(not(feature = "oauth-client"))]
+    let _ = (resource, operation);
+
+    #[cfg(feature = "oauth-client")]
+    let mut observed_revision = initial_scope_revision;
+    #[cfg(feature = "oauth-client")]
+    let mut attempts = 0;
+
+    loop {
+        #[cfg(feature = "oauth-client")]
+        let retry_request = request.try_clone();
+
+        let response = request
+            .send()
+            .await
+            .map_err(HttpRequestSendError::request)?;
+
+        #[cfg(feature = "oauth-client")]
+        {
+            let challenge = if response.status() == reqwest::StatusCode::FORBIDDEN {
+                scope_challenge(response.headers())
+            } else {
+                None
+            };
+            let Some(challenge) = challenge else {
+                return Ok(response);
+            };
+            let (Some(runtime), Some(provider), Some(mut retry_request)) = (
+                scope_escalation.as_ref(),
+                token_provider.as_ref(),
+                retry_request,
+            ) else {
+                return Ok(response);
+            };
+            if attempts >= runtime.max_attempts {
+                return Ok(response);
+            }
+
+            attempts += 1;
+            let decision = runtime
+                .respond_to_challenge(challenge, resource, operation, attempts, observed_revision)
+                .await
+                .map_err(HttpRequestSendError::oauth)?;
+            observed_revision = decision.revision;
+
+            let token = provider
+                .get_token()
+                .await
+                .map_err(HttpRequestSendError::oauth)?;
+            let headers = bearer_headers(&token).map_err(|message| {
+                HttpRequestSendError::oauth(OAuthClientError::ScopeEscalation(message))
+            })?;
+            retry_request = retry_request.headers(headers);
+            request = retry_request;
+        }
+
+        #[cfg(not(feature = "oauth-client"))]
+        return Ok(response);
+    }
+}
+
+#[cfg(feature = "oauth-client")]
+fn scope_challenge(headers: &reqwest::header::HeaderMap) -> Option<OAuthScopeChallenge> {
+    headers
+        .get_all(reqwest::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(OAuthScopeChallenge::from_www_authenticate)
+}
+
+fn http_status_error(status: reqwest::StatusCode, headers: &reqwest::header::HeaderMap) -> String {
+    #[cfg(feature = "oauth-client")]
+    if let Some(challenge) = scope_challenge(headers) {
+        let mut message = format!(
+            "server returned HTTP {status}: insufficient_scope requires {}",
+            challenge.required_scopes.join(" ")
+        );
+        if let Some(resource_metadata) = challenge.resource_metadata {
+            message.push_str(&format!(" (resource metadata: {resource_metadata})"));
+        }
+        return message;
+    }
+
+    #[cfg(not(feature = "oauth-client"))]
+    let _ = headers;
+    format!("server returned HTTP {status}")
+}
+
+fn operation_label(parsed: Option<&serde_json::Value>) -> String {
+    let Some(method) = parsed
+        .and_then(|value| value.get("method"))
+        .and_then(serde_json::Value::as_str)
+    else {
+        return "unknown".to_string();
+    };
+    let target = match method {
+        "tools/call" | "prompts/get" => parsed
+            .and_then(|value| value.pointer("/params/name"))
+            .and_then(serde_json::Value::as_str),
+        "resources/read" => parsed
+            .and_then(|value| value.pointer("/params/uri"))
+            .and_then(serde_json::Value::as_str),
+        "tasks/get" | "tasks/update" | "tasks/cancel" => parsed
+            .and_then(|value| value.pointer("/params/taskId"))
+            .and_then(serde_json::Value::as_str),
+        _ => None,
+    };
+    match target {
+        Some(target) => format!("{method}:{target}"),
+        None => method.to_string(),
+    }
 }
 
 #[async_trait]
@@ -781,6 +1057,7 @@ impl ClientTransport for HttpClientTransport {
             .as_ref()
             .and_then(|value| value.get("method"))
             .and_then(serde_json::Value::as_str);
+        let operation = operation_label(parsed_message.as_ref());
         let outbound_version = parsed_message
             .as_ref()
             .and_then(|value| {
@@ -857,6 +1134,12 @@ impl ClientTransport for HttpClientTransport {
             request = request.header(key.as_str(), value.as_str());
         }
 
+        #[cfg(feature = "oauth-client")]
+        let initial_scope_revision = match &self.scope_escalation {
+            Some(runtime) => runtime.state.lock().await.revision,
+            None => 0,
+        };
+
         // Dynamic token provider overrides static Authorization header
         #[cfg(feature = "oauth-client")]
         if let Some(ref provider) = self.token_provider {
@@ -864,7 +1147,7 @@ impl ClientTransport for HttpClientTransport {
                 .get_token()
                 .await
                 .map_err(|e| Error::Transport(format!("Token provider error: {}", e)))?;
-            request = request.header("Authorization", format!("Bearer {}", token));
+            request = request.headers(bearer_headers(&token).map_err(Error::Transport)?);
         }
 
         let request = request.body(message.to_string());
@@ -899,21 +1182,36 @@ impl ClientTransport for HttpClientTransport {
             let sse_retry_delay = self.sse_retry_delay.clone();
             let sse_reconnect_signal = self.sse_reconnect_signal.clone();
             let max_sse_event_size = self.config.max_sse_event_size;
+            let request_resource = self.url.clone();
+            #[cfg(feature = "oauth-client")]
+            let token_provider = self.token_provider.clone();
+            #[cfg(feature = "oauth-client")]
+            let scope_escalation = self.scope_escalation.clone();
             self.request_tasks.retain(|_, task| !task.is_finished());
             let task = tokio::spawn(async move {
-                let response = match request.send().await {
+                let response_result = send_http_request(
+                    request,
+                    &request_resource,
+                    &operation,
+                    #[cfg(feature = "oauth-client")]
+                    token_provider,
+                    #[cfg(feature = "oauth-client")]
+                    scope_escalation,
+                    #[cfg(feature = "oauth-client")]
+                    initial_scope_revision,
+                )
+                .await;
+                let response = match response_result {
                     Ok(r) => r,
                     Err(e) => {
-                        tracing::error!(error = %e, "Background HTTP request failed");
+                        let connection_failed = e.connection_failed;
+                        tracing::error!(error = %e.message, "Background HTTP request failed");
                         if let Some(id) = &req_id {
-                            let _ = tx
-                                .send(transport_error_frame(
-                                    id,
-                                    &format!("HTTP request failed: {e}"),
-                                ))
-                                .await;
+                            let _ = tx.send(transport_error_frame(id, &e.message)).await;
                         }
-                        connected.store(false, Ordering::Release);
+                        if connection_failed {
+                            connected.store(false, Ordering::Release);
+                        }
                         return;
                     }
                 };
@@ -926,6 +1224,7 @@ impl ClientTransport for HttpClientTransport {
                 }
 
                 if !status.is_success() {
+                    let status_error = http_status_error(status, response.headers());
                     let body = response.text().await.unwrap_or_default();
 
                     // Forward a JSON-RPC error body so the message loop can
@@ -952,12 +1251,7 @@ impl ClientTransport for HttpClientTransport {
 
                     tracing::error!(status = %status, body = %body, "HTTP error from server");
                     if let Some(id) = &req_id {
-                        let _ = tx
-                            .send(transport_error_frame(
-                                id,
-                                &format!("server returned HTTP {status}"),
-                            ))
-                            .await;
+                        let _ = tx.send(transport_error_frame(id, &status_error)).await;
                     }
                     connected.store(false, Ordering::Release);
                     return;
@@ -1208,10 +1502,19 @@ impl ClientTransport for HttpClientTransport {
         // Pre-session (initialize) and notifications: handle synchronously.
         // For initialize this extracts session headers and starts the SSE
         // stream; for notifications the expected response is a bare 202.
-        let response = request
-            .send()
-            .await
-            .map_err(|e| Error::Transport(format!("HTTP request failed: {}", e)))?;
+        let response = send_http_request(
+            request,
+            &self.url,
+            &operation,
+            #[cfg(feature = "oauth-client")]
+            self.token_provider.clone(),
+            #[cfg(feature = "oauth-client")]
+            self.scope_escalation.clone(),
+            #[cfg(feature = "oauth-client")]
+            initial_scope_revision,
+        )
+        .await
+        .map_err(|e| Error::Transport(e.message))?;
 
         let status = response.status();
 
@@ -1240,6 +1543,8 @@ impl ClientTransport for HttpClientTransport {
         }
 
         if !status.is_success() {
+            #[cfg(feature = "oauth-client")]
+            let status_error = http_status_error(status, response.headers());
             let body = response.text().await.unwrap_or_default();
             if is_modern_request
                 && let Ok(mut error) = serde_json::from_str::<serde_json::Value>(&body)
@@ -1273,9 +1578,18 @@ impl ClientTransport for HttpClientTransport {
                     self.url
                 )));
             }
+            #[cfg(feature = "oauth-client")]
+            if status == reqwest::StatusCode::FORBIDDEN
+                && status_error.contains("insufficient_scope")
+            {
+                return Err(Error::Transport(if body.is_empty() {
+                    status_error
+                } else {
+                    format!("{status_error}: {body}")
+                }));
+            }
             return Err(Error::Transport(format!(
-                "HTTP {} from server: {}",
-                status, body
+                "HTTP {status} from server: {body}"
             )));
         }
 
@@ -1354,8 +1668,9 @@ impl ClientTransport for HttpClientTransport {
             #[cfg(feature = "oauth-client")]
             if let Some(ref provider) = self.token_provider
                 && let Ok(token) = provider.get_token().await
+                && let Ok(headers) = bearer_headers(&token)
             {
-                request = request.header("Authorization", format!("Bearer {}", token));
+                request = request.headers(headers);
             }
 
             let _ = request.send().await;
@@ -1467,9 +1782,13 @@ async fn sse_stream_loop(params: SseLoopParams) {
         #[cfg(feature = "oauth-client")]
         if let Some(ref provider) = token_provider {
             match provider.get_token().await {
-                Ok(token) => {
-                    request = request.header("Authorization", format!("Bearer {}", token));
-                }
+                Ok(token) => match bearer_headers(&token) {
+                    Ok(headers) => request = request.headers(headers),
+                    Err(error) => {
+                        tracing::warn!(%error, "Token provider failed for SSE connection");
+                        break;
+                    }
+                },
                 Err(e) => {
                     tracing::warn!(error = %e, "Token provider failed for SSE connection");
                     break;

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -915,13 +915,15 @@ impl HttpRequestSendError {
 }
 
 async fn send_http_request(
-    mut request: reqwest::RequestBuilder,
+    request: reqwest::RequestBuilder,
     resource: &str,
     operation: &str,
     #[cfg(feature = "oauth-client")] token_provider: Option<Arc<dyn TokenProvider>>,
     #[cfg(feature = "oauth-client")] scope_escalation: Option<ScopeEscalationRuntime>,
     #[cfg(feature = "oauth-client")] initial_scope_revision: usize,
 ) -> std::result::Result<reqwest::Response, HttpRequestSendError> {
+    #[cfg(feature = "oauth-client")]
+    let mut request = request;
     #[cfg(not(feature = "oauth-client"))]
     let _ = (resource, operation);
 

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -48,7 +48,9 @@ pub use handler::{ClientHandler, NotificationHandler, ServerNotification};
 pub use http::{HttpClientConfig, HttpClientTransport};
 #[cfg(feature = "oauth-client")]
 pub use oauth::{
-    OAuthClientCredentials, OAuthClientCredentialsBuilder, OAuthClientError, TokenProvider,
+    OAuthClientCredentials, OAuthClientCredentialsBuilder, OAuthClientError, OAuthScopeChallenge,
+    OAuthScopeEscalationConfig, OAuthScopeEscalationHandler, OAuthScopeEscalationRequest,
+    TokenProvider,
 };
 #[cfg(feature = "oauth-client")]
 pub use oauth_authcode::{

--- a/crates/tower-mcp/src/client/oauth.rs
+++ b/crates/tower-mcp/src/client/oauth.rs
@@ -76,6 +76,243 @@ pub trait TokenProvider: Send + Sync + 'static {
     async fn get_token(&self) -> Result<String, OAuthClientError>;
 }
 
+/// An OAuth `insufficient_scope` Bearer challenge.
+///
+/// MCP authorization servers use this challenge on HTTP 403 responses to tell
+/// clients which additional scopes are required for the attempted operation.
+/// See [`OAuthScopeChallenge::from_www_authenticate`] for parsing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthScopeChallenge {
+    /// Scopes requested by the authorization server.
+    pub required_scopes: Vec<String>,
+    /// Protected resource metadata URL supplied by the server.
+    pub resource_metadata: Option<String>,
+    /// Human-readable description supplied by the server.
+    pub error_description: Option<String>,
+}
+
+impl OAuthScopeChallenge {
+    /// Parse an `insufficient_scope` Bearer challenge from a
+    /// `WWW-Authenticate` header value.
+    ///
+    /// Returns `None` for other authentication schemes, other OAuth errors,
+    /// or challenges that do not include at least one required scope.
+    pub fn from_www_authenticate(header: &str) -> Option<Self> {
+        let mut in_bearer_challenge = false;
+        let mut found_bearer_challenge = false;
+        let mut error = None;
+        let mut scope = None;
+        let mut resource_metadata = None;
+        let mut error_description = None;
+
+        for segment in split_quoted_commas(header) {
+            let segment = segment.trim();
+            let (parameter, starts_challenge) = if let Some((candidate_scheme, remainder)) =
+                segment.split_once(char::is_whitespace)
+            {
+                if !candidate_scheme.contains('=') {
+                    if found_bearer_challenge {
+                        break;
+                    }
+                    in_bearer_challenge = candidate_scheme.eq_ignore_ascii_case("Bearer");
+                    found_bearer_challenge = in_bearer_challenge;
+                    (remainder.trim(), true)
+                } else {
+                    (segment, false)
+                }
+            } else {
+                (segment, false)
+            };
+
+            if starts_challenge && !in_bearer_challenge {
+                continue;
+            }
+            if !in_bearer_challenge {
+                continue;
+            }
+
+            let Some((name, value)) = parameter.split_once('=') else {
+                continue;
+            };
+            let value = unquote_auth_param(value.trim())?;
+            match name.trim() {
+                name if name.eq_ignore_ascii_case("error") => error = Some(value),
+                name if name.eq_ignore_ascii_case("scope") => scope = Some(value),
+                name if name.eq_ignore_ascii_case("resource_metadata") => {
+                    resource_metadata = Some(value)
+                }
+                name if name.eq_ignore_ascii_case("error_description") => {
+                    error_description = Some(value)
+                }
+                _ => {}
+            }
+        }
+
+        if error.as_deref() != Some("insufficient_scope") {
+            return None;
+        }
+        let required_scopes = unique_scopes(scope?.split_ascii_whitespace());
+        if required_scopes.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            required_scopes,
+            resource_metadata,
+            error_description,
+        })
+    }
+}
+
+/// Context passed to an [`OAuthScopeEscalationHandler`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthScopeEscalationRequest {
+    /// MCP protected-resource URL that rejected the request.
+    pub resource: String,
+    /// MCP operation that was rejected, such as `tools/call:search`.
+    pub operation: String,
+    /// Parsed authorization-server challenge.
+    pub challenge: OAuthScopeChallenge,
+    /// Scopes held before this escalation.
+    pub previous_scopes: Vec<String>,
+    /// Stable-order union of previous and newly required scopes.
+    pub requested_scopes: Vec<String>,
+    /// One-based retry attempt for this resource operation.
+    pub attempt: usize,
+}
+
+/// Application hook for interactive or headless OAuth reauthorization.
+///
+/// Implementations should acquire a token for `request.requested_scopes` and
+/// update the [`TokenProvider`] installed with
+/// [`HttpClientTransport::with_scope_aware_token_provider`](crate::client::HttpClientTransport::with_scope_aware_token_provider).
+/// After this method succeeds, the transport asks that provider for a fresh
+/// token and retries the rejected MCP operation.
+#[async_trait]
+pub trait OAuthScopeEscalationHandler: Send + Sync + 'static {
+    /// Reauthorize for the stable-order scope union in `request`.
+    async fn reauthorize(
+        &self,
+        request: OAuthScopeEscalationRequest,
+    ) -> Result<(), OAuthClientError>;
+}
+
+/// Runtime scope-escalation policy for `HttpClientTransport`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OAuthScopeEscalationConfig {
+    initial_scopes: Vec<String>,
+    max_attempts: usize,
+}
+
+impl Default for OAuthScopeEscalationConfig {
+    fn default() -> Self {
+        Self {
+            initial_scopes: Vec::new(),
+            max_attempts: 2,
+        }
+    }
+}
+
+impl OAuthScopeEscalationConfig {
+    /// Create a policy with the scopes requested for the initial token.
+    ///
+    /// Duplicate and blank scope values are removed while preserving order.
+    /// By default, at most two challenged retries are permitted per MCP
+    /// operation.
+    pub fn new(scopes: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self {
+            initial_scopes: unique_scopes(scopes.into_iter().map(Into::into).flat_map(
+                |scope: String| {
+                    scope
+                        .split_ascii_whitespace()
+                        .map(str::to_string)
+                        .collect::<Vec<_>>()
+                },
+            )),
+            ..Self::default()
+        }
+    }
+
+    /// Set the maximum number of challenged retries for one MCP operation.
+    ///
+    /// Set this to zero to surface the first HTTP 403 without reauthorizing.
+    pub fn max_attempts(mut self, max_attempts: usize) -> Self {
+        self.max_attempts = max_attempts;
+        self
+    }
+
+    /// Initial scopes tracked by the policy.
+    pub fn initial_scopes(&self) -> &[String] {
+        &self.initial_scopes
+    }
+
+    /// Maximum challenged retries for one MCP operation.
+    pub fn maximum_attempts(&self) -> usize {
+        self.max_attempts
+    }
+}
+
+fn unique_scopes(scopes: impl IntoIterator<Item = impl AsRef<str>>) -> Vec<String> {
+    let mut unique = Vec::new();
+    for scope in scopes {
+        let scope = scope.as_ref();
+        if !scope.is_empty() && !unique.iter().any(|existing| existing == scope) {
+            unique.push(scope.to_string());
+        }
+    }
+    unique
+}
+
+fn split_quoted_commas(header: &str) -> Vec<&str> {
+    let mut segments = Vec::new();
+    let mut start = 0;
+    let mut quoted = false;
+    let mut escaped = false;
+    for (index, character) in header.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' if quoted => escaped = true,
+            '"' => quoted = !quoted,
+            ',' if !quoted => {
+                segments.push(&header[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    segments.push(&header[start..]);
+    segments
+}
+
+fn unquote_auth_param(value: &str) -> Option<String> {
+    if !value.starts_with('"') {
+        return Some(value.to_string());
+    }
+    if !value.ends_with('"') || value.len() < 2 {
+        return None;
+    }
+
+    let mut unquoted = String::new();
+    let mut escaped = false;
+    for character in value[1..value.len() - 1].chars() {
+        if escaped {
+            unquoted.push(character);
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else {
+            unquoted.push(character);
+        }
+    }
+    if escaped {
+        return None;
+    }
+    Some(unquoted)
+}
+
 /// Error type for OAuth client operations.
 #[derive(Debug)]
 #[non_exhaustive]
@@ -86,6 +323,8 @@ pub enum OAuthClientError {
     TokenRequest(String),
     /// Failed to register an OAuth client.
     Registration(String),
+    /// Failed to reauthorize after an insufficient-scope challenge.
+    ScopeEscalation(String),
     /// The token response was invalid or missing required fields.
     InvalidResponse(String),
     /// Builder validation failed (missing required fields).
@@ -98,6 +337,7 @@ impl fmt::Display for OAuthClientError {
             Self::Discovery(msg) => write!(f, "OAuth discovery error: {}", msg),
             Self::TokenRequest(msg) => write!(f, "OAuth token request error: {}", msg),
             Self::Registration(msg) => write!(f, "OAuth client registration error: {}", msg),
+            Self::ScopeEscalation(msg) => write!(f, "OAuth scope escalation error: {}", msg),
             Self::InvalidResponse(msg) => write!(f, "OAuth invalid response: {}", msg),
             Self::BuildError(msg) => write!(f, "OAuth builder error: {}", msg),
         }
@@ -577,11 +817,72 @@ mod tests {
         let err = OAuthClientError::Registration("rejected".into());
         assert_eq!(err.to_string(), "OAuth client registration error: rejected");
 
+        let err = OAuthClientError::ScopeEscalation("denied".into());
+        assert_eq!(err.to_string(), "OAuth scope escalation error: denied");
+
         let err = OAuthClientError::InvalidResponse("bad json".into());
         assert_eq!(err.to_string(), "OAuth invalid response: bad json");
 
         let err = OAuthClientError::BuildError("missing field".into());
         assert_eq!(err.to_string(), "OAuth builder error: missing field");
+    }
+
+    #[test]
+    fn parses_insufficient_scope_challenge() {
+        let challenge = OAuthScopeChallenge::from_www_authenticate(
+            r#"Bearer error="insufficient_scope", scope="files.read files.write files.read", resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource", error_description="Need files, including \"shared\"""#,
+        )
+        .unwrap();
+
+        assert_eq!(challenge.required_scopes, vec!["files.read", "files.write"]);
+        assert_eq!(
+            challenge.resource_metadata.as_deref(),
+            Some("https://mcp.example.com/.well-known/oauth-protected-resource")
+        );
+        assert_eq!(
+            challenge.error_description.as_deref(),
+            Some(r#"Need files, including "shared""#)
+        );
+    }
+
+    #[test]
+    fn selects_bearer_from_multiple_authentication_challenges() {
+        let challenge = OAuthScopeChallenge::from_www_authenticate(
+            r#"Basic realm="legacy", Bearer realm="mcp", error="insufficient_scope", scope="tools.call""#,
+        )
+        .unwrap();
+
+        assert_eq!(challenge.required_scopes, vec!["tools.call"]);
+    }
+
+    #[test]
+    fn ignores_non_scope_authentication_challenges() {
+        assert!(
+            OAuthScopeChallenge::from_www_authenticate(
+                r#"Bearer error="invalid_token", scope="tools.call""#
+            )
+            .is_none()
+        );
+        assert!(
+            OAuthScopeChallenge::from_www_authenticate(
+                r#"Bearer error="insufficient_scope", scope="""#
+            )
+            .is_none()
+        );
+        assert!(OAuthScopeChallenge::from_www_authenticate(r#"Basic realm="mcp""#).is_none());
+    }
+
+    #[test]
+    fn scope_escalation_config_normalizes_scopes() {
+        let config =
+            OAuthScopeEscalationConfig::new(["openid profile", "profile", "", "tools.call"])
+                .max_attempts(3);
+
+        assert_eq!(
+            config.initial_scopes(),
+            &["openid", "profile", "tools.call"]
+        );
+        assert_eq!(config.maximum_attempts(), 3);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -526,8 +526,9 @@ pub use client::{HttpClientConfig, HttpClientTransport};
 pub use client::{
     OAuthApplicationType, OAuthAuthorizationServerMetadata, OAuthClientCredentials,
     OAuthClientError, OAuthClientRegistration, OAuthClientRegistrationMethod,
-    OAuthClientRegistrationOptions, OAuthDynamicClientRegistration, TokenProvider,
-    discover_oauth_authorization_server, resolve_oauth_client_registration,
+    OAuthClientRegistrationOptions, OAuthDynamicClientRegistration, OAuthScopeChallenge,
+    OAuthScopeEscalationConfig, OAuthScopeEscalationHandler, OAuthScopeEscalationRequest,
+    TokenProvider, discover_oauth_authorization_server, resolve_oauth_client_registration,
 };
 pub use context::{
     ChannelClientRequester, ClientRequester, ClientRequesterHandle, Extensions,

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -1132,7 +1132,11 @@ async fn test_http_client_root_management() {
 #[cfg(feature = "oauth-client")]
 mod token_provider_tests {
     use super::*;
-    use tower_mcp::{OAuthClientError, TokenProvider};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tower_mcp::{
+        OAuthClientError, OAuthScopeEscalationConfig, OAuthScopeEscalationHandler,
+        OAuthScopeEscalationRequest, TokenProvider,
+    };
 
     struct StaticTokenProvider(String);
 
@@ -1141,6 +1145,91 @@ mod token_provider_tests {
         async fn get_token(&self) -> Result<String, OAuthClientError> {
             Ok(self.0.clone())
         }
+    }
+
+    struct EscalatingTokenProvider {
+        token: Arc<tokio::sync::RwLock<String>>,
+        requests: Arc<Mutex<Vec<OAuthScopeEscalationRequest>>>,
+        reauthorization_delay: Duration,
+    }
+
+    #[async_trait]
+    impl TokenProvider for EscalatingTokenProvider {
+        async fn get_token(&self) -> Result<String, OAuthClientError> {
+            Ok(self.token.read().await.clone())
+        }
+    }
+
+    #[async_trait]
+    impl OAuthScopeEscalationHandler for EscalatingTokenProvider {
+        async fn reauthorize(
+            &self,
+            request: OAuthScopeEscalationRequest,
+        ) -> Result<(), OAuthClientError> {
+            self.requests.lock().unwrap().push(request);
+            tokio::time::sleep(self.reauthorization_delay).await;
+            *self.token.write().await = "escalated-token".to_string();
+            Ok(())
+        }
+    }
+
+    async fn start_scope_challenge_server(
+        always_reject: bool,
+    ) -> (String, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+        use axum::{
+            extract::Request,
+            http::{HeaderValue, StatusCode, header::WWW_AUTHENTICATE},
+            middleware,
+            response::IntoResponse,
+        };
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://127.0.0.1:{}", addr.port());
+        let challenge = format!(
+            r#"Bearer error="insufficient_scope", scope="tools.read", resource_metadata="{url}/.well-known/oauth-protected-resource", error_description="tools/list requires tools.read""#
+        );
+        let request_count = Arc::new(AtomicUsize::new(0));
+
+        let transport = HttpTransport::new(test_router()).disable_origin_validation();
+        let count = request_count.clone();
+        let app = transport.into_router().layer(middleware::from_fn(
+            move |request: Request, next: middleware::Next| {
+                let count = count.clone();
+                let challenge = challenge.clone();
+                async move {
+                    let method = request
+                        .headers()
+                        .get("mcp-method")
+                        .and_then(|value| value.to_str().ok());
+                    let is_tools_list = method == Some("tools/list");
+                    if is_tools_list {
+                        count.fetch_add(1, Ordering::SeqCst);
+                    }
+                    let escalated = request
+                        .headers()
+                        .get("authorization")
+                        .and_then(|value| value.to_str().ok())
+                        == Some("Bearer escalated-token");
+
+                    if is_tools_list && (always_reject || !escalated) {
+                        let mut response = StatusCode::FORBIDDEN.into_response();
+                        response
+                            .headers_mut()
+                            .insert(WWW_AUTHENTICATE, HeaderValue::from_str(&challenge).unwrap());
+                        response
+                    } else {
+                        next.run(request).await
+                    }
+                }
+            },
+        ));
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        (url, request_count, handle)
     }
 
     #[tokio::test]
@@ -1171,6 +1260,87 @@ mod token_provider_tests {
 
         let result = client.initialize("test-client", "1.0.0").await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn scope_challenge_reauthorizes_and_retries_operation() {
+        let (url, request_count, _server) = start_scope_challenge_server(false).await;
+        let token = Arc::new(tokio::sync::RwLock::new("initial-token".to_string()));
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = EscalatingTokenProvider {
+            token,
+            requests: requests.clone(),
+            reauthorization_delay: Duration::ZERO,
+        };
+        let transport = HttpClientTransport::new(&url)
+            .with_scope_aware_token_provider(provider, OAuthScopeEscalationConfig::new(["openid"]));
+        let client = McpClient::connect(transport).await.unwrap();
+
+        client.initialize("test-client", "1.0.0").await.unwrap();
+        let tools = client.list_tools().await.unwrap();
+        assert_eq!(tools.tools.len(), 2);
+        assert_eq!(request_count.load(Ordering::SeqCst), 2);
+
+        {
+            let recorded = requests.lock().unwrap();
+            assert_eq!(recorded.len(), 1);
+            assert_eq!(recorded[0].resource, url);
+            assert_eq!(recorded[0].operation, "tools/list");
+            assert_eq!(recorded[0].previous_scopes, ["openid"]);
+            assert_eq!(recorded[0].requested_scopes, ["openid", "tools.read"]);
+            assert_eq!(recorded[0].challenge.required_scopes, ["tools.read"]);
+            assert!(recorded[0].challenge.resource_metadata.is_some());
+            assert_eq!(recorded[0].attempt, 1);
+        }
+
+        client.shutdown().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn repeated_scope_challenge_stops_at_configured_retry_limit() {
+        let (url, request_count, _server) = start_scope_challenge_server(true).await;
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = EscalatingTokenProvider {
+            token: Arc::new(tokio::sync::RwLock::new("initial-token".to_string())),
+            requests: requests.clone(),
+            reauthorization_delay: Duration::ZERO,
+        };
+        let transport = HttpClientTransport::new(&url).with_scope_aware_token_provider(
+            provider,
+            OAuthScopeEscalationConfig::new(["openid"]).max_attempts(3),
+        );
+        let client = McpClient::connect(transport).await.unwrap();
+
+        client.initialize("test-client", "1.0.0").await.unwrap();
+        let error = client.list_tools().await.unwrap_err().to_string();
+
+        assert!(error.contains("insufficient_scope"));
+        assert!(error.contains("tools.read"));
+        assert_eq!(request_count.load(Ordering::SeqCst), 4);
+        assert_eq!(requests.lock().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn concurrent_scope_challenges_share_one_reauthorization() {
+        let (url, request_count, _server) = start_scope_challenge_server(false).await;
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let provider = EscalatingTokenProvider {
+            token: Arc::new(tokio::sync::RwLock::new("initial-token".to_string())),
+            requests: requests.clone(),
+            reauthorization_delay: Duration::from_millis(50),
+        };
+        let transport = HttpClientTransport::new(&url)
+            .with_scope_aware_token_provider(provider, OAuthScopeEscalationConfig::new(["openid"]));
+        let client = McpClient::connect(transport).await.unwrap();
+        client.initialize("test-client", "1.0.0").await.unwrap();
+
+        let (first, second) = tokio::join!(client.list_tools(), client.list_tools());
+
+        assert_eq!(first.unwrap().tools.len(), 2);
+        assert_eq!(second.unwrap().tools.len(), 2);
+        assert_eq!(requests.lock().unwrap().len(), 1);
+        assert!((3..=4).contains(&request_count.load(Ordering::SeqCst)));
+        client.shutdown().await.unwrap();
     }
 }
 

--- a/examples/conformance-client/src/auth_scenarios.rs
+++ b/examples/conformance-client/src/auth_scenarios.rs
@@ -6,9 +6,10 @@
 
 use anyhow::{Context, Result};
 use tower_mcp::{
-    HttpClientConfig, HttpClientTransport, OAuthAuthorizationServerMetadata,
+    HttpClientConfig, HttpClientTransport, OAuthAuthorizationServerMetadata, OAuthClientError,
     OAuthClientRegistration, OAuthClientRegistrationOptions, OAuthDynamicClientRegistration,
-    resolve_oauth_client_registration,
+    OAuthScopeEscalationConfig, OAuthScopeEscalationHandler, OAuthScopeEscalationRequest,
+    TokenProvider, resolve_oauth_client_registration,
 };
 
 use crate::handlers;
@@ -16,6 +17,56 @@ use crate::handlers;
 struct OAuthFlowResult {
     access_token: String,
     requested_scope: Option<String>,
+}
+
+struct ConformanceScopeTokenProvider {
+    token: tokio::sync::RwLock<String>,
+    server_url: String,
+    context: Option<serde_json::Value>,
+}
+
+#[async_trait::async_trait]
+impl TokenProvider for ConformanceScopeTokenProvider {
+    async fn get_token(&self) -> std::result::Result<String, OAuthClientError> {
+        Ok(self.token.read().await.clone())
+    }
+}
+
+#[async_trait::async_trait]
+impl OAuthScopeEscalationHandler for ConformanceScopeTokenProvider {
+    async fn reauthorize(
+        &self,
+        request: OAuthScopeEscalationRequest,
+    ) -> std::result::Result<(), OAuthClientError> {
+        let requested_scope = request.requested_scopes.join(" ");
+        let flow = perform_oauth_flow(&self.server_url, &self.context, Some(&requested_scope))
+            .await
+            .map_err(|error| OAuthClientError::ScopeEscalation(error.to_string()))?;
+        *self.token.write().await = flow.access_token;
+        Ok(())
+    }
+}
+
+fn scope_aware_transport(
+    server_url: &str,
+    context: &Option<serde_json::Value>,
+    flow: OAuthFlowResult,
+    max_attempts: usize,
+) -> HttpClientTransport {
+    let initial_scopes = flow
+        .requested_scope
+        .as_deref()
+        .into_iter()
+        .flat_map(str::split_ascii_whitespace);
+    let config = OAuthScopeEscalationConfig::new(initial_scopes).max_attempts(max_attempts);
+    HttpClientTransport::new(server_url).with_scope_aware_token_provider(
+        ConformanceScopeTokenProvider {
+            token: tokio::sync::RwLock::new(flow.access_token),
+            server_url: server_url.to_string(),
+            context: context.clone(),
+        },
+        config,
+    )
 }
 
 /// Standard OAuth authorization-code flow.
@@ -43,141 +94,55 @@ pub async fn authorization_server_migration(
     run_authed_client(server_url, &second.access_token).await
 }
 
-/// Scope step-up: connect, try tools, re-auth on failure, retry.
+/// Scope step-up through the reusable challenge-driven HTTP policy.
 pub async fn scope_step_up(server_url: &str, context: &Option<serde_json::Value>) -> Result<()> {
-    let initial_flow = perform_oauth_flow(server_url, context, None).await?;
-    let access_token = &initial_flow.access_token;
-
-    let transport = HttpClientTransport::new(server_url).bearer_token(access_token);
+    let flow = perform_oauth_flow(server_url, context, None).await?;
+    let transport = scope_aware_transport(server_url, context, flow, 2);
     let client = crate::core_scenarios::client_builder()?
         .connect(transport, handlers::BasicHandler)
         .await?;
 
     crate::core_scenarios::activate(&client).await?;
-
-    // Try listing/calling tools -- may fail with 403 at any point
-    let mut needs_reauth = false;
-
-    let tools_result = client.list_tools().await;
-    let tools = match tools_result {
-        Ok(t) => Some(t),
-        Err(e) => {
-            let err_str = e.to_string();
-
-            if err_str.contains("403") || err_str.contains("insufficient_scope") {
-                tracing::info!("Got 403/insufficient_scope on list_tools, will re-authenticate");
-                needs_reauth = true;
-                None
-            } else {
-                return Err(e.into());
-            }
-        }
-    };
-
-    if let Some(tools) = &tools {
+    let outcome: Result<()> = async {
+        let tools = client.list_tools().await?;
         for tool in &tools.tools {
             let args = crate::core_scenarios::build_tool_arguments(&tool.input_schema);
-            match client.call_tool(&tool.name, args).await {
-                Ok(_) => {}
-                Err(e) => {
-                    let err_str = e.to_string();
-                    if err_str.contains("403") || err_str.contains("insufficient_scope") {
-                        tracing::info!(
-                            "Got 403/insufficient_scope on call_tool, will re-authenticate"
-                        );
-                        needs_reauth = true;
-                        break;
-                    }
-                    return Err(e.into());
-                }
-            }
+            client.call_tool(&tool.name, args).await?;
         }
+        Ok(())
     }
-
-    client.shutdown().await?;
-
-    if needs_reauth {
-        // Probe the server with the old token to get the required scope from 403 WWW-Authenticate
-        let escalated_scope = probe_for_scope(server_url, access_token).await;
-        tracing::info!(scope = ?escalated_scope, "Escalated scope from 403 probe");
-
-        // Re-authenticate with escalated scope
-        let union_scope = union_scopes(
-            initial_flow.requested_scope.as_deref(),
-            escalated_scope.as_deref(),
-        );
-        let new_flow = perform_oauth_flow(server_url, context, union_scope.as_deref()).await?;
-        let transport = HttpClientTransport::new(server_url).bearer_token(&new_flow.access_token);
-        let client = crate::core_scenarios::client_builder()?
-            .connect(transport, handlers::BasicHandler)
-            .await?;
-
-        crate::core_scenarios::activate(&client).await?;
-
-        // Second attempt -- may still fail with 403 if server requires further escalation
-        match client.list_tools().await {
-            Ok(tools) => {
-                for tool in &tools.tools {
-                    let args = crate::core_scenarios::build_tool_arguments(&tool.input_schema);
-                    let _ = client.call_tool(&tool.name, args).await;
-                }
-            }
-            Err(e) => {
-                let err_str = e.to_string();
-                if !err_str.contains("403") && !err_str.contains("insufficient_scope") {
-                    client.shutdown().await?;
-                    return Err(e.into());
-                }
-                tracing::info!("Second attempt also got 403, step-up complete");
-            }
-        }
-        client.shutdown().await?;
-    }
-
+    .await;
+    let shutdown = client.shutdown().await;
+    outcome?;
+    shutdown?;
     Ok(())
 }
 
-/// Scope retry limit: retry up to 3 times on 403.
+/// Scope retry limit: at most three HTTP attempts for one challenged operation.
 pub async fn scope_retry_limit(
     server_url: &str,
     context: &Option<serde_json::Value>,
 ) -> Result<()> {
-    for attempt in 0..3 {
-        tracing::info!(attempt, "Auth attempt");
-        let flow = perform_oauth_flow(server_url, context, None).await?;
-        let transport = HttpClientTransport::new(server_url).bearer_token(&flow.access_token);
-        let client = crate::core_scenarios::client_builder()?
-            .connect(transport, handlers::BasicHandler)
-            .await?;
+    let flow = perform_oauth_flow(server_url, context, None).await?;
+    // Two challenged retries plus the original request give the conformance
+    // scenario its required three-attempt ceiling.
+    let transport = scope_aware_transport(server_url, context, flow, 2);
+    let client = crate::core_scenarios::client_builder()?
+        .connect(transport, handlers::BasicHandler)
+        .await?;
 
-        crate::core_scenarios::activate(&client).await?;
+    crate::core_scenarios::activate(&client).await?;
+    let outcome: Result<()> = async {
         let tools = client.list_tools().await?;
-
-        let mut success = true;
         for tool in &tools.tools {
             let args = crate::core_scenarios::build_tool_arguments(&tool.input_schema);
-            match client.call_tool(&tool.name, args).await {
-                Ok(_) => {}
-                Err(e) => {
-                    let err_str = e.to_string();
-                    if err_str.contains("403") || err_str.contains("insufficient_scope") {
-                        success = false;
-                        break;
-                    }
-                    client.shutdown().await?;
-                    return Err(e.into());
-                }
-            }
+            client.call_tool(&tool.name, args).await?;
         }
-
-        client.shutdown().await?;
-
-        if success {
-            return Ok(());
-        }
+        Ok(())
     }
-
-    anyhow::bail!("Failed after 3 auth attempts")
+    .await;
+    client.shutdown().await?;
+    outcome
 }
 
 /// Resource mismatch: server's PRM resource doesn't match, client should error.
@@ -1349,55 +1314,6 @@ fn validate_resource(server_url: &str, resource: &str) -> Result<()> {
 // ============================================================================
 // WWW-Authenticate parsing
 // ============================================================================
-
-/// Probe the server with a token to extract scope from 403 WWW-Authenticate.
-async fn probe_for_scope(server_url: &str, token: &str) -> Option<String> {
-    let http = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .build()
-        .ok()?;
-
-    let mut request = http
-        .post(server_url)
-        .header("Content-Type", "application/json")
-        .header("Accept", "application/json, text/event-stream")
-        .header("Authorization", format!("Bearer {}", token))
-        .header("Mcp-Method", "tools/call")
-        .header("Mcp-Name", "test-tool");
-    let mut params = serde_json::json!({
-        "name": "test-tool",
-        "arguments": {}
-    });
-    if crate::core_scenarios::uses_final_protocol() {
-        request = request.header("MCP-Protocol-Version", "2026-07-28");
-        params["_meta"] = serde_json::json!({
-            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
-            "io.modelcontextprotocol/clientCapabilities": {},
-            "io.modelcontextprotocol/clientInfo": {
-                "name": "conformance-client",
-                "version": "0.1.0"
-            }
-        });
-    }
-    let resp = request
-        .json(&serde_json::json!({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "tools/call",
-            "params": params
-        }))
-        .send()
-        .await
-        .ok()?;
-
-    let www_auth = resp
-        .headers()
-        .get("www-authenticate")
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string())?;
-
-    extract_www_auth_param(&www_auth, "scope")
-}
 
 /// Extract a parameter value from a WWW-Authenticate header.
 /// Handles: `param="value"` in comma-or-space-separated list.


### PR DESCRIPTION
## Summary

- add public `OAuthScopeChallenge`, `OAuthScopeEscalationConfig`, request context, and async reauthorization handler APIs
- make `HttpClientTransport` recognize final-spec HTTP 403 Bearer `insufficient_scope` challenges, preserve challenge metadata, union prior and required scopes, fetch a fresh token, and replay only the rejected operation
- serialize concurrent escalations and enforce a configurable per-operation retry ceiling (two retries by default)
- replace stale `Authorization` values rather than appending a second bearer header
- move the conformance client's manual probe/reconnect logic onto the reusable transport policy
- refresh the client conformance check counts produced by the pinned suites

## Validation

- `cargo test --workspace --all-features` (858 library tests plus integrations and doctests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p tower-mcp --no-default-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- focused OAuth parser and HTTP escalation tests, including bounded repeated challenges and concurrent challenge coalescing
- official `@modelcontextprotocol/conformance@0.1.16` client suite: 26/26 scenarios, 311 checks
- official `@modelcontextprotocol/conformance@0.2.0-alpha.10` final client suite: 32/32 scenarios, 399 checks

Refs #953