### PR TITLE
feat(protocol): stabilize 2026 version naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ use tower_mcp::schemars::JsonSchema;
 | `macros` | Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`) |
 | `resilience` | Re-export tower-resilience circuit breaker, rate limiter, and bulkhead layers |
 | `mcp-apps` | Typed, security-bounded server support for the stable MCP Apps extension. Runtime advertisement remains explicit via `McpRouter::with_mcp_apps()`. |
-| `protocol-2026-07-28` | Compile the experimental implementation of the released 2026-07-28 protocol. Use `ProtocolSupport` to narrow the exact versions enabled by a server at runtime. |
+| `protocol-2026-07-28` | Compile the released 2026-07-28 protocol implementation. Use `ProtocolSupport` to narrow the exact versions enabled by a client or server at runtime. |
 | `stateless` | Compatibility alias for the former 2026 protocol feature name. New integrations should use `protocol-2026-07-28`. |
 
 Example with features:
@@ -594,12 +594,20 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 
-The `protocol-2026-07-28` feature enables the experimental implementation of the released
-2026-07-28 protocol (version-gated, behind
+The `protocol-2026-07-28` feature enables the released, opt-in 2026-07-28
+protocol implementation (version-gated, behind
 `MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, per-request
 `_meta` capabilities, and SEP-2322 Multi Round-Trip Requests. It is not enabled by default and is
-not yet included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
+intentionally not included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
 runtime enablement are reported separately.
+
+`PROTOCOL_VERSION_2026_07_28` is the canonical constant for the released wire
+revision. The former status-bearing names `EXPERIMENTAL_PROTOCOL_VERSION` and
+`UPCOMING_PROTOCOL_VERSION` remain deprecated aliases. `LATEST_PROTOCOL_VERSION`
+and `SUPPORTED_PROTOCOL_VERSIONS` continue to describe the non-breaking default
+compatibility set, not every published protocol. Use
+`COMPILED_PROTOCOL_VERSIONS` and `ProtocolSupport` to inspect and select the
+implementations available to a particular build and runtime.
 
 Clients opt in independently at runtime, then use the discover-based lifecycle.
 Every later request receives the required `_meta`, HTTP headers are generated

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Current Status
 
 - **Version**: 0.14.x
-- **Spec version**: 2025-11-25 by default (plus the released 2026-07-28 protocol as an experimental implementation behind `protocol-2026-07-28`)
+- **Spec version**: 2025-11-25 by default, plus the released 2026-07-28 protocol as an opt-in implementation behind `protocol-2026-07-28`
 - **Server conformance (2025-11-25)**: 39/39
 - **Client conformance (2025-11-25)**: 311/311 (empty baseline)
 - **Server conformance (2026-07-28)**: 114/114 (empty baseline)
@@ -46,9 +46,12 @@ All features from the 2025-11-25 spec are implemented, including:
 - Sampling (all transports)
 - Completion (autocomplete)
 
-The released 2026-07-28 revision is implemented behind the experimental
+The released 2026-07-28 revision is implemented behind the opt-in
 `protocol-2026-07-28` feature with an exact per-instance `ProtocolSupport`
-allow-list. The legacy 2025-era implementation remains the default.
+allow-list. `PROTOCOL_VERSION_2026_07_28` is the canonical wire-version
+constant; the former `EXPERIMENTAL_PROTOCOL_VERSION` and
+`UPCOMING_PROTOCOL_VERSION` names are deprecated compatibility aliases. The
+legacy 2025-era implementation remains the non-breaking default.
 
 Implemented final-revision areas include:
 
@@ -65,7 +68,7 @@ Implemented final-revision areas include:
 
 | SEP | Title | Status | Issue |
 |-----|-------|--------|-------|
-| 2575/2567 | Final stateless/sessionless MCP lifecycle | Implemented (experimental, `protocol-2026-07-28`) | #929, #1059 |
+| 2575/2567 | Final stateless/sessionless MCP lifecycle | Implemented (opt-in, `protocol-2026-07-28`) | #929, #1059 |
 | 2322 | Multi Round-Trip Requests (MRTR) | Implemented; policy/composition follow-ups remain | #950 |
 | 2549 | Cache hints and response caching | Implemented | #1047, #1053 |
 | 2243 | Standard/custom HTTP headers | Implemented | #1049, #1051 |
@@ -78,7 +81,7 @@ Open SEPs are tracked automatically via `.github/workflows/sep-sync.yml` and lab
 ## Future Directions
 
 - **1.0.0 stable release**: API freeze and stability guarantees
