### PR TITLE
feat(tasks): push notifications/tasks on state transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,8 +727,9 @@ and cross-principal protections.
 - [x] [`subscriptions/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `protocol-2026-07-28`)
 - [x] [Per-request `_meta` client capabilities -- `StatelessRequestMeta` (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `protocol-2026-07-28`)
 - [x] [Multi Round-Trip Requests for tools, prompts, and resources (SEP-2322)](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr) (requires `protocol-2026-07-28`)
+- [x] [Tasks extension -- `tasks/get`, `tasks/update`, `tasks/cancel`, `notifications/tasks`, task ownership (SEP-2663)](examples/tasks.rs) (requires `protocol-2026-07-28` and `McpRouter::with_tasks`)
 
-We track all MCP Specification Enhancement Proposals (SEPs) as [GitHub issues](https://github.com/joshrotenberg/tower-mcp/issues?q=label%3Asep). A weekly workflow syncs status from the upstream spec repository.
+We read SEPs upstream rather than mirroring them here. Browse the `SEP` label on [modelcontextprotocol/modelcontextprotocol](https://github.com/modelcontextprotocol/modelcontextprotocol/issues?q=label%3ASEP) when auditing spec coverage.
 
 ## Examples
 

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -5523,6 +5523,13 @@ pub struct SubscriptionFilter {
     /// Replaces the former `resources/subscribe` RPC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resource_subscriptions: Option<Vec<String>>,
+    /// Task IDs to receive `notifications/tasks` for (SEP-2663). Unlike the
+    /// list-changed flags this names individual tasks, so a client observes
+    /// only the tasks it created. A client that sets this without declaring
+    /// the `io.modelcontextprotocol/tasks` extension is answered with
+    /// `-32021`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_ids: Option<Vec<String>>,
 }
 
 /// Parameters for a `notifications/subscriptions/acknowledged` notification:

--- a/crates/tower-mcp-types/src/tasks.rs
+++ b/crates/tower-mcp-types/src/tasks.rs
@@ -185,6 +185,11 @@ impl DetailedTask {
         }
     }
 
+    /// Server-generated identifier of the task this describes.
+    pub fn task_id(&self) -> &str {
+        &self.metadata().task_id
+    }
+
     /// Shared task metadata.
     pub fn metadata(&self) -> &TaskMetadata {
         match self {

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -80,6 +80,23 @@
 //! Expiry follows the same rule: [`Task::is_expired`] runs from creation, and
 //! an expired task reads as absent rather than as expired, so a retention
 //! window cannot be probed either.
+//!
+//! # Status notifications
+//!
+//! A client may watch a task instead of polling it, by naming its ID in the
+//! `taskIds` filter of a `subscriptions/listen` stream. Each
+//! `notifications/tasks` carries the complete task, identical to the
+//! `tasks/get` response at that moment, so a client that hears about a
+//! completion already holds the result.
+//!
+//! The router announces the transitions it drives. A server that drives one
+//! itself, most commonly [`TaskStore::require_input`], announces it with
+//! [`McpRouter::notify_task_status_changed`](crate::McpRouter::notify_task_status_changed).
+//!
+//! Notifications are best effort and `tasks/get` stays authoritative: a task
+//! outlives the request that created it, so there may be no subscriber at the
+//! moment a transition happens, and a client that missed one loses nothing but
+//! time.
 
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write as _;

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -146,8 +146,14 @@ pub enum ServerNotification {
     ToolsListChanged,
     /// The list of available prompts has changed
     PromptsListChanged,
-    /// Task status has changed
+    /// Task status has changed, in the legacy flat shape.
     TaskStatusChanged(crate::protocol::TaskStatusParams),
+    /// Task status has changed, in the final SEP-2663 shape.
+    ///
+    /// Carries the complete status-discriminated task, identical to what
+    /// `tasks/get` would have returned at that moment. Delivered only on
+    /// `subscriptions/listen` streams that named this task ID.
+    FinalTaskStatusChanged(crate::tasks::TaskStatusNotificationParams),
 }
 
 /// Sender for server notifications

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3819,6 +3819,7 @@ mod tests {
         extensions
     }
 
+    #[cfg(feature = "stateless")]
     fn tasks_client_extensions() -> Extensions {
         final_extensions(ClientCapabilities {
             extensions: Some(
@@ -3830,6 +3831,7 @@ mod tests {
         })
     }
 
+    #[cfg(feature = "stateless")]
     #[tokio::test]
     async fn final_tasks_require_server_opt_in_and_client_declaration() {
         let tool = || {
@@ -3947,6 +3949,7 @@ mod tests {
         assert!(matches!(response, McpResponse::CallTool(_)));
     }
 
+    #[cfg(feature = "stateless")]
     #[tokio::test]
     async fn final_task_methods_serve_the_negotiated_wire_shapes() {
         let router = McpRouter::new()
@@ -4068,7 +4071,7 @@ mod tests {
         assert!(matches!(error, Error::JsonRpc(e) if e.code == -32601));
     }
 
-    #[cfg(feature = "oauth")]
+    #[cfg(all(feature = "oauth", feature = "stateless"))]
     #[tokio::test]
     async fn task_operations_are_bound_to_the_creating_principal() {
         fn as_principal(subject: &str) -> Extensions {

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -148,7 +148,7 @@ fn unknown_task_error(task_id: &str) -> JsonRpcError {
 
 /// The client capability shape a server names in a `-32021` when it cannot
 /// service a request without the Tasks extension.
-fn tasks_client_capabilities() -> crate::protocol::ClientCapabilities {
+pub(crate) fn tasks_client_capabilities() -> crate::protocol::ClientCapabilities {
     crate::protocol::ClientCapabilities {
         extensions: Some(
             [(
@@ -1920,6 +1920,24 @@ impl McpRouter {
         sent
     }
 
+    /// Push a task's current state to subscribed `subscriptions/listen`
+    /// streams as a `notifications/tasks` notification.
+    ///
+    /// The router already announces the transitions it drives: completion,
+    /// failure, cancellation, and the resumption that follows a
+    /// `tasks/update`. Call this after driving a transition yourself, most
+    /// commonly [`TaskStore::require_input`], which a tool handler invokes on
+    /// the store directly.
+    ///
+    /// Announcing task creation is deliberately left out. A client learns the
+    /// task ID from the `tools/call` result, so it cannot have subscribed to a
+    /// task before that result reaches it.
+    ///
+    /// [`TaskStore::require_input`]: crate::async_task::TaskStore::require_input
+    pub async fn notify_task_status_changed(&self, task_id: &str) {
+        self.notify_task_state(task_id).await;
+    }
+
     /// Notify clients that the list of available resources has changed
     ///
     /// Returns `true` if the notification was sent.
@@ -2245,6 +2263,18 @@ impl McpRouter {
 
     /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
     async fn final_get_task(&self, task_id: &str) -> Result<McpResponse> {
+        let detailed = self.detailed_task(task_id).await?;
+        Ok(McpResponse::FinalGetTask(crate::tasks::GetTaskResult::new(
+            detailed,
+        )))
+    }
+
+    /// Build the complete status-discriminated view of a task.
+    ///
+    /// Both `tasks/get` and `notifications/tasks` render a task through this
+    /// one path, which is what makes a pushed notification identical to the
+    /// poll response a client would have received at that moment.
+    async fn detailed_task(&self, task_id: &str) -> Result<crate::tasks::DetailedTask> {
         let (task, result, error) = self
             .inner
             .task_store
@@ -2262,7 +2292,7 @@ impl McpRouter {
         metadata.status_message = task.status_message.clone();
         metadata.poll_interval_ms = task.poll_interval;
 
-        let detailed = match task.status {
+        Ok(match task.status {
             TaskStatus::Working => crate::tasks::DetailedTask::working(metadata),
             TaskStatus::InputRequired => {
                 // Every request still awaiting a response, not just the most
@@ -2299,11 +2329,57 @@ impl McpRouter {
             // `TaskStatus` is non_exhaustive. Report an unrecognized status as
             // working rather than inventing a terminal state.
             _ => crate::tasks::DetailedTask::working(metadata),
+        })
+    }
+
+    /// Push the current state of a task to subscribed listen streams.
+    ///
+    /// Best effort by design. A task outlives the request that created it, so
+    /// there may be no subscriber at all, and SEP-2663 keeps `tasks/get`
+    /// authoritative precisely so a dropped notification costs a client
+    /// nothing beyond a slower poll. A failure to read the task back is
+    /// therefore logged rather than propagated: the caller has already
+    /// committed the state change this announces.
+    async fn notify_task_state(&self, task_id: &str) {
+        if !self.final_tasks_enabled() {
+            return;
+        }
+
+        let detailed = match self.detailed_task(task_id).await {
+            Ok(detailed) => detailed,
+            Err(error) => {
+                tracing::debug!(
+                    target: "mcp::tasks",
+                    task_id = %task_id,
+                    %error,
+                    "skipping task notification: task state unavailable"
+                );
+                return;
+            }
         };
 
-        Ok(McpResponse::FinalGetTask(crate::tasks::GetTaskResult::new(
-            detailed,
-        )))
+        let notification = ServerNotification::FinalTaskStatusChanged(
+            crate::tasks::TaskStatusNotificationParams {
+                task: detailed,
+                meta: None,
+            },
+        );
+
+        // Delivery goes through the transport-lifetime sink rather than the
+        // originating request's sender: the `tools/call` that created the task
+        // has usually completed by the time a terminal transition happens, and
+        // its stream is gone.
+        #[cfg(all(feature = "http", feature = "stateless"))]
+        if let Ok(active) = self.inner.modern_notification_sink.read()
+            && let Some(sink) = active.as_ref()
+        {
+            sink(&notification);
+            return;
+        }
+
+        if let Some(tx) = &self.inner.notification_tx {
+            let _ = tx.try_send(notification);
+        }
     }
 
     /// Effective SEP-2549 cache scope to emit alongside a TTL hint.
@@ -2646,10 +2722,12 @@ impl McpRouter {
                     let task_id_clone = task_id.clone();
 
                     let tool_name = params.name.clone();
+                    let notifier = self.clone();
                     tokio::spawn(async move {
                         // Check for cancellation before starting
                         if cancellation_token.is_cancelled() {
                             tracing::debug!(task_id = %task_id_clone, "Task cancelled before execution");
+                            notifier.notify_task_state(&task_id_clone).await;
                             return;
                         }
 
@@ -2660,6 +2738,7 @@ impl McpRouter {
 
                         if cancellation_token.is_cancelled() {
                             tracing::debug!(task_id = %task_id_clone, "Task cancelled during execution");
+                            notifier.notify_task_state(&task_id_clone).await;
                         } else {
                             // A tool result carrying `isError: true` completes
                             // the task: the tool ran and produced a domain
@@ -2682,6 +2761,7 @@ impl McpRouter {
                                 error = error_msg.as_deref().unwrap_or_default(),
                                 "tool call completed"
                             );
+                            notifier.notify_task_state(&task_id_clone).await;
                         }
                     });
 
@@ -3275,6 +3355,10 @@ impl McpRouter {
                         .await
                         .map_err(task_store_error)?
                         .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                    // Answering the last outstanding request resumes the task,
+                    // so the status a subscriber sees changes here even though
+                    // the ack itself is empty.
+                    self.notify_task_state(&params.task_id).await;
                     return Ok(McpResponse::FinalTaskAck(
                         crate::tasks::TaskAcknowledgement::new(),
                     ));
@@ -3317,6 +3401,7 @@ impl McpRouter {
                         .await
                         .map_err(task_store_error)?
                         .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                    self.notify_task_state(&params.task_id).await;
                     return Ok(McpResponse::FinalTaskAck(
                         crate::tasks::TaskAcknowledgement::new(),
                     ));

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -4009,9 +4009,6 @@ fn stateless_sse_with_notifications(
         .into_response()
 }
 
-/// Serve the final, sessionless `subscriptions/listen` protocol over its
-/// owning POST response.
-#[cfg(feature = "stateless")]
 /// Whether a `subscriptions/listen` request declared the Tasks extension.
 ///
 /// The listen handler runs ahead of the router, so it reads the per-request
@@ -4028,6 +4025,9 @@ fn listen_request_declares_tasks(parsed: &serde_json::Value) -> bool {
         })
 }
 
+/// Serve the final, sessionless `subscriptions/listen` protocol over its
+/// owning POST response.
+#[cfg(feature = "stateless")]
 async fn handle_modern_subscriptions_listen_sse(
     state: Arc<AppState>,
     parsed: &serde_json::Value,

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1299,6 +1299,21 @@ impl SessionHandle {
     }
 }
 
+#[cfg(feature = "stateless")]
+impl AppState {
+    /// Whether the served router opted into the Tasks extension.
+    ///
+    /// A boxed service is opaque here, so it reads as not enabled: the
+    /// acknowledgement then declines the task IDs rather than promising
+    /// notifications this transport cannot confirm anyone will send.
+    fn tasks_extension_enabled(&self) -> bool {
+        match &self.service_source {
+            ServiceSource::Router { router, .. } => router.final_tasks_enabled(),
+            ServiceSource::Service(_) => false,
+        }
+    }
+}
+
 /// The source of the MCP service for session creation.
 #[derive(Clone)]
 enum ServiceSource {
@@ -1410,6 +1425,7 @@ impl ModernSubscriptionRegistry {
                 | ServerNotification::ResourcesListChanged
                 | ServerNotification::ToolsListChanged
                 | ServerNotification::PromptsListChanged
+                | ServerNotification::FinalTaskStatusChanged(_)
         );
         if !subscription_scoped {
             return false;
@@ -3996,6 +4012,22 @@ fn stateless_sse_with_notifications(
 /// Serve the final, sessionless `subscriptions/listen` protocol over its
 /// owning POST response.
 #[cfg(feature = "stateless")]
+/// Whether a `subscriptions/listen` request declared the Tasks extension.
+///
+/// The listen handler runs ahead of the router, so it reads the per-request
+/// capabilities straight out of `_meta` rather than from request extensions.
+#[cfg(feature = "stateless")]
+fn listen_request_declares_tasks(parsed: &serde_json::Value) -> bool {
+    parsed
+        .get("params")
+        .and_then(crate::stateless::StatelessRequestMeta::from_params)
+        .and_then(|meta| meta.client_capabilities)
+        .and_then(|capabilities| capabilities.extensions)
+        .is_some_and(|declared| {
+            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
+        })
+}
+
 async fn handle_modern_subscriptions_listen_sse(
     state: Arc<AppState>,
     parsed: &serde_json::Value,
@@ -4028,7 +4060,19 @@ async fn handle_modern_subscriptions_listen_sse(
             StatusCode::BAD_REQUEST,
         );
     };
-    let accepted = accepted_subscription_filter(requested);
+    // SEP-2663: a client asking for task notifications must have declared the
+    // extension, on this request like every other final-protocol request.
+    if requested.task_ids.is_some() && !listen_request_declares_tasks(parsed) {
+        return json_rpc_error_response_with_status(
+            id,
+            JsonRpcError::missing_required_client_capability(
+                crate::router::tasks_client_capabilities(),
+            ),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    let accepted = accepted_subscription_filter(requested, state.tasks_extension_enabled());
     let (rx, guard) = state
         .modern_subscriptions
         .register(subscription_id.clone(), accepted.clone());

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -112,6 +112,23 @@ struct StdioSubscriptions {
     active: HashMap<RequestId, SubscriptionFilter>,
     modern_mode: bool,
     server_info: Option<Implementation>,
+    /// Whether the served router opted into the Tasks extension. Captured at
+    /// startup because the listen handler only sees the generic service.
+    tasks_enabled: bool,
+}
+
+/// Whether a stdio `subscriptions/listen` request declared the Tasks
+/// extension in its per-request `_meta`.
+#[cfg(feature = "stateless")]
+fn stdio_request_declares_tasks(parsed: &serde_json::Value) -> bool {
+    parsed
+        .get("params")
+        .and_then(crate::stateless::StatelessRequestMeta::from_params)
+        .and_then(|meta| meta.client_capabilities)
+        .and_then(|capabilities| capabilities.extensions)
+        .is_some_and(|declared| {
+            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
+        })
 }
 
 #[cfg(feature = "stateless")]
@@ -218,7 +235,22 @@ impl StdioSubscriptions {
             ]));
         }
 
-        let accepted = accepted_subscription_filter(requested);
+        // SEP-2663: asking for task notifications without declaring the
+        // extension is answered with the missing-capability error, the same
+        // way the three task methods answer it.
+        if requested.task_ids.is_some() && !stdio_request_declares_tasks(parsed) {
+            let response = JsonRpcResponse::error(
+                Some(request_id),
+                crate::error::JsonRpcError::missing_required_client_capability(
+                    crate::router::tasks_client_capabilities(),
+                ),
+            );
+            return Ok(StdioSubscriptionInput::Handled(vec![
+                serde_json::to_string(&response)?,
+            ]));
+        }
+
+        let accepted = accepted_subscription_filter(requested, self.tasks_enabled);
         let acknowledgment = subscription_acknowledgment(request_id.clone(), accepted.clone());
         let acknowledgment = serde_json::to_string(&acknowledgment)?;
         self.modern_mode = true;
@@ -236,6 +268,7 @@ impl StdioSubscriptions {
                     | ServerNotification::ResourcesListChanged
                     | ServerNotification::ToolsListChanged
                     | ServerNotification::PromptsListChanged
+                    | ServerNotification::FinalTaskStatusChanged(_)
             )
         {
             return None;
@@ -353,6 +386,11 @@ pub(crate) fn serialize_notification(notification: &ServerNotification) -> Optio
         ServerNotification::TaskStatusChanged(params) => {
             let notif = JsonRpcNotification::new(notifications::TASK_STATUS_CHANGED)
                 .with_params(serde_json::to_value(params).unwrap_or_default());
+            serde_json::to_string(&notif).ok()
+        }
+        ServerNotification::FinalTaskStatusChanged(params) => {
+            let notif = JsonRpcNotification::new(notifications::TASK_STATUS_CHANGED)
+                .with_params(serde_json::to_value(params).ok()?);
             serde_json::to_string(&notif).ok()
         }
     }
@@ -539,6 +577,7 @@ impl StdioTransport {
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
+            tasks_enabled: self.router.final_tasks_enabled(),
             ..StdioSubscriptions::default()
         };
 
@@ -1267,6 +1306,7 @@ impl BidirectionalStdioTransport {
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
+            tasks_enabled: self.router.final_tasks_enabled(),
             ..StdioSubscriptions::default()
         };
 

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -7,12 +7,23 @@ use crate::protocol::{
     SubscriptionsListenResultMeta, notifications,
 };
 
-pub(crate) fn accepted_subscription_filter(requested: SubscriptionFilter) -> SubscriptionFilter {
+/// Narrow a requested filter to what this server will actually honor.
+///
+/// The acknowledgement reports this filter back to the client, so anything
+/// dropped here is a promise the server declines to make. `tasks_enabled`
+/// reflects whether the server opted into the Tasks extension: without it
+/// there is nothing to notify about, so the task IDs are dropped rather than
+/// acknowledged and then silently ignored.
+pub(crate) fn accepted_subscription_filter(
+    requested: SubscriptionFilter,
+    tasks_enabled: bool,
+) -> SubscriptionFilter {
     SubscriptionFilter {
         tools_list_changed: requested.tools_list_changed.filter(|enabled| *enabled),
         prompts_list_changed: requested.prompts_list_changed.filter(|enabled| *enabled),
         resources_list_changed: requested.resources_list_changed.filter(|enabled| *enabled),
         resource_subscriptions: requested.resource_subscriptions,
+        task_ids: requested.task_ids.filter(|_| tasks_enabled),
     }
 }
 
@@ -28,6 +39,13 @@ pub(crate) fn subscription_matches(
             .resource_subscriptions
             .as_ref()
             .is_some_and(|subscriptions| subscriptions.iter().any(|item| item == uri)),
+        // A task is named individually rather than opted into as a class, so
+        // an unlisted task ID never matches even a subscriber that asked for
+        // every other notification type.
+        ServerNotification::FinalTaskStatusChanged(params) => filter
+            .task_ids
+            .as_ref()
+            .is_some_and(|ids| ids.iter().any(|id| id == params.task.task_id())),
         _ => false,
     }
 }

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -103,3 +103,78 @@ pub(crate) fn subscription_complete_response(
         serde_json::to_value(result).expect("subscription result is serializable"),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tasks::{DetailedTask, TaskMetadata, TaskStatusNotificationParams};
+
+    fn task_notification(task_id: &str) -> ServerNotification {
+        ServerNotification::FinalTaskStatusChanged(TaskStatusNotificationParams {
+            task: DetailedTask::working(TaskMetadata::new(
+                task_id.to_string(),
+                "2026-07-28T00:00:00Z".to_string(),
+                "2026-07-28T00:00:01Z".to_string(),
+                Some(60_000),
+            )),
+            meta: None,
+        })
+    }
+
+    fn subscribed_to(task_ids: &[&str]) -> SubscriptionFilter {
+        SubscriptionFilter {
+            task_ids: Some(task_ids.iter().map(|id| id.to_string()).collect()),
+            ..SubscriptionFilter::default()
+        }
+    }
+
+    #[test]
+    fn task_notifications_match_only_the_named_task_ids() {
+        let filter = subscribed_to(&["task-a", "task-b"]);
+        assert!(subscription_matches(&task_notification("task-a"), &filter));
+        assert!(subscription_matches(&task_notification("task-b"), &filter));
+        assert!(!subscription_matches(&task_notification("task-c"), &filter));
+    }
+
+    #[test]
+    fn a_broad_subscription_still_excludes_unnamed_tasks() {
+        // Tasks are named individually rather than opted into as a class, so
+        // asking for every other notification type grants nothing here.
+        let filter = SubscriptionFilter {
+            tools_list_changed: Some(true),
+            prompts_list_changed: Some(true),
+            resources_list_changed: Some(true),
+            resource_subscriptions: Some(vec!["file:///everything".to_string()]),
+            task_ids: None,
+        };
+        assert!(!subscription_matches(&task_notification("task-a"), &filter));
+    }
+
+    #[test]
+    fn accepted_filter_declines_task_ids_when_the_server_has_no_tasks() {
+        let requested = subscribed_to(&["task-a"]);
+
+        let accepted = accepted_subscription_filter(requested.clone(), true);
+        assert_eq!(
+            accepted.task_ids.as_deref(),
+            Some(&["task-a".to_string()][..])
+        );
+
+        // The acknowledgement reports what the server agreed to honor, so a
+        // server without the extension must not echo the IDs back.
+        let declined = accepted_subscription_filter(requested, false);
+        assert!(declined.task_ids.is_none());
+    }
+
+    #[test]
+    fn task_notifications_serialize_as_notifications_tasks() {
+        let json = crate::transport::stdio::serialize_notification(&task_notification("task-a"))
+            .expect("task notification is serializable");
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["method"], "notifications/tasks");
+        // The DetailedTask is flattened into params rather than nested.
+        assert_eq!(value["params"]["taskId"], "task-a");
+        assert_eq!(value["params"]["status"], "working");
+        assert_eq!(value["params"]["ttlMs"], 60_000);
+    }
+}

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -286,3 +286,270 @@ async fn subscriptions_listen_session_fallback_placeholder() {
         "headerless request on 2025-11-25 session must return Method Not Found"
     );
 }
+
+// =============================================================================
+// Task status notifications (SEP-2663)
+// =============================================================================
+
+#[cfg(feature = "stateless")]
+mod tasks {
+    use super::*;
+    use std::time::Duration;
+    use tower_mcp::TaskSupportMode;
+
+    const TASKS_EXTENSION: &str = "io.modelcontextprotocol/tasks";
+
+    fn task_router() -> McpRouter {
+        let slow = ToolBuilder::new("slow")
+            .description("Finish after a beat, so the task is observably working first")
+            .task_support(TaskSupportMode::Optional)
+            .handler(|_: serde_json::Value| async move {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                Ok(CallToolResult::text("done"))
+            })
+            .build();
+        McpRouter::new()
+            .server_info("listen-test-server", "1.0.0")
+            .tool(slow)
+            .with_tasks()
+    }
+
+    fn final_request(id: &str, method: &str, params: serde_json::Value) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header("Mcp-Protocol-Version", "2026-07-28")
+            .header("Mcp-Method", method);
+        // SEP-2243 requires Mcp-Name to mirror params.name on tools/call.
+        if let Some(name) = params.get("name").and_then(serde_json::Value::as_str) {
+            builder = builder.header("Mcp-Name", name);
+        }
+        builder
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "method": method,
+                    "params": params,
+                })
+                .to_string(),
+            ))
+            .unwrap()
+    }
+
+    fn meta(declares_tasks: bool) -> serde_json::Value {
+        let capabilities = if declares_tasks {
+            serde_json::json!({ "extensions": { TASKS_EXTENSION: {} } })
+        } else {
+            serde_json::json!({})
+        };
+        serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+            "io.modelcontextprotocol/clientCapabilities": capabilities,
+        })
+    }
+
+    async fn body_string(response: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    /// A task subscriber sees the terminal transition even though the
+    /// `tools/call` that created the task has already returned.
+    #[tokio::test]
+    async fn completing_a_task_reaches_a_subscribed_listen_stream() {
+        let (app, handle) = HttpTransport::new(task_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router_with_handle();
+
+        let create = app
+            .clone()
+            .oneshot(final_request(
+                "call-1",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "slow",
+                    "arguments": {},
+                    "task": { "ttl": 60000 },
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::OK);
+        let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
+        let task_id = created["result"]["taskId"]
+            .as_str()
+            .expect("final create result carries a flat taskId")
+            .to_string();
+
+        let listen = app
+            .oneshot(final_request(
+                "listen-1",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "notifications": { "taskIds": [task_id, "some-other-task"] },
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(listen.status(), StatusCode::OK);
+        assert_eq!(handle.subscription_count(), 1);
+
+        // Outlive the handler's sleep, then drain so the body terminates.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(handle.close_subscriptions(), 1);
+
+        let body = body_string(listen).await;
+        assert!(
+            body.contains("notifications/subscriptions/acknowledged"),
+            "stream must begin with an acknowledgment: {body}"
+        );
+        assert!(
+            body.contains(&format!("\"taskIds\":[\"{task_id}\",\"some-other-task\"]")),
+            "the acknowledgment must echo the accepted task IDs: {body}"
+        );
+        assert!(
+            body.contains("notifications/tasks"),
+            "the completion must reach the stream: {body}"
+        );
+        assert!(
+            body.contains("\"status\":\"completed\""),
+            "the notification must carry the terminal status: {body}"
+        );
+        assert!(
+            body.contains(&format!("\"taskId\":\"{task_id}\"")),
+            "the notification must name the task: {body}"
+        );
+        assert!(
+            body.contains("\"io.modelcontextprotocol/subscriptionId\":\"listen-1\""),
+            "the notification must be tagged with the subscription: {body}"
+        );
+    }
+
+    /// A subscriber that named a different task hears nothing.
+    #[tokio::test]
+    async fn an_unnamed_task_never_reaches_a_stream() {
+        let (app, handle) = HttpTransport::new(task_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router_with_handle();
+
+        let create = app
+            .clone()
+            .oneshot(final_request(
+                "call-1",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "slow",
+                    "arguments": {},
+                    "task": { "ttl": 60000 },
+                }),
+            ))
+            .await
+            .unwrap();
+        let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
+        let task_id = created["result"]["taskId"].as_str().unwrap().to_string();
+
+        let listen = app
+            .oneshot(final_request(
+                "listen-1",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "notifications": { "taskIds": ["a-task-this-client-does-not-own"] },
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(listen.status(), StatusCode::OK);
+
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        handle.close_subscriptions();
+
+        let body = body_string(listen).await;
+        assert!(
+            !body.contains("notifications/tasks"),
+            "a task the stream did not name must not appear: {body}"
+        );
+        assert!(
+            !body.contains(&task_id),
+            "the unrelated task ID must not leak: {body}"
+        );
+    }
+
+    /// SEP-2663: requesting task notifications without declaring the extension
+    /// is answered with the missing-capability error, not a silent drop.
+    #[tokio::test]
+    async fn task_ids_without_the_extension_are_rejected() {
+        let app = HttpTransport::new(task_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router();
+
+        let response = app
+            .oneshot(final_request(
+                "listen-1",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(false),
+                    "notifications": { "taskIds": ["task-a"] },
+                }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body: serde_json::Value = serde_json::from_str(&body_string(response).await).unwrap();
+        assert_eq!(body["id"], "listen-1");
+        assert_eq!(body["error"]["code"], -32021);
+        assert!(
+            body["error"]["data"]["requiredCapabilities"]["extensions"][TASKS_EXTENSION]
+                .is_object(),
+            "the error must name the extension the client is missing: {body}"
+        );
+    }
+
+    /// A server without the extension acknowledges the rest of the filter and
+    /// declines the task IDs rather than promising notifications it will never
+    /// send.
+    #[tokio::test]
+    async fn a_server_without_tasks_declines_the_task_ids() {
+        let (app, handle) = HttpTransport::new(router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router_with_handle();
+
+        let response = app
+            .oneshot(final_request(
+                "listen-1",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "notifications": { "taskIds": ["task-a"], "toolsListChanged": true },
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        handle.close_subscriptions();
+
+        let body = body_string(response).await;
+        assert!(body.contains("notifications/subscriptions/acknowledged"));
+        assert!(
+            body.contains("\"toolsListChanged\":true"),
+            "the rest of the filter still stands: {body}"
+        );
+        assert!(
+            !body.contains("taskIds"),
+            "a server without the extension must not acknowledge task IDs: {body}"
+        );
+    }
+}

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -91,6 +91,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 // `http_auth.rs`, and ownership begins to bind automatically. Nothing here
 // needs to change: the router reads the principal from the request context.
 //
+// # Watching a task instead of polling
+//
+// A client can poll `tasks/get`, or it can ask to be told. It opens a
+// `subscriptions/listen` stream naming the task IDs it cares about:
+//
+// ```json
+// {"jsonrpc":"2.0","id":"listen-1","method":"subscriptions/listen","params":{
+//   "_meta":{
+//     "io.modelcontextprotocol/protocolVersion":"2026-07-28",
+//     "io.modelcontextprotocol/clientCapabilities":{
+//       "extensions":{"io.modelcontextprotocol/tasks":{}}}},
+//   "notifications":{"taskIds":["<the id from tools/call>"]}}}
+// ```
+//
+// Tasks are named one at a time rather than opted into as a class, so a
+// subscriber that asked for every other notification type still hears nothing
+// about a task it did not name. Requesting task IDs without declaring the
+// extension is answered with -32021, the same as issuing a task method
+// without it. The acknowledgement echoes the task IDs the server agreed to;
+// a server that never called `with_tasks()` echoes none.
+//
+// Each `notifications/tasks` carries the complete task, identical to the
+// `tasks/get` response at that moment, so a client that hears about a
+// completion already has the result and never needs the follow-up poll. The
+// router announces the transitions it drives: completion, failure,
+// cancellation, and the resumption that follows a `tasks/update`. Creation is
+// not announced, since a client cannot subscribe to an ID it has not received
+// yet. A server that drives a transition itself, most commonly
+// `TaskStore::require_input`, calls `McpRouter::notify_task_status_changed`.
+//
+// Notifications are best effort. `tasks/get` stays authoritative, so a client
+// that misses one because it was not listening yet loses nothing but time.
+//
+// # Denials
+//
 // A denied request returns exactly what an unknown task returns: -32602 with
 // "Task not found". SEP-2663 mandates -32602 for an unknown or expired task
 // but leaves the authorization failure to the server, so this is tower-mcp


### PR DESCRIPTION
Slice 4 of #951: server-pushed task status notifications and the subscription
filter that routes them.

SEP-2663 lets a server push `notifications/tasks` instead of making clients
poll `tasks/get`. Each notification carries the complete `DetailedTask` for the
current status, identical to what `tasks/get` would have returned at that
moment. Clients opt in per task ID through the `subscriptions/listen` filter.

## Plan

**Types**

- Add `taskIds` to `SubscriptionFilter`. SEP-2663 extends the SEP-2575 filter
  with a list of task IDs rather than a single on/off flag, so a client
  subscribes to the tasks it created and nothing else.

**Notification path**

- Add `ServerNotification::FinalTaskStatusChanged` carrying
  `TaskStatusNotificationParams`. The existing `TaskStatusChanged` variant
  holds the legacy flat `TaskStatusParams` and stays on the legacy path;
  the final shape flattens a status-discriminated `DetailedTask`.
- Serialize it as `notifications/tasks`.
- Extract the `DetailedTask` construction out of `final_get_task` so a
  notification and a poll response are built from one code path, which is what
  makes "identical to what `tasks/get` would have returned" true by
  construction rather than by inspection.
- Emit on every state transition the router drives: creation, completion,
  failure, cancellation, and both directions of the input-required flow.

**Routing**

- Treat the notification as subscription-scoped in the HTTP registry, so it
  goes to `subscriptions/listen` streams rather than to the originating
  request's stream. Task work outlives the `tools/call` that started it, so the
  originating stream is usually gone by the time a terminal transition happens.
- Match a notification against a subscription by task ID.
- Return `-32021` with `requiredCapabilities.extensions` when a client asks for
  task notifications without declaring `io.modelcontextprotocol/tasks`. The SEP
  requires this for `subscriptions/listen` specifically, alongside the same
  requirement on the three task methods.
- Drop `taskIds` from the acknowledgement when the server has not enabled the
  extension. The ack reports what the server agreed to honor, and a server
  without tasks agreed to nothing.

## Out of scope

The multi-instance shared-store test and the advertisement-by-default decision
are the remainder of slice 4 and land separately.

Refs #951
