### PR TITLE
ci(coverage): enforce an 80% workspace line floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    env:
+      COVERAGE_MIN_LINES: "80"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
@@ -168,6 +170,7 @@ jobs:
           cargo llvm-cov report --lcov --output-path lcov.info
           cargo llvm-cov report --json --summary-only --output-path coverage-summary.json
           cargo llvm-cov report > coverage.txt
+          cargo llvm-cov report --html --output-dir coverage-html
       - name: Write job summary
         run: |
           jq -r '
@@ -180,8 +183,8 @@ jobs:
           ' coverage-summary.json >> "$GITHUB_STEP_SUMMARY"
           {
             echo ""
-            echo "No threshold is enforced. \`lcov.info\` is attached to the run"
-            echo "as the \`coverage\` artifact."
+            echo "Line coverage must remain at or above ${COVERAGE_MIN_LINES}%."
+            echo "Detailed reports are attached to the run as the \`coverage\` artifact."
             echo ""
             echo "<details><summary>Per-file coverage</summary>"
             echo ""
@@ -192,12 +195,22 @@ jobs:
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
+        if: always()
         with:
           name: coverage
           path: |
             lcov.info
             coverage-summary.json
             coverage.txt
+            coverage-html/
+      - name: Enforce line coverage floor
+        run: |
+          measured="$(jq -r '.data[0].totals.lines.percent' coverage-summary.json)"
+          echo "Measured line coverage: ${measured}% (required: ${COVERAGE_MIN_LINES}%)"
+          if ! cargo llvm-cov report --fail-under-lines "${COVERAGE_MIN_LINES}"; then
+            echo "::error title=Line coverage below ${COVERAGE_MIN_LINES}%::Measured line coverage ${measured}% is below the required ${COVERAGE_MIN_LINES}% floor."
+            exit 1
+          fi
 
   examples:
     name: Examples

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,22 @@ cargo test --workspace --doc --all-features
 
 All of these must pass before submitting a PR.
 
+## Coverage
+
+CI enforces an 80% workspace line-coverage floor. Install the required stable
+toolchain components and
+[`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov), then reproduce
+the gate locally with the same test and feature scope:
+
+```bash
+rustup component add llvm-tools-preview
+cargo install cargo-llvm-cov --locked
+cargo llvm-cov --workspace --all-features --fail-under-lines 80
+```
+
+Region and function coverage remain informational. CI also publishes LCOV,
+JSON summary, text, and HTML reports in the `coverage` artifact.
+
 ## Fuzzing
 
 The JSON-RPC wire parser has a `cargo-fuzz` target that also runs on a weekly


### PR DESCRIPTION
## Summary

- enforce an explicit 80% workspace line-coverage floor in the existing `cargo llvm-cov` job
- keep line, region, and function reporting while gating only on lines
- publish LCOV, JSON summary, text, and HTML artifacts before the threshold check so diagnostics survive a coverage failure
- report both the measured percentage and required floor on failure
- document the exact local reproduction command and prerequisites

The current clean run measures **83.1189%** line coverage, leaving about 3.12 percentage points of margin.

## Validation

- `actionlint .github/workflows/ci.yml`
- `cargo fmt --all -- --check`
- clean `cargo llvm-cov --workspace --all-features --no-report` run
- generated and verified LCOV, JSON summary, text, and HTML reports
- `cargo llvm-cov report --fail-under-lines 80`

Closes #1104