### PR TITLE
fix(oauth): harden resource server setup

### DIFF
--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -61,7 +61,7 @@ websocket = ["dep:axum", "dep:uuid"]
 unix = ["http"]
 childproc = []
 # OAuth 2.1 resource server support
-oauth = ["dep:jsonwebtoken", "http"]
+oauth = ["dep:jsonwebtoken", "http", "dep:url"]
 # JWKS endpoint fetching for JWT validation (requires oauth)
 jwks = ["oauth", "dep:reqwest"]
 # Test utilities for MCP servers

--- a/crates/tower-mcp/src/oauth/error.rs
+++ b/crates/tower-mcp/src/oauth/error.rs
@@ -63,7 +63,7 @@ impl OAuthError {
 
         // Add resource_metadata parameter if available
         if let Some(url) = resource_metadata_url {
-            parts.push(format!("resource_metadata=\"{}\"", url));
+            parts.push(auth_parameter("resource_metadata", url));
         }
 
         match self {
@@ -77,13 +77,13 @@ impl OAuthError {
             }
             OAuthError::InvalidToken { description } => {
                 parts.push("error=\"invalid_token\"".to_string());
-                parts.push(format!("error_description=\"{}\"", description));
+                parts.push(auth_parameter("error_description", description));
                 format!("Bearer {}", parts.join(", "))
             }
             OAuthError::InsufficientScope { required, .. } => {
                 parts.push("error=\"insufficient_scope\"".to_string());
                 if !required.is_empty() {
-                    parts.push(format!("scope=\"{}\"", required.join(" ")));
+                    parts.push(auth_parameter("scope", &required.join(" ")));
                 }
                 format!("Bearer {}", parts.join(", "))
             }
@@ -102,6 +102,27 @@ impl OAuthError {
             }
         }
     }
+}
+
+/// Encode a quoted `WWW-Authenticate` parameter without permitting header
+/// injection. Quotes and backslashes are escaped; control and non-ASCII
+/// characters are replaced with a space or `?` so the result is always a
+/// valid HTTP header value.
+fn auth_parameter(name: &str, value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '"' | '\\' => {
+                escaped.push('\\');
+                escaped.push(character);
+            }
+            '\t' => escaped.push(' '),
+            character if character.is_ascii_control() => escaped.push(' '),
+            character if !character.is_ascii() => escaped.push('?'),
+            character => escaped.push(character),
+        }
+    }
+    format!("{name}=\"{escaped}\"")
 }
 
 impl fmt::Display for OAuthError {
@@ -196,5 +217,20 @@ mod tests {
             OAuthError::InvalidAudience.to_string(),
             "token audience does not match"
         );
+    }
+
+    #[test]
+    fn test_www_authenticate_escapes_untrusted_parameters() {
+        let err = OAuthError::InvalidToken {
+            description: "bad\"\\token\r\nX-Injected: yes".to_string(),
+        };
+        let header =
+            err.www_authenticate(Some("https://example.com/metadata\"\r\nX-Resource: yes"));
+
+        assert!(!header.contains('\r'));
+        assert!(!header.contains('\n'));
+        assert!(header.contains("metadata\\\"  X-Resource"));
+        assert!(header.contains("bad\\\"\\\\token  X-Injected"));
+        assert!(header.parse::<http::HeaderValue>().is_ok());
     }
 }

--- a/crates/tower-mcp/src/oauth/metadata.rs
+++ b/crates/tower-mcp/src/oauth/metadata.rs
@@ -4,12 +4,51 @@
 //! to enable OAuth 2.1 client discovery of authorization servers.
 
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use url::Url;
+
+/// Errors returned when validating MCP Protected Resource Metadata.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum ProtectedResourceMetadataError {
+    /// The resource identifier is not a valid absolute URL.
+    #[error("invalid protected resource URL: {0}")]
+    InvalidResourceUrl(#[source] url::ParseError),
+
+    /// MCP HTTP resource identifiers must use HTTP or HTTPS.
+    #[error("protected resource URL must use http or https, got {0}")]
+    UnsupportedResourceScheme(String),
+
+    /// Resource identifiers cannot contain URL fragments.
+    #[error("protected resource URL must not contain a fragment")]
+    ResourceHasFragment,
+
+    /// MCP Protected Resource Metadata must advertise an authorization server.
+    #[error("protected resource metadata must advertise at least one authorization server")]
+    MissingAuthorizationServer,
+
+    /// An advertised authorization-server issuer is not a valid absolute URL.
+    #[error("invalid authorization server URL {url}: {source}")]
+    InvalidAuthorizationServerUrl {
+        /// The invalid issuer URL.
+        url: String,
+        /// The URL parsing failure.
+        #[source]
+        source: url::ParseError,
+    },
+
+    /// An advertised authorization-server issuer does not use HTTP(S).
+    #[error("authorization server URL must use http or https, got {0}")]
+    UnsupportedAuthorizationServerScheme(String),
+}
 
 /// Protected Resource Metadata per RFC 9728 Section 3.
 ///
 /// This metadata document tells OAuth clients which authorization server(s)
 /// to use and what scopes are available. It is served at
-/// `/.well-known/oauth-protected-resource` relative to the resource's base URL.
+/// the RFC 9728 well-known location for the resource URL. For a resource with
+/// a path, such as `https://example.com/mcp`, that location is
+/// `https://example.com/.well-known/oauth-protected-resource/mcp`.
 ///
 /// # Example
 ///
