### PR TITLE
feat(runtime): enforce exact MCP inspection profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,7 +653,7 @@ retries, and shutdown with runnable examples.
 - [x] [Initialize/initialized lifecycle](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
 - [x] [tools/list and tools/call](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
 - [x] [Tool annotations](https://modelcontextprotocol.io/specification/2025-11-25/server/tools)
-- [x] [Batch requests](https://modelcontextprotocol.io/specification/2025-11-25/basic#batching)
+- [x] [Request batches](https://modelcontextprotocol.io/specification/2025-03-26/changelog) (`2025-03-26` only; batching was [removed in `2025-06-18`](https://modelcontextprotocol.io/specification/2025-06-18/changelog), so `2025-11-25` and `2026-07-28` reject top-level arrays)
 - [x] [resources/list, resources/read, resources/subscribe](https://modelcontextprotocol.io/specification/2025-11-25/server/resources)
 - [x] [resources/templates/list](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resource-templates)
 - [x] [prompts/list, prompts/get](https://modelcontextprotocol.io/specification/2025-11-25/server/prompts)

--- a/crates/tower-mcp/src/guides/protocol_versions.rs
+++ b/crates/tower-mcp/src/guides/protocol_versions.rs
@@ -223,6 +223,14 @@ tower-mcp version-gates these paths. It also keeps deprecated legacy features
 available where their protocol revision requires them. Do not branch on server
 display name or version; use negotiated protocol and capabilities.
 
+Top-level JSON-RPC arrays need a finer distinction than “legacy.” Request
+batches are accepted only for the exact `2025-03-26` revision. Batching was
+removed in `2025-06-18`, so `2025-11-25` and `2026-07-28` reject arrays before
+dispatch. `JsonRpcService` records the legacy revision returned by
+`initialize`; HTTP uses the session's negotiated revision, while final
+requests use their per-request metadata. A multi-version `ProtocolSupport`
+allowlist is never treated as enough context to guess batch policy.
+
 ## Interoperability policy
 
 For broad interoperability:

--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -7,18 +7,23 @@
 //!
 //! The service handles:
 //! - Single request processing
-//! - Batch request processing (concurrent execution)
+//! - Exact-revision batch policy and concurrent request-batch execution
 //! - JSON-RPC version validation
 //! - Error conversion to JSON-RPC error responses
 
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
 use tower::{Layer, ServiceExt};
 use tower_service::Service;
 
 use crate::error::{Error, JsonRpcError, Result};
+use crate::inspection::{
+    McpDirection, McpInspection, McpInspectionError, McpInspectionErrorKind, McpInspector,
+    McpProtocolRevision,
+};
 use crate::protocol::{
     JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage, McpRequest, ResultType,
 };
@@ -66,7 +71,9 @@ impl<S> Layer<S> for JsonRpcLayer {
 /// Service that handles JSON-RPC framing.
 ///
 /// Wraps an MCP service and handles JSON-RPC request/response conversion.
-/// Supports both single requests and batch requests.
+/// Supports single requests for every implemented revision. Request batches
+/// are accepted only after the exact runtime revision is known to be
+/// `2025-03-26`; later MCP revisions removed top-level JSON-RPC batching.
 ///
 /// Can be created directly via [`JsonRpcService::new`] or through the
 /// [`JsonRpcLayer`] for [`ServiceBuilder`](tower::ServiceBuilder) composition.
@@ -83,6 +90,7 @@ pub struct JsonRpcService<S> {
     inner: S,
     extensions: Extensions,
     protocol_support: ProtocolSupport,
+    negotiated_revision: Arc<RwLock<Option<McpProtocolRevision>>>,
 }
 
 impl<S> JsonRpcService<S> {
@@ -92,6 +100,7 @@ impl<S> JsonRpcService<S> {
             inner,
             extensions: Extensions::new(),
             protocol_support: ProtocolSupport::default(),
+            negotiated_revision: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -116,19 +125,148 @@ impl<S> JsonRpcService<S> {
 
     /// Construct and set an exact runtime protocol-version allow-list.
     pub fn protocol_versions<I, V>(
-        mut self,
+        self,
         versions: I,
     ) -> std::result::Result<Self, ProtocolSupportError>
     where
         I: IntoIterator<Item = V>,
         V: Into<String>,
     {
-        self.protocol_support = ProtocolSupport::try_new(versions)?;
-        Ok(self)
+        Ok(self.protocol_support(ProtocolSupport::try_new(versions)?))
     }
 
     pub(crate) fn configured_protocol_support(&self) -> &ProtocolSupport {
         &self.protocol_support
+    }
+
+    /// Validate a decoded inbound value using the exact runtime revision.
+    ///
+    /// Per-request metadata wins for the final protocol. Legacy traffic uses
+    /// the revision captured from a successful `initialize` response. A
+    /// single-version runtime policy is also exact; an allowlist with several
+    /// versions is never used to guess batch semantics.
+    pub(crate) fn inspect_incoming_value(
+        &self,
+        value: &serde_json::Value,
+        direction: McpDirection,
+    ) -> std::result::Result<McpInspection, JsonRpcError> {
+        let protocol_support = self
+            .extensions
+            .get::<ProtocolSupport>()
+            .unwrap_or(&self.protocol_support);
+        let revision = self.resolve_revision(value, protocol_support)?;
+        inspect_runtime_value(value, revision, protocol_support, direction)
+    }
+
+    /// Pin an already-negotiated revision supplied by a transport session.
+    #[cfg_attr(not(feature = "http"), allow(dead_code))]
+    pub(crate) fn with_negotiated_protocol_version(self, version: &str) -> Self {
+        if let Ok(revision) = version.parse()
+            && let Ok(mut selected) = self.negotiated_revision.write()
+        {
+            *selected = Some(revision);
+        }
+        self
+    }
+
+    fn resolve_revision(
+        &self,
+        value: &serde_json::Value,
+        protocol_support: &ProtocolSupport,
+    ) -> std::result::Result<McpProtocolRevision, JsonRpcError> {
+        if let Some(items) = value.as_array() {
+            let mut declared = items.iter().filter_map(|item| {
+                item.pointer("/params/_meta/io.modelcontextprotocol~1protocolVersion")
+                    .and_then(serde_json::Value::as_str)
+            });
+            if let Some(version) = declared.next() {
+                if declared.any(|candidate| candidate != version) {
+                    return Err(JsonRpcError::invalid_request(
+                        "A JSON-RPC batch cannot mix MCP protocol revisions",
+                    ));
+                }
+                return allowed_revision(version, protocol_support);
+            }
+        }
+
+        if let Some(version) = value
+            .pointer("/params/_meta/io.modelcontextprotocol~1protocolVersion")
+            .and_then(serde_json::Value::as_str)
+        {
+            return allowed_revision(version, protocol_support);
+        }
+
+        if value.get("method").and_then(serde_json::Value::as_str) == Some("initialize") {
+            let requested = value
+                .pointer("/params/protocolVersion")
+                .and_then(serde_json::Value::as_str);
+            let selected = requested
+                .filter(|version| {
+                    crate::protocol::SUPPORTED_PROTOCOL_VERSIONS.contains(version)
+                        && protocol_support.contains(version)
+                })
+                .or_else(|| {
+                    protocol_support.versions().iter().find_map(|version| {
+                        crate::protocol::SUPPORTED_PROTOCOL_VERSIONS
+                            .contains(&version.as_str())
+                            .then_some(version.as_str())
+                    })
+                })
+                .ok_or_else(|| {
+                    JsonRpcError::unsupported_protocol_version(
+                        requested.unwrap_or("unknown"),
+                        protocol_support.versions().iter().map(String::as_str),
+                    )
+                })?;
+            return allowed_revision(selected, protocol_support);
+        }
+
+        if let Some(revision) = self
+            .extensions
+            .get::<McpProtocolRevision>()
+            .copied()
+            .or_else(|| {
+                self.negotiated_revision
+                    .read()
+                    .ok()
+                    .and_then(|revision| *revision)
+            })
+        {
+            if protocol_support.contains(revision.as_str()) {
+                return Ok(revision);
+            }
+            return Err(JsonRpcError::unsupported_protocol_version(
+                revision.as_str(),
+                protocol_support.versions().iter().map(String::as_str),
+            ));
+        }
+
+        if protocol_support.versions().len() == 1 {
+            return allowed_revision(protocol_support.preferred(), protocol_support);
+        }
+
+        if value.is_array() {
+            return Err(JsonRpcError::invalid_request(
+                "Cannot determine the exact MCP revision for a batch before protocol negotiation",
+            ));
+        }
+
+        // Before legacy initialization only version-invariant single calls
+        // such as `ping` are meaningful. Use the most-preferred enabled
+        // legacy implementation for their semantic profile; initialization
+        // itself is handled above and records the actual negotiated revision.
+        let provisional = protocol_support
+            .versions()
+            .iter()
+            .find(|version| {
+                crate::protocol::SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
+            })
+            .ok_or_else(|| {
+                JsonRpcError::invalid_request(
+                    "Request does not declare an MCP revision and no legacy revision is enabled",
+                )
+            })?;
+        allowed_revision(provisional, protocol_support)
     }
 
     /// Validate the lifecycle metadata on a request without dispatching it.
@@ -144,6 +282,9 @@ impl<S> JsonRpcService<S> {
         req: &JsonRpcRequest,
     ) -> std::result::Result<Option<String>, JsonRpcError> {
         req.validate()?;
+        let value = serde_json::to_value(req)
+            .map_err(|error| JsonRpcError::invalid_request(error.to_string()))?;
+        self.inspect_incoming_value(&value, McpDirection::ClientToServer)?;
         let mut extensions = self.extensions.clone();
         let protocol_support = extensions
             .get::<ProtocolSupport>()
@@ -166,11 +307,16 @@ impl<S> JsonRpcService<S> {
             req,
             self.extensions.clone(),
             self.protocol_support.clone(),
+            self.negotiated_revision.clone(),
         )
         .await
     }
 
-    /// Process a batch of JSON-RPC requests concurrently
+    /// Process a `2025-03-26` batch of JSON-RPC requests concurrently.
+    ///
+    /// The exact revision must have been negotiated by `initialize`, supplied
+    /// by a transport session, or be the sole entry in [`ProtocolSupport`].
+    /// Later revisions return an invalid-request error.
     pub async fn call_batch(
         &mut self,
         requests: Vec<JsonRpcRequest>,
@@ -188,6 +334,11 @@ impl<S> JsonRpcService<S> {
             )));
         }
 
+        let value = serde_json::to_value(JsonRpcMessage::Batch(requests.clone()))
+            .map_err(Error::Serialization)?;
+        self.inspect_incoming_value(&value, McpDirection::ClientToServer)
+            .map_err(Error::JsonRpc)?;
+
         // Process all requests concurrently
         let futures: Vec<_> = requests
             .into_iter()
@@ -195,9 +346,18 @@ impl<S> JsonRpcService<S> {
                 let inner = self.inner.clone();
                 let extensions = self.extensions.clone();
                 let protocol_support = self.protocol_support.clone();
+                let negotiated_revision = self.negotiated_revision.clone();
                 let req_id = req.id.clone();
                 async move {
-                    match process_single_request(inner, req, extensions, protocol_support).await {
+                    match process_single_request(
+                        inner,
+                        req,
+                        extensions,
+                        protocol_support,
+                        negotiated_revision,
+                    )
+                    .await
+                    {
                         Ok(resp) => resp,
                         Err(e) => {
                             // Convert errors to error responses instead of dropping
@@ -231,10 +391,13 @@ impl<S> JsonRpcService<S> {
                 let response = self.call_single(req).await?;
                 Ok(JsonRpcResponseMessage::Single(response))
             }
-            JsonRpcMessage::Batch(requests) => {
-                let responses = self.call_batch(requests).await?;
-                Ok(JsonRpcResponseMessage::Batch(responses))
-            }
+            JsonRpcMessage::Batch(requests) => match self.call_batch(requests).await {
+                Ok(responses) => Ok(JsonRpcResponseMessage::Batch(responses)),
+                Err(Error::JsonRpc(error)) => Ok(JsonRpcResponseMessage::Single(
+                    JsonRpcResponse::error(None, error),
+                )),
+                Err(error) => Err(error),
+            },
             _ => Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
                 None,
                 JsonRpcError::invalid_request("Unsupported message type"),
@@ -252,6 +415,7 @@ where
             inner: self.inner.clone(),
             extensions: self.extensions.clone(),
             protocol_support: self.protocol_support.clone(),
+            negotiated_revision: self.negotiated_revision.clone(),
         }
     }
 }
@@ -274,15 +438,8 @@ where
     }
 
     fn call(&mut self, req: JsonRpcRequest) -> Self::Future {
-        let inner = self.inner.clone();
-        let extensions = self.extensions.clone();
-        let protocol_support = self.protocol_support.clone();
-        Box::pin(process_single_request(
-            inner,
-            req,
-            extensions,
-            protocol_support,
-        ))
+        let mut service = self.clone();
+        Box::pin(async move { service.call_single(req).await })
     }
 }
 
@@ -305,73 +462,8 @@ where
     }
 
     fn call(&mut self, msg: JsonRpcMessage) -> Self::Future {
-        let inner = self.inner.clone();
-        let extensions = self.extensions.clone();
-        let protocol_support = self.protocol_support.clone();
-        Box::pin(async move {
-            match msg {
-                JsonRpcMessage::Single(req) => {
-                    let response =
-                        process_single_request(inner, req, extensions, protocol_support).await?;
-                    Ok(JsonRpcResponseMessage::Single(response))
-                }
-                JsonRpcMessage::Batch(requests) => {
-                    if requests.is_empty() {
-                        // Empty batch is an invalid request per JSON-RPC spec
-                        return Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
-                            None,
-                            JsonRpcError::invalid_request("Empty batch request"),
-                        )));
-                    }
-
-                    // Process all requests concurrently
-                    let futures: Vec<_> = requests
-                        .into_iter()
-                        .map(|req| {
-                            let inner = inner.clone();
-                            let extensions = extensions.clone();
-                            let protocol_support = protocol_support.clone();
-                            let req_id = req.id.clone();
-                            async move {
-                                match process_single_request(
-                                    inner,
-                                    req,
-                                    extensions,
-                                    protocol_support,
-                                )
-                                .await
-                                {
-                                    Ok(resp) => resp,
-                                    Err(e) => {
-                                        // Convert errors to error responses instead of dropping
-                                        JsonRpcResponse::error(
-                                            Some(req_id),
-                                            JsonRpcError::internal_error(e.to_string()),
-                                        )
-                                    }
-                                }
-                            }
-                        })
-                        .collect();
-
-                    let results: Vec<JsonRpcResponse> = futures::future::join_all(futures).await;
-
-                    // Empty results only possible if input was empty (already handled above)
-                    if results.is_empty() {
-                        return Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
-                            None,
-                            JsonRpcError::internal_error("All batch requests failed"),
-                        )));
-                    }
-
-                    Ok(JsonRpcResponseMessage::Batch(results))
-                }
-                _ => Ok(JsonRpcResponseMessage::Single(JsonRpcResponse::error(
-                    None,
-                    JsonRpcError::invalid_request("Unsupported message type"),
-                ))),
-            }
-        })
+        let mut service = self.clone();
+        Box::pin(async move { service.call_message(msg).await })
     }
 }
 
@@ -381,9 +473,11 @@ async fn process_single_request<S>(
     req: JsonRpcRequest,
     mut extensions: Extensions,
     configured_protocol_support: ProtocolSupport,
+    negotiated_revision: Arc<RwLock<Option<McpProtocolRevision>>>,
 ) -> std::result::Result<JsonRpcResponse, Error>
 where
     S: Service<RouterRequest, Response = RouterResponse, Error = std::convert::Infallible>
+        + Clone
         + Send
         + 'static,
     S::Future: Send,
@@ -401,6 +495,19 @@ where
         .cloned()
         .unwrap_or(configured_protocol_support);
     extensions.insert(protocol_support.clone());
+
+    let inspection_service = JsonRpcService {
+        inner: inner.clone(),
+        extensions: extensions.clone(),
+        protocol_support: protocol_support.clone(),
+        negotiated_revision: negotiated_revision.clone(),
+    };
+    let request_value = serde_json::to_value(&req).map_err(Error::Serialization)?;
+    if let Err(error) =
+        inspection_service.inspect_incoming_value(&request_value, McpDirection::ClientToServer)
+    {
+        return Ok(JsonRpcResponse::error(Some(req.id), error));
+    }
 
     #[cfg(feature = "stateless")]
     let protocol_version = match prepare_modern_request(&req, &mut extensions, &protocol_support) {
@@ -433,10 +540,79 @@ where
 
     // Convert to JSON-RPC response
     let mut response = response.into_jsonrpc();
+    if method == "initialize"
+        && let JsonRpcResponse::Result(result) = &response
+        && let Some(version) = result
+            .result
+            .get("protocolVersion")
+            .and_then(serde_json::Value::as_str)
+        && protocol_support.contains(version)
+        && let Ok(revision) = version.parse::<McpProtocolRevision>()
+        && let Ok(mut selected) = negotiated_revision.write()
+    {
+        *selected = Some(revision);
+    }
     if let Some(version) = protocol_version.as_deref() {
         apply_protocol_result_fields(&mut response, &method, version);
     }
     Ok(response)
+}
+
+fn allowed_revision(
+    version: &str,
+    protocol_support: &ProtocolSupport,
+) -> std::result::Result<McpProtocolRevision, JsonRpcError> {
+    if !protocol_support.contains(version) {
+        return Err(JsonRpcError::unsupported_protocol_version(
+            version,
+            protocol_support.versions().iter().map(String::as_str),
+        ));
+    }
+    version.parse().map_err(|_| {
+        JsonRpcError::unsupported_protocol_version(
+            version,
+            protocol_support.versions().iter().map(String::as_str),
+        )
+    })
+}
+
+/// Apply the shared types-only MCP profile after runtime policy has selected
+/// one exact revision.
+pub(crate) fn inspect_runtime_value(
+    value: &serde_json::Value,
+    revision: McpProtocolRevision,
+    protocol_support: &ProtocolSupport,
+    direction: McpDirection,
+) -> std::result::Result<McpInspection, JsonRpcError> {
+    if !protocol_support.contains(revision.as_str()) {
+        return Err(JsonRpcError::unsupported_protocol_version(
+            revision.as_str(),
+            protocol_support.versions().iter().map(String::as_str),
+        ));
+    }
+    McpInspector::for_revision(revision)
+        .inspect(value, Some(direction))
+        .map_err(inspection_error_to_json_rpc)
+}
+
+fn inspection_error_to_json_rpc(error: McpInspectionError) -> JsonRpcError {
+    match error.kind() {
+        McpInspectionErrorKind::MissingParams | McpInspectionErrorKind::InvalidParams => {
+            JsonRpcError::invalid_params(error.to_string())
+        }
+        McpInspectionErrorKind::UnsupportedProfile => JsonRpcError::unsupported_protocol_version(
+            error.revision().unwrap_or("unknown"),
+            crate::inspection::MCP_INSPECTION_PROFILES.iter().copied(),
+        ),
+        McpInspectionErrorKind::JsonRpc
+        | McpInspectionErrorKind::BatchUnavailable
+        | McpInspectionErrorKind::InitializeInBatch
+        | McpInspectionErrorKind::MessageKindMismatch
+        | McpInspectionErrorKind::DirectionMismatch => {
+            JsonRpcError::invalid_request(error.to_string())
+        }
+        _ => JsonRpcError::invalid_request(error.to_string()),
+    }
 }
 
 /// Validate a request using the final per-request metadata lifecycle.
@@ -636,7 +812,7 @@ mod tests {
 
         // Initialize first
         let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": "2025-03-26",
             "capabilities": {},
             "clientInfo": { "name": "test", "version": "1.0" }
         }));
