### PR TITLE
fix(tasks): make final task creation server-directed

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -952,7 +952,7 @@ pub struct ElicitationFormCapability {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ElicitationUrlCapability {}
 
-/// Client capability for async task management
+/// Legacy 2025-11-25 client capability for async task management.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientTasksCapability {
@@ -962,7 +962,7 @@ pub struct ClientTasksCapability {
     /// Support for cancelling tasks
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancel: Option<ClientTasksCancelCapability>,
-    /// Which request types support task-augmented requests
+    /// Legacy task-augmented request support.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requests: Option<ClientTasksRequestsCapability>,
 }
@@ -975,7 +975,7 @@ pub struct ClientTasksListCapability {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClientTasksCancelCapability {}
 
-/// Capability declaring which request types support task-augmented requests on the client
+/// Legacy client capability declaring task-augmented request support.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientTasksRequestsCapability {
@@ -987,7 +987,7 @@ pub struct ClientTasksRequestsCapability {
     pub elicitation: Option<ClientTasksElicitationCapability>,
 }
 
-/// Nested capability for task-augmented sampling requests
+/// Legacy capability for task-augmented sampling requests.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientTasksSamplingCapability {
@@ -996,11 +996,11 @@ pub struct ClientTasksSamplingCapability {
     pub create_message: Option<ClientTasksSamplingCreateMessageCapability>,
 }
 
-/// Marker capability for task-augmented sampling/createMessage support
+/// Legacy task-augmented sampling marker.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClientTasksSamplingCreateMessageCapability {}
 
-/// Nested capability for task-augmented elicitation requests
+/// Legacy capability for task-augmented elicitation requests.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ClientTasksElicitationCapability {
@@ -1009,7 +1009,7 @@ pub struct ClientTasksElicitationCapability {
     pub create: Option<ClientTasksElicitationCreateCapability>,
 }
 
-/// Marker capability for task-augmented elicitation/create support
+/// Legacy task-augmented elicitation marker.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClientTasksElicitationCreateCapability {}
 
@@ -1761,7 +1761,9 @@ pub struct CreateMessageParams {
     /// Tool choice mode (SEP-1577)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
-    /// Task parameters for async execution
+    /// Legacy 2025-11-25 task parameters for async execution.
+    ///
+    /// This field is invalid on the 2026-07-28 protocol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<TaskRequestParams>,
     /// Optional protocol-level metadata
@@ -2124,7 +2126,7 @@ pub struct LoggingCapability {
     pub deprecated: Option<DeprecationInfo>,
 }
 
-/// Capability for async task management
+/// Legacy 2025-11-25 server capability for async task management.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TasksCapability {
@@ -2134,7 +2136,7 @@ pub struct TasksCapability {
     /// Support for cancelling tasks
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cancel: Option<TasksCancelCapability>,
-    /// Which request types support task-augmented requests
+    /// Legacy task-augmented request support.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requests: Option<TasksRequestsCapability>,
 }
@@ -2147,7 +2149,7 @@ pub struct TasksListCapability {}
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TasksCancelCapability {}
 
-/// Capability declaring which request types support task-augmented requests
+/// Legacy server capability declaring task-augmented request support.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TasksRequestsCapability {
@@ -2156,7 +2158,7 @@ pub struct TasksRequestsCapability {
     pub tools: Option<TasksToolsRequestsCapability>,
 }
 
-/// Nested capability for task-augmented tool requests
+/// Legacy capability for task-augmented tool requests.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TasksToolsRequestsCapability {
@@ -2165,7 +2167,7 @@ pub struct TasksToolsRequestsCapability {
     pub call: Option<TasksToolsCallCapability>,
 }
 
-/// Marker capability for task-augmented tools/call support
+/// Legacy task-augmented tools/call marker.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TasksToolsCallCapability {}
 
@@ -2479,7 +2481,9 @@ pub struct CallToolParams {
         with = "crate::protocol::meta_object_serde"
     )]
     pub meta: Option<RequestMeta>,
-    /// Task parameters for async execution
+    /// Legacy 2025-11-25 task parameters for async execution.
+    ///
+    /// This field is invalid on the 2026-07-28 protocol.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task: Option<TaskRequestParams>,
 }
@@ -3996,25 +4000,36 @@ pub const RESULT_TYPE_TASK: &str = "task";
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum TaskSupportMode {
-    /// Task execution is required (tool MUST be called with task params)
+    /// Task execution is required.
+    ///
+    /// Legacy clients must include task parameters. On the final protocol the
+    /// server creates a task whenever the extension is negotiated, and rejects
+    /// clients that did not declare it.
     Required,
-    /// Task execution is optional (tool MAY be called with or without task params)
+    /// Task execution is optional.
+    ///
+    /// Legacy clients choose by including task parameters. On the final
+    /// protocol this is server policy: the router creates a task when both
+    /// peers negotiated the extension and otherwise completes synchronously.
     Optional,
-    /// Task execution is forbidden (tool MUST NOT be called with task params)
+    /// Task execution is forbidden; the tool always completes synchronously.
     #[default]
     Forbidden,
 }
 
-/// Execution metadata for a tool definition
+/// Legacy 2025-11-25 task execution metadata for a tool definition.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolExecution {
-    /// Whether the tool supports task-augmented requests (defaults to "forbidden")
+    /// Whether the legacy tool supports task-augmented requests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub task_support: Option<TaskSupportMode>,
 }
 
