### PR TITLE
docs: add task-oriented usage guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 
 | Guide | Use it when |
 |---|---|
+| [Client usage](docs/client.md) | Choosing a transport, connecting, handling callbacks, making requests, configuring caching, or defining retry policy |
+| [HTTP deployment](docs/deployment.md) | Mounting an endpoint, configuring proxies and origins, choosing session/scaling policy, or placing middleware and timeouts |
+| [Protocol versions](docs/protocol-versions.md) | Selecting compile-time and runtime support, comparing lifecycle behavior, planning interoperability, or upgrading revisions |
 | [OAuth authorization](docs/oauth.md) | Protecting an MCP resource server, building an interactive or service client, choosing registration/storage policy, or preparing an OAuth deployment |
 | [MCP Apps](docs/mcp-apps.md) | Returning typed app resources from tools with negotiation and safe fallback |
 | [Examples index](examples/README.md) | Looking for a runnable server, client, transport, middleware, or extension pattern |
@@ -619,6 +622,10 @@ let router = McpRouter::new()
 
 tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
+For application-facing guidance on the stable default, opt-in 2026-07-28
+implementation, compile-time features, runtime allowlists, interoperability,
+and upgrade policy, start with the [protocol-version guide](docs/protocol-versions.md).
+
 - **Server (2025-11-25):** 48/48 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
 - **Client (2025-11-25):** all 18 scenarios green, 235 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
 - **Server (2026-07-28):** 114/114 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
@@ -626,105 +633,17 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 Both protocol revisions run on the same harness pin so the results are directly comparable with each other and with rmcp's current conformance workflow. Because the suite is upstream-maintained and grows with the spec, these counts shift as scenarios are added or version-gated -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 
-The `protocol-2026-07-28` feature enables the released, opt-in 2026-07-28
-protocol implementation (version-gated, behind
-`MCP-Protocol-Version: 2026-07-28`) covering `server/discover`, `subscriptions/listen`, per-request
-`_meta` capabilities, and SEP-2322 Multi Round-Trip Requests. It is not enabled by default and is
-intentionally not included in `SUPPORTED_PROTOCOL_VERSIONS`; compile-time availability and per-transport
-runtime enablement are reported separately.
+The released 2026-07-28 implementation is available through the opt-in
+`protocol-2026-07-28` feature. It covers sessionless dispatch,
+`server/discover`, `subscriptions/listen`, per-request metadata, response-cache
+hints, Multi Round-Trip Requests, and the final Tasks extension. The default
+runtime remains 2025-11-25, including for clients built with `full`.
 
-`PROTOCOL_VERSION_2026_07_28` is the canonical constant for the released wire
-revision. The former status-bearing names `EXPERIMENTAL_PROTOCOL_VERSION` and
-`UPCOMING_PROTOCOL_VERSION` remain deprecated aliases. `LATEST_PROTOCOL_VERSION`
-and `SUPPORTED_PROTOCOL_VERSIONS` continue to describe the non-breaking default
-compatibility set, not every published protocol. Use
-`COMPILED_PROTOCOL_VERSIONS` and `ProtocolSupport` to inspect and select the
-implementations available to a particular build and runtime.
-
-Clients opt in independently at runtime, then use the discover-based lifecycle.
-Every later request receives the required `_meta`, HTTP headers are generated
-from the JSON-RPC frame, and MRTR results are followed through the configured
-client handler with a bounded round count:
-
-```rust,no_run
-use std::time::Duration;
-use tower_mcp::{HttpClientTransport, ProtocolSupport};
-use tower_mcp::client::{ClientCacheConfig, McpClient};
-
-# async fn connect() -> Result<(), tower_mcp::BoxError> {
-let support = ProtocolSupport::try_new(["2026-07-28"])?;
-let cache = ClientCacheConfig::default()
-    .with_partition("user-123")
-    .with_max_ttl(Duration::from_secs(60 * 60));
-let transport = HttpClientTransport::new("https://example.com/mcp");
-let client = McpClient::builder()
-    .protocol_support(support)
-    .max_mrtr_rounds(8)
-    .response_cache(cache)
-    .connect_simple(transport)
-    .await?;
-
-let discovery = client.discover("my-client", "1.0.0").await?;
-println!("server versions: {:?}", discovery.supported_versions);
-# Ok(())
-# }
-```
-
-On the final lifecycle, `server/discover`, paginated list operations, and
-`resources/read` honor `ttlMs` and `cacheScope`. Private entries use the
-configured authorization-context partition; list/resource notifications
-invalidate matching entries. The cache is bounded, caps server TTLs at 24
-hours by default, never stores MRTR retries, and can be disabled or configured
-to serve stale data after refresh errors.
-
-MRTR-aware tool, prompt, resource, and resource-template handlers return
-`RequestOutcome<T>`. Retry values are exposed on `RequestContext`, while
-`RequestStateCodec` provides versioned, expiring, HMAC-SHA256 state tokens:
-
-```rust
-use tower_mcp::{
-    CallToolResult, InputRequest, InputRequiredResult, InputRequests, ListRootsParams,
-    NoParams, RequestOutcome, ToolBuilder,
-};
-
-let tool = ToolBuilder::new("workspace_summary")
-    .mrtr_handler::<NoParams, _, _>(|ctx, _| async move {
-        if ctx.input_responses().is_some_and(|r| r.contains_key("roots")) {
-            return Ok(RequestOutcome::Complete(CallToolResult::text("ready")));
-        }
-
-        let requests: InputRequests = [(
-            "roots".into(),
-            InputRequest::ListRoots(ListRootsParams::default()),
-        )]
-        .into_iter()
-        .collect();
-        Ok(RequestOutcome::input_required(
-            InputRequiredResult::with_requests(requests),
-        ))
-    })
-    .build();
-```
-
-Each MRTR retry is an independent MCP request. Router/transport middleware
-therefore runs once per round, and MRTR tool, prompt, and static-resource
-builders support the same per-handler `.layer()` composition as complete
-handlers. Tool `.guard()` checks also run on every round. Resource templates
-use router/transport middleware for both complete and MRTR handlers because
-they do not have a separate per-template Tower service.
-
-The server does not own a continuation loop, so there is no server-global
-round counter to configure. Clients bound automatic retries with
-`McpClientBuilder::max_mrtr_rounds`; a server workflow that needs its own cap
-should encode and verify a round counter inside `requestState`.
-
-`RequestStateCodec` intentionally leaves authenticated-principal binding under
-application control: HTTP/custom-service authentication can place any
-application-defined identity in request extensions. If continuation state can
-affect authorization, resource access, or business logic, use `encode_for` and
-`decode_for` with that stable principal identifier on every round. This keeps
-the codec transport-neutral while following the final specification's replay
-and cross-principal protections.
+Compile-time availability and runtime allowlists are separate. The
+[protocol-version guide](docs/protocol-versions.md) explains the constants,
+feature policy, lifecycle differences, interoperability, and upgrade path;
+the [client guide](docs/client.md) covers final discovery, caching, MRTR,
+retries, and shutdown with runnable examples.
 
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
 

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -90,7 +90,7 @@
 //! requires only a dependency change -- no import paths need to change:
 //!
 //! ```toml