@@ -658,7 +834,7 @@ mod tests {
 
     #[cfg(feature = "stateless")]
     #[tokio::test]
-    async fn modern_batch_metadata_is_isolated_per_request() {
+    async fn modern_batch_is_rejected_by_exact_profile() {
         let router = create_test_router();
         let mut service = JsonRpcService::new(router);
         let final_request = JsonRpcRequest::new(1, "tools/list").with_params(serde_json::json!({
@@ -671,19 +847,19 @@ mod tests {
         let legacy_request =
             JsonRpcRequest::new(2, "tools/list").with_params(serde_json::json!({}));
 
-        let responses = service
+        let error = service
             .call_batch(vec![final_request, legacy_request])
             .await
-            .unwrap();
-        let JsonRpcResponse::Result(final_response) = &responses[0] else {
-            panic!("final request should bypass legacy session state");
+            .unwrap_err();
+        let Error::JsonRpc(error) = error else {
+            panic!("final batch should fail with a JSON-RPC error");
         };
-        assert_eq!(final_response.result["resultType"], "complete");
-
-        let JsonRpcResponse::Error(legacy_response) = &responses[1] else {
-            panic!("legacy request must not inherit final request metadata");
-        };
-        assert_eq!(legacy_response.error.code, -32600);
+        assert_eq!(error.code, -32600);
+        assert!(
+            error
+                .message
+                .contains("does not permit top-level JSON-RPC batches")
+        );
     }
 
     #[cfg(feature = "stateless")]
@@ -753,7 +929,7 @@ mod tests {
 
         // Initialize
         let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": "2025-03-26",
             "capabilities": {},
             "clientInfo": { "name": "test", "version": "1.0" }
         }));
@@ -867,6 +1043,28 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn exact_profile_rejects_malformed_present_params() {
+        let router = create_test_router();
+        let mut service = JsonRpcService::new(router.clone());
+        let initialize = JsonRpcRequest::new(0, "initialize").with_params(serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "1.0"}
+        }));
+        service.call_single(initialize).await.unwrap();
+        router.handle_notification(crate::protocol::McpNotification::Initialized);
+
+        let request = JsonRpcRequest::new(1, "tools/list")
+            .with_params(serde_json::json!(["not", "an", "object"]));
+        let response = service.call_single(request).await.unwrap();
+        let JsonRpcResponse::Error(error) = response else {
+            panic!("malformed present params should be rejected");
+        };
+        assert_eq!(error.error.code, -32602);
+        assert!(error.error.message.contains("`tools/list` params"));
+    }
+
+    #[tokio::test]
     async fn test_request_before_initialize() {
         let router = create_test_router();
         let mut service = JsonRpcService::new(router);
@@ -910,7 +1108,7 @@ mod tests {
 
         // Initialize
         let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": "2025-03-26",
             "capabilities": {},
             "clientInfo": { "name": "test", "version": "1.0" }
         }));
@@ -931,14 +1129,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn negotiated_2025_11_rejects_batch() {
+        let router = create_test_router();
+        let mut service = JsonRpcService::new(router.clone());
+        let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
+            "protocolVersion": "2025-11-25",
+            "capabilities": {},
+            "clientInfo": { "name": "test", "version": "1.0" }
+        }));
+        service.call_single(init_req).await.unwrap();
+        router.handle_notification(crate::protocol::McpNotification::Initialized);
+
+        let message = JsonRpcMessage::Batch(vec![JsonRpcRequest::new(2, "ping")]);
+        let response = service.call_message(message).await.unwrap();
+        let JsonRpcResponseMessage::Single(JsonRpcResponse::Error(error)) = response else {
+            panic!("2025-11-25 batch should produce one JSON-RPC error");
+        };
+        assert_eq!(error.error.code, -32600);
+        assert!(
+            error
+                .error
+                .message
+                .contains("does not permit top-level JSON-RPC batches")
+        );
+    }
+
+    #[tokio::test]
     async fn test_call_message_empty_batch() {
         let router = create_test_router();
         let mut service = JsonRpcService::new(router);
 
-        // call_message delegates to call_batch which returns Err for empty batch
+        // Message dispatch turns a top-level batch failure into one JSON-RPC
+        // error response because there are no member IDs to attach it to.
         let msg = JsonRpcMessage::Batch(vec![]);
-        let result = service.call_message(msg).await;
-        assert!(result.is_err());
+        let result = service.call_message(msg).await.unwrap();
+        let JsonRpcResponseMessage::Single(JsonRpcResponse::Error(error)) = result else {
+            panic!("empty batch should produce one JSON-RPC error response");
+        };
+        assert_eq!(error.error.code, -32600);
     }
 
     #[tokio::test]
