### PR TITLE
test(interop): run rmcp 3.1 compatibility in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,3 +214,14 @@ jobs:
           cargo build -p mcp-repl
           cargo build --manifest-path examples/conformance-server/Cargo.toml
           cargo build --manifest-path examples/codegen-mcp/Cargo.toml
+
+  rmcp-compat:
+    name: rmcp 3.1 wire compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run differential compatibility harness
+        run: cargo run --locked -p rmcp-compat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -784,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1623,7 +1623,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2201,12 +2201,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0-beta.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13a8472324b3d6c74f092cc5d07b2707b128196b020ed7c3c2d52bede542680"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -2248,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2284,7 +2284,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2341,7 +2341,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2712,7 +2712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2880,7 +2880,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3689,7 +3689,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 tower-mcp = { path = "../../crates/tower-mcp", features = ["http"] }
-rmcp = { version = "3.0.0-beta.1", features = [
+rmcp = { version = "=3.1.0", features = [
     "server",
     "macros",
     "transport-streamable-http-server",

--- a/tools/rmcp-compat/README.md
+++ b/tools/rmcp-compat/README.md
@@ -8,9 +8,12 @@ each, and structurally compares the responses.
 
 The harness runs three in-process servers:
 
-- **rmcp** on port 4001 via `StreamableHttpService`
-- **tower-mcp** on port 4002 in default (bare JSON) mode
-- **tower-mcp SSE** on port 4003 with `.sse_responses(true)` to match rmcp's SSE wrapping
+- **rmcp** via `StreamableHttpService`
+- **tower-mcp** in default (bare JSON) mode
+- **tower-mcp SSE** with `.sse_responses(true)` to match rmcp's SSE wrapping
+
+Each server binds a separately reserved OS-assigned loopback port. Multiple
+harness processes can run concurrently without fixed-port collisions.
 
 It then runs a series of checks across all four operation groups:
 
@@ -33,8 +36,7 @@ It then runs a series of checks across all four operation groups:
 cargo run -p rmcp-compat
 ```
 
-The tool binds ports 4001, 4002, and 4003 on localhost. Make sure those ports
-are free before running.
+The selected loopback ports are printed at startup.
 
 ## Output format
 
@@ -69,7 +71,7 @@ Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)
 Known diffs are documented divergences that are intentional or explained. They
 appear as `[KNOWN-DIFF]` and do not cause a non-zero exit code.
 
-Current known diffs (against rmcp 3.0.0-beta.1):
+Current known diffs (verified against rmcp 3.1.0):
 
 **`error.message` phrasing for method-not-found:**
 rmcp returns just the method name (e.g. `"nonexistent/method"`); tower-mcp
@@ -92,7 +94,7 @@ A `tools/list` sent before `notifications/initialized` is rejected by tower-mcp
 with `-32600` (InvalidRequest) per #901. rmcp does not enforce this ordering and
 returns the tools list. tower-mcp is the stricter, more spec-compliant side, so
 this is a documented divergence rather than a tower-mcp bug. (With rmcp 1.7.0
-this surfaced as a FAIL; rmcp 2.1.0 and 3.0.0-beta.1 did not change the
+this surfaced as a FAIL; rmcp 2.1.0 and 3.1.0 did not change the
 behavior, so it is classified as a KNOWN-DIFF.)
 
 **SSE response wrapping (default mode):**
@@ -125,7 +127,7 @@ validates that the opt-in SSE mode matches rmcp's behavior exactly.
 Change the version constraint in `tools/rmcp-compat/Cargo.toml`:
 
 ```toml
-rmcp = { version = "3.0.0-beta.1", features = [...] }
+rmcp = { version = "=3.1.0", features = [...] }
 ```
 
 Then run the harness and update any KNOWN-DIFF entries that have changed.
@@ -135,13 +137,9 @@ Note the 1.x -> 2.x jump renamed `rmcp::model::Content` to
 `StreamableHttpService`, `LocalSessionManager`, `ServerHandler`, and the
 `#[tool]`/`#[tool_router]`/`#[tool_handler]` macro surfaces were unchanged.
 
-The 2.x -> 3.x jump (3.0.0-beta.1 implements the 2026-07-28 SEP batch)
-required no harness code changes: the harness does not use the surfaces that
-broke (Meta type split, `CallToolResult.structured_content` widening,
-`Annotations.last_modified`, the removed experimental tasks API). The
-`StreamableHttpServerConfig.stateful_mode` field was renamed
-`legacy_session_mode`; the harness uses `StreamableHttpServerConfig::default()`
-and the default remains `legacy_session_mode: true`, so rmcp still serves the
-2025-11-25 session-based flow that the harness exercises. rmcp 3.x dispatches
-the 2026-07-28 stateless protocol per-request, so requests negotiating
-`2025-11-25` behave as before.
+The 2.x -> 3.1 jump required no harness API changes: the harness does not use
+the surfaces that broke (Meta type split, `CallToolResult.structured_content`
+widening, `Annotations.last_modified`, or the removed experimental tasks API).
+The harness uses `StreamableHttpServerConfig::default()`, whose legacy-session
+mode serves the 2025-11-25 flow exercised here. Final-protocol interoperability
+is tracked separately in #1102.

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -3,9 +3,8 @@
 //! Starts both servers in-process as tokio tasks, fires identical MCP JSON-RPC
 //! requests at each, and structurally compares the responses.
 //!
-//! rmcp server: port 4001 (path: /mcp/)
-//! tower-mcp server: port 4002 (path: /)
-//! tower-mcp SSE mode server: port 4003 (path: /)
+//! Each server binds an OS-assigned loopback port so concurrent local and CI
+//! runs cannot collide.
 //!
 //! Run with:
 //!   cargo run -p rmcp-compat
@@ -13,6 +12,7 @@
 use anyhow::Result;
 use serde::Serialize;
 use serde_json::Value;
+use std::sync::atomic::{AtomicU16, Ordering};
 use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
 
 // ============================================================
@@ -24,7 +24,7 @@ struct EchoInput {
     message: String,
 }
 
-async fn start_tower_mcp_server(port: u16) {
+async fn start_tower_mcp_server(listener: tokio::net::TcpListener) {
     let echo = ToolBuilder::new("echo")
         .description("Echo a message back")
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
@@ -34,10 +34,9 @@ async fn start_tower_mcp_server(port: u16) {
         .server_info("tower-mcp-compat-test", "0.1.0")
         .tool(echo);
 
-    let addr = format!("127.0.0.1:{port}");
     let transport = HttpTransport::new(router).disable_origin_validation();
 
-    if let Err(e) = transport.serve(&addr).await {
+    if let Err(e) = axum::serve(listener, transport.into_router()).await {
         eprintln!("tower-mcp server error: {e}");
     }
 }
@@ -46,7 +45,7 @@ async fn start_tower_mcp_server(port: u16) {
 // tower-mcp server (SSE mode -- mirrors rmcp's SSE wrapping)
 // ============================================================
 
-async fn start_tower_mcp_sse_server(port: u16) {
+async fn start_tower_mcp_sse_server(listener: tokio::net::TcpListener) {
     let echo = ToolBuilder::new("echo")
         .description("Echo a message back")
         .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
@@ -56,12 +55,11 @@ async fn start_tower_mcp_sse_server(port: u16) {
         .server_info("tower-mcp-compat-test-sse", "0.1.0")
         .tool(echo);
 
-    let addr = format!("127.0.0.1:{port}");
     let transport = HttpTransport::new(router)
         .disable_origin_validation()
         .sse_responses(true);
 
-    if let Err(e) = transport.serve(&addr).await {
+    if let Err(e) = axum::serve(listener, transport.into_router()).await {
         eprintln!("tower-mcp SSE server error: {e}");
     }
 }
@@ -118,7 +116,7 @@ mod rmcp_server {
     }
 }
 
-async fn start_rmcp_server(port: u16) {
+async fn start_rmcp_server(listener: tokio::net::TcpListener) {
     use rmcp::transport::streamable_http_server::{
         StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
     };
@@ -130,8 +128,6 @@ async fn start_rmcp_server(port: u16) {
     );
 
     let axum_router = axum::Router::new().nest_service("/mcp", service);
-    let addr = format!("127.0.0.1:{port}");
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     if let Err(e) = axum::serve(listener, axum_router).await {
         eprintln!("rmcp server error: {e}");
     }
@@ -143,35 +139,43 @@ async fn start_rmcp_server(port: u16) {
 
 struct ServerConfig {
     name: &'static str,
-    port: u16,
+    port: &'static AtomicU16,
     path: &'static str,
 }
 
 impl ServerConfig {
+    fn port(&self) -> u16 {
+        self.port.load(Ordering::Relaxed)
+    }
+
     fn url(&self) -> String {
-        format!("http://127.0.0.1:{}{}", self.port, self.path)
+        format!("http://127.0.0.1:{}{}", self.port(), self.path)
     }
 
     fn display_name(&self) -> String {
-        format!("{} (port {})", self.name, self.port)
+        format!("{} (port {})", self.name, self.port())
     }
 }
 
+static RMCP_PORT: AtomicU16 = AtomicU16::new(0);
+static TOWER_MCP_PORT: AtomicU16 = AtomicU16::new(0);
+static TOWER_MCP_SSE_PORT: AtomicU16 = AtomicU16::new(0);
+
 const RMCP: ServerConfig = ServerConfig {
     name: "rmcp",
-    port: 4001,
+    port: &RMCP_PORT,
     path: "/mcp/",
 };
 
 const TOWER_MCP: ServerConfig = ServerConfig {
     name: "tower-mcp",
-    port: 4002,
+    port: &TOWER_MCP_PORT,
     path: "/",
 };
 
 const TOWER_MCP_SSE: ServerConfig = ServerConfig {
     name: "tower-mcp-sse",
-    port: 4003,
+    port: &TOWER_MCP_SSE_PORT,
     path: "/",
 };
 
@@ -1167,7 +1171,7 @@ async fn check_invalid_params(
 /// Send tools/list WITHOUT the notifications/initialized step. tower-mcp rejects
 /// this with -32600 (InvalidRequest) per #901. rmcp does not enforce the ordering
 /// and returns the tools list, so this is a KNOWN-DIFF (tower-mcp is the stricter,
-/// more spec-compliant side), verified current as of rmcp 3.0.0-beta.1.
+/// more spec-compliant side), verified current as of rmcp 3.1.0.
 async fn check_initialized_enforcement(client: &reqwest::Client) -> Vec<CheckResult> {
     // Start fresh sessions without sending notifications/initialized
     let init_body = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"compat-enforcement-test","version":"0.1.0"}}}"#;
@@ -1403,9 +1407,17 @@ async fn check_sse_response_mode(
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tokio::spawn(start_tower_mcp_server(4002));
-    tokio::spawn(start_tower_mcp_sse_server(4003));
-    tokio::spawn(start_rmcp_server(4001));
+    let rmcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let tower_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let tower_sse_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+
+    RMCP_PORT.store(rmcp_listener.local_addr()?.port(), Ordering::Relaxed);
+    TOWER_MCP_PORT.store(tower_listener.local_addr()?.port(), Ordering::Relaxed);
+    TOWER_MCP_SSE_PORT.store(tower_sse_listener.local_addr()?.port(), Ordering::Relaxed);
+
+    tokio::spawn(start_rmcp_server(rmcp_listener));
+    tokio::spawn(start_tower_mcp_server(tower_listener));
+    tokio::spawn(start_tower_mcp_sse_server(tower_sse_listener));
 
     println!(
         "Waiting for servers: {}, {}, and {}...",
@@ -1419,15 +1431,18 @@ async fn main() -> Result<()> {
     let tower_sse_ready = wait_for_ready(&TOWER_MCP_SSE).await;
 
     if !rmcp_ready {
-        eprintln!("ERROR: rmcp server did not start on port 4001");
+        eprintln!("ERROR: {} did not become ready", RMCP.display_name());
         std::process::exit(1);
     }
     if !tower_ready {
-        eprintln!("ERROR: tower-mcp server did not start on port 4002");
+        eprintln!("ERROR: {} did not become ready", TOWER_MCP.display_name());
         std::process::exit(1);
     }
     if !tower_sse_ready {
-        eprintln!("ERROR: tower-mcp SSE server did not start on port 4003");
+        eprintln!(
+            "ERROR: {} did not become ready",
+            TOWER_MCP_SSE.display_name()
+        );
         std::process::exit(1);
     }
 


### PR DESCRIPTION
## Summary

- pin the differential harness to released `rmcp = 3.1.0` and refresh the lockfile
- re-audit the four existing known differences; the result remains 17/21 pass, 0 fail, 4 known differences, 0 errors
- reserve three OS-assigned listeners before server startup, eliminating fixed-port collisions
- run the actual `rmcp-compat` executable as a dedicated required CI job
- refresh the harness documentation and point final-protocol expansion to #1102

## Validation

- `cargo run --locked -p rmcp-compat`
- two concurrent `cargo run -p rmcp-compat` processes, both green on distinct ports
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `actionlint .github/workflows/ci.yml`
- `cargo metadata --locked --no-deps --format-version 1`

Closes #1101