### PR TITLE
feat(tasks): dispatch the final task methods

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -841,6 +841,26 @@ pub enum McpResponse {
     UnsubscribeResource(EmptyResult),
     ListPrompts(ListPromptsResult),
     GetPrompt(GetPromptResult),
+    // The final Tasks extension variants are declared before their legacy
+    // counterparts on purpose. This enum is `untagged`, so deserialization
+    // tries variants in declaration order, and each final type validates
+    // `resultType` in a custom deserializer. Strict-first means a genuine
+    // final payload matches its own variant and anything else falls through
+    // to the legacy shape; the reverse order would let `TaskObject` silently
+    // swallow a final `tasks/get` result.
+    /// Flat `resultType: "task"` handle for the final Tasks extension
+    /// (SEP-2663), as opposed to the legacy nested [`CreateTaskResult`].
+    FinalCreateTask(crate::tasks::CreateTaskResult),
+    /// Status-discriminated `tasks/get` result for the final Tasks extension
+    /// (SEP-2663).
+    FinalGetTask(crate::tasks::GetTaskResult),
+    /// Complete acknowledgement for a final `tasks/update` or `tasks/cancel`
+    /// (SEP-2663).
+    ///
+    /// One variant covers both methods because they produce byte-identical
+    /// results; two untagged variants that cannot be distinguished would be
+    /// worse than one that says so.
+    FinalTaskAck(crate::tasks::TaskAcknowledgement),
     CreateTask(CreateTaskResult),
     GetTaskInfo(TaskObject),
     /// Ack-only response for `tasks/update` (SEP-2663).

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -101,6 +101,33 @@ fn client_declares_tasks(_extensions: &crate::context::Extensions) -> bool {
     false
 }
 
+/// Decode the wire `inputResponses` map into typed responses.
+///
+/// A key whose value does not match any known response shape is dropped here
+/// rather than failing the request: the store treats an unmatched key as
+/// ignorable, and SEP-2663 requires ignoring responses that do not correspond
+/// to an outstanding request.
+fn decode_input_responses(
+    responses: &std::collections::HashMap<String, serde_json::Value>,
+) -> crate::protocol::InputResponses {
+    responses
+        .iter()
+        .filter_map(|(key, value)| {
+            serde_json::from_value(value.clone())
+                .ok()
+                .map(|response| (key.clone(), response))
+        })
+        .collect()
+}
+
+/// Error for a task the server cannot serve.
+///
+/// Unknown and expired tasks are deliberately indistinguishable, so a caller
+/// cannot probe for the existence of a task whose retention window closed.
+fn unknown_task_error(task_id: &str) -> JsonRpcError {
+    JsonRpcError::invalid_params(format!("Task not found: {task_id}"))
+}
+
 /// The client capability shape a server names in a `-32021` when it cannot
 /// service a request without the Tasks extension.
 fn tasks_client_capabilities() -> crate::protocol::ClientCapabilities {
@@ -2152,6 +2179,85 @@ impl McpRouter {
             .contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
     }
 
+    /// Reject a final task method that was not negotiated by both peers.
+    ///
+    /// An unnegotiated method is reported as absent rather than forbidden:
+    /// the server genuinely does not serve it for this client.
+    fn require_negotiated_tasks(
+        &self,
+        extensions: &crate::context::Extensions,
+        method: &str,
+    ) -> Result<()> {
+        if self.final_tasks_enabled() && client_declares_tasks(extensions) {
+            Ok(())
+        } else {
+            Err(Error::JsonRpc(JsonRpcError::method_not_found(method)))
+        }
+    }
+
+    /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
+    async fn final_get_task(&self, task_id: &str) -> Result<McpResponse> {
+        let (task, result, error) = self
+            .inner
+            .task_store
+            .get_task_result(task_id)
+            .await
+            .map_err(task_store_error)?
+            .ok_or_else(|| Error::JsonRpc(unknown_task_error(task_id)))?;
+
+        let mut metadata = crate::tasks::TaskMetadata::new(
+            task.task_id.clone(),
+            task.created_at.clone(),
+            task.last_updated_at.clone(),
+            task.ttl,
+        );
+        metadata.status_message = task.status_message.clone();
+        metadata.poll_interval_ms = task.poll_interval;
+
+        let detailed = match task.status {
+            TaskStatus::Working => crate::tasks::DetailedTask::working(metadata),
+            TaskStatus::InputRequired => {
+                // Every request still awaiting a response, not just the most
+                // recent one.
+                let outstanding = self
+                    .inner
+                    .task_store
+                    .outstanding_input_requests(task_id)
+                    .await
+                    .map_err(task_store_error)?
+                    .unwrap_or_default();
+                crate::tasks::DetailedTask::input_required(metadata, outstanding)
+            }
+            TaskStatus::Completed => {
+                // The exact object the synchronous call would have returned,
+                // including `isError: true` results.
+                let object = result
+                    .map(serde_json::to_value)
+                    .transpose()
+                    .map_err(|e| {
+                        Error::JsonRpc(JsonRpcError::internal_error(format!(
+                            "failed to encode task result: {e}"
+                        )))
+                    })?
+                    .and_then(|value| value.as_object().cloned())
+                    .unwrap_or_default();
+                crate::tasks::DetailedTask::completed(metadata, object)
+            }
+            TaskStatus::Failed => crate::tasks::DetailedTask::failed(
+                metadata,
+                error.unwrap_or_else(|| JsonRpcError::internal_error("Task failed")),
+            ),
+            TaskStatus::Cancelled => crate::tasks::DetailedTask::cancelled(metadata),
+            // `TaskStatus` is non_exhaustive. Report an unrecognized status as
+            // working rather than inventing a terminal state.
+            _ => crate::tasks::DetailedTask::working(metadata),
+        };
+
+        Ok(McpResponse::FinalGetTask(crate::tasks::GetTaskResult::new(
+            detailed,
+        )))
+    }
+
     /// Effective SEP-2549 cache scope to emit alongside a TTL hint.
     ///
     /// Returns the configured scope, or `private` (the conservative choice)
@@ -2538,6 +2644,25 @@ impl McpRouter {
                             ))
                         })?;
 
