### PR TITLE
ci(conformance): align stable suites on current harness

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  CONFORMANCE_VERSION: "0.2.0-alpha.10"
 
 jobs:
   server-conformance:
@@ -35,7 +36,7 @@ jobs:
 
       - name: Wait for server
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if nc -z 127.0.0.1 3001 2>/dev/null; then
               echo "Server is ready"
               exit 0
@@ -47,7 +48,12 @@ jobs:
           exit 1
 
       - name: Run conformance suite
-        run: npx @modelcontextprotocol/conformance@0.1.16 server --url http://127.0.0.1:3001/mcp --expected-failures ./conformance-baseline.yml
+        run: |
+          npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
+            --url http://127.0.0.1:3001/mcp \
+            --suite all \
+            --spec-version 2025-11-25 \
+            --expected-failures ./conformance-baseline.yml
 
       - name: Show server logs on failure
         if: failure()
@@ -72,7 +78,7 @@ jobs:
 
       - name: Wait for server
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if nc -z 127.0.0.1 3001 2>/dev/null; then
               echo "Server is ready"
               exit 0
@@ -226,8 +232,9 @@ jobs:
       - name: Run client conformance suite
         run: |
           # The empty baseline makes any regression fail immediately.
-          npx @modelcontextprotocol/conformance@0.1.16 client \
+          npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" client \
             --suite all \
+            --spec-version 2025-11-25 \
             --command "cargo run --manifest-path examples/conformance-client/Cargo.toml --" \
             --expected-failures ./conformance-baseline-client.yml
 
@@ -253,7 +260,7 @@ jobs:
 
       - name: Wait for server
         run: |
-          for i in $(seq 1 30); do
+          for _ in $(seq 1 30); do
             if nc -z 127.0.0.1 3001 2>/dev/null; then
               echo "Server is ready"
               exit 0
@@ -271,7 +278,7 @@ jobs:
           # including stateless requests, caching, header validation, and
           # the 14 MRTR input-required-result scenarios. The empty baseline
           # keeps CI strict if a regression appears.
-          npx @modelcontextprotocol/conformance@0.2.0-alpha.10 server \
+          npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" server \
             --url http://127.0.0.1:3001/mcp \
             --spec-version 2026-07-28 \
             --suite all \
@@ -306,7 +313,7 @@ jobs:
           # Actions default bash already sets it; stated here because the
           # gating depends on it).
           set -o pipefail
-          npx @modelcontextprotocol/conformance@0.2.0-alpha.10 client \
+          npx -y "@modelcontextprotocol/conformance@${CONFORMANCE_VERSION}" client \
             --suite all \
             --spec-version 2026-07-28 \
             --command "cargo run --manifest-path examples/conformance-client/Cargo.toml --" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,5 +39,5 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for build commands, PR guidelines, and co
 - `crates/tower-mcp-macros/src/` - Optional proc macros
 - `examples/` - Example servers and clients (23 standalone `.rs` files)
   - `codegen-mcp/` - MCP server builder (generates tower-mcp code)
