### PR TITLE
feat(extensions): add runtime negotiation

### DIFF
--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -379,6 +379,19 @@ impl McpClientBuilder {
         self
     }
 
+    /// Add one validated MCP protocol-extension declaration.
+    ///
+    /// Repeated declarations for the same identifier use last-write-wins
+    /// semantics. Other configured capabilities are preserved.
+    pub fn with_protocol_extension(mut self, extension: crate::ExtensionDeclaration) -> Self {
+        let (identifier, settings) = extension.into_parts();
+        self.capabilities
+            .extensions
+            .get_or_insert_default()
+            .insert(identifier, settings);
+        self
+    }
+
     /// Set the exact ordered protocol versions enabled for this client.
     ///
     /// The default is [`ProtocolSupport::stable`], even when the experimental
@@ -3584,6 +3597,25 @@ mod tests {
     fn test_builder_with_elicitation() {
         let builder = McpClientBuilder::new().with_elicitation();
         assert!(builder.capabilities.elicitation.is_some());
+    }
+
+    #[test]
+    fn builder_adds_protocol_extension_without_replacing_other_capabilities() {
+        let extension = crate::ExtensionDeclaration::new(
+            "com.example/rendering",
+            serde_json::json!({"formats": ["html"]}),
+        )
+        .unwrap();
+        let builder = McpClientBuilder::new()
+            .with_sampling()
+            .with_protocol_extension(extension);
+
+        assert!(builder.capabilities.sampling.is_some());
+        assert_eq!(
+            builder.capabilities.extensions.as_ref().unwrap()["com.example/rendering"]["formats"]
+                [0],
+            "html"
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -480,6 +480,14 @@ impl RequestContext {
         self.extensions.get::<T>()
     }
 
+    /// Protocol extensions declared by both the client and server.
+    ///
+    /// Unknown or one-sided declarations are not included. The returned view
+    /// preserves each peer's settings object for extension-specific policy.
+    pub fn negotiated_extensions(&self) -> Option<&crate::NegotiatedExtensions> {
+        self.extension()
+    }
+
     /// Get a mutable reference to the extensions.
     ///
     /// This allows middleware to insert data that handlers can access via

--- a/crates/tower-mcp/src/extension.rs
+++ b/crates/tower-mcp/src/extension.rs
@@ -1,0 +1,210 @@
+//! Protocol extension declarations and runtime negotiation.
+//!
+//! MCP extensions are opt-in. A client and server each declare extension
+//! support under `capabilities.extensions`; an extension is active only when
+//! both peers declare the same identifier. Unknown extensions remain
+//! round-trippable protocol data but are never activated implicitly.
+
+use std::collections::{BTreeMap, HashMap};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::protocol::{
+    ClientCapabilities, MetaValidationError, ServerCapabilities, validate_extension_identifier,
+};
+
+/// A validated local MCP protocol-extension declaration.
+///
+/// Extension identifiers use the mandatory vendor-prefix form defined by
+/// SEP-2133, for example `io.modelcontextprotocol/ui`. Settings must serialize
+/// to a JSON object; use [`empty`](Self::empty) when an extension has no
+/// settings.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ExtensionDeclaration {
+    identifier: String,
+    settings: Value,
+}
+
+impl ExtensionDeclaration {
+    /// Declare an extension with an empty settings object.
+    pub fn empty(identifier: impl Into<String>) -> Result<Self, MetaValidationError> {
+        Self::new(identifier, serde_json::json!({}))
+    }
+
+    /// Declare an extension with typed settings.
+    pub fn new(
+        identifier: impl Into<String>,
+        settings: impl Serialize,
+    ) -> Result<Self, MetaValidationError> {
+        let identifier = identifier.into();
+        validate_extension_identifier(&identifier)?;
+        let settings = serde_json::to_value(settings)
+            .map_err(|_| MetaValidationError::InvalidExtensionSettings(identifier.clone()))?;
+        if !settings.is_object() {
+            return Err(MetaValidationError::InvalidExtensionSettings(identifier));
+        }
+        Ok(Self {
+            identifier,
+            settings,
+        })
+    }
+
+    /// Extension identifier.
+    pub fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    /// Extension-defined local settings object.
+    pub fn settings(&self) -> &Value {
+        &self.settings
+    }
+
+    pub(crate) fn into_parts(self) -> (String, Value) {
+        (self.identifier, self.settings)
+    }
+}
+
+/// The settings each peer declared for one negotiated extension.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NegotiatedExtension {
+    client_settings: Value,
+    server_settings: Value,
+}
+
+impl NegotiatedExtension {
+    /// Settings advertised by the MCP client.
+    pub fn client_settings(&self) -> &Value {
+        &self.client_settings
+    }
+
+    /// Settings advertised by the MCP server.
+    pub fn server_settings(&self) -> &Value {
+        &self.server_settings
+    }
+}
+
+/// Protocol extensions declared by both the client and server.
+///
+/// This is inserted into each [`RequestContext`](crate::RequestContext), so
+/// handlers and per-capability middleware can make extension-specific policy
+/// decisions without inspecting raw capability maps.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct NegotiatedExtensions {
+    extensions: BTreeMap<String, NegotiatedExtension>,
+}
+
+impl NegotiatedExtensions {
+    /// Compute the exact identifier intersection of two capability maps.
+    pub fn from_capabilities(client: &ClientCapabilities, server: &ServerCapabilities) -> Self {
+        Self::from_maps(client.extensions.as_ref(), server.extensions.as_ref())
+    }
+
+    pub(crate) fn from_maps(
+        client: Option<&HashMap<String, Value>>,
+        server: Option<&HashMap<String, Value>>,
+    ) -> Self {
+        let mut extensions = BTreeMap::new();
+        let (Some(client), Some(server)) = (client, server) else {
+            return Self { extensions };
+        };
+
+        for (identifier, client_settings) in client {
+            let Some(server_settings) = server.get(identifier) else {
+                continue;
+            };
+            if validate_extension_identifier(identifier).is_err()
+                || !client_settings.is_object()
+                || !server_settings.is_object()
+            {
+                continue;
+            }
+            extensions.insert(
+                identifier.clone(),
+                NegotiatedExtension {
+                    client_settings: client_settings.clone(),
+                    server_settings: server_settings.clone(),
+                },
+            );
+        }
+        Self { extensions }
+    }
+
+    /// Return the negotiated declaration for an extension identifier.
+    pub fn get(&self, identifier: &str) -> Option<&NegotiatedExtension> {
+        self.extensions.get(identifier)
+    }
+
+    /// Return whether both peers declared an extension identifier.
+    pub fn contains(&self, identifier: &str) -> bool {
+        self.extensions.contains_key(identifier)
+    }
+
+    /// Iterate over negotiated extensions in identifier order.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, &NegotiatedExtension)> {
+        self.extensions
+            .iter()
+            .map(|(identifier, extension)| (identifier.as_str(), extension))
+    }
+
+    /// Number of negotiated extension identifiers.
+    pub fn len(&self) -> usize {
+        self.extensions.len()
+    }
+
+    /// Return whether no extension was declared by both peers.
+    pub fn is_empty(&self) -> bool {
+        self.extensions.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declaration_requires_vendor_prefix_and_object_settings() {
+        assert!(ExtensionDeclaration::empty("com.example/feature").is_ok());
+        assert!(matches!(
+            ExtensionDeclaration::empty("feature"),
+            Err(MetaValidationError::MissingExtensionPrefix(_))
+        ));
+        assert!(matches!(
+            ExtensionDeclaration::new("com.example/feature", true),
+            Err(MetaValidationError::InvalidExtensionSettings(_))
+        ));
+    }
+
+    #[test]
+    fn negotiation_is_the_exact_identifier_intersection() {
+        let client = ClientCapabilities {
+            extensions: Some(HashMap::from([
+                (
+                    "com.example/shared".to_string(),
+                    serde_json::json!({"client": true}),
+                ),
+                ("com.example/client-only".to_string(), serde_json::json!({})),
+            ])),
+            ..ClientCapabilities::default()
+        };
+        let server = ServerCapabilities {
+            extensions: Some(HashMap::from([
+                (
+                    "com.example/shared".to_string(),
+                    serde_json::json!({"server": true}),
+                ),
+                ("com.example/server-only".to_string(), serde_json::json!({})),
+            ])),
+            ..ServerCapabilities::default()
+        };
+
+        let negotiated = NegotiatedExtensions::from_capabilities(&client, &server);
+
+        assert_eq!(negotiated.len(), 1);
+        let shared = negotiated.get("com.example/shared").unwrap();
+        assert_eq!(shared.client_settings()["client"], true);
+        assert_eq!(shared.server_settings()["server"], true);
+        assert!(!negotiated.contains("com.example/client-only"));
+        assert!(!negotiated.contains("com.example/server-only"));
+    }
+}

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -464,6 +464,7 @@ pub mod deployment;
 pub mod error;
 #[cfg(any(feature = "http", feature = "websocket"))]
 pub mod event_store;