+                    // The final wire is flat with `resultType: "task"`; the
+                    // legacy shape nests a `task` compatibility mirror. Pick
+                    // by protocol version rather than emitting a hybrid.
+                    if is_final_protocol_request(&extensions) {
+                        let mut metadata = crate::tasks::TaskMetadata::new(
+                            task.task_id.clone(),
+                            task.created_at.clone(),
+                            task.last_updated_at.clone(),
+                            task.ttl,
+                        );
+                        metadata.status_message = task.status_message.clone();
+                        metadata.poll_interval_ms = task.poll_interval;
+                        return Ok(McpResponse::FinalCreateTask(
+                            crate::tasks::CreateTaskResult::new(crate::tasks::Task::new(
+                                metadata,
+                                task.status,
+                            )),
+                        ));
+                    }
                     Ok(McpResponse::CreateTask(CreateTaskResult::new(task)))
                 } else {
                     // Synchronous request: validate task_support != Required
@@ -3040,7 +3165,8 @@ impl McpRouter {
 
             McpRequest::GetTaskInfo(params) => {
                 if is_final_protocol_request(&extensions) {
-                    return Err(Error::JsonRpc(JsonRpcError::method_not_found("tasks/get")));
+                    self.require_negotiated_tasks(&extensions, "tasks/get")?;
+                    return self.final_get_task(&params.task_id).await;
                 }
 
                 // SEP-2663 DetailedTask: `tasks/get` carries the
@@ -3080,9 +3206,22 @@ impl McpRouter {
 
             McpRequest::UpdateTask(params) => {
                 if is_final_protocol_request(&extensions) {
-                    return Err(Error::JsonRpc(JsonRpcError::method_not_found(
-                        "tasks/update",
-                    )));
+                    self.require_negotiated_tasks(&extensions, "tasks/update")?;
+                    // Partial responses are the normal case: the store
+                    // consumes what matches an outstanding request and ignores
+                    // unknown, already-answered, and superseded keys.
+                    self.inner
+                        .task_store
+                        .apply_input_responses(
+                            &params.task_id,
+                            decode_input_responses(&params.input_responses),
+                        )
+                        .await
+                        .map_err(task_store_error)?
+                        .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                    return Ok(McpResponse::FinalTaskAck(
+                        crate::tasks::TaskAcknowledgement::new(),
+                    ));
                 }
 
                 // SEP-2663 `tasks/update`: validate the task exists and
@@ -3109,9 +3248,19 @@ impl McpRouter {
 
             McpRequest::CancelTask(params) => {
                 if is_final_protocol_request(&extensions) {
-                    return Err(Error::JsonRpc(JsonRpcError::method_not_found(
-                        "tasks/cancel",
-                    )));
+                    self.require_negotiated_tasks(&extensions, "tasks/cancel")?;
+                    // The final ack does not require a terminal transition:
+                    // cancelling an already-terminal task is acknowledged, and
+                    // the observable status is polled via `tasks/get`.
+                    self.inner
+                        .task_store
+                        .cancel_task(&params.task_id, params.reason.as_deref())
+                        .await
+                        .map_err(task_store_error)?
+                        .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                    return Ok(McpResponse::FinalTaskAck(
+                        crate::tasks::TaskAcknowledgement::new(),
+                    ));
                 }
 
                 // First check if the task exists and is not already terminal
@@ -3636,7 +3785,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            matches!(response, McpResponse::CreateTask(_)),
+            matches!(response, McpResponse::FinalCreateTask(_)),
             "a negotiated request must receive a task, got {response:?}"
         );
 
@@ -3650,6 +3799,127 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(response, McpResponse::CallTool(_)));
+    }
+
+    #[tokio::test]
+    async fn final_task_methods_serve_the_negotiated_wire_shapes() {
+        let router = McpRouter::new()
+            .tool(
+                ToolBuilder::new("optional_task")
+                    .task_support(TaskSupportMode::Optional)
+                    .handler(|input: AddInput| async move {
+                        Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                    })
+                    .build(),
+            )
+            .with_tasks();
+
+        let McpResponse::FinalCreateTask(created) = router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::CallTool(CallToolParams {
+                    name: "optional_task".to_string(),
+                    arguments: serde_json::json!({"a": 1, "b": 2}),
+                    input_responses: None,
+                    request_state: None,
+                    meta: None,
+                    task: Some(TaskRequestParams { ttl: None }),
+                }),
+                tasks_client_extensions(),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("Expected a final create-task response");
+        };
+
+        // Flat, with no legacy nested mirror.
+        let wire = serde_json::to_value(&created).unwrap();
+        assert_eq!(wire["resultType"], "task");
+        assert!(wire.get("task").is_none(), "final results are flat: {wire}");
+        assert!(wire["ttlMs"].is_number() || wire["ttlMs"].is_null());
+        assert!(wire.get("ttl").is_none(), "legacy field name leaked");
+        let task_id = created.task.metadata.task_id.clone();
+
+        // tasks/get returns a status-discriminated DetailedTask.
+        let McpResponse::FinalGetTask(fetched) = router
+            .handle(
+                RequestId::Number(2),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: task_id.clone(),
+                    meta: None,
+                }),
+                tasks_client_extensions(),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("Expected a final get-task response");
+        };
+        let wire = serde_json::to_value(&fetched).unwrap();
+        assert_eq!(wire["resultType"], "complete");
+        assert_eq!(wire["taskId"], serde_json::json!(task_id));
+        assert!(wire["status"].is_string());
+
+        // Both ack methods produce the complete acknowledgement.
+        for (id, request) in [
+            (
+                3,
+                McpRequest::UpdateTask(UpdateTaskParams {
+                    task_id: task_id.clone(),
+                    input_responses: HashMap::new(),
+                    meta: None,
+                }),
+            ),
+            (
+                4,
+                McpRequest::CancelTask(CancelTaskParams {
+                    task_id: task_id.clone(),
+                    reason: None,
+                    meta: None,
+                }),
+            ),
+        ] {
+            let response = router
+                .handle(RequestId::Number(id), request, tasks_client_extensions())
+                .await
+                .unwrap();
+            let McpResponse::FinalTaskAck(ack) = response else {
+                panic!("Expected a final ack for request {id}");
+            };
+            assert_eq!(
+                serde_json::to_value(&ack).unwrap(),
+                serde_json::json!({"resultType": "complete"})
+            );
+        }
+
+        // An unknown task is invalid params, not a method error.
+        let error = router
+            .handle(
+                RequestId::Number(5),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: "does-not-exist".to_string(),
+                    meta: None,
+                }),
+                tasks_client_extensions(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::JsonRpc(e) if e.code == -32602));
+
+        // Without the client declaration the methods remain absent.
+        let error = router
+            .handle(
+                RequestId::Number(6),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: task_id.clone(),
+                    meta: None,
+                }),
+                final_extensions(ClientCapabilities::default()),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::JsonRpc(e) if e.code == -32601));
     }
 
     #[test]


