### PR TITLE
feat(client): add typed tasks/update API

### DIFF
--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -87,7 +87,7 @@ use crate::protocol::{
     RequestOutcome, ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability,
     SamplingCapability, SubscriptionFilter, SubscriptionsAcknowledgedParams,
     SubscriptionsListenParams, SubscriptionsListenResult, TaskObject, TaskRequestParams,
-    ToolDefinition, notifications,
+    ToolDefinition, UpdateTaskParams, notifications,
 };
 use response_cache::{CacheLookup, ClientResponseCache};
 use tower_mcp_types::JsonRpcError;
@@ -893,6 +893,36 @@ impl McpClient {
             meta: None,
         };
         let _ack: serde_json::Value = self.send_request("tasks/cancel", &params).await?;
+        Ok(())
+    }
+
+    /// Answer a task's outstanding input requests via `tasks/update`
+    /// (SEP-2663).
+    ///
+    /// Responses are matched to outstanding requests by key. Read the keys
+    /// from the `inputRequests` of an `input_required` task returned by
+    /// [`task_get`](Self::task_get).
+    ///
+    /// A partial map is valid and expected: requests left unanswered stay
+    /// outstanding and the task remains `input_required` until every one is
+    /// answered. Keys the server does not currently have outstanding, whether
+    /// unknown, already answered, or superseded by a later request, are
+    /// ignored rather than rejected, so replaying a stale update is safe.
+    ///
+    /// The acknowledgment carries no data and is discarded. Poll
+    /// [`task_get`](Self::task_get) to observe the resulting state.
+    pub async fn task_update(&self, task_id: &str, input_responses: InputResponses) -> Result<()> {
+        self.ensure_initialized()?;
+        let input_responses = input_responses
+            .into_iter()
+            .map(|(key, response)| serde_json::to_value(response).map(|value| (key, value)))
+            .collect::<std::result::Result<_, _>>()?;
+        let params = UpdateTaskParams {
+            task_id: task_id.to_string(),
+            input_responses,
+            meta: None,
+        };
+        let _ack: serde_json::Value = self.send_request("tasks/update", &params).await?;
         Ok(())
     }
 

--- a/crates/tower-mcp/tests/client_tasks.rs
+++ b/crates/tower-mcp/tests/client_tasks.rs
@@ -134,3 +134,72 @@ async fn task_get_unknown_id_errors() {
         .expect_err("unknown task id must error");
     assert!(err.to_string().contains("not found"), "got: {err}");
 }
+
+/// `task_update` answers outstanding requests and tolerates stale keys.
+///
+/// The store ignores any key it does not currently have outstanding, so a
+/// client replaying an update must not fail the task.
+#[tokio::test]
+async fn task_update_sends_typed_responses_and_tolerates_stale_keys() {
+    use tower_mcp::protocol::{ElicitAction, ElicitResult, InputResponse, InputResponses};
+
+    let client = McpClient::connect(ChannelTransport::new(task_router()))
+        .await
+        .expect("connect");
+    client
+        .initialize("test", "1.0.0")
+        .await
+        .expect("initialize");
+
+    let created = client
+        .call_tool_as_task("compute", serde_json::json!({}), None)
+        .await
+        .expect("task-augmented call");
+
+    let mut responses = InputResponses::new();
+    responses.insert(
+        "approval".to_string(),
+        InputResponse::Elicit(ElicitResult {
+            action: ElicitAction::Accept,
+            content: None,
+            meta: None,
+        }),
+    );
+
+    // Nothing is outstanding on this task, so every key is ignorable. The
+    // call must still succeed: ignoring is the specified behavior, not an
+    // error condition.
+    client
+        .task_update(&created.task.task_id, responses.clone())
+        .await
+        .expect("tasks/update with no outstanding requests must be accepted");
+
+    // Replaying the same update is equally safe.
+    client
+        .task_update(&created.task.task_id, responses)
+        .await
+        .expect("replayed tasks/update must be accepted");
+
+    // An empty map is a valid no-op.
+    client
+        .task_update(&created.task.task_id, InputResponses::new())
+        .await
+        .expect("empty tasks/update must be accepted");
+
+    // The task was not disturbed by any of it.
+    let done = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.task_wait(&created.task.task_id),
+    )
+    .await
+    .expect("task_wait timed out")
+    .expect("task_wait");
+    assert_eq!(done.status, TaskStatus::Completed);
+
+    // Unknown task ids error rather than silently succeeding.
+    let err = client
+        .task_update("task-does-not-exist", InputResponses::new())
+        .await
+        .expect_err("unknown task id must error");
+    assert!(err.to_string().contains("not found"), "got: {err}");
+}


### PR DESCRIPTION
Completes the client half of the Tasks extension, and the last item in slice 3 of #951.

## Problem

`McpClient` had `task_get`, `task_cancel`, and `task_wait`, but no way to answer a task's outstanding input requests. The server side has supported this since #1076 (store) and #1088 (dispatch), so the input-required round trip could not be driven from the client at all.

## Change

`task_update(task_id, InputResponses)` takes the typed map rather than raw JSON, mirroring how `InputRequests` already surfaces on the read side, and serializes at the boundary.

Most of the work here is documentation, because the semantics invite mistakes:

| Behavior | Why it matters |
|---|---|
| A partial map is expected | Unanswered requests stay outstanding; the task stays `input_required` until all are answered |
| Non-outstanding keys are ignored, not rejected | Unknown, already-answered, and superseded keys all fall in this bucket, so replaying a stale update is safe |
| The ack carries no data | The resulting state comes from polling `task_get` |

## Tests

The ignorable cases get explicit coverage, since "succeeded but changed nothing" is the behavior most likely to be reported as a bug: an update against a task with nothing outstanding, a replay of the same update, and an empty map are each accepted, and none disturb the task. Unknown task ids still error.

## Remaining on #951

`notifications/tasks` with `subscriptions/listen` filtering, the multi-instance shared-store test, and then the advertisement-by-default decision.