+pub mod extension;
 pub mod extract;
 pub mod filter;
 pub mod jsonrpc;
@@ -539,6 +540,7 @@ pub use context::{
     outgoing_request_channel,
 };
 pub use error::{BoxError, Error, Result, ResultExt, ToolError};
+pub use extension::{ExtensionDeclaration, NegotiatedExtension, NegotiatedExtensions};
 pub use filter::{
     CapabilityFilter, DenialBehavior, Filterable, PromptFilter, ResourceFilter, ToolFilter,
 };

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -83,6 +83,22 @@ fn is_final_protocol_request(_extensions: &crate::context::Extensions) -> bool {
     false
 }
 
+#[cfg(feature = "stateless")]
+fn final_client_capabilities(
+    extensions: &crate::context::Extensions,
+) -> Option<&ClientCapabilities> {
+    extensions
+        .get::<crate::stateless::StatelessRequestMeta>()
+        .and_then(|meta| meta.client_capabilities.as_ref())
+}
+
+#[cfg(not(feature = "stateless"))]
+fn final_client_capabilities(
+    _extensions: &crate::context::Extensions,
+) -> Option<&ClientCapabilities> {
+    None
+}
+
 /// Return whether `actual` contains every field and value in `required`.
 ///
 /// Client capability objects are extensible, so extra advertised properties