-/// Parameters for task-augmented requests (the `task` field in CallToolParams)
+/// Legacy 2025-11-25 task-augmentation parameters.
+///
+/// The final Tasks extension has no `task` field on `tools/call`; task creation
+/// is server-directed after extension negotiation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskRequestParams {
@@ -4105,12 +4120,12 @@ pub struct TaskObject {
 #[deprecated(note = "Use TaskObject instead")]
 pub type TaskInfo = TaskObject;
 
-/// Result of creating a task (returned when `tools/call` is task-augmented).
+/// Backwards-compatible task-creation result used by the 2025-11-25 API.
 ///
-/// Per SEP-2663, `CreateTaskResult = Result & Task`: the task fields are
-/// inlined at the top of the result and `resultType` is set to `"task"` so
-/// clients can distinguish a task handle from a normal `CallToolResult` on
-/// the same RPC.
+/// This compatibility type accepts both the historical nested object and the
+/// final flat fields so the pre-final high-level client API can keep its return
+/// type. The 2026-07-28 runtime never emits it on the wire; it uses the exact
+/// [`crate::tasks::CreateTaskResult`] instead.
 ///
 /// Serialization layout:
 /// ```jsonc
@@ -4122,17 +4137,14 @@ pub type TaskInfo = TaskObject;
 ///   "lastUpdatedAt": "...",
 ///   "ttl": null,
 ///   "pollInterval": 5000,
-///   // The nested `task` field is emitted purely for back-compat with the
-///   // 2025-11-25 experimental wire format. New clients should read the
-///   // top-level fields and ignore `task`. This nested mirror will be
-///   // removed in a future release.
+///   // The nested `task` field preserves the 2025-11-25 wire format.
 ///   "task": { "taskId": ..., "status": ..., ... }
 /// }
 /// ```
 #[derive(Debug, Clone)]
 pub struct CreateTaskResult {
-    /// The created task object. Serialized both inline (per SEP-2663) and
-    /// under the legacy `task` key for back-compat.
+    /// The created task object. This compatibility serializer emits both the
+    /// flat fields and the legacy nested mirror.
     pub task: TaskObject,
     /// Optional protocol-level metadata
     pub meta: Option<Value>,
@@ -4142,8 +4154,7 @@ impl CreateTaskResult {
     /// Wire-spec discriminator value (always `"task"`).
     pub const RESULT_TYPE: &'static str = RESULT_TYPE_TASK;
 
-    /// Build a result from a [`TaskObject`], with the SEP-2663 discriminator
-    /// pre-populated when serialized.
+    /// Build a compatibility result from a [`TaskObject`].
     pub fn new(task: TaskObject) -> Self {
         Self { task, meta: None }
     }
@@ -4154,8 +4165,8 @@ impl Serialize for CreateTaskResult {
     where
         S: serde::Serializer,
     {
-        // Serialize the TaskObject to a JSON object, then inject the
-        // SEP-2663 discriminator and the nested `task` mirror for back-compat.
+        // Serialize the compatibility object with both the flat discriminator
+        // and the legacy nested task mirror.
         let mut value = serde_json::to_value(&self.task)
             .map_err(|e| serde::ser::Error::custom(format!("task serialize: {e}")))?;
         let obj = value

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -1,8 +1,9 @@
 //! Async task management for long-running MCP operations
 //!
 //! This module provides task lifecycle management for operations that may take
-//! longer than a typical request/response cycle. Tasks can be created via
-//! task-augmented `tools/call` requests, tracked, polled for status, and cancelled.
+//! longer than a typical request/response cycle. Legacy clients request task
+//! augmentation explicitly; final-protocol servers elect tasks after extension
+//! negotiation. Tasks can be tracked, polled, updated with input, and cancelled.
 //!
 //! Task state lives behind the pluggable [`TaskStore`] trait, mirroring the
 //! shape of [`crate::session_store`] and [`crate::event_store`]: a trait, an
@@ -812,9 +813,9 @@ impl crate::McpRouter {
     ///
     /// Compiling the task APIs does not advertise them. A server opts in here,
     /// and only then does the final protocol path advertise
-    /// `io.modelcontextprotocol/tasks`, accept task-augmented `tools/call`
-    /// requests, or serve the final task methods. Legacy 2025-11-25 task
-    /// behavior is unaffected either way.
+    /// `io.modelcontextprotocol/tasks`, elect to return tasks from ordinary
+    /// `tools/call` requests, or serve the final task methods. Legacy
+    /// 2025-11-25 task behavior is unaffected either way.
     pub fn with_tasks(self) -> Self {
         self.with_protocol_extension(tasks_extension())
     }

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -92,6 +92,25 @@ use crate::protocol::{
 use response_cache::{CacheLookup, ClientResponseCache};
 use tower_mcp_types::JsonRpcError;
 
+/// One response to a final-protocol `tools/call` request.
+///
+/// Task creation is server-directed in SEP-2663, so a client that declares
+/// the Tasks extension must be prepared for an ordinary tool call to return a
+/// task handle. [`McpClient::call_tool`] drives that task transparently;
+/// [`McpClient::call_tool_once_task_aware`] exposes this enum for callers that
+/// want direct control of the lifecycle.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(untagged)]
+#[non_exhaustive]
+pub enum TaskAwareCallToolOutcome {
+    /// The server elected to create a task.
+    Task(crate::tasks::CreateTaskResult),
+    /// The request completed synchronously.
+    Complete(CallToolResult),
+    /// The request needs one or more client inputs before it can complete.
+    InputRequired(crate::protocol::InputRequiredResult),
+}
+
 trait CacheableResponse:
     Clone + serde::Serialize + serde::de::DeserializeOwned + Send + Sync + 'static
 {
@@ -785,11 +804,19 @@ impl McpClient {
                 task: None,
             };
             let outcome = self
-                .send_tool_request_with_schema_retry(&params, &mut schema_retry_available)
+                .send_task_aware_tool_request_with_schema_retry(
+                    &params,
+                    &mut schema_retry_available,
+                )
                 .await?;
             match outcome {
-                RequestOutcome::Complete(result) => return Ok(result),
-                RequestOutcome::InputRequired(required) => {
+                TaskAwareCallToolOutcome::Complete(result) => return Ok(result),
+                TaskAwareCallToolOutcome::Task(created) => {
+                    return self
+                        .complete_final_task(&created.task.metadata.task_id)
+                        .await;
+                }
+                TaskAwareCallToolOutcome::InputRequired(required) => {
                     if round == self.max_mrtr_rounds {
                         return Err(Error::Transport(format!(
                             "MRTR round limit ({}) exceeded for tools/call",
@@ -818,6 +845,33 @@ impl McpClient {
         input_responses: Option<InputResponses>,
         request_state: Option<String>,
     ) -> Result<RequestOutcome<CallToolResult>> {
+        match self
+            .call_tool_once_task_aware(name, arguments, input_responses, request_state)
+            .await?
+        {
+            TaskAwareCallToolOutcome::Complete(result) => Ok(RequestOutcome::Complete(result)),
+            TaskAwareCallToolOutcome::InputRequired(required) => {
+                Ok(RequestOutcome::InputRequired(required))
+            }
+            TaskAwareCallToolOutcome::Task(created) => Err(Error::Transport(format!(
+                "tools/call returned task '{}'; use call_tool_once_task_aware for direct task lifecycle control",
+                created.task.metadata.task_id
+            ))),
+        }
+    }
+
+    /// Send one `tools/call` attempt and preserve a server-created task.
+    ///
+    /// Unlike [`call_tool`](Self::call_tool), this does not poll a task or
+    /// automatically fulfil input requests. Final-protocol callers can use it
+    /// to retain the exact task handle returned from the ordinary request.
+    pub async fn call_tool_once_task_aware(
+        &self,
+        name: &str,
+        arguments: serde_json::Value,
+        input_responses: Option<InputResponses>,
+        request_state: Option<String>,
+    ) -> Result<TaskAwareCallToolOutcome> {
         self.ensure_initialized()?;
         let params = CallToolParams {
             name: name.to_string(),
@@ -827,10 +881,12 @@ impl McpClient {
             meta: None,
             task: None,
         };
-        self.send_request("tools/call", &params).await
+        let mut schema_retry_available = self.uses_final_protocol().await;
+        self.send_task_aware_tool_request_with_schema_retry(&params, &mut schema_retry_available)
+            .await
     }
 
-    /// Make a task-augmented tool call (SEP-2663).
+    /// Request direct control of a tool task lifecycle.
     ///
     /// Instead of blocking until the tool finishes, the server creates a
     /// task and immediately returns a [`CreateTaskResult`] carrying the task
@@ -839,10 +895,10 @@ impl McpClient {
     /// carries the [`CallToolResult`] the synchronous call would have
     /// returned.
     ///
-    /// `ttl_ms` is the requested task time-to-live in milliseconds; `None`
-    /// lets the server choose. The tool must support task execution
-    /// (advertised via the server's tasks capability); servers reject
-    /// task-augmented calls to unsupported tools.
+    /// On 2025-11-25, `ttl_ms` is sent in the legacy task-augmentation field.
+    /// On 2026-07-28, task creation is server-directed: this sends an ordinary
+    /// request and requires the server to elect a task. A final client cannot
+    /// request a TTL, so a non-`None` `ttl_ms` is rejected on that lifecycle.
     pub async fn call_tool_as_task(
         &self,
         name: &str,
@@ -850,6 +906,41 @@ impl McpClient {
         ttl_ms: Option<u64>,
     ) -> Result<CreateTaskResult> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            if ttl_ms.is_some() {
+                return Err(Error::Transport(
+                    "ttl_ms is server-selected by the final Tasks extension".to_string(),
+                ));
+            }
+            let params = CallToolParams {
+                name: name.to_string(),
+                arguments,
+                input_responses: None,
+                request_state: None,
+                meta: None,
+                task: None,
+            };
+            let mut schema_retry_available = true;
+            return match self
+                .send_task_aware_tool_request_with_schema_retry(
+                    &params,
+                    &mut schema_retry_available,
+                )
+                .await?
+            {
+                TaskAwareCallToolOutcome::Task(created) => {
+                    Ok(Self::legacy_create_task_from_final(created))
+                }
+                TaskAwareCallToolOutcome::Complete(_) => Err(Error::Transport(
+                    "server completed tools/call synchronously; final task creation is server-directed"
+                        .to_string(),
+                )),
+                TaskAwareCallToolOutcome::InputRequired(_) => Err(Error::Transport(
+                    "server requested input instead of creating a task".to_string(),
+                )),
+            };
+        }
+
         let params = CallToolParams {
             name: name.to_string(),
             arguments,
@@ -871,7 +962,29 @@ impl McpClient {
     /// an invalid-params error from the server.
     pub async fn task_get(&self, task_id: &str) -> Result<TaskObject> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            return Self::legacy_task_from_final(self.task_get_detailed(task_id).await?);
+        }
         let params = GetTaskInfoParams {
+            task_id: task_id.to_string(),
+            meta: None,
+        };
+        self.send_request("tasks/get", &params).await
+    }
+
+    /// Fetch the exact final-protocol `tasks/get` result.
+    ///
+    /// This preserves status-specific payloads, including all outstanding
+    /// `inputRequests`. It is available only after selecting the 2026-07-28
+    /// lifecycle; legacy callers should use [`task_get`](Self::task_get).
+    pub async fn task_get_detailed(&self, task_id: &str) -> Result<crate::tasks::GetTaskResult> {
+        self.ensure_initialized()?;
+        if !self.uses_final_protocol().await {
+            return Err(Error::Transport(
+                "task_get_detailed requires the 2026-07-28 client lifecycle".to_string(),
+            ));
+        }
+        let params = crate::tasks::GetTaskParams {
             task_id: task_id.to_string(),
             meta: None,
         };
@@ -883,10 +996,20 @@ impl McpClient {
     /// Cancellation is cooperative: the acknowledgment is an empty result
     /// and the observable status may remain non-terminal for a while after
     /// the ack; poll [`task_get`](Self::task_get) to observe the terminal
-    /// state. The ack body is discarded, so legacy peers that return the
+    /// state. `reason` is a legacy-only field and is omitted on the final
+    /// protocol. The ack body is discarded, so legacy peers that return the
     /// task object are also tolerated.
     pub async fn task_cancel(&self, task_id: &str, reason: Option<String>) -> Result<()> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            let params = crate::tasks::CancelTaskParams {
+                task_id: task_id.to_string(),
+                meta: None,
+            };
+            let _ack: crate::tasks::CancelTaskResult =
+                self.send_request("tasks/cancel", &params).await?;
+            return Ok(());
+        }
         let params = CancelTaskParams {
             task_id: task_id.to_string(),
             reason,
@@ -899,9 +1022,9 @@ impl McpClient {
     /// Answer a task's outstanding input requests via `tasks/update`
     /// (SEP-2663).
     ///
-    /// Responses are matched to outstanding requests by key. Read the keys
-    /// from the `inputRequests` of an `input_required` task returned by
-    /// [`task_get`](Self::task_get).
+    /// Responses are matched to outstanding requests by key. Final-protocol
+    /// callers read the keys from the `inputRequests` of an `input_required`
+    /// task returned by [`task_get_detailed`](Self::task_get_detailed).
     ///
     /// A partial map is valid and expected: requests left unanswered stay
     /// outstanding and the task remains `input_required` until every one is
@@ -913,6 +1036,16 @@ impl McpClient {
     /// [`task_get`](Self::task_get) to observe the resulting state.
     pub async fn task_update(&self, task_id: &str, input_responses: InputResponses) -> Result<()> {
         self.ensure_initialized()?;
+        if self.uses_final_protocol().await {
+            let params = crate::tasks::UpdateTaskParams {
+                task_id: task_id.to_string(),
+                input_responses,
+                meta: None,
+            };
+            let _ack: crate::tasks::UpdateTaskResult =
+                self.send_request("tasks/update", &params).await?;
+            return Ok(());
+        }
         let input_responses = input_responses
             .into_iter()
             .map(|(key, response)| serde_json::to_value(response).map(|value| (key, value)))
@@ -928,11 +1061,17 @@ impl McpClient {
 
     /// Poll `tasks/get` until the task reaches a terminal state.
     ///
-    /// Honors the server's suggested `pollInterval` (default 1000 ms,
-    /// clamped to 50 ms..30 s). A task purged after its TTL surfaces as the
-    /// server's task-not-found error. Wrap in
+    /// Honors the server's suggested polling interval (default 1000 ms,
+    /// clamped to 50 ms..30 s). On the final protocol it also fulfils
+    /// `input_required` requests through the registered client handlers. A
+    /// task purged after its TTL surfaces as the server's task-not-found
+    /// error. Wrap in
     /// [`tokio::time::timeout`] to bound the overall wait.
     pub async fn task_wait(&self, task_id: &str) -> Result<TaskObject> {
+        if self.uses_final_protocol().await {
+            let result = self.wait_for_final_task(task_id).await?;
+            return Self::legacy_task_from_final(result);
+        }
         loop {
             let task = self.task_get(task_id).await?;
             if task.status.is_terminal() {
@@ -1485,6 +1624,134 @@ impl McpClient {
     }
 
     // --- Internal helpers ---
+
+    async fn send_task_aware_tool_request_with_schema_retry(
+        &self,
+        params: &CallToolParams,
+        retry_available: &mut bool,
+    ) -> Result<TaskAwareCallToolOutcome> {
+        self.send_tool_request_with_schema_retry(params, retry_available)
+            .await
+    }
+
+    async fn wait_for_final_task(&self, task_id: &str) -> Result<crate::tasks::GetTaskResult> {
+        loop {
+            let task = self.task_get_detailed(task_id).await?;
+            match task.task.status() {
+                crate::protocol::TaskStatus::Completed
+                | crate::protocol::TaskStatus::Failed
+                | crate::protocol::TaskStatus::Cancelled => return Ok(task),
+                crate::protocol::TaskStatus::InputRequired => {
+                    let requests = task.task.input_requests().cloned().ok_or_else(|| {
+                        Error::Transport(format!(
+                            "task '{task_id}' is input_required without inputRequests"
+                        ))
+                    })?;
+                    if requests.is_empty() {
+                        return Err(Error::Transport(format!(
+                            "task '{task_id}' is input_required without inputRequests"
+                        )));
+                    }
+                    let responses = self.resolve_input_requests(requests).await?;
+                    self.task_update(task_id, responses).await?;
+                }
+                crate::protocol::TaskStatus::Working => {
+                    let interval_ms = task
+                        .task
+                        .metadata()
+                        .poll_interval_ms
+                        .unwrap_or(1000)
+                        .clamp(50, 30_000);
+                    tokio::time::sleep(std::time::Duration::from_millis(interval_ms)).await;
+                }
+                _ => {
+                    return Err(Error::Transport(format!(
+                        "task '{task_id}' returned an unsupported status"
+                    )));
+                }
+            }
+        }
+    }
+
+    async fn complete_final_task(&self, task_id: &str) -> Result<CallToolResult> {
+        let task = self.wait_for_final_task(task_id).await?;
+        match task.task.status() {
+            crate::protocol::TaskStatus::Completed => {
+                let result = task.task.result().cloned().ok_or_else(|| {
+                    Error::Transport(format!(
+                        "completed task '{task_id}' did not contain a result"
+                    ))
+                })?;
+                serde_json::from_value(serde_json::Value::Object(result)).map_err(|error| {
+                    Error::Transport(format!(
+                        "failed to deserialize completed task '{task_id}' result: {error}"
+                    ))
+                })
+            }
+            crate::protocol::TaskStatus::Failed => {
+                let error = task.task.error().cloned().unwrap_or_else(|| {
+                    JsonRpcError::internal_error(format!(
+                        "task '{task_id}' failed without an error payload"
+                    ))
+                });
+                Err(Error::JsonRpc(error))
+            }
+            crate::protocol::TaskStatus::Cancelled => {
+                Err(Error::Transport(format!("task '{task_id}' was cancelled")))
+            }
+            _ => Err(Error::Transport(format!(
+                "task '{task_id}' did not reach a terminal state"
+            ))),
+        }
+    }
+
+    fn legacy_create_task_from_final(created: crate::tasks::CreateTaskResult) -> CreateTaskResult {
+        let metadata = created.task.metadata;
+        CreateTaskResult {
+            task: TaskObject {
+                task_id: metadata.task_id,
+                status: created.task.status,
+                status_message: metadata.status_message,
+                created_at: metadata.created_at,
+                last_updated_at: metadata.last_updated_at,
+                ttl: metadata.ttl_ms,
+                poll_interval: metadata.poll_interval_ms,
+                result: None,
+                error: None,
+                meta: None,
+            },
+            meta: created.meta.map(serde_json::Value::Object),
+        }
+    }
+
+    fn legacy_task_from_final(result: crate::tasks::GetTaskResult) -> Result<TaskObject> {
+        let task = &result.task;
+        let metadata = task.metadata();
+        let completed = task
+            .result()
+            .cloned()
+            .map(serde_json::Value::Object)
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| {
+                Error::Transport(format!(
+                    "failed to deserialize task '{}' result: {error}",
+                    metadata.task_id
+                ))
+            })?;
+        Ok(TaskObject {
+            task_id: metadata.task_id.clone(),
+            status: task.status(),
+            status_message: metadata.status_message.clone(),
+            created_at: metadata.created_at.clone(),
+            last_updated_at: metadata.last_updated_at.clone(),
+            ttl: metadata.ttl_ms,
+            poll_interval: metadata.poll_interval_ms,
+            result: completed,
+            error: task.error().cloned(),
+            meta: result.meta.map(serde_json::Value::Object),
+        })
+    }
 
     async fn send_tool_request_with_schema_retry<R>(
         &self,
@@ -3325,6 +3592,50 @@ mod tests {
                 "tools/list",
                 "tools/call"
             ]
+        );
+    }
+
+    #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_call_tool_as_task_sends_no_legacy_task_parameter() {
+        let transport = MockTransport::with_responses(vec![
+            final_discover_result(),
+            serde_json::json!({
+                "resultType": "task",
+                "taskId": "task-final",
+                "status": "working",
+                "createdAt": "2026-07-31T00:00:00Z",
+                "lastUpdatedAt": "2026-07-31T00:00:00Z",
+                "ttlMs": null,
+                "pollIntervalMs": 50
+            }),
+        ]);
+        let outgoing = transport.outgoing.clone();
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .with_tasks()
+            .connect_simple(transport)
+            .await
+            .unwrap();
+        client.discover("test-client", "1.0.0").await.unwrap();
+
+        let created = client
+            .call_tool_as_task("long-tool", serde_json::json!({}), None)
+            .await
+            .unwrap();
+        assert_eq!(created.task.task_id, "task-final");
+
+        let messages = outgoing.lock().unwrap();
+        let call: serde_json::Value = serde_json::from_str(&messages[1]).unwrap();
+        assert_eq!(call["method"], "tools/call");
+        assert!(
+            call["params"].get("task").is_none(),
+            "final tools/call leaked the legacy task parameter: {call}"
+        );
+        assert!(
+            call["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"]["extensions"]
+                .get(crate::protocol::TASKS_EXTENSION_ID)
+                .is_some()
         );
     }
 

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -67,9 +67,8 @@ fn task_store_error(e: TaskStoreError) -> Error {
 
 /// Whether this request is using the final, stateless 2026-07-28 lifecycle.
 ///
-/// Tasks support is intentionally withheld on that path until the complete
-/// SEP-2663 contract is implemented. Stable sessionful requests retain the
-/// crate's existing experimental task behavior.
+/// Stable sessionful requests retain the crate's legacy task behavior; final
+/// requests use extension negotiation and server-directed task creation.
 #[cfg(feature = "stateless")]
 fn is_final_protocol_request(extensions: &crate::context::Extensions) -> bool {
     extensions
@@ -2309,7 +2308,7 @@ impl McpRouter {
             TaskStatus::Completed => {
                 // The exact object the synchronous call would have returned,
                 // including `isError: true` results.
-                let object = result
+                let mut object = result
                     .map(serde_json::to_value)
                     .transpose()
                     .map_err(|e| {
@@ -2319,6 +2318,13 @@ impl McpRouter {
                     })?
                     .and_then(|value| value.as_object().cloned())
                     .unwrap_or_default();
+                // This object is nested inside tasks/get, so it does not pass
+                // through the JSON-RPC response stamper that adds the final
+                // protocol's required complete discriminator.
+                object.insert(
+                    "resultType".to_string(),
+                    serde_json::Value::String("complete".to_string()),
+                );
                 crate::tasks::DetailedTask::completed(metadata, object)
             }
             TaskStatus::Failed => crate::tasks::DetailedTask::failed(
@@ -2533,11 +2539,16 @@ impl McpRouter {
 
             McpRequest::ListTools(params) => {
                 let final_protocol = is_final_protocol_request(&extensions);
+                let final_tasks_negotiated = final_protocol
+                    && self.final_tasks_enabled()
+                    && client_declares_tasks(&extensions);
                 let filter = self.inner.tool_filter.as_ref();
                 let disabled = self.inner.disabled_tools.read().unwrap().clone();
                 let is_visible = |t: &Tool| {
                     !disabled.contains(&t.name)
-                        && !(final_protocol && matches!(t.task_support, TaskSupportMode::Required))
+                        && !(final_protocol
+                            && matches!(t.task_support, TaskSupportMode::Required)
+                            && !final_tasks_negotiated)
                         && filter
                             .map(|f| f.is_visible(&self.session, t))
                             .unwrap_or(true)
@@ -2639,31 +2650,59 @@ impl McpRouter {
                     return Err(filter.denial_error(&params.name));
                 }
 
-                // On the final path, task behavior follows negotiation rather
-                // than protocol version. A client that did not declare the
-                // extension must never receive a task.
-                if is_final_protocol_request(&extensions) {
-                    let tasks_negotiated =
-                        self.final_tasks_enabled() && client_declares_tasks(&extensions);
+                // Task creation is client-directed on the legacy protocol and
+                // server-directed on the final protocol. `Some(None)` means
+                // create a task using the server-selected TTL.
+                let final_protocol = is_final_protocol_request(&extensions);
+                let task_ttl = if final_protocol {
+                    if params.task.is_some() {
+                        return Err(Error::JsonRpc(JsonRpcError::invalid_params(
+                            "The final Tasks extension does not allow a 'task' request parameter",
+                        )));
+                    }
 
-                    if !tasks_negotiated {
-                        if matches!(tool.task_support, TaskSupportMode::Required) {
-                            // The server cannot service this tool without a
-                            // task, so say which capability is missing instead
-                            // of hiding the tool.
+                    let server_enabled = self.final_tasks_enabled();
+                    let tasks_negotiated = server_enabled && client_declares_tasks(&extensions);
+                    match tool.task_support {
+                        TaskSupportMode::Required if !server_enabled => {
+                            // Match tools/list: a final-only task tool is not
+                            // part of this server's surface until it opts in.
+                            return Err(Error::JsonRpc(JsonRpcError::method_not_found(
+                                &params.name,
+                            )));
+                        }
+                        TaskSupportMode::Required if !tasks_negotiated => {
                             return Err(Error::JsonRpc(
                                 JsonRpcError::missing_required_client_capability(
                                     tasks_client_capabilities(),
                                 ),
                             ));
                         }
-                        if params.task.is_some() {
-                            return Err(Error::JsonRpc(JsonRpcError::invalid_params(
-                                "The Tasks extension was not negotiated for this request",
-                            )));
+                        TaskSupportMode::Required | TaskSupportMode::Optional
+                            if tasks_negotiated =>
+                        {
+                            Some(None)
                         }
+                        _ => None,
                     }
-                }
+                } else {
+                    match (&params.task, tool.task_support) {
+                        (Some(_), TaskSupportMode::Forbidden) => {
+                            return Err(Error::JsonRpc(JsonRpcError::invalid_params(format!(
+                                "Tool '{}' does not support async tasks",
+                                params.name
+                            ))));
+                        }
+                        (None, TaskSupportMode::Required) => {
+                            return Err(Error::JsonRpc(JsonRpcError::invalid_params(format!(
+                                "Tool '{}' requires async task execution (include 'task' in params)",
+                                params.name
+                            ))));
+                        }
+                        (Some(task), _) => Some(task.ttl),
+                        (None, _) => None,
+                    }
+                };
 
                 // Final 2026-07-28 requests declare client capabilities on
                 // every request. Reject a tool before any handler work begins
@@ -2683,15 +2722,7 @@ impl McpRouter {
                     ));
                 }
 
-                if let Some(task_params) = params.task {
-                    // Task-augmented request: validate task_support != Forbidden
-                    if matches!(tool.task_support, TaskSupportMode::Forbidden) {
-                        return Err(Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Tool '{}' does not support async tasks",
-                            params.name
-                        ))));
-                    }
-
+                if let Some(task_ttl) = task_ttl {
                     // Create the task
                     let (task_id, cancellation_token) = self
                         .inner
@@ -2699,7 +2730,7 @@ impl McpRouter {
                         .create_task(
                             &params.name,
                             params.arguments.clone(),
-                            task_params.ttl,
+                            task_ttl,
                             request_principal(&extensions),
                         )
                         .await
@@ -2798,14 +2829,6 @@ impl McpRouter {
                     }
                     Ok(McpResponse::CreateTask(CreateTaskResult::new(task)))
                 } else {
-                    // Synchronous request: validate task_support != Required
-                    if matches!(tool.task_support, TaskSupportMode::Required) {
-                        return Err(Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Tool '{}' requires async task execution (include 'task' in params)",
-                            params.name
-                        ))));
-                    }
-
                     // Extract progress token from request metadata
                     let progress_token = params.meta.and_then(|m| m.progress_token);
                     let ctx = self.create_context_with_extensions(
@@ -3909,25 +3932,24 @@ mod tests {
             "the legacy capability shape is never advertised on the final path"
         );
 
-        // A client that did not declare the extension still gets no task.
-        let error = router
+        // A client that did not declare the extension gets the synchronous
+        // form of an optional tool.
+        let response = router
             .handle(
                 RequestId::Number(4),
-                McpRequest::CallTool(task_params(Some(TaskRequestParams { ttl: None }))),
+                McpRequest::CallTool(task_params(None)),
                 final_extensions(ClientCapabilities::default()),
             )
             .await
-            .unwrap_err();
-        assert!(
-            matches!(error, Error::JsonRpc(e) if e.code == -32602),
-            "server opt-in alone must not be enough"
-        );
+            .unwrap();
+        assert!(matches!(response, McpResponse::CallTool(_)));
 
-        // Both sides declared: the augmentation is accepted.
+        // Both sides declared: the server elects a task from an ordinary
+        // tools/call request.
         let response = router
             .handle(
                 RequestId::Number(5),
-                McpRequest::CallTool(task_params(Some(TaskRequestParams { ttl: None }))),
+                McpRequest::CallTool(task_params(None)),
                 tasks_client_extensions(),
             )
             .await
@@ -3937,16 +3959,17 @@ mod tests {
             "a negotiated request must receive a task, got {response:?}"
         );
 
-        // An unaugmented call on the same tool stays synchronous.
-        let response = router
+        // The removed legacy request flag is invalid even when the extension
+        // was negotiated.
+        let error = router
             .handle(
                 RequestId::Number(6),
-                McpRequest::CallTool(task_params(None)),
+                McpRequest::CallTool(task_params(Some(TaskRequestParams { ttl: None }))),
                 tasks_client_extensions(),
             )
             .await
-            .unwrap();
-        assert!(matches!(response, McpResponse::CallTool(_)));
+            .unwrap_err();
+        assert!(matches!(error, Error::JsonRpc(e) if e.code == -32602));
     }
 
     #[cfg(feature = "stateless")]
@@ -3972,7 +3995,7 @@ mod tests {
                     input_responses: None,
                     request_state: None,
                     meta: None,
-                    task: Some(TaskRequestParams { ttl: None }),
+                    task: None,
                 }),
                 tasks_client_extensions(),
             )
@@ -4071,6 +4094,76 @@ mod tests {
         assert!(matches!(error, Error::JsonRpc(e) if e.code == -32601));
     }
 
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn final_required_task_tools_follow_per_request_capabilities() {
+        let router = McpRouter::new()
+            .tool(
+                ToolBuilder::new("required_task")
+                    .task_support(TaskSupportMode::Required)
+                    .handler(|input: AddInput| async move {
+                        Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                    })
+                    .build(),
+            )
+            .with_tasks();
+        let params = || CallToolParams {
+            name: "required_task".to_string(),
+            arguments: serde_json::json!({"a": 1, "b": 2}),
+            input_responses: None,
+            request_state: None,
+            meta: None,
+            task: None,
+        };
+
+        let McpResponse::ListTools(without_tasks) = router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::ListTools(ListToolsParams::default()),
+                final_extensions(ClientCapabilities::default()),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected tools/list")
+        };
+        assert!(without_tasks.tools.is_empty());
+
+        let McpResponse::ListTools(with_tasks) = router
+            .handle(
+                RequestId::Number(2),
+                McpRequest::ListTools(ListToolsParams::default()),
+                tasks_client_extensions(),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected tools/list")
+        };
+        assert_eq!(with_tasks.tools.len(), 1);
+        assert!(with_tasks.tools[0].execution.is_none());
+
+        let error = router
+            .handle(
+                RequestId::Number(3),
+                McpRequest::CallTool(params()),
+                final_extensions(ClientCapabilities::default()),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::JsonRpc(error) if error.code == -32021));
+
+        let response = router
+            .handle(
+                RequestId::Number(4),
+                McpRequest::CallTool(params()),
+                tasks_client_extensions(),
+            )
+            .await
+            .unwrap();
+        assert!(matches!(response, McpResponse::FinalCreateTask(_)));
+    }
+
     #[cfg(all(feature = "oauth", feature = "stateless"))]
     #[tokio::test]
     async fn task_operations_are_bound_to_the_creating_principal() {
@@ -4108,7 +4201,7 @@ mod tests {
                     input_responses: None,
                     request_state: None,
                     meta: None,
-                    task: Some(TaskRequestParams { ttl: None }),
+                    task: None,
                 }),
                 as_principal("alice"),
             )
@@ -4199,6 +4292,144 @@ mod tests {
                 .is_ok(),
             "a refused cancel must not have cancelled the task"
         );
+    }
+
+    #[cfg(all(feature = "oauth", feature = "stateless"))]
+    #[tokio::test]
+    async fn final_tasks_work_across_independent_routers_with_a_shared_store() {
+        fn as_principal(subject: &str) -> Extensions {
+            let mut extensions = tasks_client_extensions();
+            extensions.insert(crate::oauth::token::TokenClaims {
+                sub: Some(subject.to_string()),
+                iss: None,
+                aud: None,
+                exp: None,
+                scope: None,
+                client_id: None,
+                extra: HashMap::new(),
+            });
+            extensions
+        }
+
+        fn router_with_store(store: Arc<dyn TaskStore>) -> McpRouter {
+            McpRouter::new()
+                .tool(
+                    ToolBuilder::new("shared_task")
+                        .task_support(TaskSupportMode::Optional)
+                        .handler(|_input: serde_json::Value| async move {
+                            tokio::time::sleep(tokio::time::Duration::from_secs(60)).await;
+                            Ok(CallToolResult::text("done"))
+                        })
+                        .build(),
+                )
+                .task_store(store)
+                .with_tasks()
+        }
+
+        let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+        let router_a = router_with_store(store.clone());
+        let router_b = router_with_store(store);
+
+        let McpResponse::FinalCreateTask(created) = router_a
+            .handle(
+                RequestId::Number(1),
+                McpRequest::CallTool(CallToolParams {
+                    name: "shared_task".to_string(),
+                    arguments: serde_json::json!({}),
+                    input_responses: None,
+                    request_state: None,
+                    meta: None,
+                    task: None,
+                }),
+                as_principal("alice"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("router A did not create a final task")
+        };
+        let task_id = created.task.metadata.task_id;
+
+        // A separate router instance can read the shared task for its owner.
+        assert!(
+            router_b
+                .handle(
+                    RequestId::Number(2),
+                    McpRequest::GetTaskInfo(GetTaskInfoParams {
+                        task_id: task_id.clone(),
+                        meta: None,
+                    }),
+                    as_principal("alice"),
+                )
+                .await
+                .is_ok()
+        );
+
+        // Another principal sees the same response as an unknown ID.
+        let denied = router_b
+            .handle(
+                RequestId::Number(3),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: task_id.clone(),
+                    meta: None,
+                }),
+                as_principal("bob"),
+            )
+            .await
+            .unwrap_err();
+        let unknown = router_b
+            .handle(
+                RequestId::Number(4),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: "unknown-task".to_string(),
+                    meta: None,
+                }),
+                as_principal("bob"),
+            )
+            .await
+            .unwrap_err();
+        let (Error::JsonRpc(denied), Error::JsonRpc(unknown)) = (denied, unknown) else {
+            panic!("expected JSON-RPC task denials")
+        };
+        assert_eq!(denied.code, unknown.code);
+        assert_eq!(
+            denied.message.replace(&task_id, "<task-id>"),
+            unknown.message.replace("unknown-task", "<task-id>")
+        );
+        assert_eq!(denied.data, unknown.data);
+
+        // Router B mutates the shared task, and router A immediately observes
+        // the terminal state through the same backend.
+        assert!(matches!(
+            router_b
+                .handle(
+                    RequestId::Number(5),
+                    McpRequest::CancelTask(CancelTaskParams {
+                        task_id: task_id.clone(),
+                        reason: None,
+                        meta: None,
+                    }),
+                    as_principal("alice"),
+                )
+                .await
+                .unwrap(),
+            McpResponse::FinalTaskAck(_)
+        ));
+        let McpResponse::FinalGetTask(fetched) = router_a
+            .handle(
+                RequestId::Number(6),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id,
+                    meta: None,
+                }),
+                as_principal("alice"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("router A did not read the shared task")
+        };
+        assert_eq!(fetched.task.status(), TaskStatus::Cancelled);
     }
 
     #[test]
@@ -4391,7 +4622,7 @@ mod tests {
 
     #[cfg(feature = "stateless")]
     #[tokio::test]
-    async fn final_protocol_rejects_incomplete_tasks_dispatch() {
+    async fn final_protocol_enforces_tasks_negotiation() {
         let optional = ToolBuilder::new("optional_task")
             .task_support(TaskSupportMode::Optional)
             .handler(|input: AddInput| async move {
@@ -4404,7 +4635,7 @@ mod tests {
                 Ok(CallToolResult::text(format!("{}", input.a + input.b)))
             })
             .build();
-        let mut router = McpRouter::new().tool(optional).tool(required);
+        let mut router = McpRouter::new().tool(optional).tool(required).with_tasks();
         init_router(&mut router).await;
 
         // The optional tool remains synchronously callable on the final path.
@@ -4425,7 +4656,7 @@ mod tests {
             .unwrap();
         assert!(matches!(response, McpResponse::CallTool(_)));
 
-        // Task augmentation is invalid while the final extension is withheld.
+        // The removed legacy task augmentation is invalid on the final wire.
         let error = router
             .handle(
                 RequestId::Number(2),

--- a/crates/tower-mcp/tests/client_tasks.rs
+++ b/crates/tower-mcp/tests/client_tasks.rs
@@ -203,3 +203,63 @@ async fn task_update_sends_typed_responses_and_tolerates_stale_keys() {
         .expect_err("unknown task id must error");
     assert!(err.to_string().contains("not found"), "got: {err}");
 }
+
+/// Final task creation is server-directed: an ordinary tools/call produces a
+/// task, and the high-level client transparently drives it to completion.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_call_tool_transparently_completes_server_created_task() {
+    let client = McpClient::builder()
+        .protocol_support(tower_mcp::ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect_simple(ChannelTransport::new(task_router().with_tasks()))
+        .await
+        .expect("connect");
+    client.discover("test", "1.0.0").await.expect("discover");
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.call_tool("compute", serde_json::json!({})),
+    )
+    .await
+    .expect("call_tool timed out")
+    .expect("call_tool");
+    assert_eq!(result.first_text(), Some("the answer is 42"));
+}
+
+/// Callers can retain the exact final task handle instead of asking the
+/// high-level client to poll it automatically.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_task_aware_call_exposes_direct_lifecycle() {
+    use tower_mcp::client::TaskAwareCallToolOutcome;
+
+    let client = McpClient::builder()
+        .protocol_support(tower_mcp::ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect_simple(ChannelTransport::new(task_router().with_tasks()))
+        .await
+        .expect("connect");
+    client.discover("test", "1.0.0").await.expect("discover");
+
+    let outcome = client
+        .call_tool_once_task_aware("compute", serde_json::json!({}), None, None)
+        .await
+        .expect("tools/call");
+    let TaskAwareCallToolOutcome::Task(created) = outcome else {
+        panic!("expected server-created task")
+    };
+
+    let done = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.task_wait(&created.task.metadata.task_id),
+    )
+    .await
+    .expect("task_wait timed out")
+    .expect("task_wait");
+    assert_eq!(done.status, TaskStatus::Completed);
+    assert_eq!(
+        done.result.as_ref().and_then(CallToolResult::first_text),
+        Some("the answer is 42")
+    );
+}

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -304,7 +304,7 @@ mod tasks {
             .description("Finish after a beat, so the task is observably working first")
             .task_support(TaskSupportMode::Optional)
             .handler(|_: serde_json::Value| async move {
-                tokio::time::sleep(Duration::from_millis(20)).await;
+                tokio::time::sleep(Duration::from_millis(100)).await;
                 Ok(CallToolResult::text("done"))
             })
             .build();
@@ -376,7 +376,6 @@ mod tasks {
                     "_meta": meta(true),
                     "name": "slow",
                     "arguments": {},
-                    "task": { "ttl": 60000 },
                 }),
             ))
             .await
@@ -403,7 +402,7 @@ mod tasks {
         assert_eq!(handle.subscription_count(), 1);
 
         // Outlive the handler's sleep, then drain so the body terminates.
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
         assert_eq!(handle.close_subscriptions(), 1);
 
         let body = body_string(listen).await;
@@ -450,7 +449,6 @@ mod tasks {
                     "_meta": meta(true),
                     "name": "slow",
                     "arguments": {},
-                    "task": { "ttl": 60000 },
                 }),
             ))
             .await
@@ -471,7 +469,7 @@ mod tasks {
             .unwrap();
         assert_eq!(listen.status(), StatusCode::OK);
 
-        tokio::time::sleep(Duration::from_millis(150)).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
         handle.close_subscriptions();
 
         let body = body_string(listen).await;

--- a/examples/conformance-server/src/tools.rs
+++ b/examples/conformance-server/src/tools.rs
@@ -63,7 +63,8 @@ pub fn build_tools() -> Vec<Tool> {
         build_elicitation_sep1034_defaults(),
         build_elicitation_sep1330_enums(),
         build_per_request_meta(),
-        // Stable task fixture. Final advertisement is withheld until #951 is complete.
+        // Stable task fixture. Final Tasks remains an explicit server opt-in,
+        // which this general-purpose conformance server does not enable.
         build_create_task(),
         // Fixtures for the official 2026-07-28 conformance suite (#948)
         build_json_schema_2020_12(),

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -30,10 +30,10 @@ struct ReportInput {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // `Optional` lets one tool serve both worlds: a client that negotiated the
-    // extension may ask for a task, and everyone else gets the synchronous
-    // result. `Required` instead refuses callers that cannot take a task,
-    // answering with -32021 and naming the extension they need to declare.
+    // `Optional` lets one tool serve both worlds: the server returns a task
+    // when the extension is negotiated, while other clients get the
+    // synchronous result. `Required` instead refuses callers that cannot take
+    // a task, answering with -32021 and naming the extension they must declare.
     let build_report = ToolBuilder::new("build_report")
         .description("Crunch records into a report. Slow enough to be worth a task.")
         .task_support(TaskSupportMode::Optional)


### PR DESCRIPTION
## Summary

- split Tasks dispatch cleanly by protocol version: legacy callers keep the `task` request parameter, while 2026-07-28 rejects it and lets the server's `TaskSupportMode` policy elect tasks after extension negotiation
- expose required-task tools only to capable final clients and return the specified `-32021` required-capability error when support is missing
- make the client task-aware on ordinary final `tools/call`, with transparent completion plus an exact direct-lifecycle outcome and exact final `tasks/get` / `tasks/update` / `tasks/cancel` wire types
- preserve `resultType: "complete"` inside completed task results
- prove task ownership and cancellation across two independently constructed routers sharing one `TaskStore`
- update notification fixtures and documentation to the server-directed final model

## Verification

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo fmt --all -- --check`

Closes #951