### PR TITLE
test(interop): cover 2026-07-28 against rmcp 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
           cargo build --manifest-path examples/codegen-mcp/Cargo.toml
 
   rmcp-compat:
-    name: rmcp 3.1 wire compatibility
+    name: rmcp 3.1 stable + final wire compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2223,11 +2223,15 @@ impl McpRouter {
         extensions: &crate::context::Extensions,
         method: &str,
     ) -> Result<()> {
-        if self.final_tasks_enabled() && client_declares_tasks(extensions) {
-            Ok(())
-        } else {
-            Err(Error::JsonRpc(JsonRpcError::method_not_found(method)))
+        if !self.final_tasks_enabled() {
+            return Err(Error::JsonRpc(JsonRpcError::method_not_found(method)));
         }
+        if client_declares_tasks(extensions) {
+            return Ok(());
+        }
+        Err(Error::JsonRpc(
+            JsonRpcError::missing_required_client_capability(tasks_client_capabilities()),
+        ))
     }
 
     /// Verify the caller may act on this task.
@@ -4079,7 +4083,7 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, Error::JsonRpc(e) if e.code == -32602));
 
-        // Without the client declaration the methods remain absent.
+        // A server that advertises Tasks names the capability a client omitted.
         let error = router
             .handle(
                 RequestId::Number(6),
@@ -4091,7 +4095,14 @@ mod tests {
             )
             .await
             .unwrap_err();
-        assert!(matches!(error, Error::JsonRpc(e) if e.code == -32601));
+        let Error::JsonRpc(error) = error else {
+            panic!("expected a JSON-RPC error");
+        };
+        assert_eq!(error.code, -32021);
+        assert_eq!(
+            error.data.as_ref().unwrap()["requiredCapabilities"]["extensions"]["io.modelcontextprotocol/tasks"],
+            serde_json::json!({})
+        );
     }
 
     #[cfg(feature = "stateless")]
@@ -4727,8 +4738,31 @@ mod tests {
                 )
                 .await
                 .unwrap_err();
-            assert!(matches!(error, Error::JsonRpc(error) if error.code == -32601));
+            let Error::JsonRpc(error) = error else {
+                panic!("expected a JSON-RPC error");
+            };
+            assert_eq!(error.code, -32021);
+            assert_eq!(
+                error.data.as_ref().unwrap()["requiredCapabilities"]["extensions"]["io.modelcontextprotocol/tasks"],
+                serde_json::json!({})
+            );
         }
+
+        // If the server itself did not advertise the extension, the method is
+        // unavailable regardless of what the client declared.
+        let router_without_tasks = McpRouter::new();
+        let error = router_without_tasks
+            .handle(
+                RequestId::Number(7),
+                McpRequest::GetTaskInfo(GetTaskInfoParams {
+                    task_id: "task-unknown".to_string(),
+                    meta: None,
+                }),
+                final_extensions(tasks_client_capabilities()),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::JsonRpc(error) if error.code == -32601));
     }
 
     #[cfg(feature = "stateless")]

--- a/tools/rmcp-compat/Cargo.toml
+++ b/tools/rmcp-compat/Cargo.toml
@@ -10,7 +10,7 @@ name = "rmcp-compat"
 path = "src/main.rs"
 
 [dependencies]