@@ -351,6 +367,8 @@ struct McpRouterInner {
     prompt_filter: Option<PromptFilter>,
     /// Router-level extensions (for state and middleware data)
     extensions: Arc<crate::context::Extensions>,
+    /// Locally supported MCP protocol extensions and their server settings.
+    protocol_extensions: HashMap<String, serde_json::Value>,
     /// Minimum log level for filtering outgoing log notifications (set by client via logging/setLevel)
     min_log_level: Arc<RwLock<LogLevel>>,
     /// Page size for list method pagination (None = return all results)
@@ -499,6 +517,7 @@ impl McpRouter {
                 task_store: Arc::new(MemoryTaskStore::new()),
                 subscriptions: Arc::new(RwLock::new(HashSet::new())),
                 extensions: Arc::new(crate::context::Extensions::new()),
+                protocol_extensions: HashMap::new(),
                 completion_handler: None,
                 tool_filter: None,
                 resource_filter: None,
@@ -844,6 +863,20 @@ impl McpRouter {
         self.with_state(value)
     }
 
+    /// Advertise one validated MCP protocol extension.
+    ///
+    /// This is separate from [`with_extension`](Self::with_extension), which
+    /// stores process-local Rust values for handlers. Protocol extensions are
+    /// advertised on the wire and become active only when the client declares
+    /// the same identifier.
+    pub fn with_protocol_extension(mut self, extension: crate::ExtensionDeclaration) -> Self {
+        let (identifier, settings) = extension.into_parts();
+        Arc::make_mut(&mut self.inner)
+            .protocol_extensions
+            .insert(identifier, settings);
+        self
+    }
+
     /// Get the router's extensions.
     pub fn extensions(&self) -> &crate::context::Extensions {
         &self.inner.extensions
@@ -892,6 +925,23 @@ impl McpRouter {
         // visible; per-request meta (SEP-2575) is now reachable too.
         let mut merged = (*self.inner.extensions).clone();
         merged.merge(per_request);
+        let negotiated_extensions = if is_final_protocol_request(per_request) {
+            let server_capabilities = self
+                .capabilities_for_protocol(Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION));
+            final_client_capabilities(per_request)
+                .map(|client_capabilities| {
+                    crate::NegotiatedExtensions::from_capabilities(
+                        client_capabilities,
+                        &server_capabilities,
+                    )
+                })
+                .unwrap_or_default()
+        } else {
+            self.session
+                .get::<crate::NegotiatedExtensions>()
+                .unwrap_or_default()
+        };
+        merged.insert(negotiated_extensions);
 
         // The final protocol does not permit servers to initiate JSON-RPC
         // requests. Legacy transports may provide a requester scoped to the
@@ -1432,6 +1482,13 @@ impl McpRouter {
             inner.prompts.insert(name.clone(), prompt.clone());
         }
 
+        // Merge protocol extension declarations (last wins).
+        for (identifier, settings) in &other_inner.protocol_extensions {
+            inner
+                .protocol_extensions
+                .insert(identifier.clone(), settings.clone());
+        }
+
         self
     }
 
@@ -1500,6 +1557,14 @@ impl McpRouter {
         // Merge prompts (no prefix - could be added in future if needed)
         for (name, prompt) in &other_inner.prompts {
             inner.prompts.insert(name.clone(), prompt.clone());
+        }
+
+        // Protocol extensions are server-wide declarations and are not
+        // namespace-prefixed. Nested declarations use last-write-wins.
+        for (identifier, settings) in &other_inner.protocol_extensions {
+            inner
+                .protocol_extensions
+                .insert(identifier.clone(), settings.clone());
         }
 
         self
@@ -2003,21 +2068,19 @@ impl McpRouter {
             },
             experimental: None,
             extensions: {
+                let mut map = self.inner.protocol_extensions.clone();
                 let has_task_support = self
                     .inner
                     .tools
                     .values()
                     .any(|t| !matches!(t.task_support, TaskSupportMode::Forbidden));
                 if has_task_support {
-                    let mut map = std::collections::HashMap::new();
                     map.insert(
                         tower_mcp_types::protocol::TASKS_EXTENSION_ID.to_string(),
                         serde_json::json!({}),
                     );
-                    Some(map)
-                } else {
-                    None
                 }
+                (!map.is_empty()).then_some(map)
             },
         }
     }
@@ -2130,6 +2193,12 @@ impl McpRouter {
                 // Transition session state to Initializing
                 self.session.mark_initializing();
                 let capabilities = self.capabilities_for_protocol(Some(&protocol_version));
+                self.session.insert(params.capabilities.clone());
+                self.session
+                    .insert(crate::NegotiatedExtensions::from_capabilities(
+                        &params.capabilities,
+                        &capabilities,
+                    ));
 
                 Ok(McpResponse::Initialize(InitializeResult {
                     protocol_version,
@@ -3397,6 +3466,111 @@ mod tests {
             ..Default::default()
         });
         extensions
+    }
+
+    #[test]
+    fn router_advertises_only_locally_declared_protocol_extensions() {
+        let router = McpRouter::new().with_protocol_extension(
+            crate::ExtensionDeclaration::new(
+                "com.example/rendering",
+                serde_json::json!({"formats": ["html"]}),
+            )
+            .unwrap(),
+        );
+
+        let stable = router.capabilities();
+        let final_capabilities =
+            router.capabilities_for_protocol(Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION));
+        for capabilities in [stable, final_capabilities] {
+            let extensions = capabilities.extensions.unwrap();
+            assert_eq!(extensions.len(), 1);
+            assert_eq!(extensions["com.example/rendering"]["formats"][0], "html");
+            assert!(!extensions.contains_key("com.example/client-only"));
+        }
+    }
+
+    #[tokio::test]
+    async fn initialize_persists_negotiated_extensions_for_legacy_contexts() {
+        let router = McpRouter::new().with_protocol_extension(
+            crate::ExtensionDeclaration::new(
+                "com.example/shared",
+                serde_json::json!({"server": true}),
+            )
+            .unwrap(),
+        );
+        let client_capabilities = ClientCapabilities {
+            extensions: Some(HashMap::from([
+                (
+                    "com.example/shared".to_string(),
+                    serde_json::json!({"client": true}),
+                ),
+                ("com.example/client-only".to_string(), serde_json::json!({})),
+            ])),
+            ..ClientCapabilities::default()
+        };
+
+        router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::Initialize(InitializeParams {
+                    protocol_version: crate::protocol::LATEST_PROTOCOL_VERSION.to_string(),
+                    capabilities: client_capabilities,
+                    client_info: Implementation {
+                        name: "extension-test".to_string(),
+                        version: "1.0.0".to_string(),
+                        title: None,
+                        description: None,
+                        icons: None,
+                        website_url: None,
+                        meta: None,
+                    },
+                    meta: None,
+                }),
+                Extensions::new(),
+            )
+            .await
+            .unwrap();
+
+        let context = router.create_context(RequestId::Number(2), None);
+        let negotiated = context.negotiated_extensions().unwrap();
+        assert!(negotiated.contains("com.example/shared"));
+        assert!(!negotiated.contains("com.example/client-only"));
+    }
+
+    #[cfg(feature = "stateless")]
+    #[test]
+    fn final_request_context_exposes_only_negotiated_extensions() {
+        let router = McpRouter::new().with_protocol_extension(
+            crate::ExtensionDeclaration::new(
+                "com.example/shared",
+                serde_json::json!({"server": true}),
+            )
+            .unwrap(),
+        );
+        let per_request = final_extensions(ClientCapabilities {
+            extensions: Some(HashMap::from([
+                (
+                    "com.example/shared".to_string(),
+                    serde_json::json!({"client": true}),
+                ),
+                ("com.example/client-only".to_string(), serde_json::json!({})),
+            ])),
+            ..ClientCapabilities::default()
+        });
+
+        let context =
+            router.create_context_with_extensions(RequestId::Number(1), None, &per_request);
+        let negotiated = context.negotiated_extensions().unwrap();
+
+        assert_eq!(negotiated.len(), 1);
+        assert_eq!(
+            negotiated
+                .get("com.example/shared")
+                .unwrap()
+                .client_settings()["client"],
+            true
+        );
+        assert!(!negotiated.contains("com.example/client-only"));
     }
 
     #[cfg(feature = "stateless")]


### PR DESCRIPTION
## Summary

- add validated additive protocol-extension declarations for clients and routers
- advertise only locally configured server extensions and preserve declarations across router merge/nest
- compute the exact client/server extension intersection while retaining each peer's settings
- expose negotiated extensions through legacy and final request contexts for handlers and per-capability middleware
- preserve unknown valid wire extensions without implicitly activating one-sided declarations

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo check -p tower-mcp --no-default-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`
- stable MCP conformance: 26/26 scenarios, 311 checks
- 2026-07-28 MCP conformance: 32/32 scenarios, 399 checks

Relates to #1060.