### PR TITLE
feat(tasks): bind task operations to the authenticated principal

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -74,6 +74,11 @@ pub struct Task {
     /// message string. A tool that returns `CallToolResult { isError: true }`
     /// is a *completed* task carrying an error result, so it never sets this.
     pub error: Option<JsonRpcError>,
+    /// Principal that created the task, or `None` when it was created
+    /// without an authenticated context.
+    ///
+    /// Never serialized: ownership is an authorization fact, not wire state.
+    pub owner: TaskOwner,
     /// Input requests currently awaiting a client response, keyed as sent.
     pub input_requests: InputRequests,
     /// Keys answered by a previous `tasks/update`.
@@ -91,7 +96,13 @@ pub struct Task {
 
 impl Task {
     /// Create a new task
-    fn new(id: String, tool_name: String, arguments: serde_json::Value, ttl: Option<u64>) -> Self {
+    fn new(
+        id: String,
+        tool_name: String,
+        arguments: serde_json::Value,
+        ttl: Option<u64>,
+        owner: TaskOwner,
+    ) -> Self {
         let cancelled = Arc::new(AtomicBool::new(false));
         let now_str = chrono_now_iso8601();
         Self {
@@ -107,6 +118,7 @@ impl Task {
             status_message: Some("Task started".to_string()),
             result: None,
             error: None,
+            owner,
             input_requests: InputRequests::new(),
             answered_input_keys: BTreeSet::new(),
             superseded_input_keys: BTreeSet::new(),
@@ -173,6 +185,26 @@ pub fn generate_task_id() -> String {
         let _ = write!(id, "{byte:02x}");
     }
     id
+}
+
+/// The principal a task belongs to.
+///
+/// `None` means the task was created without an authenticated context, which
+/// is the normal case for a server with no authentication configured.
+///
+/// SEP-2663 notes that a task ID can behave as a bearer token. Recording the
+/// owner is what stops the ID from being sufficient authority on its own once
+/// a second principal learns it.
+pub type TaskOwner = Option<String>;
+
+/// Whether `principal` may act on a task owned by `owner`.
+///
+/// Matching is equality, not "protect owned tasks and leave unowned ones
+/// open". An unowned task can only exist if it was created with no
+/// authenticated context, so a request that now carries a principal is a
+/// different security context and is refused.
+pub fn owner_matches(owner: &TaskOwner, principal: Option<&str>) -> bool {
+    owner.as_deref() == principal
 }
 
 /// Outcome of applying `tasks/update.inputResponses` to a task.
@@ -270,15 +302,25 @@ pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<JsonRpcError
 ///   trait.
 #[async_trait]
 pub trait TaskStore: Send + Sync + 'static {
-    /// Create and store a new task.
+    /// Create and store a new task owned by `owner`.
     ///
     /// Returns the task ID and a cancellation token for the spawned work.
+    /// `owner` is the authenticated principal responsible for the task, or
+    /// `None` when the request carried no authenticated context.
     async fn create_task(
         &self,
         tool_name: &str,
         arguments: serde_json::Value,
         ttl: Option<u64>,
+        owner: TaskOwner,
     ) -> Result<(String, CancellationToken)>;
+
+    /// Read a task's owner.
+    ///
+    /// The outer `Option` distinguishes a known task from an unknown or
+    /// expired one; the inner [`TaskOwner`] distinguishes an owned task from
+    /// one created without an authenticated principal.
+    async fn task_owner(&self, task_id: &str) -> Result<Option<TaskOwner>>;
 
     /// Get task object by ID. Returns `None` if unknown.
     async fn get_task(&self, task_id: &str) -> Result<Option<TaskObject>>;
@@ -427,9 +469,10 @@ impl TaskStore for MemoryTaskStore {
         tool_name: &str,
         arguments: serde_json::Value,
         ttl: Option<u64>,
+        owner: TaskOwner,
     ) -> Result<(String, CancellationToken)> {
         let id = generate_task_id();
-        let task = Task::new(id.clone(), tool_name.to_string(), arguments, ttl);
+        let task = Task::new(id.clone(), tool_name.to_string(), arguments, ttl, owner);
         let token = task.cancellation_token.clone();
 
         if let Ok(mut tasks) = self.tasks.write() {
@@ -445,6 +488,17 @@ impl TaskStore for MemoryTaskStore {
                 .get(task_id)
                 .filter(|t| !t.is_expired())
                 .map(|t| t.to_task_object())
+        } else {
+            None
+        })
+    }
+
+    async fn task_owner(&self, task_id: &str) -> Result<Option<TaskOwner>> {
+        Ok(if let Ok(tasks) = self.tasks.read() {
+            tasks
+                .get(task_id)
+                .filter(|t| !t.is_expired())
+                .map(|t| t.owner.clone())
         } else {
             None
         })
@@ -783,7 +837,7 @@ mod tests {
     async fn test_create_task() {
         let store = MemoryTaskStore::new();
         let (id, token) = store
-            .create_task("test-tool", serde_json::json!({"a": 1}), None)
+            .create_task("test-tool", serde_json::json!({"a": 1}), None, None)
             .await
             .unwrap();
 
@@ -803,7 +857,7 @@ mod tests {
     async fn test_task_lifecycle() {
         let store = MemoryTaskStore::new();
         let (id, _) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -823,7 +877,7 @@ mod tests {
     async fn test_task_cancellation() {
         let store = MemoryTaskStore::new();
         let (id, token) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -845,7 +899,7 @@ mod tests {
     async fn test_task_failure() {
         let store = MemoryTaskStore::new();
         let (id, _) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -865,15 +919,15 @@ mod tests {
     async fn test_list_tasks() {
         let store = MemoryTaskStore::new();
         store
-            .create_task("tool1", serde_json::json!({}), None)
+            .create_task("tool1", serde_json::json!({}), None, None)
             .await
             .unwrap();
         store
-            .create_task("tool2", serde_json::json!({}), None)
+            .create_task("tool2", serde_json::json!({}), None, None)
             .await
             .unwrap();
         let (id3, _) = store
-            .create_task("tool3", serde_json::json!({}), None)
+            .create_task("tool3", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -900,7 +954,7 @@ mod tests {
     async fn test_terminal_state_immutable() {
         let store = MemoryTaskStore::new();
         let (id, _) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -927,15 +981,15 @@ mod tests {
     async fn test_task_ids_unique() {
         let store = MemoryTaskStore::new();
         let (id1, _) = store
-            .create_task("tool", serde_json::json!({}), None)
+            .create_task("tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
         let (id2, _) = store
-            .create_task("tool", serde_json::json!({}), None)
+            .create_task("tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
         let (id3, _) = store
-            .create_task("tool", serde_json::json!({}), None)
+            .create_task("tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -948,7 +1002,7 @@ mod tests {
     async fn test_get_task_result() {
         let store = MemoryTaskStore::new();
         let (id, _) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -966,7 +1020,7 @@ mod tests {
     async fn test_wait_for_completion_returns_terminal_snapshot() {
         let store = MemoryTaskStore::new();
         let (id, _) = store
-            .create_task("test-tool", serde_json::json!({}), None)
+            .create_task("test-tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
 
@@ -993,7 +1047,7 @@ mod tests {
         // Compile-time check that TaskStore is object-safe.
         let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
         let (id, _) = store
-            .create_task("tool", serde_json::json!({}), None)
+            .create_task("tool", serde_json::json!({}), None, None)
             .await
             .unwrap();
         assert!(store.get_task(&id).await.unwrap().is_some());
@@ -1050,7 +1104,7 @@ mod tests {
 
     async fn working_task(store: &MemoryTaskStore, ttl: Option<u64>) -> String {
         store
-            .create_task("tool", serde_json::json!({}), ttl)
+            .create_task("tool", serde_json::json!({}), ttl, None)
             .await
             .unwrap()
             .0
@@ -1319,6 +1373,57 @@ mod tests {
         );
         assert!(result.unwrap().is_error);
         assert!(error.is_none(), "no JSON-RPC error accompanies isError");
+    }
+
+    #[tokio::test]
+    async fn tasks_record_their_creating_principal() {
+        let store = MemoryTaskStore::new();
+        let (owned, _) = store
+            .create_task("tool", serde_json::json!({}), None, Some("alice".into()))
+            .await
+            .unwrap();
+        let (unowned, _) = store
+            .create_task("tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.task_owner(&owned).await.unwrap(),
+            Some(Some("alice".to_string()))
+        );
+        assert_eq!(store.task_owner(&unowned).await.unwrap(), Some(None));
+        assert_eq!(
+            store.task_owner("does-not-exist").await.unwrap(),
+            None,
+            "an unknown task has no owner record at all"
+        );
+
+        // Ownership is an authorization fact and must not reach the wire.
+        let wire = serde_json::to_value(store.get_task(&owned).await.unwrap().unwrap()).unwrap();
+        assert!(
+            wire.get("owner").is_none(),
+            "owner leaked to the wire: {wire}"
+        );
+        assert!(!wire.to_string().contains("alice"));
+    }
+
+    #[test]
+    fn owner_matching_is_equality_not_leniency() {
+        assert!(owner_matches(&None, None), "no auth configured");
+        assert!(owner_matches(&Some("alice".into()), Some("alice")));
+
+        assert!(
+            !owner_matches(&Some("alice".into()), Some("bob")),
+            "a different principal must not inherit the task"
+        );
+        assert!(
+            !owner_matches(&Some("alice".into()), None),
+            "dropping the token must not grant access"
+        );
+        assert!(
+            !owner_matches(&None, Some("alice")),
+            "an unowned task belongs to a different security context"
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -120,6 +120,24 @@ fn decode_input_responses(
         .collect()
 }
 
+/// The authenticated principal for this request, if any.
+///
+/// Sourced from the OAuth `sub` claim that the HTTP and WebSocket transports
+/// bridge into MCP extensions. Without the `oauth` feature there is no
+/// principal, so tasks are unowned and behave as they did before ownership
+/// existed.
+#[cfg(feature = "oauth")]
+fn request_principal(extensions: &crate::context::Extensions) -> Option<String> {
+    extensions
+        .get::<crate::oauth::token::TokenClaims>()
+        .and_then(|claims| claims.sub.clone())
+}
+
+#[cfg(not(feature = "oauth"))]
+fn request_principal(_extensions: &crate::context::Extensions) -> Option<String> {
+    None
+}
+
 /// Error for a task the server cannot serve.
 ///
 /// Unknown and expired tasks are deliberately indistinguishable, so a caller
@@ -2195,6 +2213,36 @@ impl McpRouter {
         }
     }
 
+    /// Verify the caller may act on this task.
+    ///
+    /// A task the caller does not own is reported exactly as an unknown task.
+    /// Distinguishing the two would confirm that an ID is real, which is the
+    /// thing unguessable IDs exist to prevent.
+    async fn authorize_task(
+        &self,
+        task_id: &str,
+        extensions: &crate::context::Extensions,
+    ) -> Result<()> {
+        let owner = self
+            .inner
+            .task_store
+            .task_owner(task_id)
+            .await
+            .map_err(task_store_error)?
+            .ok_or_else(|| Error::JsonRpc(unknown_task_error(task_id)))?;
+
+        if crate::async_task::owner_matches(&owner, request_principal(extensions).as_deref()) {
+            Ok(())
+        } else {
+            tracing::debug!(
+                target: "mcp::tasks",
+                task_id = %task_id,
+                "task operation refused: principal does not own the task"
+            );
+            Err(Error::JsonRpc(unknown_task_error(task_id)))
+        }
+    }
+
     /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
     async fn final_get_task(&self, task_id: &str) -> Result<McpResponse> {
         let (task, result, error) = self
@@ -2572,7 +2620,12 @@ impl McpRouter {
                     let (task_id, cancellation_token) = self
                         .inner
                         .task_store
-                        .create_task(&params.name, params.arguments.clone(), task_params.ttl)
+                        .create_task(
+                            &params.name,
+                            params.arguments.clone(),
+                            task_params.ttl,
+                            request_principal(&extensions),
+                        )
                         .await
                         .map_err(task_store_error)?;
 
@@ -3166,8 +3219,10 @@ impl McpRouter {
             McpRequest::GetTaskInfo(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/get")?;
+                    self.authorize_task(&params.task_id, &extensions).await?;
                     return self.final_get_task(&params.task_id).await;
                 }
+                self.authorize_task(&params.task_id, &extensions).await?;
 
                 // SEP-2663 DetailedTask: `tasks/get` carries the
                 // status-discriminated payload inline. `completed` includes
@@ -3207,6 +3262,7 @@ impl McpRouter {
             McpRequest::UpdateTask(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/update")?;
+                    self.authorize_task(&params.task_id, &extensions).await?;
                     // Partial responses are the normal case: the store
                     // consumes what matches an outstanding request and ignores
                     // unknown, already-answered, and superseded keys.
@@ -3223,6 +3279,8 @@ impl McpRouter {
                         crate::tasks::TaskAcknowledgement::new(),
                     ));
                 }
+
+                self.authorize_task(&params.task_id, &extensions).await?;
 
                 // SEP-2663 `tasks/update`: validate the task exists and
                 // acknowledge with an empty result. tower-mcp does not yet
@@ -3249,6 +3307,7 @@ impl McpRouter {
             McpRequest::CancelTask(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/cancel")?;
+                    self.authorize_task(&params.task_id, &extensions).await?;
                     // The final ack does not require a terminal transition:
                     // cancelling an already-terminal task is acknowledged, and
                     // the observable status is polled via `tasks/get`.
@@ -3262,6 +3321,8 @@ impl McpRouter {
                         crate::tasks::TaskAcknowledgement::new(),
                     ));
                 }
+
+                self.authorize_task(&params.task_id, &extensions).await?;
 
                 // First check if the task exists and is not already terminal
                 let current = self
@@ -3920,6 +3981,136 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, Error::JsonRpc(e) if e.code == -32601));
+    }
+
+    #[cfg(feature = "oauth")]
+    #[tokio::test]
+    async fn task_operations_are_bound_to_the_creating_principal() {
+        fn as_principal(subject: &str) -> Extensions {
+            let mut extensions = tasks_client_extensions();
+            extensions.insert(crate::oauth::token::TokenClaims {
+                sub: Some(subject.to_string()),
+                iss: None,
+                aud: None,
+                exp: None,
+                scope: None,
+                client_id: None,
+                extra: HashMap::new(),
+            });
+            extensions
+        }
+
+        let router = McpRouter::new()
+            .tool(
+                ToolBuilder::new("optional_task")
+                    .task_support(TaskSupportMode::Optional)
+                    .handler(|input: AddInput| async move {
+                        Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                    })
+                    .build(),
+            )
+            .with_tasks();
+
+        let McpResponse::FinalCreateTask(created) = router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::CallTool(CallToolParams {
+                    name: "optional_task".to_string(),
+                    arguments: serde_json::json!({"a": 1, "b": 2}),
+                    input_responses: None,
+                    request_state: None,
+                    meta: None,
+                    task: Some(TaskRequestParams { ttl: None }),
+                }),
+                as_principal("alice"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("Expected a final create-task response");
+        };
+        let task_id = created.task.metadata.task_id.clone();
+
+        // The owner is served normally.
+        assert!(
+            router
+                .handle(
+                    RequestId::Number(2),
+                    McpRequest::GetTaskInfo(GetTaskInfoParams {
+                        task_id: task_id.clone(),
+                        meta: None,
+                    }),
+                    as_principal("alice"),
+                )
+                .await
+                .is_ok()
+        );
+
+        // Knowing the ID is not authority. Every operation is refused for a
+        // different principal, and for one that dropped its token.
+        for (id, label, context) in [
+            (3, "another principal", as_principal("bob")),
+            (4, "no principal", tasks_client_extensions()),
+        ] {
+            for (offset, request) in [
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: task_id.clone(),
+                    meta: None,
+                }),
+                McpRequest::UpdateTask(UpdateTaskParams {
+                    task_id: task_id.clone(),
+                    input_responses: HashMap::new(),
+                    meta: None,
+                }),
+                McpRequest::CancelTask(CancelTaskParams {
+                    task_id: task_id.clone(),
+                    reason: None,
+                    meta: None,
+                }),
+            ]
+            .into_iter()
+            .enumerate()
+            {
+                let error = router
+                    .handle(
+                        RequestId::Number(id * 10 + offset as i64),
+                        request,
+                        context.clone(),
+                    )
+                    .await
+                    .unwrap_err();
+                assert!(
+                    matches!(error, Error::JsonRpc(ref e) if e.code == -32602),
+                    "{label} was served: {error:?}"
+                );
+                // The refusal must be indistinguishable from an unknown task,
+                // or it confirms the ID is real.
+                let Error::JsonRpc(error) = error else {
+                    unreachable!()
+                };
+                assert!(
+                    error.message.contains("not found"),
+                    "refusal leaked that the task exists: {}",
+                    error.message
+                );
+            }
+        }
+
+        // The task survived every refused operation.
+        assert!(
+            router
+                .handle(
+                    RequestId::Number(9),
+                    McpRequest::GetTaskInfo(GetTaskInfoParams {
+                        task_id: task_id.clone(),
+                        meta: None,
+                    }),
+                    as_principal("alice"),
+                )
+                .await
+                .is_ok(),
+            "a refused cancel must not have cancelled the task"
+        );
     }
 
     #[test]
@@ -5172,15 +5363,25 @@ mod tests {
             tool_name: &str,
             arguments: serde_json::Value,
             ttl: Option<u64>,
+            owner: crate::async_task::TaskOwner,
         ) -> crate::async_task::Result<(String, crate::async_task::CancellationToken)> {
             self.creates
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            self.inner.create_task(tool_name, arguments, ttl).await
+            self.inner
+                .create_task(tool_name, arguments, ttl, owner)
+                .await
         }
 
         async fn get_task(&self, task_id: &str) -> crate::async_task::Result<Option<TaskObject>> {
             self.gets.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.inner.get_task(task_id).await
+        }
+
+        async fn task_owner(
+            &self,
+            task_id: &str,
+        ) -> crate::async_task::Result<Option<crate::async_task::TaskOwner>> {
+            self.inner.task_owner(task_id).await
         }
 
         async fn get_task_result(


### PR DESCRIPTION
Part of slice 4 of #951, taken ahead of the notification work because it is the remaining item with security weight.

## Problem

#1076 made task IDs unguessable, which stops enumeration. It does not stop a *different* authenticated caller from acting on a task once they learn its ID. SEP-2663 notes task IDs can behave as bearer tokens, so today the ID alone is sufficient authority: any `tasks/get`, `tasks/update`, or `tasks/cancel` carrying a valid ID is served, regardless of who is asking.

Nothing currently records who created a task.

## Change

Tasks record the principal that created them, and every later operation must match.

The principal comes from the `TokenClaims` the HTTP and WebSocket transports already bridge into MCP extensions, using `sub`. With the `oauth` feature off there is no principal and tasks are unowned, which preserves current behavior for deployments with no authentication.

| Task owner | Request principal | Result |
|---|---|---|
| None | None | Allowed. No authentication configured |
| `alice` | `alice` | Allowed |
| `alice` | `bob` | Denied |
| `alice` | None | Denied |
| None | `alice` | Denied |

The last row is strict on purpose: matching is equality, not "owned tasks are protected and unowned ones are open". An unowned task can only exist if it was created without a principal, so a request that now carries one is a different security context.

A denial returns the same `-32602` as an unknown task. A caller must not be able to distinguish "not yours" from "does not exist"; the former confirms the ID is real.

## API

`TaskStore::create_task` takes the owner, and a new `task_owner` method exposes it for the authorization check. Both are breaking for external implementations, landing in the same pre-1.0 window as the #1076 changes.

Ownership is never serialized into `TaskObject` or `DetailedTask`, so it does not reach the wire.

## Checks

- [ ] Tasks record the creating principal
- [ ] `tasks/get`, `tasks/update`, and `tasks/cancel` verify it
- [ ] Denials are indistinguishable from unknown tasks
- [ ] Unauthenticated deployments behave as before
- [ ] Ownership does not appear on the wire