### PR TITLE
docs: publish guides in rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ If you've used [axum](https://docs.rs/axum), tower-mcp's API will feel familiar:
 
 | Guide | Use it when |
 |---|---|
-| [Client usage](docs/client.md) | Choosing a transport, connecting, handling callbacks, making requests, configuring caching, or defining retry policy |
-| [HTTP deployment](docs/deployment.md) | Mounting an endpoint, configuring proxies and origins, choosing session/scaling policy, or placing middleware and timeouts |
-| [Protocol versions](docs/protocol-versions.md) | Selecting compile-time and runtime support, comparing lifecycle behavior, planning interoperability, or upgrading revisions |
-| [OAuth authorization](docs/oauth.md) | Protecting an MCP resource server, building an interactive or service client, choosing registration/storage policy, or preparing an OAuth deployment |
-| [MCP Apps](docs/mcp-apps.md) | Returning typed app resources from tools with negotiation and safe fallback |
+| [Client usage](https://docs.rs/tower-mcp/latest/tower_mcp/guides/client/) | Choosing a transport, connecting, handling callbacks, making requests, configuring caching, or defining retry policy |
+| [HTTP deployment](https://docs.rs/tower-mcp/latest/tower_mcp/guides/deployment/) | Mounting an endpoint, configuring proxies and origins, choosing session/scaling policy, or placing middleware and timeouts |
+| [Protocol versions](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/) | Selecting compile-time and runtime support, comparing lifecycle behavior, planning interoperability, or upgrading revisions |
+| [OAuth authorization](https://docs.rs/tower-mcp/latest/tower_mcp/guides/oauth/) | Protecting an MCP resource server, building an interactive or service client, choosing registration/storage policy, or preparing an OAuth deployment |
+| [MCP Apps](https://docs.rs/tower-mcp/latest/tower_mcp/guides/mcp_apps/) | Returning typed app resources from tools with negotiation and safe fallback |
 | [Examples index](examples/README.md) | Looking for a runnable server, client, transport, middleware, or extension pattern |
 
 ## Quick Start
@@ -503,7 +503,7 @@ Ok(app)
 }
 ```
 
-See the [OAuth authorization guide](docs/oauth.md) for JWKS validation,
+See the [OAuth authorization guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/oauth/) for JWKS validation,
 interactive authorization code, registration choices, persistence, scope
 step-up, service credentials, and the production checklist. The
 [`http_auth`](examples/http_auth.rs) and
@@ -624,7 +624,7 @@ tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotoco
 
 For application-facing guidance on the stable default, opt-in 2026-07-28
 implementation, compile-time features, runtime allowlists, interoperability,
-and upgrade policy, start with the [protocol-version guide](docs/protocol-versions.md).
+and upgrade policy, start with the [protocol-version guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/).
 
 - **Server (2025-11-25):** 48/48 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
 - **Client (2025-11-25):** all 18 scenarios green, 235 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
@@ -640,9 +640,9 @@ hints, Multi Round-Trip Requests, and the final Tasks extension. The default
 runtime remains 2025-11-25, including for clients built with `full`.
 
 Compile-time availability and runtime allowlists are separate. The
-[protocol-version guide](docs/protocol-versions.md) explains the constants,
+[protocol-version guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/) explains the constants,
 feature policy, lifecycle differences, interoperability, and upgrade path;
-the [client guide](docs/client.md) covers final discovery, caching, MRTR,
+the [client guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/client/) covers final discovery, caching, MRTR,
 retries, and shutdown with runnable examples.
 
 [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2484) (accepted) makes merged conformance scenarios a prerequisite for standards-track SEPs reaching `final`, which elevates the conformance suite from a nice-to-have to spec-gating infrastructure. We run it on every PR to catch regressions early and to stay ahead of new scenarios as the spec evolves.
@@ -672,7 +672,7 @@ retries, and shutdown with runnable examples.
 - [x] [SSE event IDs and stream resumption](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#resumability-and-redelivery) (SEP-1699)
 - [x] [`_meta` field on all protocol types](https://modelcontextprotocol.io/specification/2025-11-25)
 - [x] [Protocol extension declaration and runtime negotiation (SEP-2133)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2133)
-- [x] [Typed MCP Apps server resources and tool linkage (SEP-1865)](docs/mcp-apps.md) (requires `mcp-apps`; runtime opt-in remains explicit)
+- [x] [Typed MCP Apps server resources and tool linkage (SEP-1865)](https://docs.rs/tower-mcp/latest/tower_mcp/guides/mcp_apps/) (requires `mcp-apps`; runtime opt-in remains explicit)
 - [x] [Strict HTTP headers: `Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version` (SEP-2243)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) (final)
 - [x] [`server/discover` RPC -- stateless capability discovery (SEP-2575)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2575) (requires `protocol-2026-07-28`)
 - [x] [`subscriptions/listen` SSE endpoint -- client-initiated server-push stream (SEP-2567)](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2567) (requires `protocol-2026-07-28`)

--- a/crates/tower-mcp/src/apps.rs
+++ b/crates/tower-mcp/src/apps.rs
@@ -13,6 +13,9 @@
 //! `text/html;profile=mcp-app` MIME type. External CSP sources are restricted
 //! to origins: credentials, paths, queries, fragments, and unsupported schemes
 //! are rejected.
+//!
+//! See [`crate::guides::mcp_apps`] for the task-oriented setup, security
+//! boundary, CSP and permissions policy, and visibility guidance.
 
 use std::collections::HashSet;
 use std::fmt;

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -5,6 +5,9 @@
 //! handles request/response correlation, server-initiated requests
 //! (sampling, elicitation, roots), and notifications.
 //!
+//! See [`crate::guides::client`] for transport selection, lifecycle setup,
+//! callbacks, common requests, caching, retry policy, and shutdown guidance.
+//!
 //! # Example
 //!
 //! ```rust,no_run

--- a/crates/tower-mcp/src/deployment.rs
+++ b/crates/tower-mcp/src/deployment.rs
@@ -337,10 +337,9 @@
 //!
 //! # See Also
 //!
-//! - The repository's
-//!   [HTTP deployment guide](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/deployment.md)
-//!   is the task-oriented starting point for endpoint mounting, proxy headers,
-//!   protocol policy, timeouts, and production checklists.
+//! - [`crate::guides::deployment`] is the task-oriented starting point for
+//!   endpoint mounting, proxy headers, protocol policy, timeouts, and
+//!   production checklists.
 //! - [`session_store`] for the `SessionStore` trait and implementations.
 //! - [`event_store`] for the `EventStore` trait and SSE event persistence.
 //! - The `session_store` and `event_store` examples in the repo show

--- a/crates/tower-mcp/src/guides.rs
+++ b/crates/tower-mcp/src/guides.rs
@@ -1,0 +1,21 @@
+//! Task-oriented guides for building and operating tower-mcp applications.
+//!
+//! These guides complement the API reference and point to the authoritative
+//! MCP specification for wire-protocol semantics:
+//!
+//! - [`client`] — transports, lifecycle, callbacks, requests, caching, retries,
+//!   and shutdown.
+//! - [`deployment`] — endpoint mounting, reverse proxies, origin and host
+//!   policy, sessions, scaling, timeouts, health, and middleware order.
+//! - [`protocol_versions`] — compile-time availability, runtime allowlists,
+//!   lifecycle differences, interoperability, and upgrades.
+//! - [`oauth`] — protected resource servers, interactive clients,
+//!   service-to-service clients, persistence, and production policy.
+//! - [`mcp_apps`] — typed MCP Apps resources, negotiation, fallback, CSP,
+//!   permissions, and visibility.
+
+pub mod client;
+pub mod deployment;
+pub mod mcp_apps;
+pub mod oauth;
+pub mod protocol_versions;

--- a/crates/tower-mcp/src/guides/client.rs
+++ b/crates/tower-mcp/src/guides/client.rs
@@ -1,3 +1,4 @@
+#![doc = r####"
 # Client guide
 
 This guide covers the choices an application makes when using tower-mcp as an
@@ -11,7 +12,7 @@ specification rather than this guide:
 - [2026-07-28 discovery](https://modelcontextprotocol.io/specification/2026-07-28/server/discover)
 
 For authorization-code, client-credentials, and custom token-provider setup,
-continue with the [OAuth authorization guide](oauth.md).
+continue with the [OAuth authorization guide](crate::guides::oauth).
 
 ## Choose a transport
 
@@ -93,7 +94,7 @@ async fn main() -> Result<(), BoxError> {
 
 For a static bearer token, API key, or basic credentials, configure the
 `HttpClientTransport` before connecting. For token acquisition and refresh,
-use a token provider from the [OAuth guide](oauth.md); avoid copying tokens
+use a token provider from the [OAuth guide](crate::guides::oauth); avoid copying tokens
 into custom headers yourself.
 
 ### Released 2026-07-28 lifecycle
@@ -132,7 +133,7 @@ async fn main() -> Result<(), BoxError> {
 
 Do not call `initialize` on this path. `discover` selects a mutually supported
 modern version, and the client then adds the required per-request `_meta` and
-HTTP headers. See the [protocol-version guide](protocol-versions.md) for
+HTTP headers. See the [protocol-version guide](crate::guides::protocol_versions) for
 stable-only, final-only, and dual-era policies.
 
 ## Handle callbacks and server requests
@@ -144,7 +145,7 @@ advertises.
 
 For notification callbacks:
 
-```rust
+```rust,no_run
 use tower_mcp::BoxError;
 use tower_mcp::client::{
     McpClient, NotificationHandler, StdioClientTransport,
@@ -173,7 +174,7 @@ elicitation. Pair the implementation with the matching builder call:
 - `with_sampling()` must be paired with `handle_create_message`.
 - `with_elicitation()` must be paired with `handle_elicit` and a real consent UI.
 
-The [client handler example](../examples/client_handler.rs) contains a complete
+The [client handler example](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/client_handler.rs) contains a complete
 implementation. On the 2026-07-28 path, the same handler resolves embedded
 Multi Round-Trip Request inputs; `max_mrtr_rounds` bounds the automatic loop
 and defaults to eight.
@@ -285,7 +286,7 @@ For final-protocol notifications, keep the returned `SubscriptionHandle`, wait
 for `acknowledged()`, and call `cancel()` when finished. Dropping the handle
 requests best-effort cancellation; explicit cancellation confirms the stream
 closed. The runnable flow is in
-[`stateless_http_client.rs`](../examples/stateless_http_client.rs).
+[`stateless_http_client.rs`](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/stateless_http_client.rs).
 
 ## Runnable examples
 
@@ -305,5 +306,6 @@ cargo run --example stateless_http_client \
   --features "http,http-client,protocol-2026-07-28"
 ```
 
-See the [examples index](../examples/README.md) for OAuth, task, subscription,
-and conformance clients.
+See the [examples index](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/README.md)
+for OAuth, task, subscription, and conformance clients.
+"####]

--- a/crates/tower-mcp/src/guides/deployment.rs
+++ b/crates/tower-mcp/src/guides/deployment.rs
@@ -1,3 +1,4 @@
+#![doc = r####"
 # HTTP deployment guide
 
 This guide covers mounting and operating tower-mcp's Streamable HTTP server.
@@ -8,7 +9,7 @@ requirements live in the MCP specifications:
 - [2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
 - [2026-07-28 key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
 
-Read the [OAuth authorization guide](oauth.md) before exposing an MCP endpoint
+Read the [OAuth authorization guide](crate::guides::oauth) before exposing an MCP endpoint
 outside a trusted network.
 
 ## Install the server transport
@@ -22,7 +23,7 @@ axum = "0.8"
 
 Add `protocol-2026-07-28` when this deployment should accept the released
 sessionless protocol. Compile-time availability and runtime selection are
-separate; see the [protocol-version guide](protocol-versions.md).
+separate; see the [protocol-version guide](crate::guides::protocol_versions).
 
 ## Standalone or mounted
 
@@ -71,7 +72,7 @@ async fn main() -> Result<(), BoxError> {
 The MCP endpoint is now `/mcp` and its built-in health route is
 `/mcp/health`. Use `into_router_at_with_handle` when an admin endpoint needs a
 `SessionHandle` for session count, inspection, or termination. The
-[`axum_embedding` example](../examples/axum_embedding.rs) is the canonical
+[`axum_embedding` example](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/axum_embedding.rs) is the canonical
 shared-router pattern.
 
 When OAuth is enabled, prefer `into_oauth_router_at` rather than nesting an
@@ -201,9 +202,9 @@ let transport = HttpTransport::new(McpRouter::new())
 
 The snippet shows the trait wiring; replace both memory implementations with
 an external backend for a real multi-instance deployment. See
-[`horizontal_scaling.rs`](../examples/horizontal_scaling.rs),
-[`session_store.rs`](../examples/session_store.rs), and
-[`event_store.rs`](../examples/event_store.rs).
+[`horizontal_scaling.rs`](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/horizontal_scaling.rs),
+[`session_store.rs`](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/session_store.rs), and
+[`event_store.rs`](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/event_store.rs).
 
 ## Reverse proxies and SSE
 
@@ -293,7 +294,7 @@ dependencies should gate traffic.
 
 Own the axum server lifecycle when you need graceful shutdown:
 
-```rust
+```rust,no_run
 use tower_mcp::{BoxError, HttpTransport, McpRouter};
 
 #[tokio::main]
@@ -351,5 +352,7 @@ cargo run --example stateless_http_client \
   --features "http,http-client,protocol-2026-07-28"
 ```
 
-The rustdoc [`deployment` module](https://docs.rs/tower-mcp/latest/tower_mcp/deployment/)
-contains additional systemd, proxy, and capacity-planning notes.
+The feature-gated
+[`tower_mcp::deployment`](https://docs.rs/tower-mcp/latest/tower_mcp/deployment/)
+reference contains additional systemd, proxy, and capacity-planning notes.
+"####]

--- a/crates/tower-mcp/src/guides/mcp_apps.rs
+++ b/crates/tower-mcp/src/guides/mcp_apps.rs
@@ -1,3 +1,4 @@
+#![doc = r####"
 # MCP Apps server support
 
 tower-mcp provides an opt-in, typed server surface for the stable
@@ -51,7 +52,8 @@ let router = McpRouter::new()
 ```
 
 See the complete runnable
-[`mcp_apps`](../examples/mcp_apps.rs) example.
+[`mcp_apps`](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/mcp_apps.rs)
+example.
 
 ## What the typed API guarantees
 
@@ -131,3 +133,4 @@ App-originated calls. Cross-server App calls remain a host policy violation.
 Visibility metadata is not server-side authorization. Apply normal Tower
 authentication, authorization, rate limits, and audit middleware to every
 tool, including App-only tools.
+"####]

--- a/crates/tower-mcp/src/guides/oauth.rs
+++ b/crates/tower-mcp/src/guides/oauth.rs
@@ -1,3 +1,4 @@
+#![doc = r####"
 # OAuth authorization with tower-mcp
 
 This guide explains how to assemble tower-mcp's OAuth resource-server and
@@ -437,3 +438,4 @@ security boundaries rather than identity-provider details.
 [rfc9700]: https://www.rfc-editor.org/rfc/rfc9700
 [rfc9728]: https://www.rfc-editor.org/rfc/rfc9728
 [cimd]: https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
+"####]

--- a/crates/tower-mcp/src/guides/protocol_versions.rs
+++ b/crates/tower-mcp/src/guides/protocol_versions.rs
@@ -1,3 +1,4 @@
+#![doc = r####"
 # Protocol-version guide
 
 tower-mcp separates three questions that are easy to conflate:
@@ -200,7 +201,7 @@ client/transport for fallback, and call `initialize` only after classifying the
 server as legacy. Reusing a partially probed connection risks mixing lifecycle
 state.
 
-See the [client guide](client.md) for complete setup and request patterns.
+See the [client guide](crate::guides::client) for complete setup and request patterns.
 
 ## Behavioral differences applications must account for
 
@@ -296,5 +297,6 @@ cargo run --example stateless_http_client \
 cargo run --example tasks --features protocol-2026-07-28
 ```
 
-The [examples index](../examples/README.md) also links the stable HTTP and
-conformance implementations.
+The [examples index](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/README.md)
+also links the stable HTTP and conformance implementations.
+"####]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -176,18 +176,19 @@
 //!
 //! For complete server and client setup, registration and persistence policy,
 //! and a production checklist, see the
-//! [OAuth authorization guide](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/oauth.md).
+//! [`guides::oauth`].
 //!
 //! ## Task-oriented Guides
 //!
-//! - [Client usage](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/client.md) —
+//! - [`guides::client`] —
 //!   transport selection, lifecycle, callbacks, requests, caching, retries, and shutdown.
-//! - [HTTP deployment](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/deployment.md) —
+//! - [`guides::deployment`] —
 //!   mounting, reverse proxies, origin/host validation, sessions, scaling, timeouts,
 //!   middleware order, health, and graceful shutdown.
-//! - [Protocol versions](https://github.com/joshrotenberg/tower-mcp/blob/main/docs/protocol-versions.md) —
+//! - [`guides::protocol_versions`] —
 //!   compile-time availability, runtime allowlists, lifecycle differences,
 //!   interoperability, and upgrades.
+//! - [`guides`] — OAuth, MCP Apps, and the complete task-oriented guide index.
 //! - [Examples index](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/README.md) —
 //!   runnable server, client, transport, middleware, OAuth, and extension patterns.
 //!
@@ -491,6 +492,7 @@ pub mod event_store;
 pub mod extension;
 pub mod extract;
 pub mod filter;
+pub mod guides;
 pub mod jsonrpc;
 pub mod middleware;
 #[cfg(feature = "stateless")]

--- a/crates/tower-mcp/src/oauth/mod.rs
+++ b/crates/tower-mcp/src/oauth/mod.rs
@@ -94,6 +94,10 @@
 //! 3. Client fetches the resource's RFC 9728 well-known metadata URL
 //! 4. Client obtains token from the authorization server
 //! 5. Client retries with `Authorization: Bearer <token>`
+//!
+//! See [`crate::guides::oauth`] for complete resource-server and client setup,
+//! registration and persistence policy, identity-provider integration, and a
+//! production checklist.
 
 pub mod error;
 pub mod metadata;

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,10 +8,11 @@ If you are dropping tower-mcp into an existing axum application,
 `HttpTransport::into_router()` composes with your own routes, state, and
 tower middleware.
 
-For a guided path, see [client usage](../docs/client.md),
-[HTTP deployment](../docs/deployment.md),
-[protocol versions](../docs/protocol-versions.md), and
-[OAuth authorization](../docs/oauth.md).
+For a guided path, see
+[client usage](https://docs.rs/tower-mcp/latest/tower_mcp/guides/client/),
+[HTTP deployment](https://docs.rs/tower-mcp/latest/tower_mcp/guides/deployment/),
+[protocol versions](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/), and
+[OAuth authorization](https://docs.rs/tower-mcp/latest/tower_mcp/guides/oauth/).
 
 ## Running Examples
 
@@ -42,7 +43,7 @@ cargo run --example stateless_http_client --features "http,http-client,protocol-
 cargo run --example server_discover --features "http,protocol-2026-07-28"
 cargo run --example tasks --features protocol-2026-07-28
 
-# OAuth resource server and clients (see ../docs/oauth.md for configuration)
+# OAuth resource server and clients (see the published OAuth guide for configuration)
 cargo run --example http_auth --features jwks -- --auth jwks
 cargo run --example oauth_client --features oauth-client -- --mode authorization-code
 cargo run --example oauth_client --features oauth-client -- --mode credentials
@@ -93,7 +94,8 @@ cargo run --example tool_macro --features macros
 | [oauth_client](oauth_client.rs) | Static tokens, client credentials, interactive authorization code with PKCE/scope escalation, and custom providers |
 | [external_api_auth](external_api_auth.rs) | Downstream API authentication patterns |
 
-See the [OAuth authorization guide](../docs/oauth.md) for end-to-end setup,
+See the [OAuth authorization guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/oauth/)
+for end-to-end setup,
 registration and storage policy, identity-provider integration, and the
 production checklist.
 

--- a/examples/http_auth.rs
+++ b/examples/http_auth.rs
@@ -287,9 +287,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 .authorization_server(&issuer)
                 .scope("mcp:read")
                 .scope("mcp:write")
-                .resource_documentation(
-                    "https://github.com/joshrotenberg/tower-mcp/blob/main/docs/oauth.md",
-                );
+                .resource_documentation("https://docs.rs/tower-mcp/latest/tower_mcp/guides/oauth/");
             let transport = HttpTransport::new(mcp_router).disable_origin_validation();
             oauth::wrap(transport, metadata, validator)?
         }

--- a/examples/oauth_client.rs
+++ b/examples/oauth_client.rs
@@ -23,7 +23,7 @@
 //!   cargo run --example oauth_client --features oauth-client -- --mode custom
 //!
 //! The authorization-code mode expects a real OAuth authorization server. See
-//! `docs/oauth.md` for its environment variables and an end-to-end setup.
+//! [`tower_mcp::guides::oauth`] for its environment variables and an end-to-end setup.
 
 use async_trait::async_trait;
 use tower_mcp::client::{


### PR DESCRIPTION
## Summary

- publish the client, deployment, protocol-version, OAuth, and MCP Apps guides under tower_mcp::guides
- replace repository-only Markdown links with rustdoc and docs.rs links
- cross-link the task-oriented guides from their corresponding API modules
- remove the standalone docs directory

## Why

The library documentation otherwise ships as rustdoc. Making these guides real doc-only modules gives users one coherent published documentation surface and makes their Rust examples part of the doctest suite.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- cargo package -p tower-mcp --allow-dirty --no-verify --list