@@ -967,7 +1195,7 @@ mod tests {
 
         // Initialize
         let init_req = JsonRpcRequest::new(1, "initialize").with_params(serde_json::json!({
-            "protocolVersion": "2025-11-25",
+            "protocolVersion": "2025-03-26",
             "capabilities": {},
             "clientInfo": { "name": "test", "version": "1.0" }
         }));

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -4985,7 +4985,9 @@ mod tests {
             .build();
 
         let router = McpRouter::new().tool(add_tool);
-        let mut service = JsonRpcService::new(router.clone());
+        let mut service = JsonRpcService::new(router.clone())
+            .protocol_versions(["2025-03-26"])
+            .unwrap();
 
         // Initialize session first
         init_jsonrpc_service(&mut service, &router).await;
@@ -5175,7 +5177,9 @@ mod tests {
             .build();
 
         let router = McpRouter::new().tool(add_tool);
-        let mut service = JsonRpcService::new(router.clone());
+        let mut service = JsonRpcService::new(router.clone())
+            .protocol_versions(["2025-03-26"])
+            .unwrap();
 
         init_jsonrpc_service(&mut service, &router).await;
 

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -272,10 +272,12 @@ use crate::context::{
 use crate::error::{Error, JsonRpcError, Result};
 #[cfg(feature = "stateless")]
 use crate::error::{ErrorCode, McpErrorCode};
-use crate::jsonrpc::{JsonRpcService, apply_protocol_result_fields};
+use crate::inspection::{McpDirection, McpProtocolRevision};
+use crate::jsonrpc::{JsonRpcService, apply_protocol_result_fields, inspect_runtime_value};
 use crate::protocol::{
-    ClientCapabilities, Implementation, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse,
-    LATEST_PROTOCOL_VERSION, McpNotification, PROTOCOL_VERSION_2026_07_28, RequestId,
+    ClientCapabilities, Implementation, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
+    JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, PROTOCOL_VERSION_2026_07_28,
+    RequestId,
 };
 #[cfg(feature = "stateless")]
 use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
@@ -2862,6 +2864,39 @@ async fn handle_post(
         }
     };
 
+    // A version header supplies enough exact context to reject a batch before
+    // any object-only HTTP classification runs. Legacy batches without a
+    // header are validated against their session revision after lookup below.
+    if parsed.is_array()
+        && let Some(version) = get_protocol_version(&headers)
+    {
+        let revision = match version.parse::<McpProtocolRevision>() {
+            Ok(revision) => revision,
+            Err(_) => {
+                return json_rpc_error_response(
+                    None,
+                    JsonRpcError::unsupported_protocol_version(
+                        version,
+                        state.protocol_support.versions().iter().map(String::as_str),
+                    ),
+                );
+            }
+        };
+        if let Err(error) = inspect_runtime_value(
+            &parsed,
+            revision,
+            &state.protocol_support,
+            McpDirection::ClientToServer,
+        ) {
+            let status = if revision == McpProtocolRevision::V2026_07_28 {
+                StatusCode::BAD_REQUEST
+            } else {
+                StatusCode::OK
+            };
+            return json_rpc_error_response_with_status(None, error, status);
+        }
+    }
+
     // Check if this is an initialize request (creates new session)
     let is_init = is_initialize_request(&parsed);
     let request_method = parsed
@@ -2913,6 +2948,28 @@ async fn handle_post(
                 ),
                 StatusCode::BAD_REQUEST,
             );
+        }
+
+        let revision = match body_version.parse::<McpProtocolRevision>() {
+            Ok(revision) => revision,
+            Err(_) => {
+                return json_rpc_error_response_with_status(
+                    id,
+                    JsonRpcError::unsupported_protocol_version(
+                        body_version,
+                        state.protocol_support.versions().iter().map(String::as_str),
+                    ),
+                    StatusCode::BAD_REQUEST,
+                );
+            }
+        };
+        if let Err(error) = inspect_runtime_value(
+            &parsed,
+            revision,
+            &state.protocol_support,
+            McpDirection::ClientToServer,
+        ) {
+            return json_rpc_error_response_with_status(id, error, StatusCode::BAD_REQUEST);
         }
 
         let sep_2243_mode = super::http_headers::mode_for_version(&body_version);
@@ -3289,6 +3346,27 @@ async fn handle_post(
         return handle_modern_subscriptions_listen_sse(state, &parsed).await;
     }
 
+    // Runtime allowlist enforcement precedes semantic profile validation.
+    // This is especially important for optional-session traffic: an unknown
+    // header must not be interpreted under a fallback revision.
+    if !is_init
+        && let Some(version) = get_protocol_version(&headers)
+        && !state.protocol_support.contains(&version)
+    {
+        return json_rpc_error_response(
+            extract_request_id(&parsed),
+            JsonRpcError::unsupported_protocol_version(
+                version,
+                state.protocol_support.versions().iter().map(String::as_str),
+            ),
+        );
+    }
+
+    let uses_transient_session = !is_init
+        && !modern_request
+        && get_session_id(&headers).is_none()
+        && state.optional_sessions;
+
     // Get or create session
     let session = if is_init {
         // Create new session for initialize
@@ -3363,6 +3441,102 @@ async fn handle_post(
         return json_rpc_error_response(None, JsonRpcError::session_required());
     };
 
+    // Session lookup establishes the exact legacy revision. Validate the raw
+    // envelope before object-only notification/response routing, then let the
+    // existing request dispatcher consume the typed shape.
+    let session_protocol_version = if uses_transient_session {
+        let version = state
+            .protocol_support
+            .versions()
+            .iter()
+            .find(|version| {
+                crate::protocol::SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str())
+            })
+            .map_or_else(
+                || state.protocol_support.preferred().to_string(),
+                Clone::clone,
+            );
+        *session.protocol_version.write().await = version.clone();
+        version
+    } else {
+        session.protocol_version.read().await.clone()
+    };
+    let session_revision = match session_protocol_version.parse::<McpProtocolRevision>() {
+        Ok(revision) => revision,
+        Err(_) => {
+            return json_rpc_error_response(
+                extract_request_id(&parsed),
+                JsonRpcError::unsupported_protocol_version(
+                    session_protocol_version,
+                    state.protocol_support.versions().iter().map(String::as_str),
+                ),
+            );
+        }
+    };
+    if !is_init
+        && let Err(error) = inspect_runtime_value(
+            &parsed,
+            session_revision,
+            &state.protocol_support,
+            McpDirection::ClientToServer,
+        )
+    {
+        return json_rpc_error_response(extract_request_id(&parsed), error);
+    }
+
+    if parsed.is_array() {
+        if state.strict_initialization
+            && !session
+                .initialized_notification_received
+                .load(Ordering::Acquire)
+        {
+            return json_rpc_error_response(
+                None,
+                JsonRpcError::invalid_request(
+                    "Client must send notifications/initialized before making requests",
+                ),
+            );
+        }
+
+        let message: JsonRpcMessage = match serde_json::from_value(parsed) {
+            Ok(message) => message,
+            Err(error) => {
+                return json_rpc_error_response(
+                    None,
+                    JsonRpcError::invalid_request(format!("Invalid request batch: {error}")),
+                );
+            }
+        };
+
+        let mut extensions = crate::router::Extensions::new();
+        extensions.insert(state.protocol_support.clone());
+        extensions.insert(session_revision);
+        #[cfg(feature = "oauth")]
+        if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
+            extensions.insert(claims.clone());
+        }
+
+        let mut service = JsonRpcService::new(session.make_service())
+            .with_extensions(extensions)
+            .protocol_support(state.protocol_support.clone())
+            .with_negotiated_protocol_version(&session_protocol_version);
+        let response = match service.call_message(message).await {
+            Ok(response) => response,
+            Err(error) => {
+                return json_rpc_error_response(
+                    None,
+                    JsonRpcError::internal_error(error.to_string()),
+                );
+            }
+        };
+        let mut response = axum::Json(response).into_response();
+        response.headers_mut().insert(
+            MCP_PROTOCOL_VERSION_HEADER,
+            HeaderValue::from_str(&session_protocol_version).unwrap(),
+        );
+        return response;
+    }
+
     // SEP-2575 / SEP-2567: intercept `subscriptions/listen` before the standard
     // version validation. `subscriptions/listen` is only available when the
     // effective protocol version is >= 2026-07-28; otherwise we return a