-tower-mcp = { path = "../../crates/tower-mcp", features = ["http"] }
+tower-mcp = { path = "../../crates/tower-mcp", features = ["http", "protocol-2026-07-28"] }
 rmcp = { version = "=3.1.0", features = [
     "server",
     "macros",
@@ -18,7 +18,7 @@ rmcp = { version = "=3.1.0", features = [
     "transport-streamable-http-server-session",
     "schemars",
 ] }
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.13", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 schemars = "1.0"

--- a/tools/rmcp-compat/README.md
+++ b/tools/rmcp-compat/README.md
@@ -6,16 +6,19 @@ each, and structurally compares the responses.
 
 ## What it does
 
-The harness runs three in-process servers:
+The harness runs five in-process servers:
 
-- **rmcp** via `StreamableHttpService`
-- **tower-mcp** in default (bare JSON) mode
-- **tower-mcp SSE** with `.sse_responses(true)` to match rmcp's SSE wrapping
+- **rmcp stable** via `StreamableHttpService`
+- **tower-mcp stable** in default (bare JSON) mode
+- **tower-mcp stable SSE** with `.sse_responses(true)` to match rmcp's SSE wrapping
+- **rmcp final** in stateless, final-only mode
+- **tower-mcp final** with runtime support narrowed to `2026-07-28`
 
 Each server binds a separately reserved OS-assigned loopback port. Multiple
 harness processes can run concurrently without fixed-port collisions.
 
-It then runs a series of checks across all four operation groups:
+The output separates the stable and final protocol revisions. Stable coverage
+checks the established session lifecycle and common method shapes:
 
 | Check | What is verified |
 |-------|-----------------|
@@ -30,6 +33,18 @@ It then runs a series of checks across all four operation groups:
 | `initialized-enforcement` | tower-mcp rejects requests before `notifications/initialized` with `-32600` (per #901); rmcp does not enforce this ordering, so the divergence is a KNOWN-DIFF |
 | `sse-response-mode` | With `.sse_responses(true)`, both return `text/event-stream` with valid JSON-RPC |
 
+Final `2026-07-28` coverage exercises the released stateless lifecycle and
+extension surfaces:
+
+| Check | What is verified |
+|-------|-----------------|
+| `server/discover` | HTTP 200 without a session; final version advertisement; `resultType`; required cache fields; server identity in result metadata |
+| `stateless tools` | Repeated independent `tools/list` requests, no legacy session ID, and matching `tools/call` results |
+| `headers and metadata validation` | Required `Mcp-Method`/`Mcp-Name`, required per-request metadata, and unsupported-version rejection |
+| `subscriptions/listen` | Stateless SSE stream plus the mandatory first acknowledgment, subscription ID, and accepted filter |
+| `MRTR` | Matching `input_required` result followed by a byte-exact `requestState` retry and completion |
+| `Tasks extension` | Per-request extension negotiation, task creation, `tasks/get`, cancellation acknowledgment, and observable cancelled state |
+
 ## How to run
 
 ```
@@ -40,11 +55,12 @@ The selected loopback ports are printed at startup.
 
 ## Output format
 
-Each check prints one of three prefixes:
+Each check prints one of four prefixes:
 
 - **`[PASS]`** -- behavior matches between rmcp and tower-mcp for this property
 - **`[FAIL]`** -- unexpected divergence; investigate before releasing
 - **`[KNOWN-DIFF]`** -- documented behavioral difference; not a bug (see below)
+- **`[ERROR]`** -- the harness could not execute or parse the check
 
 A final summary line shows counts. The process exits with code 0 if there are
 no FAIL or ERROR results; known diffs and passes do not count against the exit
@@ -53,6 +69,8 @@ code.
 Example output:
 
 ```
+=== Stable protocol (2025-11-25) ===
+
 === initialize ===
 [PASS] initialize: protocolVersion present and equal (2025-11-25)
 [PASS] initialize: capabilities is object on both
@@ -63,7 +81,13 @@ Example output:
 [PASS] method-not-found: error.message is string on both
 [KNOWN-DIFF] method-not-found: error.message phrasing differs (both use -32601): ...
 
-Results: 17/21 checks passed (0 failed, 4 known-diffs, 0 errors)
+=== Final protocol (2026-07-28) ===
+
+=== server/discover ===
+[PASS] final-discover: server/discover returns HTTP 200 on both
+...
+
+Results: 40/44 checks passed (0 failed, 4 known-diffs, 0 errors)
 ```
 
 ## Known diffs
@@ -137,9 +161,10 @@ Note the 1.x -> 2.x jump renamed `rmcp::model::Content` to
 `StreamableHttpService`, `LocalSessionManager`, `ServerHandler`, and the
 `#[tool]`/`#[tool_router]`/`#[tool_handler]` macro surfaces were unchanged.
 
-The 2.x -> 3.1 jump required no harness API changes: the harness does not use
-the surfaces that broke (Meta type split, `CallToolResult.structured_content`
-widening, `Annotations.last_modified`, or the removed experimental tasks API).
-The harness uses `StreamableHttpServerConfig::default()`, whose legacy-session
-mode serves the 2025-11-25 flow exercised here. Final-protocol interoperability
-is tracked separately in #1102.
+The 2.x -> 3.1 jump enabled the final-protocol half of the harness. The stable
+rmcp server keeps the default legacy-session configuration. The final rmcp
+server disables legacy sessions, requires per-request protocol metadata, uses
+JSON for synchronous responses, and shares its task manager across stateless
+request handler instances. `tower-mcp` is compiled with
+`protocol-2026-07-28` and narrowed to that revision at runtime for the final
+server.

--- a/tools/rmcp-compat/src/main.rs
+++ b/tools/rmcp-compat/src/main.rs
@@ -11,9 +11,13 @@
 
 use anyhow::Result;
 use serde::Serialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 use std::sync::atomic::{AtomicU16, Ordering};
-use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+use std::time::Duration;
+use tower_mcp::{
+    CallToolResult, HttpTransport, InputRequiredResult, McpRouter, ProtocolSupport, RequestOutcome,
+    TaskSupportMode, ToolBuilder,
+};
 
 // ============================================================
 // tower-mcp server (standard mode)
@@ -22,6 +26,14 @@ use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct EchoInput {
     message: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct MrtrInput {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct SlowEchoInput {
+    delay_ms: u64,
 }
 
 async fn start_tower_mcp_server(listener: tokio::net::TcpListener) {
@@ -65,14 +77,70 @@ async fn start_tower_mcp_sse_server(listener: tokio::net::TcpListener) {
 }
 
 // ============================================================
+// tower-mcp server (2026-07-28 stateless final protocol)
+// ============================================================
+
+async fn start_tower_mcp_final_server(listener: tokio::net::TcpListener) {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a message back")
+        .handler(|input: EchoInput| async move { Ok(CallToolResult::text(input.message)) })
+        .build();
+
+    let mrtr = ToolBuilder::new("mrtr")
+        .description("Require one state-only retry before completing")
+        .mrtr_handler(|ctx, _input: MrtrInput| async move {
+            if ctx.request_state().is_none() {
+                Ok(RequestOutcome::InputRequired(
+                    InputRequiredResult::new().with_request_state("compat-mrtr-state"),
+                ))
+            } else if ctx.request_state() == Some("compat-mrtr-state") {
+                Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "mrtr complete",
+                )))
+            } else {
+                Err(tower_mcp::Error::invalid_params("unexpected requestState"))
+            }
+        })
+        .build();
+
+    let slow_echo = ToolBuilder::new("slow_echo")
+        .description("Complete asynchronously when the Tasks extension is negotiated")
+        .task_support(TaskSupportMode::Optional)
+        .handler(|input: SlowEchoInput| async move {
+            tokio::time::sleep(Duration::from_millis(input.delay_ms)).await;
+            Ok(CallToolResult::text("task complete"))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("tower-mcp-compat-final", "0.1.0")
+        .tool(echo)
+        .tool(mrtr)
+        .tool(slow_echo)
+        .with_tasks();
+
+    let transport = HttpTransport::new(router)
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).expect("known protocol"))
+        .disable_origin_validation();
+
+    if let Err(e) = axum::serve(listener, transport.into_router()).await {
+        eprintln!("tower-mcp final server error: {e}");
+    }
+}
+
+// ============================================================
 // rmcp server
 // ============================================================
 
 mod rmcp_server {
+    use std::borrow::Cow;
+
     use rmcp::{
-        ServerHandler,
+        ErrorData as McpError, ServerHandler,
         handler::server::{router::tool::ToolRouter, wrapper::Parameters},
         model::*,
+        service::{RequestContext, RoleServer},
+        task_manager::{TaskExit, TaskManager, TaskOptions},
         tool, tool_handler, tool_router,
     };
 
@@ -114,6 +182,162 @@ mod rmcp_server {
                 .with_protocol_version(ProtocolVersion::V_2025_11_25)
         }
     }
+
+    #[derive(Clone)]
+    pub struct FinalServer {
+        tool_router: ToolRouter<FinalServer>,
+        tasks: TaskManager,
+    }
+
+    #[tool_router]
+    impl FinalServer {
+        pub fn new() -> Self {
+            Self {
+                tool_router: Self::tool_router(),
+                tasks: TaskManager::new(),
+            }
+        }
+
+        #[tool(description = "Echo a message back")]
+        fn echo(
+            &self,
+            Parameters(EchoParams { message }): Parameters<EchoParams>,
+        ) -> Result<CallToolResult, McpError> {
+            Ok(CallToolResult::success(vec![ContentBlock::text(message)]))
+        }
+
+        #[tool(description = "Require one state-only retry before completing")]
+        fn mrtr(&self) -> Result<CallToolResult, McpError> {
+            // The custom dispatch below preserves InputRequiredResult; this
+            // definition exists so tools/list exposes a matching schema.
+            Ok(CallToolResult::success(vec![ContentBlock::text(
+                "mrtr complete",
+            )]))
+        }
+
+        #[tool(description = "Complete asynchronously when Tasks is negotiated")]
+        fn slow_echo(&self) -> Result<CallToolResult, McpError> {
+            // The custom dispatch below materializes the task after reading
+            // delay_ms directly from the request arguments.
+            Ok(CallToolResult::success(vec![ContentBlock::text(
+                "task complete",
+            )]))
+        }
+    }
+
+    impl ServerHandler for FinalServer {
+        async fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            context: RequestContext<RoleServer>,
+        ) -> Result<CallToolResponse, McpError> {
+            if request.name == "mrtr" {
+                return match request.request_state.as_deref() {
+                    None => Ok(InputRequiredResult::from_request_state("compat-mrtr-state").into()),
+                    Some("compat-mrtr-state") => {
+                        Ok(
+                            CallToolResult::success(vec![ContentBlock::text("mrtr complete")])
+                                .into(),
+                        )
+                    }
+                    Some(_) => Err(McpError::invalid_params("unexpected requestState", None)),
+                };
+            }
+
+            if request.name == "slow_echo"
+                && context
+                    .client_capabilities()
+                    .is_some_and(|caps| caps.supports_tasks())
+            {
+                let delay_ms = request
+                    .arguments
+                    .as_ref()
+                    .and_then(|args| args.get("delay_ms"))
+                    .and_then(serde_json::Value::as_u64)
+                    .ok_or_else(|| McpError::invalid_params("delay_ms is required", None))?;
+                let task = self.tasks.spawn(
+                    TaskOptions::new().with_poll_interval_ms(10),
+                    move |ctx| {
+                        Box::pin(async move {
+                            tokio::select! {
+                                _ = ctx.cancelled() => Err(TaskExit::Cancelled),
+                                _ = tokio::time::sleep(std::time::Duration::from_millis(delay_ms)) => {
+                                    Ok(CallToolResult::success(vec![ContentBlock::text("task complete")]))
+                                }
+                            }
+                        })
+                    },
+                );
+                return Ok(CallToolResponse::Task(CreateTaskResult::new(task)));
+            }
+
+            let call = rmcp::handler::server::tool::ToolCallContext::new(self, request, context);
+            self.tool_router.call(call).await
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<PaginatedRequestParams>,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<ListToolsResult, McpError> {
+            Ok(ListToolsResult {
+                tools: self.tool_router.list_all(),
+                ..Default::default()
+            })
+        }
+
+        fn get_tool(&self, name: &str) -> Option<Tool> {
+            self.tool_router.get(name).cloned()
+        }
+
+        async fn get_task(
+            &self,
+            request: GetTaskParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<GetTaskResult, McpError> {
+            Ok(GetTaskResult::new(self.tasks.get_task(&request.task_id)?))
+        }
+
+        async fn update_task(
+            &self,
+            request: UpdateTaskParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<(), McpError> {
+            self.tasks
+                .update_task(&request.task_id, request.input_responses)
+        }
+
+        async fn cancel_task(
+            &self,
+            request: CancelTaskParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<(), McpError> {
+            self.tasks.cancel_task(&request.task_id)
+        }
+
+        fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+            Cow::Owned(vec![ProtocolVersion::V_2026_07_28])
+        }
+
+        fn accepted_subscription_filter(
+            &self,
+            requested: &SubscriptionFilter,
+        ) -> Option<SubscriptionFilter> {
+            Some(requested.clone())
+        }
+
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(
+                ServerCapabilities::builder()
+                    .enable_tools()
+                    .enable_tool_list_changed()
+                    .enable_tasks()
+                    .build(),
+            )
+            .with_server_info(Implementation::new("rmcp-compat-final", "0.1.0"))
+            .with_protocol_version(ProtocolVersion::V_2026_07_28)
+        }
+    }
 }
 
 async fn start_rmcp_server(listener: tokio::net::TcpListener) {
@@ -130,6 +354,28 @@ async fn start_rmcp_server(listener: tokio::net::TcpListener) {
     let axum_router = axum::Router::new().nest_service("/mcp", service);
     if let Err(e) = axum::serve(listener, axum_router).await {
         eprintln!("rmcp server error: {e}");
+    }
+}
+
+async fn start_rmcp_final_server(listener: tokio::net::TcpListener) {
+    use rmcp::transport::streamable_http_server::{
+        StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+    };
+
+    let config = StreamableHttpServerConfig::default()
+        .with_legacy_session_mode(false)
+        .with_json_response(true)
+        .with_stateless_protocol_metadata_required(true);
+    let server = rmcp_server::FinalServer::new();
+    let service = StreamableHttpService::new(
+        move || Ok(server.clone()),
+        LocalSessionManager::default().into(),
+        config,
+    );
+
+    let axum_router = axum::Router::new().nest_service("/mcp", service);
+    if let Err(e) = axum::serve(listener, axum_router).await {
+        eprintln!("rmcp final server error: {e}");
     }
 }
 
@@ -160,6 +406,8 @@ impl ServerConfig {
 static RMCP_PORT: AtomicU16 = AtomicU16::new(0);
 static TOWER_MCP_PORT: AtomicU16 = AtomicU16::new(0);
 static TOWER_MCP_SSE_PORT: AtomicU16 = AtomicU16::new(0);
+static RMCP_FINAL_PORT: AtomicU16 = AtomicU16::new(0);
+static TOWER_MCP_FINAL_PORT: AtomicU16 = AtomicU16::new(0);
 
 const RMCP: ServerConfig = ServerConfig {
     name: "rmcp",
@@ -176,6 +424,18 @@ const TOWER_MCP: ServerConfig = ServerConfig {
 const TOWER_MCP_SSE: ServerConfig = ServerConfig {
     name: "tower-mcp-sse",
     port: &TOWER_MCP_SSE_PORT,
+    path: "/",
+};
+
+const RMCP_FINAL: ServerConfig = ServerConfig {
+    name: "rmcp-final",
+    port: &RMCP_FINAL_PORT,
+    path: "/mcp/",
+};
+
+const TOWER_MCP_FINAL: ServerConfig = ServerConfig {
+    name: "tower-mcp-final",
+    port: &TOWER_MCP_FINAL_PORT,
     path: "/",
 };
 
@@ -202,6 +462,7 @@ struct ServerResponse {
     body: Value,
     session_id: Option<String>,
     content_type: String,
+    status: u16,
 }
 
 async fn post_mcp(
@@ -209,6 +470,16 @@ async fn post_mcp(
     server: &ServerConfig,
     body: &str,
     session_id: Option<&str>,
+) -> Result<ServerResponse> {
+    post_mcp_with_headers(client, server, body, session_id, &[]).await
+}
+
+async fn post_mcp_with_headers(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    body: &str,
+    session_id: Option<&str>,
+    headers: &[(&str, &str)],
 ) -> Result<ServerResponse> {
     let mut req = client
         .post(server.url())
@@ -219,8 +490,12 @@ async fn post_mcp(
     if let Some(sid) = session_id {
         req = req.header("mcp-session-id", sid);
     }
+    for (name, value) in headers {
+        req = req.header(*name, *value);
+    }
 
     let resp = req.send().await?;
+    let status = resp.status().as_u16();
     let session_id = resp
         .headers()
         .get("mcp-session-id")
@@ -251,14 +526,125 @@ async fn post_mcp(
             .next()
             .ok_or_else(|| anyhow::anyhow!("no valid data: line in SSE body: {raw_body}"))?
     } else {
-        serde_json::from_slice(&bytes)
-            .map_err(|e| anyhow::anyhow!("JSON parse error: {e} | body: {raw_body}"))?
+        serde_json::from_slice(&bytes).unwrap_or_else(|_| json!({ "raw": raw_body }))
     };
     Ok(ServerResponse {
         body,
         session_id,
         content_type,
+        status,
     })
+}
+
+fn final_meta(tasks: bool) -> Value {
+    let extensions = if tasks {
+        json!({ "io.modelcontextprotocol/tasks": {} })
+    } else {
+        json!({})
+    };
+    json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientInfo": {
+            "name": "rmcp-compat-final-client",
+            "version": "0.1.0"
+        },
+        "io.modelcontextprotocol/clientCapabilities": {
+            "extensions": extensions
+        }
+    })
+}
+
+fn final_body(id: Value, method: &str, mut params: Value, tasks: bool) -> String {
+    params
+        .as_object_mut()
+        .expect("final request params must be an object")
+        .insert("_meta".to_string(), final_meta(tasks));
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": method,
+        "params": params
+    })
+    .to_string()
+}
+
+async fn post_final(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    method: &str,
+    name: Option<&str>,
+    body: &str,
+) -> Result<ServerResponse> {
+    let mut headers = vec![
+        ("mcp-protocol-version", "2026-07-28"),
+        ("mcp-method", method),
+    ];
+    if let Some(name) = name {
+        headers.push(("mcp-name", name));
+    }
+    post_mcp_with_headers(client, server, body, None, &headers).await
+}
+
+async fn post_final_stream_first_message(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    body: &str,
+) -> Result<ServerResponse> {
+    let mut resp = client
+        .post(server.url())
+        .header("content-type", "application/json")
+        .header("accept", "application/json, text/event-stream")
+        .header("mcp-protocol-version", "2026-07-28")
+        .header("mcp-method", "subscriptions/listen")
+        .body(body.to_string())
+        .send()
+        .await?;
+    let status = resp.status().as_u16();
+    let session_id = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|value| value.to_str().ok())
+        .map(str::to_owned);
+    let content_type = resp
+        .headers()
+        .get("content-type")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    let mut buffer = String::new();
+
+    loop {
+        let chunk = tokio::time::timeout(Duration::from_secs(3), resp.chunk())
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "{} timed out waiting for subscription acknowledgment (HTTP {status}, {content_type})",
+                    server.name
+                )
+            })??
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{} subscription stream ended before acknowledgment (HTTP {status}, {content_type}): {buffer}",
+                    server.name
+                )
+            })?;
+        buffer.push_str(&String::from_utf8_lossy(&chunk));
+        for line in buffer.lines() {
+            if let Some(data) = line.strip_prefix("data:") {
+                let data = data.trim();
+                if !data.is_empty()
+                    && let Ok(body) = serde_json::from_str::<Value>(data)
+                {
+                    return Ok(ServerResponse {
+                        body,
+                        session_id,
+                        content_type,
+                        status,
+                    });
+                }
+            }
+        }
+    }
 }
 
 // ============================================================