-  - `conformance-server/` - MCP spec conformance tests (39/39)
+  - `conformance-server/` - MCP spec conformance tests (48/48 stable; 114/114 final)
   - `conformance-client/` - MCP conformance client (265/265 checks)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/crates/l/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp#license)
 [![MSRV](https://img.shields.io/crates/msrv/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp)
 [![MCP](https://img.shields.io/badge/MCP-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
-[![Conformance](https://img.shields.io/badge/conformance-39%2F39_server_%7C_311_client_checks-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
+[![Conformance](https://img.shields.io/badge/conformance-48%2F48_server_%7C_235_client_checks-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
 
 Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
 
@@ -38,7 +38,7 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 | **Tower-native middleware** | Timeout, rate-limit, auth, tracing -- on the whole server or on individual tools. Any `tower::Layer` works. |
 | **All transports** | stdio, HTTP/SSE (with stream resumption), WebSocket, and child process. Same router, any transport. |
 | **In-process testing** | `TestClient` lets you test MCP servers without spawning a subprocess or opening a socket. |
-| **Conformance** | 39/39 server checks and all 26 client scenarios (311 checks) for 2025-11-25 (`conformance@0.1.16`), plus 114/114 server checks and all 32 client scenarios (399 checks) for 2026-07-28 (`conformance@0.2.0-alpha.10`), run with empty baselines in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
+| **Conformance** | 48/48 server checks and all 18 client scenarios (235 checks) for 2025-11-25, plus 114/114 server checks and all 32 client scenarios (399 checks) for 2026-07-28, all on `conformance@0.2.0-alpha.10` with empty baselines in CI on every PR via the [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance). The suite is upstream-maintained and grows with the spec, so this is a moving target -- not a one-time achievement. [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes conformance scenarios a prerequisite for standards-track SEPs reaching `final`. |
 | **Capability filtering** | Session-based tool/resource/prompt visibility for multi-tenant patterns. |
 | **No proc macros required** | Builder pattern API with optional trait-based tools. Nothing hidden behind `#[derive]`. Optional `#[tool_fn]` / `#[prompt_fn]` / `#[resource_fn]` macros available for convenience (feature: `macros`). |
 | **Async tasks** | Full task lifecycle -- background execution, cancellation, TTL cleanup, per-tool task support mode. Clients can poll or wait for long-running tool results. |
@@ -587,12 +587,12 @@ let router = McpRouter::new()
 
 tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
-- **Server (2025-11-25):** 39/39 checks (`conformance@0.1.16`)
-- **Client (2025-11-25):** all 26 scenarios green, 311 checks (`conformance@0.1.16`); the client baseline is empty
+- **Server (2025-11-25):** 48/48 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
+- **Client (2025-11-25):** all 18 scenarios green, 235 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
 - **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
 - **Client (2026-07-28):** all 32 scenarios green, 399 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
 
-Because the suite is upstream-maintained and grows with the spec, these counts shift as new scenarios are added -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
+Both protocol revisions run on the same harness pin so the results are directly comparable with each other and with rmcp's current conformance workflow. Because the suite is upstream-maintained and grows with the spec, these counts shift as scenarios are added or version-gated -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 
 The `protocol-2026-07-28` feature enables the released, opt-in 2026-07-28
 protocol implementation (version-gated, behind

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@
 
 - **Version**: 0.16.x
 - **Spec version**: 2025-11-25 by default, plus the released 2026-07-28 protocol as an opt-in implementation behind `protocol-2026-07-28`
-- **Server conformance (2025-11-25)**: 39/39
-- **Client conformance (2025-11-25)**: 311/311 (empty baseline)
+- **Server conformance (2025-11-25)**: 48/48 (empty baseline)
+- **Client conformance (2025-11-25)**: 235/235 (empty baseline)
 - **Server conformance (2026-07-28)**: 114/114 (empty baseline)
 - **Client conformance (2026-07-28)**: 399/399 (empty baseline)
 - **MSRV**: 1.90 (Rust 2024 edition)
@@ -16,8 +16,8 @@ tower-mcp targets Tier 2 per the [MCP SDK Tiering System](https://modelcontextpr
 
 | # | Requirement | Status |
 |---|-------------|--------|
-| 1 | Server conformance >= 80% | 100% (39/39) |
-| 2 | Client conformance >= 80% | 311/311 stable; 399/399 final |
+| 1 | Server conformance >= 80% | 100% (48/48 stable; 114/114 final) |
+| 2 | Client conformance >= 80% | 235/235 stable; 399/399 final |
 | 3 | Issue triage within 1 month | Active |
 | 4 | P0 resolution within 2 weeks | 0 open |
 | 5 | Stable release >= 1.0.0 | 0.16.x -- pre-1.0 |

--- a/conformance-baseline-client.yml
+++ b/conformance-baseline-client.yml
@@ -1,9 +1,10 @@
 # MCP Conformance Suite -- Expected Failures Baseline (client, 2025-11-25)
 #
-# Applies to `@modelcontextprotocol/conformance@0.1.16 client --suite all`.
+# Applies to the 0.2.0-alpha.x suite run with
+# `client --spec-version 2025-11-25 --suite all`.
 # CI fails if any scenario regresses.
 #
-# Status at 0.1.16 after the authorization work: all 26 scenarios are green
-# (311 checks, zero failures or warnings).
+# Status at 0.2.0-alpha.10 after the authorization work: all 18 scenarios are
+# green (235 checks, zero failures or warnings).
 
 client: []

--- a/conformance-baseline.yml
+++ b/conformance-baseline.yml
@@ -1,7 +1,11 @@
 # MCP Conformance Suite -- Expected Failures Baseline
 #
-# All 39 tests currently pass. Add entries here if a conformance test
+# Applies to the 0.2.0-alpha.x suite run with
+# `server --spec-version 2025-11-25 --suite all`.
+#
+# All 48 checks currently pass. Add entries here if a conformance scenario
 # covers a feature that is intentionally unsupported or deferred.
 #
-# Format:
-#   - test_name: "reason for expected failure"
+# Format (0.2.x suite): plain scenario-name strings under the `server:` key.
+
+server: []

--- a/examples/README.md
+++ b/examples/README.md
@@ -127,8 +127,8 @@ These are standalone crates in the workspace:
 
 | Crate | Purpose |
 |-------|---------|
-| [conformance-server](conformance-server/) | MCP conformance server (39/39 stable; 114/114 final) |
-| [conformance-client](conformance-client/) | MCP conformance client (311/311 stable; 399/399 final) |
+| [conformance-server](conformance-server/) | MCP conformance server (48/48 stable; 114/114 final) |
+| [conformance-client](conformance-client/) | MCP conformance client (235/235 stable; 399/399 final) |
 | [codegen-mcp](codegen-mcp/) | MCP server that helps build MCP servers |
 
 ## Full Application

--- a/examples/conformance-client/src/auth_scenarios.rs
+++ b/examples/conformance-client/src/auth_scenarios.rs
@@ -459,18 +459,15 @@ async fn send_initial_mcp_probe(
                 }
             }));
     } else {
+        // Initialization is intentionally unauthenticated, so it cannot expose
+        // the resource's WWW-Authenticate scope hints. Probe a protected MCP
+        // operation instead; the authorization flow needs those hints before
+        // selecting its initial scope set.
         request = request.json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2025-11-25",
-                "capabilities": {},
-                "clientInfo": {
-                    "name": "conformance-client",
-                    "version": "0.1.0"
-                }
-            }
+            "method": "tools/list",
+            "params": {}
         }));
     }
 


### PR DESCRIPTION
## Summary

- pin all four official conformance jobs to `@modelcontextprotocol/conformance@0.2.0-alpha.10`
- make stable jobs select `2025-11-25 --suite all` explicitly and keep both baselines empty
- fix the stable OAuth probe so initial `WWW-Authenticate` scope hints are observed before bounded step-up
- refresh tracked conformance counts and explain the newer harness's version-gated scenario totals
- clean up pre-existing workflow shell-lint warnings in the touched readiness loops

## Results

| Protocol | Server | Client |
|---|---:|---:|
| 2025-11-25 | 48/48 | 235/235 |
| 2026-07-28 | 114/114 | 399/399 |

All four suites pass with zero failures/warnings and empty baselines.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `actionlint .github/workflows/conformance.yml`
- all four official server/client conformance suites locally

Closes #1100