### PR TITLE
docs(tasks): document the task authorization model

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ The repo includes 31 examples; a selection organized by topic (the full set live
 | **Bidirectional** | [`sampling_server`](examples/sampling_server.rs), [`client_handler`](examples/client_handler.rs) |
 | **Dynamic** | [`dynamic_capabilities`](examples/dynamic_capabilities.rs) -- runtime tool/prompt/resource registration |
 | **Advanced** | [`proxy`](examples/proxy.rs), [`resource_templates`](examples/resource_templates.rs), [`structured_output`](examples/structured_output.rs), [`error_handling`](examples/error_handling.rs), [`testing`](examples/testing.rs) |
+| **Extensions** | [`tasks`](examples/tasks.rs) -- final Tasks extension (SEP-2663) and task ownership, [`mcp_apps`](examples/mcp_apps.rs) -- typed MCP Apps (SEP-1865) |
 | **Real-world** | [`weather_server`](examples/weather_server.rs) -- external API integration |
 | **Macros** | [`tool_macro`](examples/tool_macro.rs) -- `#[tool_fn]`, `#[prompt_fn]`, `#[resource_fn]` |
 

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -138,6 +138,11 @@ name = "mcp_apps"
 path = "../../examples/mcp_apps.rs"
 required-features = ["mcp-apps"]
 
+[[example]]
+name = "tasks"
+path = "../../examples/tasks.rs"
+required-features = ["protocol-2026-07-28"]
+
 # --- Transports ---
 [[example]]
 name = "http_server"

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -22,6 +22,64 @@
 //! let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
 //! let router = McpRouter::new().task_store(store);
 //! ```
+//!
+//! See `examples/tasks.rs` for a runnable server.
+//!
+//! # Authorization
+//!
+//! SEP-2663 requires servers to authorize every task request, and warns that a
+//! task ID can act as a bearer token: whoever holds it can poll, update, or
+//! cancel the task. This module answers that in two layers.
+//!
+//! [`generate_task_id`] draws 128 bits from the system CSPRNG, so IDs cannot
+//! be enumerated or guessed. That only protects IDs nobody has seen, so each
+//! task also records the principal that created it (see [`TaskOwner`]), and
+//! every later operation must match under [`owner_matches`].
+//!
+//! Matching is equality, not "protect owned tasks and leave unowned ones
+//! open":
+//!
+//! | Task owner | Caller  | Result                                |
+//! |------------|---------|---------------------------------------|
+//! | none       | none    | allowed, no authentication configured |
+//! | `alice`    | `alice` | allowed                               |
+//! | `alice`    | `bob`   | denied                                |
+//! | `alice`    | none    | denied                                |
+//! | none       | `alice` | denied                                |
+//!
+//! The last row is deliberate. An unowned task can only exist if it was
+//! created with no authenticated context, so a request that now carries a
+//! principal is a different security context rather than an upgrade of the
+//! same one. Servers mixing public and authenticated paths (see
+//! [`AuthConfig::public_path`](crate::auth::AuthConfig::public_path)) should
+//! expect a task created anonymously to be unreachable once a token is
+//! presented.
+//!
+//! The principal comes from the OAuth `sub` claim that the HTTP and WebSocket
+//! transports bridge into request extensions. Without the `oauth` feature
+//! there is no principal, so every task is unowned and servers with no
+//! authentication behave as they did before ownership existed.
+//!
+//! ## Why a denial looks like a missing task
+//!
+//! A refused operation returns exactly what an unknown task returns: `-32602`
+//! with "Task not found".
+//!
+//! SEP-2663 mandates `-32602` for an invalid or nonexistent task ID, but
+//! leaves the authorization failure to the server: tasks should be bound to
+//! "some sort of authorization context, the implementation of which is left to
+//! individual servers according to their existing bespoke permission models".
+//! Reusing `-32602` is therefore tower-mcp policy, not a spec requirement.
+//!
+//! The reasoning is that answering "forbidden" would confirm the ID is real,
+//! which is what unguessable IDs exist to prevent. The same SEP notes that
+//! where binding is impossible "the task ID becomes the only line of defense
+//! against contamination". A server that prefers a distinguishable error can
+//! wrap the router and translate.
+//!
+//! Expiry follows the same rule: [`Task::is_expired`] runs from creation, and
+//! an expired task reads as absent rather than as expired, so a retention
+//! window cannot be probed either.
 
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write as _;

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -1,0 +1,103 @@
+//! Final Tasks extension server (SEP-2663), including task ownership.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example tasks --features protocol-2026-07-28
+//! ```
+//!
+//! Two separate opt-ins gate this feature, and both are required:
+//!
+//! 1. the `protocol-2026-07-28` Cargo feature compiles the final protocol path;
+//! 2. [`McpRouter::with_tasks`] advertises `io.modelcontextprotocol/tasks` and
+//!    is what actually permits task dispatch at runtime.
+//!
+//! A client must *also* declare the extension on its side. A server that opts
+//! in still returns a normal synchronous result to a client that did not, so
+//! adding `with_tasks()` never changes behavior for existing clients.
+
+use std::time::Duration;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{CallToolResult, McpRouter, StdioTransport, TaskSupportMode, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ReportInput {
+    /// How many records to crunch.
+    records: u32,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // `Optional` lets one tool serve both worlds: a client that negotiated the
+    // extension may ask for a task, and everyone else gets the synchronous
+    // result. `Required` instead refuses callers that cannot take a task,
+    // answering with -32021 and naming the extension they need to declare.
+    let build_report = ToolBuilder::new("build_report")
+        .description("Crunch records into a report. Slow enough to be worth a task.")
+        .task_support(TaskSupportMode::Optional)
+        .handler(|input: ReportInput| async move {
+            tokio::time::sleep(Duration::from_millis(50 * u64::from(input.records))).await;
+            Ok(CallToolResult::text(format!(
+                "report over {} records",
+                input.records
+            )))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("tasks-example", env!("CARGO_PKG_VERSION"))
+        .tool(build_report)
+        // The runtime opt-in. Without it, registering a task-capable tool
+        // advertises nothing and no task is ever created.
+        .with_tasks();
+
+    StdioTransport::new(router).run().await?;
+    Ok(())
+}
+
+// # Task ownership
+//
+// SEP-2663 requires servers to authorize every task request, and warns that a
+// task ID can act as a bearer token: whoever holds it can poll, update, or
+// cancel the task. tower-mcp answers that in two layers.
+//
+// Task IDs are 128 bits from the system CSPRNG, so they cannot be enumerated
+// or guessed. That alone is not enough, because it only protects IDs nobody
+// has seen. So each task also records the principal that created it, taken
+// from the OAuth `sub` claim the HTTP and WebSocket transports bridge into
+// request extensions, and every later operation must match it.
+//
+// Matching is equality, not "protect owned tasks and leave unowned ones open":
+//
+// | Task owner | Caller     | Result                                  |
+// |------------|------------|-----------------------------------------|
+// | none       | none       | allowed, no authentication configured   |
+// | `alice`    | `alice`    | allowed                                 |
+// | `alice`    | `bob`      | denied                                  |
+// | `alice`    | none       | denied                                  |
+// | none       | `alice`    | denied                                  |
+//
+// The last row is the surprising one and is deliberate. An unowned task can
+// only exist if it was created with no authenticated context, so a request
+// that now carries a principal is a different security context rather than an
+// upgrade of the same one. Servers mixing public and authenticated paths (see
+// `AuthConfig::public_path`) should expect a task created anonymously to be
+// unreachable once a token is presented.
+//
+// This example has no authentication, so every task is unowned and the first
+// row applies throughout. Add an `AuthLayer` or OAuth validation, as in
+// `http_auth.rs`, and ownership begins to bind automatically. Nothing here
+// needs to change: the router reads the principal from the request context.
+//
+// A denied request returns exactly what an unknown task returns: -32602 with
+// "Task not found". SEP-2663 mandates -32602 for an unknown or expired task
+// but leaves the authorization failure to the server, so this is tower-mcp
+// policy rather than a spec requirement. Answering "forbidden" would confirm
+// the ID is real, which is precisely what unguessable IDs exist to prevent.
+// A server wanting the opposite behavior can wrap the router and translate.
+//
+// Expiry follows the same rule. `ttlMs` runs from creation, and once it
+// elapses the task reads as absent rather than as expired, so a retention
+// window cannot be probed either.


### PR DESCRIPTION
Follows #1089, which added task ownership without documenting it.

## What's here

A runnable `examples/tasks.rs` (stdio, `required-features = ["protocol-2026-07-28"]`), an Authorization section in the `async_task` module docs, and a README entry under a new **Extensions** row alongside `mcp_apps`.

## The matching table

This is the part that needed writing down:

| Task owner | Caller | Result |
|---|---|---|
| none | none | allowed, no authentication configured |
| `alice` | `alice` | allowed |
| `alice` | `bob` | denied |
| `alice` | none | denied |
| none | `alice` | denied |

The last row reads as surprising until the reason is stated: an unowned task can only exist if it was created with no authenticated context, so a request that now carries a principal is a different security context rather than an upgrade of the same one. Servers mixing public and authenticated paths are the ones likely to hit it, so the docs name `AuthConfig::public_path` directly rather than leaving it to be discovered.

## Spec vs. policy

I checked SEP-2663 rather than assuming, and the docs now separate the two.

**Spec requires:** `-32602` for an invalid or nonexistent task ID; that servers authorize every task-related request; that task IDs carry enough entropy to resist enumeration.

**Spec leaves to us:** the authorization failure itself. Tasks are to be bound to "some sort of authorization context, the implementation of which is left to individual servers according to their existing bespoke permission models."

So reusing `-32602` to make a denial indistinguishable from a missing task is tower-mcp policy, not a spec requirement, and it is now labeled that way. The reasoning is recorded (answering "forbidden" confirms the ID is real, defeating the point of unguessable IDs; the same SEP notes the ID is "the only line of defense against contamination" where binding is impossible), along with the escape hatch for servers that want a distinguishable error.

Worth noting separately: the SEP prose says `-32003` for MissingRequiredClientCapability, but the final schema pins `-32021`. Our `-32021` matches the schema and `error.rs` already documents the renumbering, so nothing to change — but the prose is stale if anyone reads it later.

## Scope

Docs and one example. No behavior change.