@@ -1402,6 +1788,710 @@ async fn check_sse_response_mode(
 }
 
 // ============================================================
+// 2026-07-28 final-protocol checks
+// ============================================================
+
+async fn final_pair(
+    client: &reqwest::Client,
+    method: &str,
+    name: Option<&str>,
+    body: &str,
+) -> Result<(ServerResponse, ServerResponse)> {
+    let rmcp = post_final(client, &RMCP_FINAL, method, name, body).await?;
+    let tower = post_final(client, &TOWER_MCP_FINAL, method, name, body).await?;
+    Ok((rmcp, tower))
+}
+
+async fn check_final_discover(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-discover";
+    let body = final_body(json!(101), "server/discover", json!({}), false);
+    let (rmcp, tower) = match final_pair(client, "server/discover", None, &body).await {
+        Ok(pair) => pair,
+        Err(error) => return vec![check_error(name, error.to_string())],
+    };
+    let mut results = Vec::new();
+
+    if rmcp.status == 200 && tower.status == 200 {
+        results.push(pass(name, "server/discover returns HTTP 200 on both"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "unexpected status: rmcp={}, tower-mcp={}",
+                rmcp.status, tower.status
+            ),
+        ));
+    }
+    if rmcp.session_id.is_none() && tower.session_id.is_none() {
+        results.push(pass(
+            name,
+            "neither stateless response creates an MCP session",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "final response exposed a session: rmcp={:?}, tower-mcp={:?}",
+                rmcp.session_id, tower.session_id
+            ),
+        ));
+    }
+
+    let rmcp_versions = rmcp.body["result"]["supportedVersions"].as_array();
+    let tower_versions = tower.body["result"]["supportedVersions"].as_array();
+    let supports_final = |versions: Option<&Vec<Value>>| {
+        versions.is_some_and(|versions| versions.iter().any(|v| v == "2026-07-28"))
+    };
+    if supports_final(rmcp_versions) && supports_final(tower_versions) {
+        results.push(pass(name, "both advertise 2026-07-28"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "final version missing: rmcp={:?}, tower-mcp={:?}",
+                rmcp_versions, tower_versions
+            ),
+        ));
+    }
+
+    let rmcp_result = &rmcp.body["result"];
+    let tower_result = &tower.body["result"];
+    if rmcp_result["resultType"] == "complete" && tower_result["resultType"] == "complete" {
+        results.push(pass(name, "resultType is complete on both"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "resultType mismatch: rmcp={}, tower-mcp={}",
+                rmcp_result["resultType"], tower_result["resultType"]
+            ),
+        ));
+    }
+    if rmcp_result["ttlMs"].is_number()
+        && tower_result["ttlMs"].is_number()
+        && rmcp_result["cacheScope"].is_string()
+        && tower_result["cacheScope"].is_string()
+    {
+        results.push(pass(name, "required cache metadata is present on both"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "cache metadata mismatch: rmcp ttl/scope={}/{}, tower-mcp ttl/scope={}/{}",
+                rmcp_result["ttlMs"],
+                rmcp_result["cacheScope"],
+                tower_result["ttlMs"],
+                tower_result["cacheScope"]
+            ),
+        ));
+    }
+    if rmcp_result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"].is_string()
+        && tower_result["_meta"]["io.modelcontextprotocol/serverInfo"]["name"].is_string()
+        && rmcp_result.get("serverInfo").is_none()
+        && tower_result.get("serverInfo").is_none()
+    {
+        results.push(pass(
+            name,
+            "server identity lives in result metadata on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!("serverInfo placement differs: rmcp={rmcp_result}, tower-mcp={tower_result}"),
+        ));
+    }
+    results
+}
+
+async fn check_final_stateless_tools(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-stateless-tools";
+    let list_body = final_body(json!(102), "tools/list", json!({}), false);
+    let first = final_pair(client, "tools/list", None, &list_body).await;
+    let second = final_pair(client, "tools/list", None, &list_body).await;
+    let ((rmcp_first, tower_first), (rmcp_second, tower_second)) = match (first, second) {
+        (Ok(first), Ok(second)) => (first, second),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    let mut results = Vec::new();
+    let has_echo = |response: &ServerResponse| {
+        response.body["result"]["tools"]
+            .as_array()
+            .is_some_and(|tools| tools.iter().any(|tool| tool["name"] == "echo"))
+    };
+    if [&rmcp_first, &tower_first, &rmcp_second, &tower_second]
+        .into_iter()
+        .all(has_echo)
+    {
+        results.push(pass(
+            name,
+            "independent tools/list requests succeed on both",
+        ));
+    } else {
+        results.push(fail(name, format!(
+            "one of the repeated tools/list requests omitted echo: rmcp first={}, tower first={}, rmcp second={}, tower second={}",
+            rmcp_first.body, tower_first.body, rmcp_second.body, tower_second.body
+        )));
+    }
+    if [&rmcp_first, &tower_first, &rmcp_second, &tower_second]
+        .into_iter()
+        .all(|response| response.session_id.is_none())
+    {
+        results.push(pass(
+            name,
+            "repeated requests remain stateless without session IDs",
+        ));
+    } else {
+        results.push(fail(name, "a repeated final request created a session ID"));
+    }
+
+    let call_body = final_body(
+        json!(103),
+        "tools/call",
+        json!({ "name": "echo", "arguments": { "message": "final hello" } }),
+        false,
+    );
+    let (rmcp_call, tower_call) =
+        match final_pair(client, "tools/call", Some("echo"), &call_body).await {
+            Ok(pair) => pair,
+            Err(error) => return vec![check_error(name, error.to_string())],
+        };
+    if rmcp_call.body["result"]["content"][0]["text"] == "final hello"
+        && tower_call.body["result"]["content"][0]["text"] == "final hello"
+    {
+        results.push(pass(
+            name,
+            "tools/call returns the same complete echo result",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "echo result differs: rmcp={}, tower-mcp={}",
+                rmcp_call.body, tower_call.body
+            ),
+        ));
+    }
+    results
+}
+
+async fn check_final_header_and_metadata_errors(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-validation";
+    let mut results = Vec::new();
+    let list_body = final_body(json!(104), "tools/list", json!({}), false);
+
+    let (rmcp, tower) = match (
+        post_mcp_with_headers(
+            client,
+            &RMCP_FINAL,
+            &list_body,
+            None,
+            &[("mcp-method", "tools/list")],
+        )
+        .await,
+        post_mcp_with_headers(
+            client,
+            &TOWER_MCP_FINAL,
+            &list_body,
+            None,
+            &[("mcp-method", "tools/list")],
+        )
+        .await,
+    ) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp.status == 400
+        && tower.status == 400
+        && rmcp.body["error"]["code"] == -32020
+        && tower.body["error"]["code"] == -32020
+    {
+        results.push(pass(
+            name,
+            "missing MCP-Protocol-Version is HTTP 400 / -32020 on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "missing MCP-Protocol-Version differs: rmcp={}/{}, tower-mcp={}/{}",
+                rmcp.status, rmcp.body, tower.status, tower.body
+            ),
+        ));
+    }
+
+    let (rmcp, tower) = match (
+        post_mcp_with_headers(
+            client,
+            &RMCP_FINAL,
+            &list_body,
+            None,
+            &[("mcp-protocol-version", "2026-07-28")],
+        )
+        .await,
+        post_mcp_with_headers(
+            client,
+            &TOWER_MCP_FINAL,
+            &list_body,
+            None,
+            &[("mcp-protocol-version", "2026-07-28")],
+        )
+        .await,
+    ) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp.status == 400
+        && tower.status == 400
+        && rmcp.body["error"]["code"] == -32020
+        && tower.body["error"]["code"] == -32020
+    {
+        results.push(pass(
+            name,
+            "missing Mcp-Method is HTTP 400 / -32020 on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "missing Mcp-Method differs: rmcp={}/{}, tower-mcp={}/{}",
+                rmcp.status, rmcp.body, tower.status, tower.body
+            ),
+        ));
+    }
+
+    let call_body = final_body(
+        json!(105),
+        "tools/call",
+        json!({ "name": "echo", "arguments": { "message": "hello" } }),
+        false,
+    );
+    let (rmcp, tower) = match (
+        post_mcp_with_headers(
+            client,
+            &RMCP_FINAL,
+            &call_body,
+            None,
+            &[
+                ("mcp-protocol-version", "2026-07-28"),
+                ("mcp-method", "tools/call"),
+            ],
+        )
+        .await,
+        post_mcp_with_headers(
+            client,
+            &TOWER_MCP_FINAL,
+            &call_body,
+            None,
+            &[
+                ("mcp-protocol-version", "2026-07-28"),
+                ("mcp-method", "tools/call"),
+            ],
+        )
+        .await,
+    ) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp.status == 400
+        && tower.status == 400
+        && rmcp.body["error"]["code"] == -32020
+        && tower.body["error"]["code"] == -32020
+    {
+        results.push(pass(name, "missing Mcp-Name is HTTP 400 / -32020 on both"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "missing Mcp-Name differs: rmcp={}/{}, tower-mcp={}/{}",
+                rmcp.status, rmcp.body, tower.status, tower.body
+            ),
+        ));
+    }
+
+    let missing_meta = json!({
+        "jsonrpc": "2.0",
+        "id": 106,
+        "method": "tools/list",
+        "params": {}
+    })
+    .to_string();
+    let (rmcp, tower) = match final_pair(client, "tools/list", None, &missing_meta).await {
+        Ok(pair) => pair,
+        Err(error) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp.status == 400
+        && tower.status == 400
+        && rmcp.body["error"]["code"] == -32602
+        && tower.body["error"]["code"] == -32602
+    {
+        results.push(pass(
+            name,
+            "missing required request metadata is HTTP 400 / -32602 on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "missing metadata differs: rmcp={}/{}, tower-mcp={}/{}",
+                rmcp.status, rmcp.body, tower.status, tower.body
+            ),
+        ));
+    }
+
+    let mut unsupported_meta = final_meta(false);
+    unsupported_meta["io.modelcontextprotocol/protocolVersion"] = json!("2099-01-01");
+    let unsupported_body = json!({
+        "jsonrpc": "2.0",
+        "id": 107,
+        "method": "tools/list",
+        "params": { "_meta": unsupported_meta }
+    })
+    .to_string();
+    let (rmcp, tower) = match (
+        post_mcp_with_headers(
+            client,
+            &RMCP_FINAL,
+            &unsupported_body,
+            None,
+            &[
+                ("mcp-protocol-version", "2099-01-01"),
+                ("mcp-method", "tools/list"),
+            ],
+        )
+        .await,
+        post_mcp_with_headers(
+            client,
+            &TOWER_MCP_FINAL,
+            &unsupported_body,
+            None,
+            &[
+                ("mcp-protocol-version", "2099-01-01"),
+                ("mcp-method", "tools/list"),
+            ],
+        )
+        .await,
+    ) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp.status >= 400 && tower.status >= 400 {
+        results.push(pass(
+            name,
+            format!(
+                "unsupported protocol version is rejected by both (rmcp HTTP {}, tower-mcp HTTP {})",
+                rmcp.status, tower.status
+            ),
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "unsupported version accepted: rmcp={}/{}, tower-mcp={}/{}",
+                rmcp.status, rmcp.body, tower.status, tower.body
+            ),
+        ));
+    }
+    results
+}
+
+async fn check_final_subscription(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-subscriptions";
+    let body = final_body(
+        json!("subscription-1"),
+        "subscriptions/listen",
+        json!({ "notifications": { "toolsListChanged": true } }),
+        false,
+    );
+    let (rmcp, tower) = match (
+        post_final_stream_first_message(client, &RMCP_FINAL, &body).await,
+        post_final_stream_first_message(client, &TOWER_MCP_FINAL, &body).await,
+    ) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    let mut results = Vec::new();
+    if rmcp.status == 200
+        && tower.status == 200
+        && rmcp.content_type.contains("text/event-stream")
+        && tower.content_type.contains("text/event-stream")
+        && rmcp.session_id.is_none()
+        && tower.session_id.is_none()
+    {
+        results.push(pass(name, "both open a stateless SSE response stream"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "stream setup differs: rmcp={}/{}/{:?}, tower-mcp={}/{}/{:?}",
+                rmcp.status,
+                rmcp.content_type,
+                rmcp.session_id,
+                tower.status,
+                tower.content_type,
+                tower.session_id
+            ),
+        ));
+    }
+    let is_ack = |response: &ServerResponse| {
+        response.body["method"] == "notifications/subscriptions/acknowledged"
+            && response.body["params"]["notifications"]["toolsListChanged"] == true
+            && response.body["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"]
+                == "subscription-1"
+    };
+    if is_ack(&rmcp) && is_ack(&tower) {
+        results.push(pass(
+            name,
+            "first stream event acknowledges the requested filter and ID",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "acknowledgment differs: rmcp={}, tower-mcp={}",
+                rmcp.body, tower.body
+            ),
+        ));
+    }
+    results
+}
+
+async fn check_final_mrtr(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-mrtr";
+    let first_body = final_body(
+        json!(108),
+        "tools/call",
+        json!({ "name": "mrtr", "arguments": {} }),
+        false,
+    );
+    let (rmcp_first, tower_first) =
+        match final_pair(client, "tools/call", Some("mrtr"), &first_body).await {
+            Ok(pair) => pair,
+            Err(error) => return vec![check_error(name, error.to_string())],
+        };
+    let mut results = Vec::new();
+    if rmcp_first.body["result"]["resultType"] == "input_required"
+        && tower_first.body["result"]["resultType"] == "input_required"
+        && rmcp_first.body["result"]["requestState"] == "compat-mrtr-state"
+        && tower_first.body["result"]["requestState"] == "compat-mrtr-state"
+    {
+        results.push(pass(
+            name,
+            "both return the same input_required continuation",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "input-required result differs: rmcp={}, tower-mcp={}",
+                rmcp_first.body, tower_first.body
+            ),
+        ));
+        return results;
+    }
+
+    let retry_body = final_body(
+        json!(109),
+        "tools/call",
+        json!({
+            "name": "mrtr",
+            "arguments": {},
+            "requestState": "compat-mrtr-state"
+        }),
+        false,
+    );
+    let (rmcp_retry, tower_retry) =
+        match final_pair(client, "tools/call", Some("mrtr"), &retry_body).await {
+            Ok(pair) => pair,
+            Err(error) => return vec![check_error(name, error.to_string())],
+        };
+    if rmcp_retry.body["result"]["content"][0]["text"] == "mrtr complete"
+        && tower_retry.body["result"]["content"][0]["text"] == "mrtr complete"
+    {
+        results.push(pass(
+            name,
+            "byte-exact requestState retry completes on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "MRTR retry differs: rmcp={}, tower-mcp={}",
+                rmcp_retry.body, tower_retry.body
+            ),
+        ));
+    }
+    results
+}
+
+async fn get_final_task(
+    client: &reqwest::Client,
+    server: &ServerConfig,
+    id: u64,
+    task_id: &str,
+    tasks: bool,
+) -> Result<ServerResponse> {
+    let body = final_body(json!(id), "tasks/get", json!({ "taskId": task_id }), tasks);
+    post_final(client, server, "tasks/get", Some(task_id), &body).await
+}
+
+async fn check_final_tasks(client: &reqwest::Client) -> Vec<CheckResult> {
+    let name = "final-tasks";
+    let unnegotiated = final_body(
+        json!(110),
+        "tasks/get",
+        json!({ "taskId": "not-a-task" }),
+        false,
+    );
+    let (rmcp_missing, tower_missing) =
+        match final_pair(client, "tasks/get", Some("not-a-task"), &unnegotiated).await {
+            Ok(pair) => pair,
+            Err(error) => return vec![check_error(name, error.to_string())],
+        };
+    let mut results = Vec::new();
+    if rmcp_missing.body["error"]["code"] == -32021 && tower_missing.body["error"]["code"] == -32021
+    {
+        results.push(pass(
+            name,
+            "tasks/get requires per-request Tasks negotiation on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "unnegotiated task error differs: rmcp={}, tower-mcp={}",
+                rmcp_missing.body, tower_missing.body
+            ),
+        ));
+    }
+
+    let create_body = final_body(
+        json!(111),
+        "tools/call",
+        json!({ "name": "slow_echo", "arguments": { "delay_ms": 1000 } }),
+        true,
+    );
+    let (rmcp_create, tower_create) =
+        match final_pair(client, "tools/call", Some("slow_echo"), &create_body).await {
+            Ok(pair) => pair,
+            Err(error) => return vec![check_error(name, error.to_string())],
+        };
+    let rmcp_task_id = rmcp_create.body["result"]["taskId"].as_str();
+    let tower_task_id = tower_create.body["result"]["taskId"].as_str();
+    let (Some(rmcp_task_id), Some(tower_task_id)) = (rmcp_task_id, tower_task_id) else {
+        results.push(fail(
+            name,
+            format!(
+                "task creation differs: rmcp={}, tower-mcp={}",
+                rmcp_create.body, tower_create.body
+            ),
+        ));
+        return results;
+    };
+    if rmcp_create.body["result"]["resultType"] == "task"
+        && tower_create.body["result"]["resultType"] == "task"
+    {
+        results.push(pass(name, "negotiated tools/call creates a task on both"));
+    } else {
+        results.push(fail(name, "task creation omitted resultType=task"));
+    }
+
+    let rmcp_get = get_final_task(client, &RMCP_FINAL, 112, rmcp_task_id, true).await;
+    let tower_get = get_final_task(client, &TOWER_MCP_FINAL, 112, tower_task_id, true).await;
+    let (rmcp_get, tower_get) = match (rmcp_get, tower_get) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp_get.body["result"]["taskId"] == rmcp_task_id
+        && tower_get.body["result"]["taskId"] == tower_task_id
+        && rmcp_get.body["result"]["status"].is_string()
+        && tower_get.body["result"]["status"].is_string()
+    {
+        results.push(pass(name, "tasks/get returns each created task"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "tasks/get differs: rmcp={}, tower-mcp={}",
+                rmcp_get.body, tower_get.body
+            ),
+        ));
+    }
+
+    let cancel = |id: u64, task_id: &str| {
+        final_body(
+            json!(id),
+            "tasks/cancel",
+            json!({ "taskId": task_id }),
+            true,
+        )
+    };
+    let rmcp_cancel_body = cancel(113, rmcp_task_id);
+    let tower_cancel_body = cancel(113, tower_task_id);
+    let rmcp_cancel = post_final(
+        client,
+        &RMCP_FINAL,
+        "tasks/cancel",
+        Some(rmcp_task_id),
+        &rmcp_cancel_body,
+    )
+    .await;
+    let tower_cancel = post_final(
+        client,
+        &TOWER_MCP_FINAL,
+        "tasks/cancel",
+        Some(tower_task_id),
+        &tower_cancel_body,
+    )
+    .await;
+    let (rmcp_cancel, tower_cancel) = match (rmcp_cancel, tower_cancel) {
+        (Ok(rmcp), Ok(tower)) => (rmcp, tower),
+        (Err(error), _) | (_, Err(error)) => return vec![check_error(name, error.to_string())],
+    };
+    if rmcp_cancel.body.get("error").is_none() && tower_cancel.body.get("error").is_none() {
+        results.push(pass(name, "tasks/cancel is acknowledged on both"));
+    } else {
+        results.push(fail(
+            name,
+            format!(
+                "tasks/cancel differs: rmcp={}, tower-mcp={}",
+                rmcp_cancel.body, tower_cancel.body
+            ),
+        ));
+    }
+
+    let mut rmcp_status = None;
+    let mut tower_status = None;
+    for attempt in 0..20 {
+        let rmcp_poll =
+            get_final_task(client, &RMCP_FINAL, 114 + attempt, rmcp_task_id, true).await;
+        let tower_poll =
+            get_final_task(client, &TOWER_MCP_FINAL, 114 + attempt, tower_task_id, true).await;
+        if let (Ok(rmcp), Ok(tower)) = (rmcp_poll, tower_poll) {
+            rmcp_status = rmcp.body["result"]["status"].as_str().map(str::to_owned);
+            tower_status = tower.body["result"]["status"].as_str().map(str::to_owned);
+            if rmcp_status.as_deref() == Some("cancelled")
+                && tower_status.as_deref() == Some("cancelled")
+            {
+                break;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    if rmcp_status.as_deref() == Some("cancelled") && tower_status.as_deref() == Some("cancelled") {
+        results.push(pass(
+            name,
+            "cancelled lifecycle state is observable on both",
+        ));
+    } else {
+        results.push(fail(
+            name,
+            format!("cancelled state differs: rmcp={rmcp_status:?}, tower-mcp={tower_status:?}"),
+        ));
+    }
+    results
+}
+
+// ============================================================
 // Main
 // ============================================================
 
@@ -1410,25 +2500,35 @@ async fn main() -> Result<()> {
     let rmcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let tower_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
     let tower_sse_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let rmcp_final_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let tower_final_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
 
     RMCP_PORT.store(rmcp_listener.local_addr()?.port(), Ordering::Relaxed);
     TOWER_MCP_PORT.store(tower_listener.local_addr()?.port(), Ordering::Relaxed);
     TOWER_MCP_SSE_PORT.store(tower_sse_listener.local_addr()?.port(), Ordering::Relaxed);
+    RMCP_FINAL_PORT.store(rmcp_final_listener.local_addr()?.port(), Ordering::Relaxed);
+    TOWER_MCP_FINAL_PORT.store(tower_final_listener.local_addr()?.port(), Ordering::Relaxed);
 
     tokio::spawn(start_rmcp_server(rmcp_listener));
     tokio::spawn(start_tower_mcp_server(tower_listener));
     tokio::spawn(start_tower_mcp_sse_server(tower_sse_listener));
+    tokio::spawn(start_rmcp_final_server(rmcp_final_listener));
+    tokio::spawn(start_tower_mcp_final_server(tower_final_listener));
 
     println!(
-        "Waiting for servers: {}, {}, and {}...",
+        "Waiting for servers: {}, {}, {}, {}, and {}...",
         RMCP.display_name(),
         TOWER_MCP.display_name(),
-        TOWER_MCP_SSE.display_name()
+        TOWER_MCP_SSE.display_name(),
+        RMCP_FINAL.display_name(),
+        TOWER_MCP_FINAL.display_name()
     );
 
     let rmcp_ready = wait_for_ready(&RMCP).await;
     let tower_ready = wait_for_ready(&TOWER_MCP).await;
     let tower_sse_ready = wait_for_ready(&TOWER_MCP_SSE).await;
+    let rmcp_final_ready = wait_for_ready(&RMCP_FINAL).await;
+    let tower_final_ready = wait_for_ready(&TOWER_MCP_FINAL).await;
 
     if !rmcp_ready {
         eprintln!("ERROR: {} did not become ready", RMCP.display_name());
@@ -1445,11 +2545,24 @@ async fn main() -> Result<()> {
         );
         std::process::exit(1);
     }
+    if !rmcp_final_ready {
+        eprintln!("ERROR: {} did not become ready", RMCP_FINAL.display_name());
+        std::process::exit(1);
+    }
+    if !tower_final_ready {
+        eprintln!(
+            "ERROR: {} did not become ready",
+            TOWER_MCP_FINAL.display_name()
+        );
+        std::process::exit(1);
+    }
 
     println!("All servers ready. Running checks...\n");
 
     let client = reqwest::Client::new();
     let mut all_results: Vec<CheckResult> = Vec::new();
+
+    println!("=== Stable protocol (2025-11-25) ===\n");
 
     // ---- Check 1: initialize (also extracts session IDs) ----
     println!("=== initialize ===");
@@ -1589,6 +2702,33 @@ async fn main() -> Result<()> {
     }
     all_results.extend(sse_results);
 
+    println!("\n=== Final protocol (2026-07-28) ===\n");
+
+    for (heading, results) in [
+        ("server/discover", check_final_discover(&client).await),
+        (
+            "stateless tools",
+            check_final_stateless_tools(&client).await,
+        ),
+        (
+            "headers and metadata validation",
+            check_final_header_and_metadata_errors(&client).await,
+        ),
+        (
+            "subscriptions/listen",
+            check_final_subscription(&client).await,
+        ),
+        ("MRTR", check_final_mrtr(&client).await),
+        ("Tasks extension", check_final_tasks(&client).await),
+    ] {
+        println!("=== {heading} ===");
+        for result in &results {
+            print_result(result);
+        }
+        all_results.extend(results);
+        println!();
+    }
+
     // ---- Summary ----
     let total = all_results.len();
     let passed = all_results
@@ -1607,7 +2747,6 @@ async fn main() -> Result<()> {
         .iter()
         .filter(|r| matches!(r.outcome, CheckOutcome::Error))
         .count();
-
     println!(
         "\nResults: {passed}/{total} checks passed ({failed} failed, {known_diffs} known-diffs, {errors} errors)"
     );


### PR DESCRIPTION
## Summary

- add final-only stateless rmcp and tower-mcp servers to the differential harness
- compare `server/discover`, repeated stateless tool requests, required protocol headers/metadata, unsupported versions, subscription SSE acknowledgments, MRTR retry behavior, and Tasks negotiation/lifecycle
- keep stable and final output explicitly separated and document the 40/44 result (the remaining four are existing stable known differences)
- fix final Tasks methods to return `-32021` with `requiredCapabilities` when the server advertises Tasks but the request does not, while retaining `-32601` when the server does not advertise the extension

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features`
- `cargo run --locked -p rmcp-compat` — 40/44 pass, 0 fail, 4 documented stable known-diffs, 0 errors
- `actionlint .github/workflows/ci.yml`

Closes #1102.
Closes #1108.