### PR TITLE
test: check each public feature combination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,24 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets --all-features
 
+  feature-combinations:
+    name: Feature combinations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check default and each public feature
+        run: |
+          cargo check -p tower-mcp --all-targets
+          for feature in \
+            http websocket unix childproc oauth jwks testing dynamic-tools \
+            http-client oauth-client proxy macros resilience mcp-apps \
+            protocol-2026-07-28 stateless
+          do
+            cargo check -p tower-mcp --all-targets --features "$feature"
+          done
+
   wasm-types:
     name: WASM (tower-mcp-types)
     runs-on: ubuntu-latest

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -7622,6 +7622,7 @@ mod tests {
     }
 
     /// A stateless 2026-07-28 request body helper for the serverInfo tests below.
+    #[cfg(feature = "stateless")]
     fn stateless_tools_call_request() -> Request<Body> {
         Request::builder()
             .method("POST")
@@ -7653,6 +7654,7 @@ mod tests {
             .unwrap()
     }
 
+    #[cfg(feature = "stateless")]
     fn echo_router() -> McpRouter {
         use crate::{CallToolResult, ToolBuilder};
         McpRouter::new().server_info("t", "1.0.0").tool(
@@ -7668,6 +7670,7 @@ mod tests {
     /// SEP-2575: 2026-07-28 stateless responses carry server identity in
     /// `_meta["io.modelcontextprotocol/serverInfo"]` by default.
     #[tokio::test]
+    #[cfg(feature = "stateless")]
     async fn stateless_v2026_response_stamps_server_info_by_default() {
         let transport = HttpTransport::new(echo_router()).disable_origin_validation();
         let app = transport.into_router();
@@ -7689,6 +7692,7 @@ mod tests {
 
     /// `.stamp_server_info(false)` opts out of the SEP-2575 `_meta` stamp.
     #[tokio::test]
+    #[cfg(feature = "stateless")]
     async fn stateless_v2026_response_omits_server_info_when_disabled() {
         let transport = HttpTransport::new(echo_router())
             .disable_origin_validation()


### PR DESCRIPTION
Closes #1093.

## What changed

- Gate the two SEP-2575 server-info tests and their helpers on the `stateless` feature they exercise.
- Add a CI job that checks the default `tower-mcp` build and every public feature individually with `--all-targets`.

## Root cause

The existing CI check compiled only `--all-features`, so tests could accidentally call APIs hidden behind a feature gate without being caught. `cargo check -p tower-mcp --all-targets --features http` exposed one such mismatch: a test called `stamp_server_info`, which exists only with `stateless`.

## Verification

- Every public feature passes `cargo check -p tower-mcp --all-targets` individually with `RUSTFLAGS=-Dwarnings`.
- `cargo test -p tower-mcp --features http` passes (571 unit tests plus integration/doc tests).
- Both server-info tests pass with `http,protocol-2026-07-28`.
- Workspace Clippy, formatting, and `git diff --check` pass.