-//! tower-mcp = { version = "0.10", features = ["http"] }
+//! tower-mcp = { version = "0.16", features = ["http"] }
 //! ```
 //!
 //! # WASM support

--- a/crates/tower-mcp/src/deployment.rs
+++ b/crates/tower-mcp/src/deployment.rs
@@ -7,11 +7,14 @@
 //!
 //! # Overview
 //!
-//! MCP is session-oriented. The `mcp-session-id` header established during
-//! `initialize` ties subsequent requests together, and `HttpTransport`
-//! keeps live state per session (broadcast channel for SSE notifications,
-//! pending sampling requests, service instance). Two deployment shapes
-//! cover most cases:
+//! The legacy 2025-11-25 lifecycle may be session-oriented. The
+//! `mcp-session-id` header established during `initialize` ties subsequent
+//! requests together, and `HttpTransport` keeps live state per session
+//! (broadcast channel for SSE notifications, pending sampling requests,
+//! service instance). The 2026-07-28 lifecycle is sessionless; ordinary
+//! requests can be distributed independently, although application state and
+//! long-lived subscription streams may still influence routing. Two shapes
+//! cover most legacy or mixed-version deployments:
 //!
 //! 1. **Session affinity.** A load balancer routes all requests for a
 //!    given session back to the same server instance. Any in-memory
@@ -334,6 +337,10 @@
 //!
 //! # See Also
 //!
+//! - The repository's
+//!   [HTTP deployment guide](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/deployment.md)
+//!   is the task-oriented starting point for endpoint mounting, proxy headers,
+//!   protocol policy, timeouts, and production checklists.
 //! - [`session_store`] for the `SessionStore` trait and implementations.
 //! - [`event_store`] for the `EventStore` trait and SSE event persistence.
 //! - The `session_store` and `event_store` examples in the repo show

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -178,6 +178,19 @@
 //! and a production checklist, see the
 //! [OAuth authorization guide](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/oauth.md).
 //!
+//! ## Task-oriented Guides
+//!
+//! - [Client usage](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/client.md) —
+//!   transport selection, lifecycle, callbacks, requests, caching, retries, and shutdown.
+//! - [HTTP deployment](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/deployment.md) —
+//!   mounting, reverse proxies, origin/host validation, sessions, scaling, timeouts,
+//!   middleware order, health, and graceful shutdown.
+//! - [Protocol versions](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/protocol-versions.md) —
+//!   compile-time availability, runtime allowlists, lifecycle differences,
+//!   interoperability, and upgrades.
+//! - [Examples index](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/README.md) —
+//!   runnable server, client, transport, middleware, OAuth, and extension patterns.
+//!
 //! ## Middleware Placement Guide
 //!
 //! tower-mcp supports Tower middleware at multiple levels. Choose based on scope:

--- a/crates/tower-mcp/src/stateless.rs
+++ b/crates/tower-mcp/src/stateless.rs
@@ -8,7 +8,7 @@
 //!
 //! ### Automatic version-gated path (2026-07-28)
 //!
-//! When the `stateless` feature is compiled in, JSON-RPC transports
+//! When the `protocol-2026-07-28` feature is compiled in, JSON-RPC transports
 //! automatically dispatch requests whose per-request `_meta` selects the exact
 //! 2026-07-28 protocol without an initialize handshake. HTTP additionally
 //! requires a matching `MCP-Protocol-Version` header. Client identity and
@@ -17,8 +17,8 @@
 //!
 //! **This path is always active when the feature is compiled in, regardless of
 //! whether [`StatelessConfig`] was provided to the transport.** Adding
-//! `features = ["stateless"]` to your `Cargo.toml` is sufficient; you do not
-//! need to call `HttpTransport::stateless()`.
+//! `features = ["protocol-2026-07-28"]` to your `Cargo.toml` is sufficient;
+//! you do not need to call `HttpTransport::stateless()`.
 //!
 //! ### Legacy SEP-1442 opt-in path
 //!
@@ -30,10 +30,11 @@
 //!
 //! ## Feature flag
 //!
-//! This module is gated behind the `stateless` feature flag:
+//! This module is gated behind `protocol-2026-07-28`. The former `stateless`
+//! feature remains as a compatibility alias:
 //!
 //! ```toml
-//! tower-mcp = { version = "0.10", features = ["stateless"] }
+//! tower-mcp = { version = "0.16", features = ["protocol-2026-07-28"] }
 //! ```
 //!
 //! ## Key properties of stateless mode