-- **Promotion of 2026-07-28**: close the remaining transport, MRTR, Tasks, and extension gates in #929.
+- **Default protocol transition**: keep 2025-11-25 as the non-breaking default while exposing released 2026-07-28 through explicit compile-time and runtime selection (#929).
 - **Tasks extension**: complete input-required task state, notifications, expiry, and client update APIs (#951).
 - **MCP Apps interoperability**: track and adopt upstream extension conformance scenarios as they land (#1060).
 - **SEP-1763 interceptors**: tower middleware maps naturally to this proposal.

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -15,14 +15,13 @@
 //!
 //! # Stateless protocol support (2026-07-28)
 //!
-//! This crate also tracks the experimental implementation of protocol version
-//! `2026-07-28`, which adds
+//! This crate also represents the released `2026-07-28` protocol, which adds
 //! stateless operation, per-request `_meta`, and the `server/discover` RPC.
 //! Key items:
 //!
-//! - [`protocol::EXPERIMENTAL_PROTOCOL_VERSION`] -- the `"2026-07-28"` wire
-//!   version, not yet enabled by default. Useful for codegen tools and
-//!   conformance harnesses that need to reference it explicitly.
+//! - [`protocol::PROTOCOL_VERSION_2026_07_28`] -- the canonical
+//!   `"2026-07-28"` wire-version constant. Runtime enablement is a separate
+//!   concern in the parent `tower-mcp` crate.
 //! - [`protocol::KNOWN_PROTOCOL_VERSIONS`] -- every version whose wire format
 //!   is represented here, independent of runtime compile-time features.
 //! - [`protocol::DiscoverResult`] / [`protocol::DiscoverParams`] -- types for

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -216,33 +216,34 @@ pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 /// ```
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-03-26"];
 
-/// The released protocol version whose tower-mcp implementation is experimental.
+/// The released 2026-07-28 protocol version.
 ///
-/// Downstream tooling (code generators, conformance harnesses, and feature-gated
-/// runtimes) can reference the wire version without implying that the full
-/// implementation is enabled. Once the implementation passes its promotion
-/// gates, this value will move into
-/// [`SUPPORTED_PROTOCOL_VERSIONS`] and become the new
-/// [`LATEST_PROTOCOL_VERSION`].
-///
-/// See [tower-mcp#929] for the implementation and promotion checklist.
-///
-/// [tower-mcp#929]: https://github.com/joshrotenberg/tower-mcp/issues/929
-pub const EXPERIMENTAL_PROTOCOL_VERSION: &str = "2026-07-28";
+/// This date-specific constant describes the wire revision without implying
+/// compile-time or runtime enablement. In `tower-mcp`, compile the implementation
+/// with the `protocol-2026-07-28` feature and select it for a particular runtime
+/// with `ProtocolSupport`.
+pub const PROTOCOL_VERSION_2026_07_28: &str = "2026-07-28";
 
 /// All protocol versions understood by this types crate (newest first).
 ///
 /// "Known" means the crate can represent at least part of the version's wire
 /// format. It does not mean a runtime implementation was compiled or enabled.
 pub const KNOWN_PROTOCOL_VERSIONS: &[&str] =
-    &[EXPERIMENTAL_PROTOCOL_VERSION, "2025-11-25", "2025-03-26"];
+    &[PROTOCOL_VERSION_2026_07_28, "2025-11-25", "2025-03-26"];
 
-/// Deprecated alias for [`EXPERIMENTAL_PROTOCOL_VERSION`].
+/// Deprecated implementation-status name for [`PROTOCOL_VERSION_2026_07_28`].
 #[deprecated(
     since = "0.15.0",
-    note = "the 2026-07-28 spec has shipped; use EXPERIMENTAL_PROTOCOL_VERSION"
+    note = "the 2026-07-28 implementation is released and opt-in; use PROTOCOL_VERSION_2026_07_28"
 )]
-pub const UPCOMING_PROTOCOL_VERSION: &str = EXPERIMENTAL_PROTOCOL_VERSION;
+pub const EXPERIMENTAL_PROTOCOL_VERSION: &str = PROTOCOL_VERSION_2026_07_28;
+
+/// Deprecated alias for [`PROTOCOL_VERSION_2026_07_28`].
+#[deprecated(
+    since = "0.15.0",
+    note = "the 2026-07-28 spec has shipped; use PROTOCOL_VERSION_2026_07_28"
+)]
+pub const UPCOMING_PROTOCOL_VERSION: &str = PROTOCOL_VERSION_2026_07_28;
 
 /// JSON-RPC 2.0 request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -808,7 +809,7 @@ impl RequestMeta {
     /// `clientCapabilities` are required; earlier versions carry neither and
     /// always pass.
     pub fn validate_for_version(&self, protocol_version: &str) -> Result<(), MissingMetaKey> {
-        if protocol_version == EXPERIMENTAL_PROTOCOL_VERSION {
+        if protocol_version == PROTOCOL_VERSION_2026_07_28 {
             if self.protocol_version.is_none() {
                 return Err(MissingMetaKey("io.modelcontextprotocol/protocolVersion"));
             }
@@ -5216,7 +5217,7 @@ impl ResultType {
 /// explicitly implemented protocol versions opt in; an unknown future date
 /// must not silently inherit 2026 behavior.
 pub fn version_carries_result_type(protocol_version: &str) -> bool {
-    protocol_version == EXPERIMENTAL_PROTOCOL_VERSION
+    protocol_version == PROTOCOL_VERSION_2026_07_28
 }
 
 impl From<String> for ResultType {
@@ -5648,13 +5649,13 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn experimental_version_is_known_and_not_enabled_by_default() {
-        assert_eq!(EXPERIMENTAL_PROTOCOL_VERSION, "2026-07-28");
-        assert!(KNOWN_PROTOCOL_VERSIONS.contains(&EXPERIMENTAL_PROTOCOL_VERSION));
+    fn released_version_is_known_and_not_enabled_by_default() {
+        assert_eq!(PROTOCOL_VERSION_2026_07_28, "2026-07-28");
+        assert!(KNOWN_PROTOCOL_VERSIONS.contains(&PROTOCOL_VERSION_2026_07_28));
         assert!(
-            !SUPPORTED_PROTOCOL_VERSIONS.contains(&EXPERIMENTAL_PROTOCOL_VERSION),
-            "do not enable EXPERIMENTAL_PROTOCOL_VERSION by default until the \
-             #929 promotion gates pass; current: {:?}",
+            !SUPPORTED_PROTOCOL_VERSIONS.contains(&PROTOCOL_VERSION_2026_07_28),
+            "the released 2026-07-28 implementation remains explicitly \
+             compile-time/runtime selectable; current default set: {:?}",
             SUPPORTED_PROTOCOL_VERSIONS
         );
         assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&LATEST_PROTOCOL_VERSION));
@@ -5662,8 +5663,9 @@ mod tests {
 
     #[test]
     #[allow(deprecated)]
-    fn upcoming_version_alias_remains_compatible() {
-        assert_eq!(UPCOMING_PROTOCOL_VERSION, EXPERIMENTAL_PROTOCOL_VERSION);
+    fn deprecated_version_aliases_remain_compatible() {
+        assert_eq!(EXPERIMENTAL_PROTOCOL_VERSION, PROTOCOL_VERSION_2026_07_28);
+        assert_eq!(UPCOMING_PROTOCOL_VERSION, PROTOCOL_VERSION_2026_07_28);
     }
 
     // =========================================================================
@@ -7344,14 +7346,14 @@ mod draft_2026_07_28_tests {
     #[test]
     fn request_meta_carries_sep2575_keys_and_validates_by_version() {
         let meta = RequestMeta {
-            protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            protocol_version: Some(PROTOCOL_VERSION_2026_07_28.to_string()),
             client_capabilities: Some(ClientCapabilities::default()),
             ..Default::default()
         };
         let v = serde_json::to_value(&meta).unwrap();
         assert_eq!(
             v["io.modelcontextprotocol/protocolVersion"],
-            json!(EXPERIMENTAL_PROTOCOL_VERSION)
+            json!(PROTOCOL_VERSION_2026_07_28)
         );
         assert!(
             v.get("io.modelcontextprotocol/clientCapabilities")
@@ -7359,12 +7361,12 @@ mod draft_2026_07_28_tests {
         );
         // Version-aware required-key validation (SEP-2575).
         assert!(
-            meta.validate_for_version(EXPERIMENTAL_PROTOCOL_VERSION)
+            meta.validate_for_version(PROTOCOL_VERSION_2026_07_28)
                 .is_ok()
         );
         assert!(
             RequestMeta::default()
-                .validate_for_version(EXPERIMENTAL_PROTOCOL_VERSION)
+                .validate_for_version(PROTOCOL_VERSION_2026_07_28)
                 .is_err()
         );
         assert!(
@@ -7469,19 +7471,19 @@ mod draft_2026_07_28_tests {
         let params = ListToolsParams {
             cursor: None,
             meta: Some(RequestMeta {
-                protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+                protocol_version: Some(PROTOCOL_VERSION_2026_07_28.to_string()),
                 ..Default::default()
             }),
         };
         let v = serde_json::to_value(&params).unwrap();
         assert_eq!(
             v["_meta"]["io.modelcontextprotocol/protocolVersion"],
-            json!(EXPERIMENTAL_PROTOCOL_VERSION)
+            json!(PROTOCOL_VERSION_2026_07_28)
         );
         let back: ListToolsParams = serde_json::from_value(v).unwrap();
         assert_eq!(
             back.meta.unwrap().protocol_version.as_deref(),
-            Some(EXPERIMENTAL_PROTOCOL_VERSION)
+            Some(PROTOCOL_VERSION_2026_07_28)
         );
     }
 
@@ -7497,7 +7499,7 @@ mod draft_2026_07_28_tests {
 
         // 2026-07-28 carries the discriminator.
         let mut v = baseline.clone();
-        assert!(ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(ResultType::Complete.stamp_into(&mut v, PROTOCOL_VERSION_2026_07_28));
         assert_eq!(v["resultType"], json!("complete"));
         assert_eq!(v["content"], baseline["content"]);
 
@@ -7507,7 +7509,7 @@ mod draft_2026_07_28_tests {
         assert_eq!(v, baseline);
 
         assert!(!version_carries_result_type("2025-11-25"));
-        assert!(version_carries_result_type(EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(version_carries_result_type(PROTOCOL_VERSION_2026_07_28));
         assert!(!version_carries_result_type("2027-01-01"));
     }
 
@@ -7516,16 +7518,16 @@ mod draft_2026_07_28_tests {
         // InputRequiredResult and CreateTaskResult write their own resultType;
         // stamping must not overwrite it with "complete".
         let mut v = serde_json::to_value(InputRequiredResult::new()).unwrap();
-        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, PROTOCOL_VERSION_2026_07_28));
         assert_eq!(v["resultType"], json!("input_required"));
 
         let mut v = json!({"resultType": RESULT_TYPE_TASK, "taskId": "t1"});
-        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, PROTOCOL_VERSION_2026_07_28));
         assert_eq!(v["resultType"], json!("task"));
 
         // A non-object result (the empty result some methods return) is a no-op.
         let mut v = json!(null);
-        assert!(!ResultType::Complete.stamp_into(&mut v, EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(!ResultType::Complete.stamp_into(&mut v, PROTOCOL_VERSION_2026_07_28));
         assert_eq!(v, json!(null));
     }
 
@@ -7545,7 +7547,7 @@ mod draft_2026_07_28_tests {
         );
         let parsed: CallToolResult = serde_json::from_value(example).unwrap();
         let mut round_tripped = serde_json::to_value(&parsed).unwrap();
-        assert!(ResultType::Complete.stamp_into(&mut round_tripped, EXPERIMENTAL_PROTOCOL_VERSION));
+        assert!(ResultType::Complete.stamp_into(&mut round_tripped, PROTOCOL_VERSION_2026_07_28));
         assert_eq!(round_tripped["resultType"], json!("complete"));
         assert_eq!(round_tripped["content"][0]["text"], json!("42"));
 

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -77,8 +77,8 @@ macros = ["dep:tower-mcp-macros"]
 # Enabling the API does not advertise or activate the extension; applications
 # must still call `McpRouter::with_mcp_apps`.
 mcp-apps = ["dep:url"]
-# Compile the experimental MCP 2026-07-28 implementation. Runtime transports
-# may narrow the compiled set with ProtocolSupport.
+# Compile the released MCP 2026-07-28 implementation. Runtime clients and
+# servers may narrow the compiled set with ProtocolSupport.
 protocol-2026-07-28 = ["stateless"]
 # Compatibility alias for the former feature name. New consumers should enable
 # `protocol-2026-07-28`; existing `stateless` users retain the same behavior.

--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -654,8 +654,7 @@ impl HttpClientTransport {
     }
 
     fn normalize_incoming_message(&mut self, message: String) -> String {
-        if self.protocol_version.as_deref() != Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
-        {
+        if self.protocol_version.as_deref() != Some(crate::protocol::PROTOCOL_VERSION_2026_07_28) {
             return message;
         }
         let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(&message) else {
@@ -1068,7 +1067,7 @@ impl ClientTransport for HttpClientTransport {
             .and_then(serde_json::Value::as_str)
             .map(str::to_string);
         let is_modern_request =
-            outbound_version.as_deref() == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION);
+            outbound_version.as_deref() == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28);
         if is_modern_request {
             self.protocol_version = outbound_version.clone();
             // Final requests are sessionless even when a transitional peer
@@ -2444,8 +2443,7 @@ mod tests {
     #[test]
     fn sep_2243_filters_invalid_tools_and_caches_valid_mappings() {
         let mut transport = HttpClientTransport::new("http://localhost:3000");
-        transport.protocol_version =
-            Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string());
+        transport.protocol_version = Some(crate::protocol::PROTOCOL_VERSION_2026_07_28.to_string());
         let normalized = transport.normalize_incoming_message(
             serde_json::json!({
                 "jsonrpc": "2.0",

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -352,8 +352,8 @@ impl McpClientBuilder {
         Self {
             capabilities: ClientCapabilities::default(),
             roots: Vec::new(),
-            // Merely compiling an experimental implementation must not move an
-            // existing client off the established initialize/session path.
+            // Merely compiling an opt-in implementation must not move an existing
+            // client off the established initialize/session path.
             protocol_support: ProtocolSupport::stable(),
             max_mrtr_rounds: 8,
             cache_config: ClientCacheConfig::default(),
@@ -394,8 +394,8 @@ impl McpClientBuilder {
 
     /// Set the exact ordered protocol versions enabled for this client.
     ///
-    /// The default is [`ProtocolSupport::stable`], even when the experimental
-    /// final-protocol implementation was compiled. Applications opt into
+    /// The default is [`ProtocolSupport::stable`], even when the opt-in final
+    /// protocol implementation was compiled. Applications select
     /// 2026-07-28 explicitly and then call `McpClient::discover`.
     pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
         self.protocol_support = support;
@@ -663,7 +663,7 @@ impl McpClient {
         client_name: &str,
         client_version: &str,
     ) -> Result<DiscoverResult> {
-        use crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+        use crate::protocol::PROTOCOL_VERSION_2026_07_28;
 
         let client_info = Implementation {
             name: client_name.to_string(),
@@ -676,7 +676,7 @@ impl McpClient {
             .protocol_support
             .versions()
             .iter()
-            .find(|version| version.as_str() == EXPERIMENTAL_PROTOCOL_VERSION)
+            .find(|version| version.as_str() == PROTOCOL_VERSION_2026_07_28)
             .cloned()
             .ok_or_else(|| {
                 Error::Transport(
@@ -1749,7 +1749,7 @@ impl McpClient {
 
     async fn uses_final_protocol(&self) -> bool {
         self.selected_protocol_version.read().await.as_deref()
-            == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+            == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
     }
 
     fn request_meta_for(&self, version: &str, client_info: &Implementation) -> RequestMeta {
@@ -1769,7 +1769,7 @@ impl McpClient {
         let Some(version) = self.selected_protocol_version.read().await.clone() else {
             return Ok(params);
         };
-        if version != crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+        if version != crate::protocol::PROTOCOL_VERSION_2026_07_28 {
             return Ok(params);
         }
         let client_info = self.client_info.read().await.clone().ok_or_else(|| {

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -715,7 +715,7 @@ impl RequestContext {
         #[cfg(feature = "stateless")]
         if let Some(meta) = self.per_request_meta()
             && meta.protocol_version.as_deref()
-                == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+                == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
         {
             let Some(request_level) = meta.log_level else {
                 return;
@@ -1419,7 +1419,7 @@ mod tests {
         let (tx, mut rx) = notification_channel(10);
         let mut extensions = Extensions::new();
         extensions.insert(crate::stateless::StatelessRequestMeta {
-            protocol_version: Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            protocol_version: Some(crate::protocol::PROTOCOL_VERSION_2026_07_28.to_string()),
             client_capabilities: Some(Default::default()),
             ..Default::default()
         });
@@ -1437,7 +1437,7 @@ mod tests {
 
         let mut extensions = Extensions::new();
         extensions.insert(crate::stateless::StatelessRequestMeta {
-            protocol_version: Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            protocol_version: Some(crate::protocol::PROTOCOL_VERSION_2026_07_28.to_string()),
             client_capabilities: Some(Default::default()),
             log_level: Some(crate::stateless::LogLevel::Warning),
             ..Default::default()

--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -498,7 +498,7 @@ fn prepare_modern_request(
             protocol_support.versions().iter().map(String::as_str),
         ));
     }
-    if protocol_version == crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+    if protocol_version == crate::protocol::PROTOCOL_VERSION_2026_07_28
         && is_removed_modern_method(&req.method)
     {
         return Err(JsonRpcError::method_not_found(&req.method));
@@ -533,7 +533,7 @@ pub(crate) fn apply_protocol_result_fields(
     method: &str,
     protocol_version: &str,
 ) {
-    if protocol_version != crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+    if protocol_version != crate::protocol::PROTOCOL_VERSION_2026_07_28 {
         return;
     }
 
@@ -664,7 +664,7 @@ mod tests {
         let final_request = JsonRpcRequest::new(1, "tools/list").with_params(serde_json::json!({
             "_meta": {
                 "io.modelcontextprotocol/protocolVersion":
-                    crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION,
+                    crate::protocol::PROTOCOL_VERSION_2026_07_28,
                 "io.modelcontextprotocol/clientCapabilities": {}
             }
         }));
@@ -694,7 +694,7 @@ mod tests {
         let request = JsonRpcRequest::new(1, "server/discover").with_params(serde_json::json!({
             "_meta": {
                 "io.modelcontextprotocol/protocolVersion":
-                    crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+                    crate::protocol::PROTOCOL_VERSION_2026_07_28
             }
         }));
 
@@ -711,7 +711,7 @@ mod tests {
     async fn final_only_policy_never_negotiates_final_via_initialize() {
         let router = create_test_router();
         let mut service = JsonRpcService::new(router).protocol_support(
-            ProtocolSupport::try_new([crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION]).unwrap(),
+            ProtocolSupport::try_new([crate::protocol::PROTOCOL_VERSION_2026_07_28]).unwrap(),
         );
         let request = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
             "protocolVersion": "2025-11-25",
@@ -726,7 +726,7 @@ mod tests {
         assert_eq!(response.error.code, -32022);
         assert_eq!(
             response.error.data.unwrap()["supported"],
-            serde_json::json!([crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION])
+            serde_json::json!([crate::protocol::PROTOCOL_VERSION_2026_07_28])
         );
     }
 

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -137,7 +137,7 @@
 //! - [`GetPromptResult`] - Prompt expansion result
 //! - [`Content`] - Text, image, audio, or resource content
 //!
-//! ### Experimental 2026-07-28 protocol (requires `protocol-2026-07-28`)
+//! ### Released 2026-07-28 protocol (requires `protocol-2026-07-28`)
 //! - [`stateless::StatelessRequestMeta`] - Per-request `_meta` carrying protocol version,
 //!   client identity, and client capabilities for sessionless 2026-07-28 requests
 //! - [`RequestOutcome`] and [`InputRequiredResult`] - SEP-2322 Multi Round-Trip Request results
@@ -165,8 +165,8 @@
 //! - `macros` - Optional proc macros (`#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]`, `#[resource_template_fn]`)
 //! - `mcp-apps` - Typed server support for the stable MCP Apps extension. Runtime
 //!   advertisement remains explicit through [`McpRouter::with_mcp_apps`].
-//! - `protocol-2026-07-28` - Compile the experimental implementation of the released final
-//!   protocol. Use [`ProtocolSupport`] to select enabled versions at runtime. Enables
+//! - `protocol-2026-07-28` - Compile the released 2026-07-28 implementation.
+//!   Use [`ProtocolSupport`] to select enabled versions at runtime. Enables
 //!   version-gated sessionless dispatch, `server/discover` RPC, per-request `_meta` via
 //!   [`stateless::StatelessRequestMeta`], `subscriptions/listen`, SEP-2322 MRTR handlers,
 //!   and the discover-based [`McpClient`] path.
@@ -346,8 +346,8 @@
 //!
 //! ### Stateless Mode (2026-07-28, requires `protocol-2026-07-28` + `http`)
 //!
-//! The `protocol-2026-07-28` feature enables experimental support for the final
-//! 2026-07-28 MCP protocol. In this mode the initialize/initialized handshake
+//! The `protocol-2026-07-28` feature enables the released 2026-07-28 MCP
+//! protocol. In this mode the initialize/initialized handshake
 //! is replaced by two new RPCs:
 //!
 //! - **`server/discover`** -- stateless capability discovery. Clients that send requests with
@@ -377,7 +377,7 @@
 //!     .stateless(StatelessConfig::new());
 //! ```
 //!
-//! The 2026-07-28 implementation is experimental. Enable the
+//! The 2026-07-28 implementation is opt-in. Enable the
 //! `protocol-2026-07-28` Cargo feature to compile it, then use
 //! [`ProtocolSupport`] to narrow the versions enabled by an individual
 //! transport at runtime.
@@ -443,8 +443,8 @@
 //!
 //! ## MCP Specification
 //!
-//! This crate implements MCP 2025-11-25 by default and provides an
-//! experimental implementation of the released 2026-07-28 specification:
+//! This crate implements MCP 2025-11-25 by default and provides an opt-in
+//! implementation of the released 2026-07-28 specification:
 //! <https://modelcontextprotocol.io/specification/2026-07-28>
 //!
 //! Enable it with `protocol-2026-07-28`; the legacy `stateless` feature name

--- a/crates/tower-mcp/src/protocol_support.rs
+++ b/crates/tower-mcp/src/protocol_support.rs
@@ -7,17 +7,17 @@
 use std::collections::HashSet;
 
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
-use crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+use crate::protocol::PROTOCOL_VERSION_2026_07_28;
 use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
 
 /// Protocol versions compiled into this build, in preference order.
 ///
-/// Enabling `protocol-2026-07-28` adds the experimental implementation. The
-/// former `stateless` feature remains a compatibility alias and produces the
-/// same compiled set.
+/// Enabling `protocol-2026-07-28` adds the released, opt-in implementation.
+/// The former `stateless` feature remains a compatibility alias and produces
+/// the same compiled set.
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
 pub const COMPILED_PROTOCOL_VERSIONS: &[&str] =
-    &[EXPERIMENTAL_PROTOCOL_VERSION, "2025-11-25", "2025-03-26"];
+    &[PROTOCOL_VERSION_2026_07_28, "2025-11-25", "2025-03-26"];
 
 /// Protocol versions compiled into this build, in preference order.
 #[cfg(not(any(feature = "protocol-2026-07-28", feature = "stateless")))]
@@ -79,9 +79,9 @@ impl ProtocolSupport {
         }
     }
 
-    /// Enable only the stable-by-default protocol versions.
+    /// Enable only the stable-by-default compatibility set.
     ///
-    /// This excludes experimental implementations even when their Cargo
+    /// This excludes opt-in protocol implementations even when their Cargo
     /// features are compiled.
     pub fn stable() -> Self {
         Self {
@@ -155,7 +155,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn stable_policy_excludes_experimental_versions() {
+    fn stable_policy_excludes_opt_in_versions() {
         let support = ProtocolSupport::stable();
         assert_eq!(support.versions(), SUPPORTED_PROTOCOL_VERSIONS);
         assert_eq!(support.preferred(), "2025-11-25");
@@ -179,9 +179,9 @@ mod tests {
 
     #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
     #[test]
-    fn experimental_feature_adds_2026_implementation() {
-        assert!(is_protocol_version_compiled(EXPERIMENTAL_PROTOCOL_VERSION));
-        assert!(ProtocolSupport::compiled().contains(EXPERIMENTAL_PROTOCOL_VERSION));
+    fn opt_in_feature_adds_2026_implementation() {
+        assert!(is_protocol_version_compiled(PROTOCOL_VERSION_2026_07_28));
+        assert!(ProtocolSupport::compiled().contains(PROTOCOL_VERSION_2026_07_28));
     }
 
     #[cfg(not(any(feature = "protocol-2026-07-28", feature = "stateless")))]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -75,7 +75,7 @@ fn is_final_protocol_request(extensions: &crate::context::Extensions) -> bool {
     extensions
         .get::<crate::stateless::StatelessRequestMeta>()
         .and_then(|meta| meta.protocol_version.as_deref())
-        == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+        == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
 }
 
 #[cfg(not(feature = "stateless"))]
@@ -148,7 +148,7 @@ fn validate_input_required_result(
     let meta = extensions
         .get::<crate::stateless::StatelessRequestMeta>()
         .filter(|meta| {
-            meta.protocol_version.as_deref() == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+            meta.protocol_version.as_deref() == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
         })
         .ok_or_else(|| {
             Error::invalid_params(
@@ -926,8 +926,8 @@ impl McpRouter {
         let mut merged = (*self.inner.extensions).clone();
         merged.merge(per_request);
         let negotiated_extensions = if is_final_protocol_request(per_request) {
-            let server_capabilities = self
-                .capabilities_for_protocol(Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION));
+            let server_capabilities =
+                self.capabilities_for_protocol(Some(crate::protocol::PROTOCOL_VERSION_2026_07_28));
             final_client_capabilities(per_request)
                 .map(|client_capabilities| {
                     crate::NegotiatedExtensions::from_capabilities(
@@ -2092,7 +2092,7 @@ impl McpRouter {
     /// advertise that partial implementation to 2026-07-28 clients.
     fn capabilities_for_protocol(&self, protocol_version: Option<&str>) -> ServerCapabilities {
         let mut capabilities = self.capabilities();
-        if protocol_version == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION) {
+        if protocol_version == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28) {
             capabilities.tasks = None;
             if let Some(extensions) = capabilities.extensions.as_mut() {
                 extensions.remove(tower_mcp_types::protocol::TASKS_EXTENSION_ID);
@@ -2235,9 +2235,8 @@ impl McpRouter {
                 // stateless lifecycle, so its advertised surface must be safe
                 // even when this router is invoked directly without transport
                 // metadata.
-                let capabilities = self.capabilities_for_protocol(Some(
-                    crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION,
-                ));
+                let capabilities = self
+                    .capabilities_for_protocol(Some(crate::protocol::PROTOCOL_VERSION_2026_07_28));
                 Ok(McpResponse::Discover(DiscoverResult {
                     supported_versions,
                     capabilities,
@@ -2384,7 +2383,7 @@ impl McpRouter {
                 if let Some(required) = tool.required_client_capabilities()
                     && let Some(meta) = extensions.get::<crate::stateless::StatelessRequestMeta>()
                     && meta.protocol_version.as_deref()
-                        == Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+                        == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
                     && !meta
                         .client_capabilities
                         .as_ref()
@@ -3461,7 +3460,7 @@ mod tests {
     fn final_extensions(client_capabilities: ClientCapabilities) -> Extensions {
         let mut extensions = Extensions::new();
         extensions.insert(crate::stateless::StatelessRequestMeta {
-            protocol_version: Some(EXPERIMENTAL_PROTOCOL_VERSION.to_string()),
+            protocol_version: Some(PROTOCOL_VERSION_2026_07_28.to_string()),
             client_capabilities: Some(client_capabilities),
             ..Default::default()
         });
@@ -3480,7 +3479,7 @@ mod tests {
 
         let stable = router.capabilities();
         let final_capabilities =
-            router.capabilities_for_protocol(Some(crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION));
+            router.capabilities_for_protocol(Some(crate::protocol::PROTOCOL_VERSION_2026_07_28));
         for capabilities in [stable, final_capabilities] {
             let extensions = capabilities.extensions.unwrap();
             assert_eq!(extensions.len(), 1);

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -274,8 +274,8 @@ use crate::error::{Error, JsonRpcError, Result};
 use crate::error::{ErrorCode, McpErrorCode};
 use crate::jsonrpc::{JsonRpcService, apply_protocol_result_fields};
 use crate::protocol::{
-    ClientCapabilities, EXPERIMENTAL_PROTOCOL_VERSION, Implementation, JsonRpcNotification,
-    JsonRpcRequest, JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, RequestId,
+    ClientCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
+    LATEST_PROTOCOL_VERSION, McpNotification, PROTOCOL_VERSION_2026_07_28, RequestId,
 };
 #[cfg(feature = "stateless")]
 use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
@@ -2592,7 +2592,7 @@ fn request_tool_input_schema(
 /// envelope receives the specified modern error instead of drifting into the
 /// legacy session path.
 fn claims_modern_protocol(headers: &HeaderMap, parsed: &serde_json::Value) -> bool {
-    get_protocol_version(headers).as_deref() == Some(EXPERIMENTAL_PROTOCOL_VERSION)
+    get_protocol_version(headers).as_deref() == Some(PROTOCOL_VERSION_2026_07_28)
         || parsed
             .get("params")
             .and_then(serde_json::Value::as_object)
@@ -3566,11 +3566,9 @@ async fn handle_post(
 
     let negotiated_version = session.protocol_version.read().await.clone();
     let response_version = if request_method == "server/discover"
-        && state
-            .protocol_support
-            .contains(EXPERIMENTAL_PROTOCOL_VERSION)
+        && state.protocol_support.contains(PROTOCOL_VERSION_2026_07_28)
     {
-        EXPERIMENTAL_PROTOCOL_VERSION
+        PROTOCOL_VERSION_2026_07_28
     } else {
         &negotiated_version
     };
@@ -3765,7 +3763,7 @@ fn version_supports_subscriptions_listen(
     version: &str,
     protocol_support: &ProtocolSupport,
 ) -> bool {
-    version == EXPERIMENTAL_PROTOCOL_VERSION && protocol_support.contains(version)
+    version == PROTOCOL_VERSION_2026_07_28 && protocol_support.contains(version)
 }
 
 /// Returns `true` when the given protocol version string enables stateless
@@ -3773,10 +3771,10 @@ fn version_supports_subscriptions_listen(
 ///
 /// Stateless mode is introduced in the 2026-07-28 protocol (SEP-2575 /
 /// SEP-2567). Only the exact, compiled-and-enabled version opts in; unknown
-/// future dates must not silently inherit experimental behavior.
+/// future dates must not silently inherit revision-specific behavior.
 #[cfg(feature = "stateless")]
 fn is_stateless_protocol_version(version: &str) -> bool {
-    version == EXPERIMENTAL_PROTOCOL_VERSION
+    version == PROTOCOL_VERSION_2026_07_28
 }
 
 /// Stamp `_meta["io.modelcontextprotocol/serverInfo"]` onto a successful
@@ -4079,7 +4077,7 @@ async fn handle_modern_subscriptions_listen_sse(
         .into_response();
     response.headers_mut().insert(
         MCP_PROTOCOL_VERSION_HEADER,
-        HeaderValue::from_static(EXPERIMENTAL_PROTOCOL_VERSION),
+        HeaderValue::from_static(PROTOCOL_VERSION_2026_07_28),
     );
     response
 }
@@ -4392,7 +4390,7 @@ mod tests {
         ] {
             let mut response =
                 JsonRpcResponse::result(RequestId::Number(1), serde_json::json!({"value": true}));
-            apply_protocol_result_fields(&mut response, method, EXPERIMENTAL_PROTOCOL_VERSION);
+            apply_protocol_result_fields(&mut response, method, PROTOCOL_VERSION_2026_07_28);
             let json = serde_json::to_value(response).unwrap();
             assert_eq!(json["result"]["resultType"], "complete", "{method}");
             assert_eq!(json["result"]["ttlMs"], 0, "{method}");
@@ -4401,7 +4399,7 @@ mod tests {
 
         let mut ordinary =
             JsonRpcResponse::result(RequestId::Number(1), serde_json::json!({"content": []}));
-        apply_protocol_result_fields(&mut ordinary, "tools/call", EXPERIMENTAL_PROTOCOL_VERSION);
+        apply_protocol_result_fields(&mut ordinary, "tools/call", PROTOCOL_VERSION_2026_07_28);
         let json = serde_json::to_value(ordinary).unwrap();
         assert_eq!(json["result"]["resultType"], "complete");
         assert!(json["result"].get("ttlMs").is_none());
@@ -4416,11 +4414,7 @@ mod tests {
             "cacheScope": "public"
         });
         let mut response = JsonRpcResponse::result(RequestId::Number(1), explicit.clone());
-        apply_protocol_result_fields(
-            &mut response,
-            "resources/read",
-            EXPERIMENTAL_PROTOCOL_VERSION,
-        );
+        apply_protocol_result_fields(&mut response, "resources/read", PROTOCOL_VERSION_2026_07_28);
         let json = serde_json::to_value(response).unwrap();
         assert_eq!(json["result"]["ttlMs"], 42);
         assert_eq!(json["result"]["cacheScope"], "public");
@@ -4430,11 +4424,7 @@ mod tests {
                 RequestId::Number(1),
                 serde_json::json!({"resultType": discriminator}),
             );
-            apply_protocol_result_fields(
-                &mut response,
-                "tools/call",
-                EXPERIMENTAL_PROTOCOL_VERSION,
-            );
+            apply_protocol_result_fields(&mut response, "tools/call", PROTOCOL_VERSION_2026_07_28);
             let json = serde_json::to_value(response).unwrap();
             assert_eq!(json["result"]["resultType"], discriminator);
         }
@@ -4808,7 +4798,7 @@ mod tests {
         let transport = HttpTransport::new(create_test_router()).disable_origin_validation();
         let app = transport.into_router();
 
-        // A future-looking unknown version must not enter the experimental
+        // A future-looking unknown version must not enter the 2026-07-28
         // stateless path merely because its date sorts after 2026-07-28.
         let req = Request::builder()
             .method("POST")
@@ -5269,7 +5259,7 @@ mod tests {
                 .method("POST")
                 .uri("/")
                 .header("Content-Type", "application/json")
-                .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+                .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
                 .header(MCP_METHOD_HEADER, "tools/call")
                 .header(MCP_NAME_HEADER, "route");
             if let Some(value) = custom_header {
@@ -5286,7 +5276,7 @@ mod tests {
                             "arguments": {"tenant_id": "acme"},
                             "_meta": {
                                 "io.modelcontextprotocol/protocolVersion":
-                                    EXPERIMENTAL_PROTOCOL_VERSION,
+                                    PROTOCOL_VERSION_2026_07_28,
                                 "io.modelcontextprotocol/clientCapabilities": {}
                             }
                         }
@@ -7186,7 +7176,7 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json, text/event-stream")
             .header(MCP_METHOD_HEADER, "initialize")
-            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
@@ -7232,7 +7222,7 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header(MCP_METHOD_HEADER, "server/discover")
-            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
@@ -7265,7 +7255,7 @@ mod tests {
         let build_request =
             |id: i64, extra_meta: serde_json::Value, extensions: serde_json::Value| {
                 let mut meta = serde_json::json!({
-                    "io.modelcontextprotocol/protocolVersion": EXPERIMENTAL_PROTOCOL_VERSION,
+                    "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION_2026_07_28,
                     "io.modelcontextprotocol/clientCapabilities": {
                         "extensions": extensions
                     }
@@ -7279,7 +7269,7 @@ mod tests {
                     .header("Content-Type", "application/json")
                     .header("Accept", "application/json")
                     .header(MCP_METHOD_HEADER, "server/discover")
-                    .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+                    .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
                     .body(Body::from(
                         serde_json::json!({
                             "jsonrpc": "2.0",
@@ -7371,7 +7361,7 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header(MCP_METHOD_HEADER, "unknown/method")
-            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
             .body(Body::from(
                 serde_json::json!({
                     "jsonrpc": "2.0",
@@ -7411,7 +7401,7 @@ mod tests {
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .header(MCP_METHOD_HEADER, "tools/list")
-            .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+            .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
             .header(MCP_SESSION_ID_HEADER, "legacy-session-that-does-not-exist")
             .header(LAST_EVENT_ID_HEADER, "legacy-event")
             .body(Body::from(
@@ -7468,7 +7458,7 @@ mod tests {
                 .header("Accept", "application/json")
                 .header(MCP_METHOD_HEADER, "tools/call")
                 .header(MCP_NAME_HEADER, "sample")
-                .header(MCP_PROTOCOL_VERSION_HEADER, EXPERIMENTAL_PROTOCOL_VERSION)
+                .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
                 .body(Body::from(
                     serde_json::json!({
                         "jsonrpc": "2.0",

--- a/crates/tower-mcp/src/transport/http_headers.rs
+++ b/crates/tower-mcp/src/transport/http_headers.rs
@@ -80,9 +80,9 @@ pub(super) enum Sep2243Mode {
 ///
 /// Returns [`Sep2243Mode::Strict`] for the explicitly implemented 2026-07-28
 /// protocol, [`Sep2243Mode::Lenient`] otherwise. Unsupported future versions
-/// must not silently inherit experimental behavior based on date ordering.
+/// must not silently inherit revision-specific behavior based on date ordering.
 pub(super) fn mode_for_version(version: &str) -> Sep2243Mode {
-    if version == crate::protocol::EXPERIMENTAL_PROTOCOL_VERSION {
+    if version == crate::protocol::PROTOCOL_VERSION_2026_07_28 {
         Sep2243Mode::Strict
     } else {
         Sep2243Mode::Lenient

--- a/crates/tower-mcp/tests/per_request_meta.rs
+++ b/crates/tower-mcp/tests/per_request_meta.rs
@@ -52,11 +52,11 @@ async fn call_tool(body: serde_json::Value) -> (serde_json::Value, Captured) {
         .header("Content-Type", "application/json")
         .header("Accept", "application/json");
     if body["params"]["_meta"]["io.modelcontextprotocol/protocolVersion"]
-        == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+        == tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28
     {
         request = request.header(
             "Mcp-Protocol-Version",
-            tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION,
+            tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28,
         );
         request = request
             .header("Mcp-Method", "tools/call")

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -236,7 +236,7 @@ async fn stdio_supports_final_and_legacy_lifecycles_on_one_stream() {
             .await
     });
 
-    let final_version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+    let final_version = tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28;
     let requests = vec![
         serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": "server/discover",
@@ -333,7 +333,7 @@ async fn stdio_runtime_protocol_allow_list_is_exact() {
     let request = serde_json::json!({
         "jsonrpc": "2.0", "id": 1, "method": "server/discover",
         "params": {
-            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
         }
     });
     let mut stdin_writer = server_stdin_writer;
@@ -351,14 +351,14 @@ async fn stdio_runtime_protocol_allow_list_is_exact() {
     assert_eq!(frames[0]["error"]["code"], -32022);
     assert_eq!(
         frames[0]["error"]["data"]["requested"],
-        tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+        tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28
     );
     assert!(
         frames[0]["error"]["data"]["supported"]
             .as_array()
             .unwrap()
             .iter()
-            .all(|version| version != tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+            .all(|version| version != tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
     );
 }
 
@@ -396,7 +396,7 @@ async fn stdio_multiplexes_and_gracefully_closes_final_subscriptions() {
     });
     let mut writer = server_stdin_writer;
     let mut reader = BufReader::new(server_stdout_reader);
-    let version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+    let version = tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28;
 
     let tools_listen = serde_json::json!({
         "jsonrpc": "2.0",
@@ -636,7 +636,7 @@ async fn stdio_subscription_validation_uses_runtime_protocol_policy() {
         "id": 9,
         "method": "subscriptions/listen",
         "params": {
-            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
             "notifications": {"toolsListChanged": true}
         }
     });
@@ -655,7 +655,7 @@ async fn stdio_subscription_validation_uses_runtime_protocol_policy() {
     assert_eq!(frames[0]["error"]["code"], -32022);
     assert_eq!(
         frames[0]["error"]["data"]["requested"],
-        tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+        tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28
     );
 }
 
@@ -670,7 +670,7 @@ async fn stdio_subscription_requires_final_metadata_and_filter() {
             .run_with_streams(server_stdin, server_stdout)
             .await
     });
-    let version = tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION;
+    let version = tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28;
     let missing_filter = serde_json::json!({
         "jsonrpc": "2.0",
         "id": 10,
@@ -738,7 +738,7 @@ async fn middleware_wrapped_stdio_preserves_subscription_routing() {
         "id": "layered",
         "method": "subscriptions/listen",
         "params": {
-            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
             "notifications": {"toolsListChanged": true}
         }
     });
@@ -793,7 +793,7 @@ async fn bidi_stdio_preserves_subscription_routing() {
         "id": 71,
         "method": "subscriptions/listen",
         "params": {
-            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION),
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
             "notifications": {"toolsListChanged": true}
         }
     });
@@ -846,7 +846,7 @@ async fn bidi_final_handlers_cannot_initiate_client_requests() {
         "params": {
             "name": "inspect_meta",
             "arguments": {},
-            "_meta": final_meta(tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION)
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
         }
     });
     let mut stdin_writer = server_stdin_writer;

--- a/examples/conformance-client/src/core_scenarios.rs
+++ b/examples/conformance-client/src/core_scenarios.rs
@@ -12,7 +12,7 @@ fn requested_protocol_version() -> String {
 }
 
 pub(crate) fn uses_final_protocol() -> bool {
-    requested_protocol_version() == tower_mcp::protocol::EXPERIMENTAL_PROTOCOL_VERSION
+    requested_protocol_version() == tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28
 }
 
 pub(crate) fn client_builder() -> Result<McpClientBuilder> {

--- a/examples/stateless_http_client.rs
+++ b/examples/stateless_http_client.rs
@@ -24,7 +24,7 @@
 //!
 //! No separate server process is needed -- the server is started in-process.
 //! The `protocol-2026-07-28` feature is required for the server and client to
-//! compile this experimental final-protocol implementation.
+//! compile this opt-in final-protocol implementation.
 
 use std::time::Duration;
 


### PR DESCRIPTION
## Decision

The 2026-07-28 specification and tower-mcp implementation are released, but changing the crate's default lifecycle immediately would be a surprising compatibility break. This PR therefore separates status from selection:

- `PROTOCOL_VERSION_2026_07_28` becomes the canonical date-specific wire constant
- `EXPERIMENTAL_PROTOCOL_VERSION` and `UPCOMING_PROTOCOL_VERSION` remain deprecated aliases
- `protocol-2026-07-28` remains the explicit compile-time gate
- `ProtocolSupport` remains the exact per-client/per-server runtime allow-list
- `LATEST_PROTOCOL_VERSION` / `SUPPORTED_PROTOCOL_VERSIONS` continue to describe the non-breaking 2025 default compatibility set

All #929 promotion audits are complete; MCP Apps/extension implementation landed in #1069–#1070, and incomplete final Tasks behavior remains safely unadvertised under #951.

## Validation

- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo check --workspace --all-targets --all-features`
- `cargo check -p tower-mcp --no-default-features`
- stable conformance: 311 passed, 0 failed
- 2026-07-28 conformance: 399 passed, 0 failed

Closes #929.