@@ -3392,23 +3566,6 @@ async fn handle_post(
                 );
             }
         }
-    }
-
-    // Validate protocol version (if present and not init request).
-    // Per SEP-2575, unsupported versions get a JSON-RPC error with code
-    // -32022 and `{ supported, requested }` data, not a plain-text 400.
-    if !is_init
-        && let Some(version) = get_protocol_version(&headers)
-        && !state.protocol_support.contains(&version)
-    {
-        let id = extract_request_id(&parsed);
-        return json_rpc_error_response(
-            id,
-            JsonRpcError::unsupported_protocol_version(
-                version,
-                state.protocol_support.versions().iter().map(String::as_str),
-            ),
-        );
     }
 
     // SEP-2243: validate the standardized HTTP headers (Mcp-Method,
@@ -3568,6 +3725,7 @@ async fn handle_post(
     #[allow(unused_mut)]
     let mut ext = crate::router::Extensions::new();
     ext.insert(state.protocol_support.clone());
+    ext.insert(session_revision);
     #[cfg(feature = "oauth")]
     if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
         ext.insert(claims.clone());
@@ -8420,6 +8578,10 @@ mod tests {
 
     /// Helper: do the `initialize` handshake and return the session ID.
     async fn do_initialize(app: &axum::Router) -> String {
+        do_initialize_for_revision(app, "2025-11-25").await
+    }
+
+    async fn do_initialize_for_revision(app: &axum::Router, revision: &str) -> String {
         let init_request = Request::builder()
             .method("POST")
             .uri("/")
@@ -8431,7 +8593,7 @@ mod tests {
                     "id": 1,
                     "method": "initialize",
                     "params": {
-                        "protocolVersion": "2025-11-25",
+                        "protocolVersion": revision,
                         "capabilities": {},
                         "clientInfo": { "name": "test-client", "version": "1.0.0" }
                     }
@@ -8448,6 +8610,117 @@ mod tests {
             .to_str()
             .unwrap()
             .to_string()
+    }
+
+    async fn send_initialized(app: &axum::Router, session_id: &str) {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json, text/event-stream")
+            .header(MCP_SESSION_ID_HEADER, session_id)
+            .body(Body::from(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/initialized"
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+    }
+
+    async fn post_legacy_batch(app: &axum::Router, session_id: &str) -> serde_json::Value {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_SESSION_ID_HEADER, session_id)
+            .body(Body::from(
+                serde_json::json!([
+                    {"jsonrpc": "2.0", "id": 2, "method": "ping"},
+                    {"jsonrpc": "2.0", "id": 3, "method": "tools/list"}
+                ])
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.clone().oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn http_batch_policy_uses_exact_session_revision() {
+        let march_app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .protocol_versions(["2025-03-26"])
+            .unwrap()
+            .into_router();
+        let march_session = do_initialize_for_revision(&march_app, "2025-03-26").await;
+        send_initialized(&march_app, &march_session).await;
+        let march_response = post_legacy_batch(&march_app, &march_session).await;
+        assert_eq!(march_response.as_array().map(Vec::len), Some(2));
+
+        let november_app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .into_router();
+        let november_session = do_initialize(&november_app).await;
+        send_initialized(&november_app, &november_session).await;
+        let november_response = post_legacy_batch(&november_app, &november_session).await;
+        assert_eq!(november_response["error"]["code"], -32600);
+        assert!(
+            november_response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("does not permit top-level JSON-RPC batches")
+        );
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn http_final_batch_is_rejected_before_object_routing() {
+        let app = HttpTransport::new(create_test_router())
+            .disable_origin_validation()
+            .into_router();
+        let request = Request::builder()
+            .method("POST")
+            .uri("/")
+            .header("Content-Type", "application/json")
+            .header("Accept", "application/json")
+            .header(MCP_PROTOCOL_VERSION_HEADER, PROTOCOL_VERSION_2026_07_28)
+            .body(Body::from(
+                serde_json::json!([{
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/list",
+                    "params": {
+                        "_meta": {
+                            "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                            "io.modelcontextprotocol/clientCapabilities": {}
+                        }
+                    }
+                }])
+                .to_string(),
+            ))
+            .unwrap();
+        let response = app.oneshot(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(response["error"]["code"], -32600);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("does not permit top-level JSON-RPC batches")
+        );
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -333,7 +333,15 @@ async fn process_line(
 ) -> Result<Option<JsonRpcResponseMessage>> {
     // Check if it's a notification (no id field)
     let parsed: serde_json::Value = serde_json::from_str(line)?;
-    if parsed.get("id").is_none()
+    if let Err(error) =
+        service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+    {
+        return Ok(Some(JsonRpcResponseMessage::Single(
+            JsonRpcResponse::error(None, error),
+        )));
+    }
+    if !parsed.is_array()
+        && parsed.get("id").is_none()
         && let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(line)
     {
         handle_notification(router, notification)?;
@@ -423,7 +431,9 @@ where
 /// Stdio transport for MCP servers
 ///
 /// Reads JSON-RPC messages from stdin and writes responses to stdout.
-/// Supports both single requests and batch requests.
+/// Supports single requests for every implemented revision and request
+/// batches only for an exact negotiated `2025-03-26` connection. Later MCP
+/// revisions reject top-level JSON-RPC arrays.
 ///
 /// Server notifications (progress, logging, resource/tool/prompt list changes)
 /// are automatically forwarded to stdout as JSON-RPC notifications.
@@ -963,7 +973,15 @@ where
         #[cfg(not(feature = "stateless"))]
         let _ = subscriptions_enabled;
 
-        if parsed.get("id").is_none() {
+        if let Err(error) =
+            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+        {
+            let response = JsonRpcResponse::error(None, error);
+            write_line_to_stdout(writer, &serde_json::to_string(&response)?).await?;
+            return Ok(());
+        }
+
+        if !parsed.is_array() && parsed.get("id").is_none() {
             // Notification - log and ignore since we don't have router access
             tracing::debug!(
                 method = parsed.get("method").and_then(|m| m.as_str()),
@@ -1407,6 +1425,16 @@ impl BidirectionalStdioTransport {
             }
         };
 
+        if let Err(error) = self
+            .service
+            .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+        {
+            let response = JsonRpcResponse::error(None, error);
+            return self
+                .write_line(&serde_json::to_string(&response)?, writer)
+                .await;
+        }
+
         // Check if this is a response to one of our pending requests
         if parsed.get("method").is_none()
             && (parsed.get("result").is_some() || parsed.get("error").is_some())
@@ -1425,7 +1453,7 @@ impl BidirectionalStdioTransport {
         }
 
         // Check if it's a notification (no id field)
-        if parsed.get("id").is_none() {
+        if !parsed.is_array() && parsed.get("id").is_none() {
             if let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(line) {
                 handle_notification(&self.router, notification)?;
             }
@@ -1763,6 +1791,13 @@ mod tests {
     }
 
     async fn init_service(router: &McpRouter) -> JsonRpcService<McpRouter> {
+        init_service_for_revision(router, "2025-11-25").await
+    }
+
+    async fn init_service_for_revision(
+        router: &McpRouter,
+        revision: &str,
+    ) -> JsonRpcService<McpRouter> {
         let mut service = JsonRpcService::new(router.clone());
 
         // Initialize the session
@@ -1771,7 +1806,7 @@ mod tests {
             "id": 0,
             "method": "initialize",
             "params": {
-                "protocolVersion": "2025-11-25",
+                "protocolVersion": revision,
                 "capabilities": {},
                 "clientInfo": { "name": "test-client", "version": "1.0.0" }
             }
@@ -1811,6 +1846,46 @@ mod tests {
         let result = process_line(&mut service, &router, line).await;
 
         assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn stdio_accepts_batch_for_2025_03() {
+        let router = make_router();
+        let mut service = init_service_for_revision(&router, "2025-03-26").await;
+        let line = serde_json::json!([
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+        ])
+        .to_string();
+
+        let response = process_line(&mut service, &router, &line)
+            .await
+            .unwrap()
+            .unwrap();
+        let JsonRpcResponseMessage::Batch(responses) = response else {
+            panic!("2025-03-26 stdio batch should return a batch");
+        };
+        assert_eq!(responses.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn stdio_rejects_batch_for_2025_11() {
+        let router = make_router();
+        let mut service = init_service(&router).await;
+        let line = serde_json::json!([
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+        ])
+        .to_string();
+
+        let response = process_line(&mut service, &router, &line)
+            .await
+            .unwrap()
+            .unwrap();
+        let JsonRpcResponseMessage::Single(JsonRpcResponse::Error(error)) = response else {
+            panic!("2025-11-25 stdio batch should return one error");
+        };
+        assert_eq!(error.error.code, -32600);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -575,6 +575,11 @@ async fn handle_websocket(
     if let Some(ref token) = subprotocols.auth_token {
         mcp_extensions.insert(WebSocketAuthToken(token.clone()));
     }
+    if let Some(ref version) = subprotocols.protocol_version
+        && let Ok(revision) = version.parse::<crate::inspection::McpProtocolRevision>()
+    {
+        mcp_extensions.insert(revision);
+    }
 
     // Perform the WebSocket upgrade from request parts
     let ws: WebSocketUpgrade = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
@@ -877,6 +882,21 @@ where
 {
     let parsed: serde_json::Value = serde_json::from_str(text)?;
 
+    if let Err(error) =
+        service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+    {
+        let response = JsonRpcResponse::error(None, error);
+        let response = serde_json::to_string(&response)
+            .map_err(|error| Error::Transport(format!("Failed to serialize response: {error}")))?;
+        sender
+            .lock()
+            .await
+            .send(Message::Text(response.into()))
+            .await
+            .map_err(|error| Error::Transport(format!("Failed to send response: {error}")))?;
+        return Ok(());
+    }
+
     // Check if this is a response to one of our pending requests
     if parsed.get("method").is_none()
         && (parsed.get("result").is_some() || parsed.get("error").is_some())
@@ -885,7 +905,7 @@ where
     }
 
     // Check if it's a notification (no id field)
-    if parsed.get("id").is_none() {
+    if !parsed.is_array() && parsed.get("id").is_none() {
         if let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text) {
             let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
             router.handle_notification(mcp_notification);
@@ -1029,7 +1049,15 @@ async fn process_message(
 ) -> Result<Option<crate::protocol::JsonRpcResponseMessage>> {
     // Check if it's a notification (no id field)
     let parsed: serde_json::Value = serde_json::from_str(text)?;
-    if parsed.get("id").is_none()
+    if let Err(error) =
+        service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+    {
+        return Ok(Some(crate::protocol::JsonRpcResponseMessage::Single(
+            JsonRpcResponse::error(None, error),
+        )));
+    }
+    if !parsed.is_array()
+        && parsed.get("id").is_none()
         && let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text)
     {
         let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
@@ -1246,6 +1274,54 @@ mod tests {
         assert_eq!(response["result"]["ttlMs"], 0);
         assert_eq!(response["result"]["cacheScope"], "private");
         assert_eq!(response["result"]["supportedVersions"][0], "2026-07-28");
+    }
+
+    async fn websocket_batch_response(revision: &str) -> serde_json::Value {
+        let router = create_test_router();
+        let service = identity_factory()(router.clone());
+        let mut service = JsonRpcService::new(service);
+        let initialize = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": revision,
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0"}
+            }
+        });
+        process_message(&mut service, &router, &initialize.to_string())
+            .await
+            .unwrap();
+        router.handle_notification(McpNotification::Initialized);
+
+        let batch = serde_json::json!([
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+        ]);
+        let response = process_message(&mut service, &router, &batch.to_string())
+            .await
+            .unwrap()
+            .expect("batch response");
+        serde_json::to_value(response).unwrap()
+    }
+
+    #[tokio::test]
+    async fn websocket_accepts_batch_for_2025_03() {
+        let response = websocket_batch_response("2025-03-26").await;
+        assert_eq!(response.as_array().map(Vec::len), Some(2));
+    }
+
+    #[tokio::test]
+    async fn websocket_rejects_batch_for_2025_11() {
+        let response = websocket_batch_response("2025-11-25").await;
+        assert_eq!(response["error"]["code"], -32600);
+        assert!(
+            response["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("does not permit top-level JSON-RPC batches")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- retain the exact negotiated legacy revision in `JsonRpcService` and select final profiles from per-request metadata
- enforce `ProtocolSupport` before applying the shared `tower-mcp-types` MCP inspector
- accept request batches only for exact `2025-03-26` connections and reject them for `2025-11-25` and `2026-07-28`
- route top-level arrays correctly through stdio, WebSocket, and HTTP instead of treating them as notifications
- validate raw transport values and malformed present params with the shared structural/profile API
- correct README and published Rust docs to describe the revision-specific batch policy

HTTP uses the negotiated session revision for legacy traffic. Stdio and WebSocket retain the revision returned by `initialize`; final requests use their required `_meta` version. A multi-version allowlist is never used to guess batch semantics.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- default, HTTP-only, and WebSocket-only library test variants
- `RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`
- `cargo llvm-cov --workspace --all-features --summary-only --fail-under-lines 80` (81.42% lines)

Closes #1129