### PR DESCRIPTION
Completes slice 3 of #951, following #1078 (negotiation).

## Problem

The final task methods still return `MethodNotFound`, and they cannot simply be enabled: the response types are wrong for the final wire.

`McpResponse::GetTaskInfo` carries a `TaskObject`, the legacy 2025-11-25 shape with `ttl` / `pollInterval` and no status discrimination. The final path needs the `GetTaskResult` / `DetailedTask` types added in #1074.

There is also a live wire bug from #1078: a negotiated final `tools/call` returns `McpResponse::CreateTask`, which is the **legacy** `CreateTaskResult` with its nested `task` compatibility mirror. Final clients must get the flat `resultType: "task"` shape.

## Change

Three new `McpResponse` variants in `tower-mcp-types`, each carrying a `crate::tasks` type:

| Variant | Type | Wire |
|---|---|---|
| `FinalCreateTask` | `tasks::CreateTaskResult` | Flat, `resultType: "task"` |
| `FinalGetTask` | `tasks::GetTaskResult` | `resultType: "complete"` plus a status-discriminated `DetailedTask` |
| `FinalTaskAck` | `tasks::TaskAcknowledgement` | `{"resultType": "complete"}`, serving both update and cancel |

`McpResponse` is `#[non_exhaustive]`, so adding variants is additive for downstream matches. It is also `#[serde(untagged)]`, where deserialization tries variants in declaration order, so the new variants are declared **before** their legacy counterparts: each validates `resultType` in a custom deserializer, so a stricter variant first matches only genuine final payloads and otherwise falls through to the legacy shape. The reverse order would let `TaskObject` silently swallow a final payload.

One ack variant rather than two: `tasks/update` and `tasks/cancel` produce byte-identical results, and two untagged variants that cannot be told apart are worse than one that is honest about it.

Router wiring, all gated on the negotiation from #1078:

- `tasks/get` builds a `DetailedTask` from the store, sourcing outstanding requests from `outstanding_input_requests` and the structured error preserved in #1076
- `tasks/update` feeds `apply_input_responses`, so partial responses and the unknown / already-answered / superseded ignore rules work over the wire
- `tasks/cancel` acknowledges without requiring a terminal transition
- negotiated `tools/call` returns the flat final create result

Legacy 2025-11-25 dispatch is untouched.

## Scope

The typed client `tasks/update` API, `notifications/tasks`, subscription filtering, and auth binding are slice 4. Advertisement stays opt-in.

## Checks

- [ ] Final response variants with strict-before-loose untagged ordering
- [ ] `tasks/get` returns a status-discriminated `DetailedTask`
- [ ] `tasks/update` consumes partial responses through the store
- [ ] `tasks/cancel` acknowledges
- [ ] Negotiated `tools/call` returns the flat create result
- [ ] Legacy behavior unchanged