--- a/docs/client.md
+++ b/docs/client.md
@@ -1,0 +1,309 @@
+# Client guide
+
+This guide covers the choices an application makes when using tower-mcp as an
+MCP client: transport, lifecycle, callbacks, caching, retries, and the common
+request helpers. For protocol requirements, use the versioned MCP
+specification rather than this guide:
+
+- [2025-11-25 lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+- [2025-11-25 transports](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+- [2026-07-28 versioning and compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)
+- [2026-07-28 discovery](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)
+
+For authorization-code, client-credentials, and custom token-provider setup,
+continue with the [OAuth authorization guide](oauth.md).
+
+## Choose a transport
+
+| Situation | Transport | Cargo feature | Notes |
+|---|---|---|---|
+| Your application launches a local MCP server | `StdioClientTransport` | none | The normal choice for CLI tools and editor-managed subprocesses. Keep protocol messages on stdout and server logs on stderr. |
+| Your application connects to a remote Streamable HTTP endpoint | `HttpClientTransport` | `http-client` | Supports JSON and SSE responses, legacy sessions and resumption, final-protocol headers, and pluggable authentication. |
+| You have an application-specific connection | implement `ClientTransport` | none | Useful for in-memory channels or a custom framing/connection layer. |
+
+tower-mcp does not currently provide a WebSocket client transport. The
+`websocket` feature is server-side.
+
+Minimal dependencies for a remote client:
+
+```toml
+[dependencies]
+tower-mcp = { version = "0.16", features = ["http-client"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_json = "1"
+```
+
+## Connect and select a lifecycle
+
+Connecting starts the background message loop; it does not perform MCP
+lifecycle negotiation. Call exactly one lifecycle method before normal
+operations:
+
+| Protocol path | Builder default? | First MCP call |
+|---|---:|---|
+| `2025-11-25` / `2025-03-26` | yes | `client.initialize(name, version)` |
+| `2026-07-28` | no | `client.discover(name, version)` |
+
+### Stable lifecycle over stdio
+
+```rust,no_run
+use tower_mcp::BoxError;
+use tower_mcp::client::{McpClient, StdioClientTransport};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let transport = StdioClientTransport::spawn("my-mcp-server", &[]).await?;
+    let client = McpClient::connect(transport).await?;
+
+    let initialized = client.initialize("my-client", env!("CARGO_PKG_VERSION")).await?;
+    println!("connected to {}", initialized.server_info.name);
+
+    let tools = client.list_all_tools().await?;
+    println!("{} tools", tools.len());
+
+    client.shutdown().await?;
+    Ok(())
+}
+```
+
+Use `spawn_command` when you need environment variables, a working directory,
+or piped process settings. `spawn` is the compact convenience API.
+
+### Stable lifecycle over HTTP
+
+```rust,no_run
+use tower_mcp::BoxError;
+use tower_mcp::client::{HttpClientTransport, McpClient};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let transport = HttpClientTransport::new("https://mcp.example.com/mcp");
+    let client = McpClient::connect(transport).await?;
+    client.initialize("my-client", "1.0.0").await?;
+
+    let result = client
+        .call_tool_text("search", serde_json::json!({ "query": "tower" }))
+        .await?;
+    println!("{result}");
+
+    client.shutdown().await?;
+    Ok(())
+}
+```
+
+For a static bearer token, API key, or basic credentials, configure the
+`HttpClientTransport` before connecting. For token acquisition and refresh,
+use a token provider from the [OAuth guide](oauth.md); avoid copying tokens
+into custom headers yourself.
+
+### Released 2026-07-28 lifecycle
+
+Compile the implementation and select it independently at runtime:
+
+```toml
+tower-mcp = { version = "0.16", features = [
+  "http-client",
+  "protocol-2026-07-28",
+] }
+```
+
+```rust,no_run
+use tower_mcp::{BoxError, ProtocolSupport};
+use tower_mcp::client::{HttpClientTransport, McpClient};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let support = ProtocolSupport::try_new(["2026-07-28"])?;
+    let client = McpClient::builder()
+        .protocol_support(support)
+        .connect_simple(HttpClientTransport::new("https://mcp.example.com/mcp"))
+        .await?;
+
+    let discovered = client.discover("my-client", "1.0.0").await?;
+    println!("server supports {:?}", discovered.supported_versions);
+
+    let tools = client.list_all_tools().await?;
+    println!("{} tools", tools.len());
+
+    client.shutdown().await?;
+    Ok(())
+}
+```
+
+Do not call `initialize` on this path. `discover` selects a mutually supported
+modern version, and the client then adds the required per-request `_meta` and
+HTTP headers. See the [protocol-version guide](protocol-versions.md) for
+stable-only, final-only, and dual-era policies.
+
+## Handle callbacks and server requests
+
+`connect_simple` (and `McpClient::connect`) uses the unit handler. It ignores
+ordinary notifications and rejects server-initiated requests. Choose a richer
+handler only when the host application is ready to honor the capability it
+advertises.
+
+For notification callbacks:
+
+```rust
+use tower_mcp::BoxError;
+use tower_mcp::client::{
+    McpClient, NotificationHandler, StdioClientTransport,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let handler = NotificationHandler::with_log_forwarding()
+        .on_progress(|progress| {
+            eprintln!("{}", progress.message.as_deref().unwrap_or("working"));
+        })
+        .on_tools_changed(|| eprintln!("tool list changed"));
+
+    let transport = StdioClientTransport::spawn("my-mcp-server", &[]).await?;
+    let client = McpClient::connect_with_handler(transport, handler).await?;
+    client.initialize("my-client", "1.0.0").await?;
+    client.shutdown().await?;
+    Ok(())
+}
+```
+
+Implement `ClientHandler` when the server may request roots, sampling, or
+elicitation. Pair the implementation with the matching builder call:
+
+- `with_roots(...)` declares roots and answers `roots/list` from the configured list.
+- `with_sampling()` must be paired with `handle_create_message`.
+- `with_elicitation()` must be paired with `handle_elicit` and a real consent UI.
+
+The [client handler example](../examples/client_handler.rs) contains a complete
+implementation. On the 2026-07-28 path, the same handler resolves embedded
+Multi Round-Trip Request inputs; `max_mrtr_rounds` bounds the automatic loop
+and defaults to eight.
+
+## Common request patterns
+
+Prefer the all-pages helpers unless you are exposing pagination to your own
+caller:
+
+```rust,ignore
+let tools = client.list_all_tools().await?;
+let resources = client.list_all_resources().await?;
+let templates = client.list_all_resource_templates().await?;
+let prompts = client.list_all_prompts().await?;
+```
+
+Use the single-page methods (`list_tools`, `list_tools_with_cursor`, and their
+resource/prompt equivalents) when you want to control page fetches.
+
+`call_tool` preserves every content item and the protocol-level `is_error`
+flag. `call_tool_text` concatenates text items and converts a tool error result
+into a Rust error:
+
+```rust,ignore
+let full = client
+    .call_tool("render", serde_json::json!({ "format": "svg" }))
+    .await?;
+
+for item in &full.content {
+    println!("{item:?}");
+}
+
+let text = client
+    .call_tool_text("status", serde_json::json!({}))
+    .await?;
+```
+
+`read_resource`, `get_prompt`, and `call_tool` automatically follow supported
+2026-07-28 MRTR inputs through the configured handler. Their `*_once` variants
+expose `RequestOutcome` when the application needs to own the retry and user
+interaction. `call_tool` also waits for a final task result; use
+`call_tool_once_task_aware` or the task methods when you need direct lifecycle
+control.
+
+## Response caching
+
+The built-in cache is consulted only after the 2026-07-28 lifecycle is active.
+It covers `server/discover`, list operations, and `resources/read` according to
+the server's `ttlMs` and `cacheScope` hints.
+
+```rust,no_run
+use std::time::Duration;
+use tower_mcp::client::{ClientCacheConfig, McpClient};
+
+let cache = ClientCacheConfig::default()
+    .with_partition("tenant-42:user-7")
+    .with_max_ttl(Duration::from_secs(60 * 60))
+    .with_max_resource_entries(256);
+
+let builder = McpClient::builder().response_cache(cache);
+```
+
+Important defaults and boundaries:
+
+- caching is enabled, but a result with no `ttlMs` has a zero fallback TTL;
+- server TTLs are capped at 24 hours by default;
+- at most 512 distinct resource reads are retained by default;
+- stale data is not served after a refresh error unless explicitly enabled;
+- private cache entries are isolated by the configured partition;
+- list/resource change notifications invalidate matching entries;
+- MRTR interim results and task polling are not cached.
+
+Use a stable principal or tenant identifier as the private partition, not an
+access token. Call `set_cache_partition` immediately when the authorization
+context changes, or `clear_response_cache` when a broader reset is required.
+Disable the cache for diagnostics with `disable_response_cache`.
+
+## Retries and failure handling
+
+tower-mcp retries only where the library can establish a safe boundary:
+
+- legacy HTTP session expiry resets the transport, repeats `initialize`, and
+  retries the failed request once; call `disable_session_recovery` on the HTTP
+  transport if the application must own recovery;
+- final version selection retries one recognized unsupported-version response
+  with a mutually supported modern version;
+- final tool calls refresh `tools/list` and retry once after a pre-execution
+  stale-schema/header rejection;
+- MRTR rounds are retries by protocol design and are bounded by
+  `max_mrtr_rounds`.
+
+There is no blanket network retry for tool calls. A connection failure may
+occur after the server performed a side effect but before the response reached
+the client. Add application-level retries only when the operation is known to
+be idempotent or carries an application idempotency key. Apply an outer timeout
+around user-facing operations and retain a separate absolute cap even when
+progress notifications arrive.
+
+Use `is_connected` for a cheap transport-state check, but treat the result as
+a snapshot. The next operation is the authoritative health signal.
+
+## Shutdown and long-lived streams
+
+Call `client.shutdown().await` when possible so the background transport task
+can close cleanly. Dropping the client also closes its command channel, but
+does not give the application a completion point.
+
+For final-protocol notifications, keep the returned `SubscriptionHandle`, wait
+for `acknowledged()`, and call `cancel()` when finished. Dropping the handle
+requests best-effort cancellation; explicit cancellation confirms the stream
+closed. The runnable flow is in
+[`stateless_http_client.rs`](../examples/stateless_http_client.rs).
+
+## Runnable examples
+
+```bash
+# Stdio subprocess client
+cargo run --example client_cli
+
+# Stable Streamable HTTP client; start http_server in another terminal
+cargo run --example http_server --features http
+cargo run --example http_client --features http-client
+
+# Callback and bidirectional request handling
+cargo run --example client_handler
+
+# In-process 2026-07-28 server and client
+cargo run --example stateless_http_client \
+  --features "http,http-client,protocol-2026-07-28"
+```
+
+See the [examples index](../examples/README.md) for OAuth, task, subscription,
+and conformance clients.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,355 @@
+# HTTP deployment guide
+
+This guide covers mounting and operating tower-mcp's Streamable HTTP server.
+It focuses on crate behavior and deployment choices; the authoritative wire
+requirements live in the MCP specifications:
+
+- [2025-11-25 Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+- [2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
+- [2026-07-28 key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+
+Read the [OAuth authorization guide](oauth.md) before exposing an MCP endpoint
+outside a trusted network.
+
+## Install the server transport
+
+```toml
+[dependencies]
+tower-mcp = { version = "0.16", features = ["http"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+axum = "0.8"
+```
+
+Add `protocol-2026-07-28` when this deployment should accept the released
+sessionless protocol. Compile-time availability and runtime selection are
+separate; see the [protocol-version guide](protocol-versions.md).
+
+## Standalone or mounted
+
+`serve` is the shortest standalone path. It mounts the MCP endpoint at `/` and
+the health check at `/health`:
+
+```rust,no_run
+use tower_mcp::{BoxError, HttpTransport, McpRouter};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let mcp = McpRouter::new().server_info("my-server", "1.0.0");
+    HttpTransport::new(mcp).serve("127.0.0.1:3000").await?;
+    Ok(())
+}
+```
+
+Bind to loopback for a local server. Binding to `0.0.0.0` makes the service
+reachable from other hosts and should be paired with TLS termination,
+authentication, and explicit origin/host policy.
+
+For an existing axum application, mount the complete transport router at a
+stable path:
+
+```rust,no_run
+use axum::{Router, routing::get};
+use tower_mcp::{BoxError, HttpTransport, McpRouter};
+
+async fn ready() -> &'static str { "ready" }
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let mcp_service = McpRouter::new().server_info("my-server", "1.0.0");
+    let mcp = HttpTransport::new(mcp_service).into_router_at("/mcp");
+
+    let app = Router::new()
+        .route("/readyz", get(ready))
+        .merge(mcp);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+```
+
+The MCP endpoint is now `/mcp` and its built-in health route is
+`/mcp/health`. Use `into_router_at_with_handle` when an admin endpoint needs a
+`SessionHandle` for session count, inspection, or termination. The
+[`axum_embedding` example](../examples/axum_embedding.rs) is the canonical
+shared-router pattern.
+
+When OAuth is enabled, prefer `into_oauth_router_at` rather than nesting an
+already-built OAuth router manually. It derives the protected-resource
+metadata path and resource identifier from the mount path correctly.
+
+## Origin and host validation
+
+`HttpTransport` validates browser `Origin` headers by default:
+
+- a request without `Origin` is accepted;
+- localhost origins are accepted;
+- a non-localhost origin is rejected unless it exactly matches
+  `allowed_origins`;
+- an empty allowlist therefore rejects browser cross-origin access.
+
+Host validation is also enabled. Localhost variants are accepted. For
+compatibility, non-localhost hosts are accepted when `allowed_hosts` is empty;
+set an explicit allowlist in production to turn it into a strict check.
+
+```rust,no_run
+use tower_mcp::{HttpTransport, McpRouter};
+
+let transport = HttpTransport::new(McpRouter::new())
+    .allowed_origins(vec!["https://app.example.com".to_string()])
+    .allowed_hosts(vec!["mcp.example.com".to_string()]);
+```
+
+Entries in `allowed_hosts` may include a port. Configure the reverse proxy to
+preserve the public `Host` or authority value that appears in the allowlist.
+Avoid `"*"` origins for authenticated endpoints. Disabling either validation
+is intended for controlled tests and unusual trusted-network topologies, not
+as a production fix for a proxy misconfiguration.
+
+Origin validation is a security check, not a CORS response policy. Browser
+clients may also need an axum/tower-http CORS layer on the returned router to
+emit `Access-Control-Allow-*` headers. Allow the MCP methods and headers the
+client actually uses; final-protocol HTTP includes `MCP-Protocol-Version`,
+`Mcp-Method`, `Mcp-Name`, and possibly `Mcp-Param-*` headers.
+
+## Stateful legacy and sessionless final traffic
+
+One `HttpTransport` can serve both protocol eras on the same URL when
+`protocol-2026-07-28` is compiled and enabled:
+
+| Client traffic | tower-mcp path | Operational state |
+|---|---|---|
+| `initialize`, then `MCP-Session-Id` | legacy `2025-11-25` / `2025-03-26` | session state, GET/POST SSE, optional event replay |
+| `MCP-Protocol-Version: 2026-07-28`, required request metadata, no session ID | final `2026-07-28` | independent requests, `server/discover`, explicit `subscriptions/listen` streams |
+
+Legacy sessions are optional by default for compatibility with clients that
+do not retain the session header. Use `require_sessions()` when the application
+depends on strict 2025-11-25 session semantics:
+
+```rust,no_run
+use std::time::Duration;
+use tower_mcp::{HttpTransport, McpRouter};
+
+let transport = HttpTransport::new(McpRouter::new())
+    .require_sessions()
+    .session_ttl(Duration::from_secs(30 * 60))
+    .max_sessions(10_000);
+```
+
+The default session TTL is 30 minutes and the default cleanup interval is one
+minute. There is no default maximum; set one to bound per-process session
+memory. The built-in session and event stores are in-memory.
+
+The method named `stateless(StatelessConfig)` controls a historical SEP-1442
+compatibility path. It does **not** enable the released 2026-07-28 lifecycle.
+For new deployments, enable `protocol-2026-07-28` and select versions with
+`ProtocolSupport` instead.
+
+## Resumption and disconnection
+
+Legacy Streamable HTTP can attach event IDs to SSE messages. A reconnecting
+client sends `Last-Event-ID`, and the configured `EventStore` supplies later
+events. The default in-memory store can replay only while the same process and
+buffer survive. Supply an external implementation for restart or cross-node
+replay.
+
+The 2026-07-28 protocol removed SSE event IDs, `Last-Event-ID`, and replay. A
+broken final-protocol response loses that in-flight request; a client may
+issue a new request with a new request ID only when application semantics make
+that safe. A broken `subscriptions/listen` stream is opened again as a new
+subscription.
+
+Do not interpret an SSE disconnect as proof that a tool was cancelled or did
+not run. Cancellation and idempotency are application concerns at this
+boundary.
+
+## Horizontal scaling
+
+Choose a topology from the protocol behavior, not just from where metadata is
+stored:
+
+| Topology | Works well for | Limitation |
+|---|---|---|
+| One instance, in-memory stores | local and small deployments | sessions and replay buffers disappear on restart |
+| Sticky routing by legacy session | legacy sessions and bidirectional POST streams | rebalancing or instance loss breaks live process-local state |
+| Shared `SessionStore` + `EventStore` | restoring legacy metadata and replaying buffered events across nodes | does not migrate pending requests, service futures, notification channels, or an open SSE response |
+| Sessionless final requests | ordinary 2026-07-28 calls across any healthy node | an active `subscriptions/listen` connection remains owned by one node and has no replay |
+
+For legacy traffic, session affinity remains the safe default. A Layer 7 load
+balancer can hash `MCP-Session-Id` after initialization. If you use shared
+stores, keep associated POST streams and their client responses on the node
+that owns the originating request; roots, sampling, and elicitation channels
+are process-local.
+
+`SessionStore` persists identity, capabilities, timestamps, and negotiated
+version. `EventStore` persists resumable legacy notification events. Configure
+both when failover needs both behaviors:
+
+```rust,no_run
+use std::sync::Arc;
+use tower_mcp::{HttpTransport, McpRouter};
+use tower_mcp::event_store::{EventStore, MemoryEventStore};
+use tower_mcp::session_store::{MemorySessionStore, SessionStore};
+
+let sessions: Arc<dyn SessionStore> = Arc::new(MemorySessionStore::new());
+let events: Arc<dyn EventStore> = Arc::new(MemoryEventStore::new());
+
+let transport = HttpTransport::new(McpRouter::new())
+    .session_store(sessions)
+    .event_store(events);
+```
+
+The snippet shows the trait wiring; replace both memory implementations with
+an external backend for a real multi-instance deployment. See
+[`horizontal_scaling.rs`](../examples/horizontal_scaling.rs),
+[`session_store.rs`](../examples/session_store.rs), and
+[`event_store.rs`](../examples/event_store.rs).
+
+## Reverse proxies and SSE
+
+The proxy must stream response bytes promptly and keep long-lived responses
+open. An nginx location for a path-mounted endpoint looks like:
+
+```nginx
+location /mcp {
+    proxy_pass http://mcp_backend;
+    proxy_http_version 1.1;
+
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_set_header Connection "";
+    chunked_transfer_encoding on;
+
+    proxy_read_timeout 3600s;
+    proxy_send_timeout 3600s;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+}
+```
+
+Also verify these behaviors in the chosen ingress or CDN:
+
+- response buffering and compression do not batch SSE events;
+- idle timeouts exceed the intended stream lifetime or keepalives arrive
+  frequently enough;
+- request body and header limits permit MCP payloads and `Mcp-Param-*` values;
+- `MCP-Protocol-Version`, `MCP-Session-Id`, `Last-Event-ID`, `Mcp-Method`,
+  `Mcp-Name`, `Authorization`, and `WWW-Authenticate` pass unchanged;
+- 202 responses and streaming content types are not rewritten;
+- graceful deployment drain gives in-flight POST responses time to finish.
+
+Test through the public proxy URL. A direct-to-pod test will not detect
+buffering, header stripping, public-host allowlist mistakes, or TLS/resource
+identifier mismatches.
+
+## Timeouts and size limits
+
+The transport rejects POST bodies larger than 4 MiB by default. Change that
+with `max_body_size`; axum's `DefaultBodyLimit` does not control the MCP
+endpoint because tower-mcp reads the raw request body itself.
+
+Place timeouts according to what should be cancelled:
+
+1. Put a handler-specific timeout on `ToolBuilder`, `ResourceBuilder`, or
+   `PromptBuilder` when only that operation needs a deadline.
+2. Use `HttpTransport::layer` for an MCP-wide request-processing policy.
+3. Use an outer axum layer for HTTP concerns such as header parsing or a
+   short admission timeout.
+4. Do not put a short generic response timeout around the entire axum router;
+   it will also terminate intended SSE and `subscriptions/listen` streams.
+
+Always maintain an absolute operation deadline. Progress notifications are
+evidence of activity, but should not permit an unbounded request. Configure
+proxy and load-balancer idle timeouts separately from application deadlines.
+
+## Middleware order and scope
+
+tower-mcp has three relevant middleware boundaries:
+
+| Boundary | API | Sees | Good uses |
+|---|---|---|---|
+| HTTP router | `transport.into_router[_at]().layer(...)` | MCP HTTP, health, and metadata routes | CORS response policy, request IDs, HTTP tracing, forwarded-header policy |
+| MCP service | `HttpTransport::layer(...)` | parsed MCP requests | principal extensions, MCP metrics, global concurrency or timeout policy |
+| One handler | `.layer(...)` on a tool/resource/prompt builder | only that operation | operation timeout, rate limit, circuit breaker, audit policy |
+
+An outer axum layer runs before transport validation and parsing. An MCP layer
+runs after the request has become a typed router request. A handler layer runs
+only after routing selected that capability. Build authentication with
+`into_oauth_router`/`into_oauth_router_at`; those helpers keep bearer validation
+and operation-scope enforcement in the intended order.
+
+When using `HttpTransport::from_service`, wrap the supplied service before
+construction. `HttpTransport::layer` is intentionally unavailable because the
+transport cannot reconstruct the opaque service stack.
+
+## Health, shutdown, and observability
+
+The built-in health route returns process liveness. It does not prove an
+external authorization server, session store, event store, or downstream tool
+dependency is ready. Add a separate application readiness route when those
+dependencies should gate traffic.
+
+Own the axum server lifecycle when you need graceful shutdown:
+
+```rust
+use tower_mcp::{BoxError, HttpTransport, McpRouter};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let app = HttpTransport::new(McpRouter::new()).into_router_at("/mcp");
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await?;
+    Ok(())
+}
+```
+
+Use structured `tracing` output and propagate a request ID or OpenTelemetry
+context at the HTTP boundary. Avoid logging authorization headers, access
+tokens, tool secrets, or sensitive arguments. `into_router_with_handle` can
+feed active-session metrics, but high-cardinality session IDs should not be
+metric labels.
+
+## Production checklist
+
+- [ ] Mount a stable public endpoint and test the exact public URL.
+- [ ] Terminate TLS and configure OAuth or another appropriate trust boundary.
+- [ ] Keep Origin validation enabled and configure exact browser origins.
+- [ ] Configure the public host allowlist and preserve `Host` through proxies.
+- [ ] Select the intended runtime protocol versions explicitly.
+- [ ] Decide whether legacy sessions are optional or required.
+- [ ] Use affinity and/or shared stores according to the legacy features in use.
+- [ ] Disable proxy buffering and set stream-aware idle timeouts.
+- [ ] Bound bodies, sessions, handler execution, and graceful drain time.
+- [ ] Test JSON responses, POST SSE, legacy GET SSE/resumption if supported,
+      final `subscriptions/listen`, 202 notifications, and error bodies.
+- [ ] Separate liveness from dependency-aware readiness.
+- [ ] Redact secrets and confirm logs remain on stderr for stdio deployments.
+
+## Runnable examples
+
+```bash
+# Standalone HTTP server
+cargo run --example http_server --features http
+
+# Mount under /mcp in an existing axum app
+cargo run --example axum_embedding --features http
+
+# Shared-store and cross-instance patterns
+cargo run --example horizontal_scaling --features http
+cargo run --example session_store --features http
+cargo run --example event_store --features http
+
+# Final sessionless server/client in one process
+cargo run --example stateless_http_client \
+  --features "http,http-client,protocol-2026-07-28"
+```
+
+The rustdoc [`deployment` module](https://docs.rs/tower-mcp/latest/tower_mcp/deployment/)
+contains additional systemd, proxy, and capacity-planning notes.

--- a/docs/protocol-versions.md
+++ b/docs/protocol-versions.md
@@ -1,0 +1,300 @@
+# Protocol-version guide
+
+tower-mcp separates three questions that are easy to conflate:
+
+1. Which wire types does the library know?
+2. Which protocol implementations were compiled into `tower-mcp`?
+3. Which compiled versions may this client or server use at runtime?
+
+This guide explains the crate policy and APIs. The MCP specification remains
+authoritative for protocol behavior:
+
+- [2026-07-28 versioning and compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning)
+- [2026-07-28 key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [2026-07-28 discovery](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)
+- [2025-11-25 lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
+
+## Current support policy
+
+| Wire revision | Status in tower-mcp 0.16 | Compile-time switch | Lifecycle |
+|---|---|---|---|
+| `2026-07-28` | released, opt-in | `protocol-2026-07-28` | sessionless, per-request metadata, optional `server/discover` first |
+| `2025-11-25` | stable default | always available | `initialize` session lifecycle |
+| `2025-03-26` | backward compatibility | always available | `initialize` session lifecycle |
+
+The default Cargo build is intentionally conservative. A release of the MCP
+specification does not silently move existing applications to a different
+lifecycle. Enabling `full` compiles the final implementation because `full`
+includes `protocol-2026-07-28`, but client runtime selection remains stable by
+default.
+
+The former `stateless` Cargo feature is a compatibility alias. New manifests
+should use `protocol-2026-07-28`. Likewise,
+`EXPERIMENTAL_PROTOCOL_VERSION` and `UPCOMING_PROTOCOL_VERSION` are deprecated
+aliases of `PROTOCOL_VERSION_2026_07_28`; use the canonical constant in new
+code.
+
+## Types, compile-time support, and runtime support
+
+### Wire types
+
+`tower-mcp-types` exposes every protocol type the release knows without
+pulling in Tower, Tokio, or an HTTP runtime. Its known-version constants answer
+schema and serialization questions, not whether a `tower-mcp` transport can
+execute that lifecycle.
+
+### Compiled implementations
+
+`COMPILED_PROTOCOL_VERSIONS` reports the implementations present in the
+current `tower-mcp` build, in preference order. `is_protocol_version_compiled`
+answers the same question for one string.
+
+Without the final feature:
+
+```text
+["2025-11-25", "2025-03-26"]
+```
+
+With `protocol-2026-07-28`:
+
+```text
+["2026-07-28", "2025-11-25", "2025-03-26"]
+```
+
+### Runtime allowlists
+
+`ProtocolSupport` is an exact, ordered allowlist for one client or transport.
+Construction rejects an empty list, duplicates, and versions that were not
+compiled.
+
+```rust
+use tower_mcp::{BoxError, ProtocolSupport};
+
+fn main() -> Result<(), BoxError> {
+    let stable = ProtocolSupport::stable();
+    assert!(stable.contains("2025-11-25"));
+
+    let final_only = ProtocolSupport::try_new(["2026-07-28"])?;
+    assert_eq!(final_only.preferred(), "2026-07-28");
+    Ok(())
+}
+```
+
+`ProtocolSupport::compiled()` enables the whole compiled set.
+`ProtocolSupport::stable()` excludes opt-in implementations even if they were
+compiled. `ProtocolSupport::default()` is the compiled set.
+
+Two older constants have narrower meaning:
+
+- `LATEST_PROTOCOL_VERSION` is the preferred non-breaking default
+  (`2025-11-25`), not the newest published date.
+- `SUPPORTED_PROTOCOL_VERSIONS` is the stable compatibility set, not every
+  implementation that can be compiled.
+
+Use `COMPILED_PROTOCOL_VERSIONS` and `ProtocolSupport` for deployment policy.
+
+## Configure a server
+
+An HTTP server enables every compiled implementation by default. If the final
+feature is not compiled, that is the stable set. If it is compiled, the same
+endpoint is dual-era unless you narrow it.
+
+The server snippets require the `http` feature. Final-only and dual-era
+snippets also require `protocol-2026-07-28`.
+
+### Stable-only server
+
+```rust
+use tower_mcp::{HttpTransport, McpRouter, ProtocolSupport};
+
+fn main() {
+    let transport = HttpTransport::new(McpRouter::new())
+        .protocol_support(ProtocolSupport::stable());
+    drop(transport);
+}
+```
+
+### Final-only server
+
+```rust
+use tower_mcp::{BoxError, HttpTransport, McpRouter, ProtocolSupport};
+
+fn main() -> Result<(), BoxError> {
+    let support = ProtocolSupport::try_new(["2026-07-28"])?;
+    let transport = HttpTransport::new(McpRouter::new())
+        .protocol_support(support);
+    drop(transport);
+    Ok(())
+}
+```
+
+### Explicit dual-era server
+
+```rust
+use tower_mcp::{BoxError, HttpTransport, McpRouter, ProtocolSupport};
+
+fn main() -> Result<(), BoxError> {
+    let support = ProtocolSupport::try_new([
+        "2026-07-28",
+        "2025-11-25",
+        "2025-03-26",
+    ])?;
+    let transport = HttpTransport::new(McpRouter::new())
+        .protocol_support(support);
+    drop(transport);
+    Ok(())
+}
+```
+
+The order is advertised as preference order. `protocol_versions(...)` is a
+convenience method that constructs the same validated policy on the transport.
+
+On HTTP, a dual-era transport selects behavior from the incoming request:
+
+- a final request declares `2026-07-28`, includes required per-request
+  metadata, and has no session ID;
+- an `initialize` request starts a legacy lifecycle and subsequent requests
+  use its negotiated session/version rules.
+
+Both may be served concurrently at one URL. The final path is automatic when
+the feature and runtime policy allow it; do not call the historical
+`stateless(StatelessConfig)` API to activate it.
+
+## Configure a client
+
+Clients are stable by default, even in a build using `full`. This avoids a
+Cargo feature changing an application's first wire request.
+
+### Stable client
+
+```rust,ignore
+let client = McpClient::connect(transport).await?;
+client.initialize("my-client", "1.0.0").await?;
+```
+
+`initialize` sends the legacy handshake and the required
+`notifications/initialized` notification. HTTP stores the negotiated protocol
+version and session ID for later requests.
+
+### Final client
+
+```rust,ignore
+let support = ProtocolSupport::try_new(["2026-07-28"])?;
+let client = McpClient::builder()
+    .protocol_support(support)
+    .connect_simple(transport)
+    .await?;
+client.discover("my-client", "1.0.0").await?;
+```
+
+`discover` starts the modern path and records the selected version. Every
+later request carries the version, client identity, and capabilities in
+`_meta`; HTTP adds the required protocol and method headers. Do not call
+`initialize` on the same client.
+
+`discover` retries one recognized `UnsupportedProtocolVersionError` with a
+mutually supported modern version. It does not automatically convert a modern
+client into a legacy client. An application that must connect to unknown-era
+servers should own that policy: probe according to the spec, create a fresh
+client/transport for fallback, and call `initialize` only after classifying the
+server as legacy. Reusing a partially probed connection risks mixing lifecycle
+state.
+
+See the [client guide](client.md) for complete setup and request patterns.
+
+## Behavioral differences applications must account for
+
+The final revision is not just a newer version string:
+
+| Area | 2025-11-25 and earlier | 2026-07-28 |
+|---|---|---|
+| Startup | `initialize` / `notifications/initialized` | no handshake; `server/discover` is available |
+| Identity/capabilities | negotiated once | carried on every request |
+| HTTP sessions | optional/required session IDs | protocol-level sessions removed |
+| General server push | legacy GET/POST SSE streams | explicit `subscriptions/listen` POST |
+| Stream replay | optional SSE IDs and `Last-Event-ID` | removed |
+| Server input requests | bidirectional requests | MRTR `input_required` result and retry |
+| Cache hints | application-defined | `ttlMs` and `cacheScope` on cacheable results |
+| Tasks | legacy experimental shapes | negotiated `io.modelcontextprotocol/tasks` extension |
+| `ping` / `logging/setLevel` | core methods | removed from final core |
+
+tower-mcp version-gates these paths. It also keeps deprecated legacy features
+available where their protocol revision requires them. Do not branch on server
+display name or version; use negotiated protocol and capabilities.
+
+## Interoperability policy
+
+For broad interoperability:
+
+- deploy a dual-era server when both existing and final clients must connect;
+- leave clients stable unless the target server is known to support the final
+  lifecycle or the application implements era probing;
+- advertise extensions only when the corresponding application behavior is
+  enabled (`with_tasks`, `with_mcp_apps`, or a validated extension declaration);
+- treat absence of a capability as unsupported;
+- use `sse_responses(true)` only for legacy clients that incorrectly require
+  SSE-wrapped synchronous responses;
+- test the exact feature/runtime combinations you ship, not only `--all-features`.
+
+The official conformance suites run against tower-mcp's stable and final client
+and server paths on every pull request. The repository also tests wire
+compatibility with rmcp and the official TypeScript and Python SDKs. Counts
+change as upstream scenarios are added; use the current CI result as the source
+of truth.
+
+Useful local matrix checks:
+
+```bash
+# Stable default library
+cargo check -p tower-mcp --no-default-features
+
+# Stable HTTP server/client
+cargo check -p tower-mcp --no-default-features \
+  --features "http,http-client"
+
+# Dual-era HTTP server/client
+cargo check -p tower-mcp --no-default-features \
+  --features "http,http-client,protocol-2026-07-28"
+
+# Everything shipped by the workspace
+cargo test --workspace --all-targets --all-features
+```
+
+## Upgrade policy for applications
+
+Treat a protocol upgrade as an application change, even when the crate update
+is semver-compatible:
+
+1. Compile the new implementation in CI without changing runtime selection.
+2. Run the relevant conformance and integration matrix.
+3. Enable the new version on a canary server with an explicit
+   `ProtocolSupport` allowlist.
+4. Confirm proxy headers, authentication resource binding, caching, and stream
+   behavior for the new lifecycle.
+5. Opt clients in deliberately and call the lifecycle method for that era.
+6. Keep or remove legacy support according to observed client traffic and your
+   published compatibility policy.
+
+Avoid using status-bearing aliases such as “upcoming” in configuration or
+persisted data. Store the exact wire date (`2026-07-28`) and use canonical
+constants in code. If an unsupported date reaches a runtime allowlist,
+`ProtocolSupport::try_new` fails at startup rather than advertising a path the
+binary cannot execute.
+
+## Runnable examples
+
+```bash
+# Final server/discover response shape
+cargo run --example server_discover \
+  --features "http,protocol-2026-07-28"
+
+# Full final client/server lifecycle
+cargo run --example stateless_http_client \
+  --features "http,http-client,protocol-2026-07-28"
+
+# Final Tasks extension
+cargo run --example tasks --features protocol-2026-07-28
+```
+
+The [examples index](../examples/README.md) also links the stable HTTP and
+conformance implementations.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -154,7 +154,7 @@ required-features = ["http"]
 [[example]]
 name = "server_discover"
 path = "server_discover.rs"
-required-features = ["http", "stateless"]
+required-features = ["http", "protocol-2026-07-28"]
 
 [[example]]
 name = "stateless_http_client"

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,11 @@ If you are dropping tower-mcp into an existing axum application,
 `HttpTransport::into_router()` composes with your own routes, state, and
 tower middleware.
 
+For a guided path, see [client usage](../docs/client.md),
+[HTTP deployment](../docs/deployment.md),
+[protocol versions](../docs/protocol-versions.md), and
+[OAuth authorization](../docs/oauth.md).
+
 ## Running Examples
 
 ```bash
@@ -32,6 +37,10 @@ cargo run --example websocket_server --features websocket
 cargo run --example http_client --features http-client
 cargo run --example http_sse_client --features http
 cargo run --example stateless_http_client --features "http,http-client,protocol-2026-07-28"
+
+# Released 2026-07-28 discovery and Tasks extension
+cargo run --example server_discover --features "http,protocol-2026-07-28"
+cargo run --example tasks --features protocol-2026-07-28
 
 # OAuth resource server and clients (see ../docs/oauth.md for configuration)
 cargo run --example http_auth --features jwks -- --auth jwks
@@ -95,6 +104,7 @@ production checklist.
 | [client_cli](client_cli.rs) | Stdio client connecting to subprocess servers |
 | [http_client](http_client.rs) | HTTP client with McpClient API |
 | [http_sse_client](http_sse_client.rs) | SSE stream resumption (Last-Event-ID) |
+| [server_discover](server_discover.rs) | Minimal 2026-07-28 `server/discover` server and response shape |
 | [stateless_http_client](stateless_http_client.rs) | 2026-07-28 stateless protocol: server/discover, tools/list, tools/call, subscriptions/listen -- no session ID |
 
 ### Bidirectional Communication
@@ -122,6 +132,7 @@ production checklist.
 | [event_store](event_store.rs) | Custom `EventStore` for persistent SSE event buffering and cross-instance resumption |
 | [session_store](session_store.rs) | Custom `SessionStore` for persistent session metadata |
 | [testing](testing.rs) | In-process testing with TestClient |
+| [tasks](tasks.rs) | 2026-07-28 Tasks extension lifecycle, notifications, cancellation, and ownership |
 | [weather_server](weather_server.rs) | External API integration (NWS) |
 
 ### Macros

--- a/examples/server_discover.rs
+++ b/examples/server_discover.rs
@@ -20,8 +20,8 @@
 //!
 //! ## What this example does
 //!
-//! 1. Starts an `HttpTransport` server in-process with `stateless` enabled so
-//!    the 2026-07-28 code path is active.
+//! 1. Starts a dual-era `HttpTransport` server in-process with the
+//!    `protocol-2026-07-28` implementation compiled and enabled.
 //! 2. Calls `server/discover` with `MCP-Protocol-Version: 2026-07-28` and
 //!    `Mcp-Method: server/discover` (both required in 2026-07-28 strict mode).
 //! 3. Prints the discover response: supported versions, capabilities, server info.
@@ -31,7 +31,7 @@
 //!    session-based path still works alongside stateless clients.
 //!
 //! Run with:
-//!   cargo run --example server_discover --features "http,stateless"
+//!   cargo run --example server_discover --features "http,protocol-2026-07-28"
 
 use std::time::Duration;
 
@@ -101,12 +101,6 @@ fn build_router() -> McpRouter {
 
 /// Start an in-process server and return its URL.
 async fn start_server() -> (String, tokio::task::JoinHandle<()>) {
-    #[cfg(feature = "stateless")]
-    let transport = HttpTransport::new(build_router())
-        .disable_origin_validation()
-        .stateless(tower_mcp::stateless::StatelessConfig::new());
-
-    #[cfg(not(feature = "stateless"))]
     let transport = HttpTransport::new(build_router()).disable_origin_validation();
 
     let axum_router = transport.into_router();
@@ -154,7 +148,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "server/discover"
+            "method": "server/discover",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "server-discover-example",
+                        "version": "1.0.0"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
         }))
         .send()
         .await?;
@@ -175,6 +179,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
 
     let discover_body: serde_json::Value = discover_resp.json().await?;
+    if !status.is_success() {
+        return Err(format!("server/discover failed: {discover_body}").into());
+    }
 
     // The result uses supportedVersions (plural), NOT protocolVersion (singular).
     // That is the key structural difference from initialize.
@@ -220,10 +227,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     let chosen_version = supported
         .iter()
-        .find(|v| v.as_str() == Some("2025-11-25"))
+        .find(|v| v.as_str() == Some("2026-07-28"))
         .or_else(|| supported.first())
         .and_then(|v| v.as_str())
-        .unwrap_or("2025-11-25");
+        .unwrap_or("2026-07-28");
 
     println!(
         "=== tools/list (stateless, using version '{}' from discover) ===",
@@ -235,18 +242,32 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .post(&url)
         .header("Content-Type", "application/json")
         .header("Accept", "application/json")
-        .header("MCP-Protocol-Version", "2026-07-28")
+        .header("MCP-Protocol-Version", chosen_version)
         .header("Mcp-Method", "tools/list")
         .json(&serde_json::json!({
             "jsonrpc": "2.0",
             "id": 2,
-            "method": "tools/list"
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": chosen_version,
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "server-discover-example",
+                        "version": "1.0.0"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {}
+                }
+            }
         }))
         .send()
         .await?;
 
-    println!("HTTP status: {}", tools_resp.status());
+    let tools_status = tools_resp.status();
+    println!("HTTP status: {tools_status}");
     let tools_body: serde_json::Value = tools_resp.json().await?;
+    if !tools_status.is_success() {
+        return Err(format!("tools/list failed: {tools_body}").into());
+    }
     let tools = tools_body["result"]["tools"]
         .as_array()
         .expect("tools must be an array");


### PR DESCRIPTION
Closes #1119

## Summary

- add focused client, HTTP deployment, and protocol-version guides with links to the authoritative MCP specification
- cross-link the guides from the README, crate rustdoc, deployment rustdoc, and examples index
- keep the README navigational by moving detailed final-protocol usage out of the compliance overview
- index the `server_discover` and `tasks` examples
- update `server_discover` to the canonical `protocol-2026-07-28` feature and make its final requests carry the required per-request metadata
- refresh stale 0.10/stateless feature snippets in public rustdoc

## Validation

- `cargo fmt --all -- --check`
- `RUSTDOCFLAGS="-Dwarnings -Dmissing-docs" cargo doc -p tower-mcp -p tower-mcp-types -p tower-mcp-macros --no-deps --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `cargo test --doc --workspace --all-features`
- stable, HTTP client/server, and dual-era feature-matrix `cargo check` commands from the protocol guide
- exact runnable commands for `server_discover`, `stateless_http_client`, and `tasks`
- Markdown link checks for all three new guides and the examples index