@@ -90,10 +129,76 @@ impl ProtectedResourceMetadata {
 
     /// Returns the well-known path for this metadata endpoint.
     ///
-    /// Per RFC 9728, the metadata is served at
-    /// `/.well-known/oauth-protected-resource` relative to the resource URL.
+    /// This is the prefix used for root resources. For resources with a path,
+    /// use [`Self::well_known_path_for_resource`].
     pub fn well_known_path() -> &'static str {
         "/.well-known/oauth-protected-resource"
+    }
+
+    /// Return the path-aware RFC 9728 well-known path for a resource URL.
+    ///
+    /// A resource at `https://example.com/mcp` maps to
+    /// `/.well-known/oauth-protected-resource/mcp`. Query and fragment
+    /// components are not copied to the metadata endpoint.
+    pub fn well_known_path_for_resource(
+        resource: &str,
+    ) -> Result<String, ProtectedResourceMetadataError> {
+        let url = Self::parse_resource_url(resource)?;
+        let resource_path = url.path();
+        if resource_path.is_empty() || resource_path == "/" {
+            Ok(Self::well_known_path().to_string())
+        } else {
+            Ok(format!("{}{}", Self::well_known_path(), resource_path))
+        }
+    }
+
+    /// Return the absolute RFC 9728 metadata URL for this resource.
+    pub fn well_known_url(&self) -> Result<String, ProtectedResourceMetadataError> {
+        let url = Self::parse_resource_url(&self.resource)?;
+        let path = Self::well_known_path_for_resource(&self.resource)?;
+        Ok(format!("{}{}", url.origin().ascii_serialization(), path))
+    }
+
+    /// Validate metadata required by an MCP OAuth resource server.
+    ///
+    /// This checks that the resource is an absolute HTTP(S) URL without a
+    /// fragment and that at least one valid authorization-server URL is
+    /// advertised.
+    pub fn validate(&self) -> Result<(), ProtectedResourceMetadataError> {
+        Self::parse_resource_url(&self.resource)?;
+        if self.authorization_servers.is_empty() {
+            return Err(ProtectedResourceMetadataError::MissingAuthorizationServer);
+        }
+        for issuer in &self.authorization_servers {
+            let url = Url::parse(issuer).map_err(|source| {
+                ProtectedResourceMetadataError::InvalidAuthorizationServerUrl {
+                    url: issuer.clone(),
+                    source,
+                }
+            })?;
+            if !matches!(url.scheme(), "http" | "https") {
+                return Err(
+                    ProtectedResourceMetadataError::UnsupportedAuthorizationServerScheme(
+                        url.scheme().to_string(),
+                    ),
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn parse_resource_url(resource: &str) -> Result<Url, ProtectedResourceMetadataError> {
+        let url =
+            Url::parse(resource).map_err(ProtectedResourceMetadataError::InvalidResourceUrl)?;
+        if !matches!(url.scheme(), "http" | "https") {
+            return Err(ProtectedResourceMetadataError::UnsupportedResourceScheme(
+                url.scheme().to_string(),
+            ));
+        }
+        if url.fragment().is_some() {
+            return Err(ProtectedResourceMetadataError::ResourceHasFragment);
+        }
+        Ok(url)
     }
 }
 
@@ -167,5 +272,53 @@ mod tests {
             .authorization_server("https://auth2.example.com");
 
         assert_eq!(metadata.authorization_servers.len(), 2);
+    }
+
+    #[test]
+    fn test_path_aware_well_known_location() {
+        let metadata = ProtectedResourceMetadata::new("https://mcp.example.com/tenant/mcp?x=1")
+            .authorization_server("https://auth.example.com");
+
+        assert_eq!(
+            metadata.well_known_url().unwrap(),
+            "https://mcp.example.com/.well-known/oauth-protected-resource/tenant/mcp"
+        );
+        assert_eq!(
+            ProtectedResourceMetadata::well_known_path_for_resource(&metadata.resource).unwrap(),
+            "/.well-known/oauth-protected-resource/tenant/mcp"
+        );
+    }
+
+    #[test]
+    fn test_path_aware_location_preserves_encoded_path_segments() {
+        let metadata = ProtectedResourceMetadata::new("https://mcp.example.com/a%2Fb")
+            .authorization_server("https://auth.example.com");
+        assert_eq!(
+            metadata.well_known_url().unwrap(),
+            "https://mcp.example.com/.well-known/oauth-protected-resource/a%2Fb"
+        );
+    }
+
+    #[test]
+    fn test_validate_requires_authorization_server() {
+        let error = ProtectedResourceMetadata::new("https://mcp.example.com")
+            .validate()
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ProtectedResourceMetadataError::MissingAuthorizationServer
+        ));
+    }
+
+    #[test]
+    fn test_validate_rejects_resource_fragment() {
+        let error = ProtectedResourceMetadata::new("https://mcp.example.com#fragment")
+            .authorization_server("https://auth.example.com")
+            .validate()
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ProtectedResourceMetadataError::ResourceHasFragment
+        ));
     }
 }

--- a/crates/tower-mcp/src/oauth/middleware.rs
+++ b/crates/tower-mcp/src/oauth/middleware.rs
@@ -20,13 +20,14 @@ use super::token::TokenValidator;
 /// Tower layer that wraps services with OAuth 2.1 bearer token validation.
 ///
 /// Applies [`OAuthService`] middleware that extracts and validates bearer
-/// tokens from the `Authorization` header. On successful validation, injects
+/// tokens from the `Authorization` header and requires the token audience to
+/// contain the metadata resource identifier. On successful validation, injects
 /// [`TokenClaims`](super::token::TokenClaims) into request extensions for downstream handlers.
 ///
 /// # Example
 ///
 /// ```rust,no_run
-/// use tower_mcp::oauth::{OAuthLayer, JwtValidator, ProtectedResourceMetadata, ScopePolicy};
+/// use tower_mcp::oauth::{OAuthLayer, JwtValidator, ProtectedResourceMetadata};
 ///
 /// let validator = JwtValidator::from_secret(b"my-secret");
 /// let metadata = ProtectedResourceMetadata::new("https://mcp.example.com")
@@ -45,15 +46,21 @@ pub struct OAuthLayer<V: TokenValidator> {
 impl<V: TokenValidator> OAuthLayer<V> {
     /// Create a new OAuth layer with the given token validator and metadata.
     pub fn new(validator: V, metadata: ProtectedResourceMetadata) -> Self {
+        let metadata_path =
+            ProtectedResourceMetadata::well_known_path_for_resource(&metadata.resource)
+                .unwrap_or_else(|_| ProtectedResourceMetadata::well_known_path().to_string());
         Self {
             validator,
             metadata,
             scope_policy: ScopePolicy::new(),
-            public_paths: vec![ProtectedResourceMetadata::well_known_path().to_string()],
+            public_paths: vec![metadata_path],
         }
     }
 
-    /// Set the scope policy for per-operation scope enforcement.
+    /// Set the default HTTP-level scope policy.
+    ///
+    /// Use [`ScopeEnforcementLayer`](super::ScopeEnforcementLayer), or the
+    /// transport's `into_oauth_router` helper, for tool/resource/prompt scopes.
     pub fn scope_policy(mut self, policy: ScopePolicy) -> Self {
         self.scope_policy = policy;
         self
@@ -61,7 +68,8 @@ impl<V: TokenValidator> OAuthLayer<V> {
 
     /// Add a path that does not require authentication.
     ///
-    /// The `/.well-known/oauth-protected-resource` path is always public.
+    /// The resource's exact RFC 9728 metadata path is always public. Custom
+    /// public paths are also matched exactly, not as prefixes.
     pub fn public_path(mut self, path: impl Into<String>) -> Self {
         self.public_paths.push(path.into());
         self
@@ -89,9 +97,10 @@ impl<S, V: TokenValidator> Layer<S> for OAuthLayer<V> {
 /// 1. Checks if the request path is public (skips validation)
 /// 2. Extracts the `Authorization: Bearer <token>` header
 /// 3. Validates the token via [`TokenValidator`]
-/// 4. Checks default scope requirements via [`ScopePolicy`]
-/// 5. On success, injects [`TokenClaims`](super::token::TokenClaims) into request extensions
-/// 6. On failure, returns the appropriate HTTP error with `WWW-Authenticate`
+/// 4. Checks that the token audience contains the protected resource identifier
+/// 5. Checks default scope requirements via [`ScopePolicy`]
+/// 6. On success, injects [`TokenClaims`](super::token::TokenClaims) into request extensions
+/// 7. On failure, returns the appropriate HTTP error with `WWW-Authenticate`
 #[derive(Clone)]
 pub struct OAuthService<S, V: TokenValidator> {
     inner: S,
@@ -126,12 +135,7 @@ where
 
         Box::pin(async move {
             // Skip validation for public paths
-            if public_paths.iter().any(|p| path.starts_with(p.as_str())) {
-                return inner.oneshot(req).await;
-            }
-
-            // Also skip well-known paths that may be nested under a mount point
-            if path.contains("/.well-known/") {
+            if public_paths.contains(&path) {
                 return inner.oneshot(req).await;
             }
 
@@ -143,25 +147,42 @@ where
                 .and_then(|s| s.strip_prefix("Bearer "))
                 .map(|t| t.trim().to_string());
 
-            let resource_metadata_url =
-                format!("{}/.well-known/oauth-protected-resource", metadata.resource);
+            let resource_metadata_url = metadata.well_known_url().ok();
 
             let Some(token) = token else {
                 let error = OAuthError::MissingToken;
-                return Ok(oauth_error_response(&error, Some(&resource_metadata_url)));
+                return Ok(oauth_error_response(
+                    &error,
+                    resource_metadata_url.as_deref(),
+                ));
             };
 
             // Validate token
             let claims = match validator.validate_token(&token).await {
                 Ok(claims) => claims,
                 Err(error) => {
-                    return Ok(oauth_error_response(&error, Some(&resource_metadata_url)));
+                    return Ok(oauth_error_response(
+                        &error,
+                        resource_metadata_url.as_deref(),
+                    ));
                 }
             };
 
+            // Enforce the canonical MCP resource audience independently of
+            // the underlying JWT, introspection, or opaque-token validator.
+            if !claims.audience_matches(&metadata.resource) {
+                return Ok(oauth_error_response(
+                    &OAuthError::InvalidAudience,
+                    resource_metadata_url.as_deref(),
+                ));
+            }
+
             // Check default scope requirements
             if let Err(error) = scope_policy.check_default(&claims) {
-                return Ok(oauth_error_response(&error, Some(&resource_metadata_url)));
+                return Ok(oauth_error_response(
+                    &error,
+                    resource_metadata_url.as_deref(),
+                ));
             }
 
             // Inject claims into request extensions
@@ -246,6 +267,21 @@ mod tests {
     }
 
     fn make_token(claims: &serde_json::Value) -> String {
+        let mut claims = claims.clone();
+        claims
+            .as_object_mut()
+            .unwrap()
+            .entry("aud")
+            .or_insert_with(|| serde_json::json!("https://mcp.example.com"));
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            &claims,
+            &jsonwebtoken::EncodingKey::from_secret(b"test-secret"),
+        )
+        .unwrap()
+    }
+
+    fn make_token_without_default_audience(claims: &serde_json::Value) -> String {
         jsonwebtoken::encode(
             &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
             claims,
@@ -325,6 +361,85 @@ mod tests {
 
         let resp = service.ready().await.unwrap().call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_public_paths_are_exact() {
+        let layer = OAuthLayer::new(test_validator(), test_metadata()).public_path("/health");
+        let mut service = layer.layer(OkService);
+
+        for path in ["/health/private", "/.well-known/not-oauth"] {
+            let req = Request::builder().uri(path).body(Body::empty()).unwrap();
+            let resp = service.ready().await.unwrap().call(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "path: {path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_missing_or_wrong_audience_is_rejected() {
+        let layer = OAuthLayer::new(test_validator(), test_metadata());
+        let mut service = layer.layer(OkService);
+
+        for claims in [
+            serde_json::json!({"sub": "user"}),
+            serde_json::json!({"sub": "user", "aud": "https://other.example.com"}),
+        ] {
+            let token = make_token_without_default_audience(&claims);
+            let req = Request::builder()
+                .uri("/mcp")
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap();
+            let resp = service.ready().await.unwrap().call(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_path_resource_uses_path_aware_metadata_url_and_public_route() {
+        let metadata = ProtectedResourceMetadata::new("https://mcp.example.com/tenant/mcp")
+            .authorization_server("https://auth.example.com");
+        let layer = OAuthLayer::new(test_validator(), metadata);
+        let mut service = layer.layer(OkService);
+
+        let public = Request::builder()
+            .uri("/.well-known/oauth-protected-resource/tenant/mcp")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            service
+                .ready()
+                .await
+                .unwrap()
+                .call(public)
+                .await
+                .unwrap()
+                .status(),
+            StatusCode::OK
+        );
+
+        let protected = Request::builder()
+            .uri("/tenant/mcp")
+            .body(Body::empty())
+            .unwrap();
+        let response = service
+            .ready()
+            .await
+            .unwrap()
+            .call(protected)
+            .await
+            .unwrap();
+        let challenge = response
+            .headers()
+            .get("WWW-Authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(
+            challenge.contains(
+                "https://mcp.example.com/.well-known/oauth-protected-resource/tenant/mcp"
+            )
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/oauth/mod.rs
+++ b/crates/tower-mcp/src/oauth/mod.rs
@@ -1,7 +1,7 @@
 //! OAuth 2.1 resource server support for MCP.
 //!
 //! This module implements the resource server side of OAuth 2.1 as specified
-//! in the MCP 2025-11-25 authentication specification. The MCP server acts as
+//! in the MCP authorization specification. The MCP server acts as
 //! a **resource server** -- it validates tokens issued by an external
 //! authorization server and serves Protected Resource Metadata for discovery.
 //!
@@ -27,7 +27,7 @@
 //! ```rust,no_run
 //! use tower_mcp::{McpRouter, HttpTransport, ToolBuilder, CallToolResult};
 //! use tower_mcp::oauth::{
-//!     ProtectedResourceMetadata, JwtValidator, OAuthLayer, ScopePolicy,
+//!     ProtectedResourceMetadata, JwtValidator, ScopePolicy,
 //! };
 //!
 //! #[tokio::main]
@@ -59,16 +59,11 @@
 //!     let policy = ScopePolicy::new()
 //!         .default_scope("mcp:read");
 //!
-//!     // Build OAuth middleware layer
-//!     let oauth = OAuthLayer::new(validator, metadata.clone())
-//!         .scope_policy(policy);
-//!
-//!     // Build transport with metadata endpoint
-//!     let transport = HttpTransport::new(router)
-//!         .oauth(metadata);
-//!
-//!     // Apply OAuth middleware to the axum router
-//!     let app = transport.into_router().layer(oauth);
+//!     // Build a complete, fail-closed resource server. This validates and
+//!     // serves metadata, checks bearer tokens and audience, and applies both
+//!     // default and per-operation scope policy.
+//!     let app = HttpTransport::new(router)
+//!         .into_oauth_router(validator, metadata, policy)?;
 //!
 //!     let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
 //!     axum::serve(listener, app).await?;
@@ -76,11 +71,27 @@
 //! }
 //! ```
 //!
+//! # Middleware order and scope levels
+//!
+//! [`HttpTransport::into_oauth_router`](crate::HttpTransport::into_oauth_router)
+//! is the recommended setup because it fixes the security-sensitive order:
+//! [`OAuthLayer`] is the outer HTTP middleware, the transport bridges validated
+//! [`TokenClaims`] into MCP request extensions, and [`ScopeEnforcementLayer`]
+//! runs inside the MCP router. The HTTP layer's policy checks scopes that apply
+//! to every request; the router layer additionally selects tool-, resource-,
+//! and prompt-specific requirements from the same [`ScopePolicy`].
+//!
+//! For a custom composition, preserve that order and serve
+//! [`ProtectedResourceMetadata`] outside authentication. The scope layer is
+//! fail closed by default; its explicitly named permissive constructor is only
+//! for applications that intentionally mix authenticated and anonymous MCP
+//! operations.
+//!
 //! # Discovery Flow
 //!
 //! 1. Client requests MCP endpoint without a token
 //! 2. Server returns `401` with `WWW-Authenticate: Bearer resource_metadata="..."`
-//! 3. Client fetches `/.well-known/oauth-protected-resource` to discover auth server
+//! 3. Client fetches the resource's RFC 9728 well-known metadata URL
 //! 4. Client obtains token from the authorization server
 //! 5. Client retries with `Authorization: Bearer <token>`
 
@@ -92,9 +103,11 @@ pub mod token;
 
 // Re-exports
 pub use error::OAuthError;
-pub use metadata::ProtectedResourceMetadata;
+pub use metadata::{ProtectedResourceMetadata, ProtectedResourceMetadataError};
 pub use middleware::{OAuthLayer, OAuthService};
-pub use scope::{ScopeEnforcementLayer, ScopeEnforcementService, ScopePolicy, ScopeRequirement};
+pub use scope::{
+    ScopeEnforcementLayer, ScopeEnforcementService, ScopeMatcher, ScopePolicy, ScopeRequirement,
+};
 #[cfg(feature = "jwks")]
 pub use token::{JwksError, JwksValidator, JwksValidatorBuilder};
 pub use token::{JwtValidator, TokenAudience, TokenClaims, TokenValidator, ValidateAdapter};

--- a/crates/tower-mcp/src/oauth/scope.rs
+++ b/crates/tower-mcp/src/oauth/scope.rs
@@ -5,9 +5,40 @@
 //! to their required scopes.
 
 use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
 
 use super::error::OAuthError;
 use super::token::TokenClaims;
+
+/// Determines whether a granted OAuth scope satisfies a required scope.
+///
+/// The default matcher uses exact string equality. Implement this trait (or
+/// pass a closure to [`ScopePolicy::scope_matcher`]) when an authorization
+/// server defines hierarchical scopes such as `mcp:*` implying `mcp:read`.
+pub trait ScopeMatcher: Send + Sync + 'static {
+    /// Return `true` when `granted` authorizes an operation requiring
+    /// `required`.
+    fn matches(&self, granted: &str, required: &str) -> bool;
+}
+
+impl<F> ScopeMatcher for F
+where
+    F: Fn(&str, &str) -> bool + Send + Sync + 'static,
+{
+    fn matches(&self, granted: &str, required: &str) -> bool {
+        self(granted, required)
+    }
+}
+
+#[derive(Debug, Default)]
+struct ExactScopeMatcher;
+
+impl ScopeMatcher for ExactScopeMatcher {
+    fn matches(&self, granted: &str, required: &str) -> bool {
+        granted == required
+    }
+}
 
 /// A set of required OAuth scopes for an operation.
 ///
@@ -50,12 +81,26 @@ impl ScopeRequirement {
     /// `Err(OAuthError::InsufficientScope)` with details about
     /// which scopes are missing.
     pub fn check(&self, claims: &TokenClaims) -> Result<(), OAuthError> {
+        self.check_with(claims, &ExactScopeMatcher)
+    }
+
+    /// Check the requirement using a custom scope matcher.
+    pub fn check_with(
+        &self,
+        claims: &TokenClaims,
+        matcher: &dyn ScopeMatcher,
+    ) -> Result<(), OAuthError> {
         if self.required.is_empty() {
             return Ok(());
         }
 
         let provided = claims.scopes();
-        if self.required.is_subset(&provided) {
+        let satisfied = self.required.iter().all(|required| {
+            provided
+                .iter()
+                .any(|granted| matcher.matches(granted, required))
+        });
+        if satisfied {
             Ok(())
         } else {
             Err(OAuthError::InsufficientScope {
@@ -91,18 +136,53 @@ impl ScopeRequirement {
 ///     .tool_scope("dangerous_tool", "mcp:admin")
 ///     .resource_scope("secret://data", "mcp:secret");
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Clone)]
 pub struct ScopePolicy {
     default_scopes: ScopeRequirement,
     tool_scopes: HashMap<String, ScopeRequirement>,
     resource_scopes: HashMap<String, ScopeRequirement>,
     prompt_scopes: HashMap<String, ScopeRequirement>,
+    matcher: Arc<dyn ScopeMatcher>,
+}
+
+impl Default for ScopePolicy {
+    fn default() -> Self {
+        Self {
+            default_scopes: ScopeRequirement::default(),
+            tool_scopes: HashMap::new(),
+            resource_scopes: HashMap::new(),
+            prompt_scopes: HashMap::new(),
+            matcher: Arc::new(ExactScopeMatcher),
+        }
+    }
+}
+
+impl fmt::Debug for ScopePolicy {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ScopePolicy")
+            .field("default_scopes", &self.default_scopes)
+            .field("tool_scopes", &self.tool_scopes)
+            .field("resource_scopes", &self.resource_scopes)
+            .field("prompt_scopes", &self.prompt_scopes)
+            .field("matcher", &"<scope matcher>")
+            .finish()
+    }
 }
 
 impl ScopePolicy {
     /// Create an empty scope policy (no scopes required for anything).
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Use a custom matcher for exact or hierarchical scope semantics.
+    ///
+    /// The matcher receives `(granted, required)` and should return `true`
+    /// when the granted scope authorizes the required scope.
+    pub fn scope_matcher(mut self, matcher: impl ScopeMatcher) -> Self {
+        self.matcher = Arc::new(matcher);
+        self
     }
 
     /// Set a default scope required for all operations.
@@ -163,16 +243,18 @@ impl ScopePolicy {
 
     /// Check if the given claims satisfy the default scope requirement.
     pub fn check_default(&self, claims: &TokenClaims) -> Result<(), OAuthError> {
-        self.default_scopes.check(claims)
+        self.default_scopes
+            .check_with(claims, self.matcher.as_ref())
     }
 
     /// Check if the given claims satisfy the scope requirement for a tool.
     ///
     /// Checks both default scopes and tool-specific scopes.
     pub fn check_tool(&self, tool_name: &str, claims: &TokenClaims) -> Result<(), OAuthError> {
-        self.default_scopes.check(claims)?;
+        self.default_scopes
+            .check_with(claims, self.matcher.as_ref())?;
         if let Some(req) = self.tool_scopes.get(tool_name) {
-            req.check(claims)?;
+            req.check_with(claims, self.matcher.as_ref())?;
         }
         Ok(())
     }
@@ -183,18 +265,20 @@ impl ScopePolicy {
         resource_uri: &str,
         claims: &TokenClaims,
     ) -> Result<(), OAuthError> {
-        self.default_scopes.check(claims)?;
+        self.default_scopes
+            .check_with(claims, self.matcher.as_ref())?;
         if let Some(req) = self.resource_scopes.get(resource_uri) {
-            req.check(claims)?;
+            req.check_with(claims, self.matcher.as_ref())?;
         }
         Ok(())
     }
 
     /// Check if the given claims satisfy the scope requirement for a prompt.
     pub fn check_prompt(&self, prompt_name: &str, claims: &TokenClaims) -> Result<(), OAuthError> {
-        self.default_scopes.check(claims)?;
+        self.default_scopes
+            .check_with(claims, self.matcher.as_ref())?;
         if let Some(req) = self.prompt_scopes.get(prompt_name) {
-            req.check(claims)?;
+            req.check_with(claims, self.matcher.as_ref())?;
         }
         Ok(())
     }
@@ -223,8 +307,9 @@ use crate::router::{RouterRequest, RouterResponse};
 /// per-operation scope checks (e.g., different scopes for different tools).
 ///
 /// The middleware extracts [`TokenClaims`] from [`RouterRequest::extensions`]. If
-/// no claims are present, the request is passed through unchanged -- this allows
-/// the middleware to compose gracefully without OAuth.
+/// no claims are present, the request is rejected. Use
+/// [`ScopeEnforcementLayer::permissive_without_claims`] only when a surrounding
+/// component intentionally supports unauthenticated requests.
 ///
 /// # Example
 ///
@@ -245,12 +330,27 @@ use crate::router::{RouterRequest, RouterResponse};
 #[derive(Debug, Clone)]
 pub struct ScopeEnforcementLayer {
     policy: ScopePolicy,
+    require_claims: bool,
 }
 
 impl ScopeEnforcementLayer {
     /// Create a new scope enforcement layer with the given policy.
     pub fn new(policy: ScopePolicy) -> Self {
-        Self { policy }
+        Self {
+            policy,
+            require_claims: true,
+        }
+    }
+
+    /// Create a layer that skips scope checks when authentication claims are absent.
+    ///
+    /// This is an explicit opt-out from fail-closed behavior. Prefer [`Self::new`]
+    /// for protected MCP endpoints.
+    pub fn permissive_without_claims(policy: ScopePolicy) -> Self {
+        Self {
+            policy,
+            require_claims: false,
+        }
     }
 }
 
@@ -261,6 +361,7 @@ impl<S> Layer<S> for ScopeEnforcementLayer {
         ScopeEnforcementService {
             inner,
             policy: self.policy.clone(),
+            require_claims: self.require_claims,
         }
     }
 }
@@ -270,7 +371,7 @@ impl<S> Layer<S> for ScopeEnforcementLayer {
 /// Created by [`ScopeEnforcementLayer`]. For each incoming `RouterRequest`:
 ///
 /// 1. Extracts [`TokenClaims`] from `req.extensions`
-/// 2. If no claims are present, passes the request through (composable without OAuth)
+/// 2. If no claims are present, rejects the request unless permissive mode was requested
 /// 3. Matches the request type (`CallTool`, `ReadResource`, `GetPrompt`, etc.)
 /// 4. Checks the appropriate scope requirement from the [`ScopePolicy`]
 /// 5. On failure, returns a `RouterResponse` with a JSON-RPC forbidden error
@@ -279,6 +380,7 @@ impl<S> Layer<S> for ScopeEnforcementLayer {
 pub struct ScopeEnforcementService<S> {
     inner: S,
     policy: ScopePolicy,
+    require_claims: bool,
 }
 
 impl<S> Service<RouterRequest> for ScopeEnforcementService<S>
@@ -298,13 +400,20 @@ where
     }
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
-        // Extract claims from extensions; if absent, pass through
+        // Extract claims from extensions; fail closed unless explicitly configured otherwise.
         let claims = req.extensions.get::<TokenClaims>().cloned();
 
         let Some(claims) = claims else {
-            // No OAuth context -- pass through
-            let fut = self.inner.call(req);
-            return Box::pin(fut);
+            if self.require_claims {
+                let response = RouterResponse {
+                    id: req.id,
+                    inner: Err(JsonRpcError::forbidden(
+                        "authenticated token claims are required",
+                    )),
+                };
+                return Box::pin(async move { Ok(response) });
+            }
+            return Box::pin(self.inner.call(req));
         };
 
         // Check scope based on request type
@@ -470,5 +579,27 @@ mod tests {
                 .is_ok()
         );
         assert!(policy.check_prompt("any", &claims_no_scopes()).is_ok());
+    }
+
+    #[test]
+    fn test_scope_policy_custom_hierarchy() {
+        let policy = ScopePolicy::new()
+            .default_scope("mcp:read")
+            .tool_scope("admin", "mcp:admin")
+            .scope_matcher(|granted: &str, required: &str| {
+                granted == required || granted == "mcp:*"
+            });
+        let claims = claims_with_scopes("mcp:*");
+
+        assert!(policy.check_default(&claims).is_ok());
+        assert!(policy.check_tool("admin", &claims).is_ok());
+    }
+
+    #[test]
+    fn test_scope_enforcement_is_fail_closed_by_default() {
+        assert!(ScopeEnforcementLayer::new(ScopePolicy::new()).require_claims);
+        assert!(
+            !ScopeEnforcementLayer::permissive_without_claims(ScopePolicy::new()).require_claims
+        );
     }
 }

--- a/crates/tower-mcp/src/oauth/token.rs
+++ b/crates/tower-mcp/src/oauth/token.rs
@@ -85,11 +85,13 @@ impl TokenClaims {
         self.scopes().contains(scope)
     }
 
-    /// Check if the audience matches the given resource identifier.
+    /// Check if the audience contains the given resource identifier.
+    ///
+    /// Returns `false` when the token has no audience claim.
     pub fn audience_matches(&self, resource: &str) -> bool {
         match &self.aud {
             Some(aud) => aud.contains(resource),
-            None => true, // No audience claim means no restriction
+            None => false,
         }
     }
 
@@ -144,6 +146,11 @@ pub trait TokenValidator: Clone + Send + Sync + 'static {
 /// Validates JWTs using pre-configured decoding keys. Supports RSA, HMAC,
 /// and EC algorithms via the `jsonwebtoken` crate.
 ///
+/// The validator is also useful outside MCP and therefore only checks an
+/// audience when [`JwtValidator::expected_audience`] is configured. MCP's
+/// [`OAuthLayer`](super::OAuthLayer) always performs an independent audience
+/// check against the protected resource identifier.
+///
 /// # Example
 ///
 /// ```rust
@@ -168,7 +175,8 @@ impl JwtValidator {
     /// [`expected_audience`](Self::expected_audience) is called.
     fn default_validation(algorithm: Algorithm) -> Validation {
         let mut validation = Validation::new(algorithm);
-        // Disable audience validation by default -- callers opt in via expected_audience()
+        // Generic validation opts in here; OAuthLayer independently enforces
+        // its protected resource audience for MCP requests.
         validation.validate_aud = false;
         // Don't require any specific claims by default. The jsonwebtoken crate
         // requires "exp" by default, but OAuth tokens may omit it.
@@ -945,8 +953,7 @@ mod tests {
             extra: HashMap::new(),
         };
 
-        // No audience claim means no restriction
-        assert!(claims.audience_matches("anything"));
+        assert!(!claims.audience_matches("anything"));
     }
 
     #[test]

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1502,9 +1502,8 @@ impl Drop for ModernSubscriptionGuard {
 
 /// Configuration for OAuth 2.1 Protected Resource Metadata.
 ///
-/// When set on [`HttpTransport`], a `GET /.well-known/oauth-protected-resource`
-/// endpoint is added that returns the metadata JSON, enabling OAuth client
-/// discovery per RFC 9728.
+/// When set on [`HttpTransport`], a `GET` endpoint is added at the resource's
+/// path-aware RFC 9728 well-known location.
 #[cfg(feature = "oauth")]
 #[derive(Clone)]
 pub(crate) struct OAuthConfig {
@@ -2115,9 +2114,9 @@ impl HttpTransport {
 
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
     ///
-    /// When set, adds a `GET /.well-known/oauth-protected-resource` endpoint
-    /// that returns the metadata JSON, enabling OAuth client discovery per
-    /// RFC 9728.
+    /// This lower-level method only serves metadata; it does not install token
+    /// or scope enforcement. Prefer [`Self::into_oauth_router`] for a complete,
+    /// fail-closed MCP resource-server setup.
     ///
     /// # Example
     ///
@@ -2137,6 +2136,96 @@ impl HttpTransport {
     pub fn oauth(mut self, metadata: crate::oauth::ProtectedResourceMetadata) -> Self {
         self.oauth_config = Some(OAuthConfig { metadata });
         self
+    }
+
+    /// Build a fully protected OAuth resource-server router.
+    ///
+    /// This validates the Protected Resource Metadata, serves it at the
+    /// path-aware RFC 9728 endpoint, validates bearer tokens, independently
+    /// enforces the token audience against `metadata.resource`, and installs
+    /// fail-closed per-operation scope enforcement.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the resource metadata is not suitable for an MCP
+    /// resource server.
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router<V>(
+        self,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<Router, crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        let (router, _) = self.into_oauth_router_with_handle(validator, metadata, policy)?;
+        Ok(router)
+    }
+
+    /// Build a fully protected OAuth router and return its session handle.
+    ///
+    /// This is the session-management variant of [`Self::into_oauth_router`].
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router_with_handle<V>(
+        self,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<(Router, SessionHandle), crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        metadata.validate()?;
+        let oauth_layer =
+            crate::oauth::OAuthLayer::new(validator, metadata.clone()).scope_policy(policy.clone());
+        let transport = self
+            .layer(crate::oauth::ScopeEnforcementLayer::new(policy))
+            .oauth(metadata);
+        let (router, handle) = transport.into_router_with_handle();
+        Ok((router.layer(oauth_layer), handle))
+    }
+
+    /// Build a fully protected OAuth router mounted at `path`.
+    ///
+    /// The metadata route is derived from `metadata.resource`, not from the
+    /// local mount path, so it remains correct for path-based resource URLs.
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router_at<V>(
+        self,
+        path: &str,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<Router, crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        let (router, _) =
+            self.into_oauth_router_at_with_handle(path, validator, metadata, policy)?;
+        Ok(router)
+    }
+
+    /// Build a path-mounted protected OAuth router and return its session handle.
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router_at_with_handle<V>(
+        self,
+        path: &str,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<(Router, SessionHandle), crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        metadata.validate()?;
+        let oauth_layer =
+            crate::oauth::OAuthLayer::new(validator, metadata.clone()).scope_policy(policy.clone());
+        let transport = self
+            .layer(crate::oauth::ScopeEnforcementLayer::new(policy))
+            .oauth(metadata);
+        let (router, handle) = transport.into_router_at_with_handle(path);
+        Ok((router.layer(oauth_layer), handle))
     }
 
     /// Apply a tower middleware layer to MCP request processing.
@@ -2359,18 +2448,16 @@ impl HttpTransport {
 
     /// Add the OAuth Protected Resource Metadata well-known route if configured.
     #[cfg(feature = "oauth")]
-    fn add_oauth_route(&self, router: Router, base_path: &str) -> Router {
+    fn add_oauth_route(&self, router: Router, _base_path: &str) -> Router {
         if let Some(ref config) = self.oauth_config {
             let metadata = config.metadata.clone();
-            let well_known_path = if base_path.is_empty() {
-                crate::oauth::ProtectedResourceMetadata::well_known_path().to_string()
-            } else {
-                format!(
-                    "{}{}",
-                    base_path.trim_end_matches('/'),
-                    crate::oauth::ProtectedResourceMetadata::well_known_path()
+            let well_known_path =
+                crate::oauth::ProtectedResourceMetadata::well_known_path_for_resource(
+                    &metadata.resource,
                 )
-            };
+                .unwrap_or_else(|_| {
+                    crate::oauth::ProtectedResourceMetadata::well_known_path().to_string()
+                });
             router.route(
                 &well_known_path,
                 get(move || {
@@ -4418,6 +4505,120 @@ mod tests {
     use axum::http::Request;
     use proptest::prelude::*;
     use tower::ServiceExt;
+
+    #[cfg(feature = "oauth")]
+    fn oauth_test_token(audience: &str, scope: &str) -> String {
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            &serde_json::json!({
+                "sub": "test-user",
+                "aud": audience,
+                "scope": scope,
+            }),
+            &jsonwebtoken::EncodingKey::from_secret(b"resource-server-test-secret"),
+        )
+        .unwrap()
+    }
+
+    #[cfg(feature = "oauth")]
+    #[tokio::test]
+    async fn oauth_resource_server_setup_is_path_aware_and_audience_bound() {
+        let resource = "http://localhost:3000/tenant/mcp";
+        let metadata = crate::oauth::ProtectedResourceMetadata::new(resource)
+            .authorization_server("https://auth.example.com")
+            .scope("mcp:read");
+        let validator = crate::oauth::JwtValidator::from_secret(b"resource-server-test-secret")
+            .disable_exp_validation();
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_oauth_router_at(
+                "/tenant/mcp",
+                validator,
+                metadata,
+                crate::oauth::ScopePolicy::new().default_scope("mcp:read"),
+            )
+            .unwrap();
+
+        let metadata_request = Request::builder()
+            .uri("/.well-known/oauth-protected-resource/tenant/mcp")
+            .body(Body::empty())
+            .unwrap();
+        let metadata_response = app.clone().oneshot(metadata_request).await.unwrap();
+        assert_eq!(metadata_response.status(), StatusCode::OK);
+
+        let unauthenticated = Request::builder()
+            .method("POST")
+            .uri("/tenant/mcp")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.clone().oneshot(unauthenticated).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(
+            response
+                .headers()
+                .get("WWW-Authenticate")
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("http://localhost:3000/.well-known/oauth-protected-resource/tenant/mcp")
+        );
+
+        let wrong_audience = oauth_test_token("http://localhost:3000/other", "mcp:read");
+        let request = Request::builder()
+            .method("POST")
+            .uri("/tenant/mcp")
+            .header("Authorization", format!("Bearer {wrong_audience}"))
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(
+            app.clone().oneshot(request).await.unwrap().status(),
+            StatusCode::UNAUTHORIZED
+        );
+
+        let token = oauth_test_token(resource, "mcp:read");
+        let request = Request::builder()
+            .method("POST")
+            .uri("/tenant/mcp")
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2025-11-25",
+                        "capabilities": {},
+                        "clientInfo": { "name": "oauth-test", "version": "1.0" }
+                    }
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("result").is_some(), "unexpected response: {json}");
+    }
+
+    #[cfg(feature = "oauth")]
+    #[test]
+    fn oauth_resource_server_setup_validates_metadata() {
+        let result = HttpTransport::new(create_test_router()).into_oauth_router(
+            crate::oauth::JwtValidator::from_secret(b"secret"),
+            crate::oauth::ProtectedResourceMetadata::new("https://mcp.example.com"),
+            crate::oauth::ScopePolicy::new(),
+        );
+        assert!(matches!(
+            result.unwrap_err(),
+            crate::oauth::ProtectedResourceMetadataError::MissingAuthorizationServer
+        ));
+    }
 
     fn arb_json() -> impl Strategy<Value = serde_json::Value> {
         let leaf = prop_oneof![

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -281,9 +281,9 @@ impl WebSocketTransport {
 
     /// Configure OAuth 2.1 Protected Resource Metadata for this transport.
     ///
-    /// When set, adds a `GET /.well-known/oauth-protected-resource` endpoint
-    /// that returns the metadata JSON, enabling OAuth client discovery per
-    /// RFC 9728.
+    /// When set, adds a `GET` endpoint at the resource's path-aware RFC 9728
+    /// well-known location. This method only serves metadata; prefer
+    /// [`Self::into_oauth_router`] for a complete protected setup.
     ///
     /// # Example
     ///
@@ -303,6 +303,53 @@ impl WebSocketTransport {
     pub fn oauth(mut self, metadata: crate::oauth::ProtectedResourceMetadata) -> Self {
         self.oauth_config = Some(metadata);
         self
+    }
+
+    /// Build a fully protected OAuth WebSocket resource-server router.
+    ///
+    /// This validates and serves Protected Resource Metadata, authenticates
+    /// WebSocket upgrades, enforces the canonical resource audience, and
+    /// installs fail-closed per-operation scope checks.
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router<V>(
+        self,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<Router, crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        metadata.validate()?;
+        let oauth_layer =
+            crate::oauth::OAuthLayer::new(validator, metadata.clone()).scope_policy(policy.clone());
+        let router = self
+            .layer(crate::oauth::ScopeEnforcementLayer::new(policy))
+            .oauth(metadata)
+            .into_router();
+        Ok(router.layer(oauth_layer))
+    }
+
+    /// Build a path-mounted, fully protected OAuth WebSocket router.
+    #[cfg(feature = "oauth")]
+    pub fn into_oauth_router_at<V>(
+        self,
+        path: &str,
+        validator: V,
+        metadata: crate::oauth::ProtectedResourceMetadata,
+        policy: crate::oauth::ScopePolicy,
+    ) -> std::result::Result<Router, crate::oauth::ProtectedResourceMetadataError>
+    where
+        V: crate::oauth::TokenValidator,
+    {
+        metadata.validate()?;
+        let oauth_layer =
+            crate::oauth::OAuthLayer::new(validator, metadata.clone()).scope_policy(policy.clone());
+        let router = self
+            .layer(crate::oauth::ScopeEnforcementLayer::new(policy))
+            .oauth(metadata)
+            .into_router_at(path);
+        Ok(router.layer(oauth_layer))
     }
 
     /// Apply a tower middleware layer to MCP request processing.
@@ -421,20 +468,18 @@ impl WebSocketTransport {
 #[cfg(feature = "oauth")]
 fn add_oauth_route(
     router: Router,
-    base_path: &str,
+    _base_path: &str,
     metadata: Option<&crate::oauth::ProtectedResourceMetadata>,
 ) -> Router {
     if let Some(metadata) = metadata {
         let metadata = metadata.clone();
-        let well_known_path = if base_path.is_empty() {
-            crate::oauth::ProtectedResourceMetadata::well_known_path().to_string()
-        } else {
-            format!(
-                "{}{}",
-                base_path.trim_end_matches('/'),
-                crate::oauth::ProtectedResourceMetadata::well_known_path()
+        let well_known_path =
+            crate::oauth::ProtectedResourceMetadata::well_known_path_for_resource(
+                &metadata.resource,
             )
-        };
+            .unwrap_or_else(|_| {
+                crate::oauth::ProtectedResourceMetadata::well_known_path().to_string()
+            });
         router.route(
             &well_known_path,
             get(move || {
@@ -1016,6 +1061,28 @@ mod tests {
     async fn test_websocket_transport_at_path() {
         let transport = WebSocketTransport::new(create_test_router());
         let _router = transport.into_router_at("/mcp");
+    }
+
+    #[cfg(feature = "oauth")]
+    #[tokio::test]
+    async fn test_oauth_metadata_route_is_path_aware() {
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use tower::ServiceExt;
+
+        let metadata =
+            crate::oauth::ProtectedResourceMetadata::new("https://mcp.example.com/tenant/ws")
+                .authorization_server("https://auth.example.com");
+        let app = WebSocketTransport::new(create_test_router())
+            .oauth(metadata)
+            .into_router_at("/tenant/ws");
+        let request = Request::builder()
+            .uri("/.well-known/oauth-protected-resource/tenant/ws")
+            .body(Body::empty())
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -1476,10 +1476,10 @@ mod scope_enforcement_tests {
     }
 
     #[tokio::test]
-    async fn test_scope_enforcement_pass_through_without_claims() {
+    async fn test_scope_enforcement_rejects_request_without_claims() {
         let router = create_test_router();
         let policy = ScopePolicy::new().tool_scope("echo", "mcp:admin");
-        // No claims -- should pass through
+        // No claims -- the protected scope layer fails closed.
         let mut service = make_service_with_scope(router.clone(), policy, None);
 
         initialize(&router, &mut service).await;
@@ -1491,12 +1491,8 @@ mod scope_enforcement_tests {
         let resp = service.call_single(call_req).await.unwrap();
 
         match resp {
-            JsonRpcResponse::Result(r) => {
-                let content = r.result.get("content").unwrap().as_array().unwrap();
-                let text = content[0].get("text").unwrap().as_str().unwrap();
-                assert_eq!(text, "no auth");
-            }
-            JsonRpcResponse::Error(e) => panic!("Expected pass-through, got error: {:?}", e),
+            JsonRpcResponse::Error(e) => assert_eq!(e.error.code, -32007),
+            JsonRpcResponse::Result(_) => panic!("Expected request without claims to be rejected"),
             _ => panic!("unexpected response variant"),
         }
     }

--- a/examples/http_auth.rs
+++ b/examples/http_auth.rs
@@ -198,18 +198,20 @@ mod apikey {
 
 mod oauth {
     use axum::Router;
-    use tower_mcp::oauth::{JwtValidator, OAuthLayer, ProtectedResourceMetadata, ScopePolicy};
+    use tower_mcp::HttpTransport;
+    use tower_mcp::oauth::{JwtValidator, ProtectedResourceMetadata, ScopePolicy};
 
-    pub fn wrap(mcp_router: Router, metadata: ProtectedResourceMetadata) -> Router {
+    pub fn wrap(
+        transport: HttpTransport,
+        metadata: ProtectedResourceMetadata,
+    ) -> Result<Router, tower_mcp::oauth::ProtectedResourceMetadataError> {
         // In production, use RSA/EC keys or JWKS endpoint instead of a shared secret
         let validator = JwtValidator::from_secret(b"demo-secret-do-not-use-in-production")
             .disable_exp_validation(); // For demo convenience only
 
         let scope_policy = ScopePolicy::new().default_scope("mcp:read");
 
-        let oauth_layer = OAuthLayer::new(validator, metadata).scope_policy(scope_policy);
-
-        mcp_router.layer(oauth_layer)
+        transport.into_oauth_router(validator, metadata, scope_policy)
     }
 }
 
@@ -254,15 +256,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 .scope("mcp:write")
                 .resource_documentation("https://github.com/joshrotenberg/tower-mcp");
 
-            let transport = HttpTransport::new(mcp_router)
-                .disable_origin_validation()
-                .oauth(metadata.clone());
-            let mcp_axum_router = transport.into_router();
+            let transport = HttpTransport::new(mcp_router).disable_origin_validation();
 
             tracing::info!(
                 "Protected Resource Metadata: http://127.0.0.1:3000/.well-known/oauth-protected-resource"
             );
-            oauth::wrap(mcp_axum_router, metadata)
+            oauth::wrap(transport, metadata)?
         }
         other => {
             eprintln!("Unknown auth mode: {other}. Use 'apikey' or 'oauth'.");


### PR DESCRIPTION
Closes #1116

## Summary

- add validated, one-call OAuth resource-server setup for HTTP and WebSocket transports
- enforce the canonical MCP resource audience in `OAuthLayer`, independently of validator configuration
- serve RFC 9728 metadata at path-aware well-known locations
- make operation-level scope enforcement fail closed, with an explicit permissive constructor
- match public routes exactly and remove arbitrary well-known/prefix bypasses
- add a customizable scope implication matcher
- safely quote untrusted `WWW-Authenticate` parameters
- update the OAuth module docs and `http_auth` example to demonstrate the safe middleware order

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`
