### PR TITLE
fix(mcp-repl): preserve quoted tool arguments

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -192,6 +192,20 @@ getting-started> prompt greet name=World   # prompt args tab-complete via comple
 getting-started> info                      # replay the startup banner (identity, instructions, counts) + capabilities
 ```
 
+Single or double quotes group whitespace into one argument, and the REPL
+removes those grouping quotes before schema coercion. A backslash escapes the
+next character outside single quotes. JSON object and array arguments retain
+their JSON quotes and spaces exactly, including when passed through `call`:
+
+```text
+getting-started> echo message="hello world"
+getting-started> call echo {"message": "hello world"}
+```
+
+An unmatched quote, trailing escape, or unclosed JSON argument is reported
+locally without calling the server. A quoted or escaped `&` is ordinary input;
+only a plain trailing `&` requests task-augmented execution.
+
 `resources` lists concrete resources and `templates` lists parameterized
 (`{variable}`) ones; each points at the other so a server that splits its
 resources across the two MCP lists is not confusing.

--- a/examples/mcp-repl/src/command.rs
+++ b/examples/mcp-repl/src/command.rs
@@ -1,0 +1,252 @@
+//! Quote-aware command-line tokenization for interactive and `--exec` input.
+//!
+//! This is intentionally smaller than a shell parser: quotes group one
+//! argument, backslashes escape the next character outside single quotes,
+//! and a top-level trailing `&` selects task-augmented execution. JSON object
+//! and array literals remain byte-for-byte intact so raw `call` arguments and
+//! schema-coerced object values do not lose their JSON quotes.
+
+/// A tokenized REPL command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommand {
+    /// Command name followed by its arguments.
+    pub words: Vec<String>,
+    /// Whether an unquoted trailing `&` requested task-augmented execution.
+    pub background: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Quote {
+    Single,
+    Double,
+}
+
+#[derive(Debug)]
+struct Word {
+    text: String,
+    protected: bool,
+}
+
+/// Split one command line without losing quoted whitespace or JSON syntax.
+pub fn parse(line: &str) -> Result<ParsedCommand, String> {
+    let mut words = Vec::new();
+    let mut current = String::new();
+    let mut word_started = false;
+    let mut protected = false;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut json_stack = Vec::new();
+    let mut json_string = false;
+    let mut json_escaped = false;
+
+    for ch in line.chars() {
+        if !json_stack.is_empty() {
+            current.push(ch);
+            word_started = true;
+            if json_string {
+                if json_escaped {
+                    json_escaped = false;
+                } else if ch == '\\' {
+                    json_escaped = true;
+                } else if ch == '"' {
+                    json_string = false;
+                }
+                continue;
+            }
+            match ch {
+                '"' => json_string = true,
+                '{' => json_stack.push('}'),
+                '[' => json_stack.push(']'),
+                '}' | ']' => {
+                    let expected = json_stack.pop().expect("non-empty JSON stack");
+                    if ch != expected {
+                        return Err(format!(
+                            "mismatched JSON delimiter: expected `{expected}`, found `{ch}`"
+                        ));
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        if escaped {
+            current.push(ch);
+            word_started = true;
+            protected = true;
+            escaped = false;
+            continue;
+        }
+
+        match quote {
+            Some(Quote::Single) => {
+                if ch == '\'' {
+                    quote = None;
+                } else {
+                    current.push(ch);
+                }
+                word_started = true;
+                protected = true;
+            }
+            Some(Quote::Double) => {
+                if ch == '"' {
+                    quote = None;
+                } else if ch == '\\' {
+                    escaped = true;
+                } else {
+                    current.push(ch);
+                }
+                word_started = true;
+                protected = true;
+            }
+            None => match ch {
+                '\\' => {
+                    escaped = true;
+                    word_started = true;
+                    protected = true;
+                }
+                '\'' => {
+                    quote = Some(Quote::Single);
+                    word_started = true;
+                    protected = true;
+                }
+                '"' => {
+                    quote = Some(Quote::Double);
+                    word_started = true;
+                    protected = true;
+                }
+                '{' | '[' if current.is_empty() || current.ends_with('=') => {
+                    current.push(ch);
+                    word_started = true;
+                    json_stack.push(if ch == '{' { '}' } else { ']' });
+                }
+                c if c.is_whitespace() => {
+                    finish_word(&mut words, &mut current, &mut word_started, &mut protected);
+                }
+                _ => {
+                    current.push(ch);
+                    word_started = true;
+                }
+            },
+        }
+    }
+
+    if escaped {
+        return Err("trailing backslash escapes no character".to_string());
+    }
+    if let Some(quote) = quote {
+        let name = match quote {
+            Quote::Single => "single",
+            Quote::Double => "double",
+        };
+        return Err(format!("unmatched {name} quote"));
+    }
+    if json_string {
+        return Err("unterminated string in JSON argument".to_string());
+    }
+    if let Some(expected) = json_stack.last() {
+        return Err(format!("unclosed JSON argument: expected `{expected}`"));
+    }
+    finish_word(&mut words, &mut current, &mut word_started, &mut protected);
+
+    let background = words
+        .last()
+        .is_some_and(|word| word.text == "&" && !word.protected);
+    if background {
+        words.pop();
+    }
+
+    Ok(ParsedCommand {
+        words: words.into_iter().map(|word| word.text).collect(),
+        background,
+    })
+}
+
+fn finish_word(
+    words: &mut Vec<Word>,
+    current: &mut String,
+    word_started: &mut bool,
+    protected: &mut bool,
+) {
+    if *word_started {
+        words.push(Word {
+            text: std::mem::take(current),
+            protected: *protected,
+        });
+    }
+    *word_started = false;
+    *protected = false;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quotes_group_whitespace_and_are_removed() {
+        let parsed = parse(r#"tool a="hello world" b='single value'"#).unwrap();
+        assert_eq!(parsed.words, ["tool", "a=hello world", "b=single value"]);
+        assert!(!parsed.background);
+    }
+
+    #[test]
+    fn escapes_quotes_backslashes_and_whitespace() {
+        let parsed = parse(r#"tool a="say \"hi\"" path='C:\tmp' note=two\ words"#).unwrap();
+        assert_eq!(
+            parsed.words,
+            ["tool", "a=say \"hi\"", "path=C:\\tmp", "note=two words"]
+        );
+    }
+
+    #[test]
+    fn json_objects_and_arrays_keep_their_quotes_and_spaces() {
+        let parsed = parse(
+            r#"call run.start {"instruction": "Reply with exactly hello", "items": [1, 2]} &"#,
+        )
+        .unwrap();
+        assert_eq!(
+            parsed.words,
+            [
+                "call",
+                "run.start",
+                r#"{"instruction": "Reply with exactly hello", "items": [1, 2]}"#,
+            ]
+        );
+        assert!(parsed.background);
+    }
+
+    #[test]
+    fn only_a_plain_trailing_ampersand_backgrounds() {
+        assert!(parse("tool a=1 &").unwrap().background);
+        assert!(!parse(r#"tool value="&""#).unwrap().background);
+        assert_eq!(
+            parse(r#"tool value="&""#).unwrap().words,
+            ["tool", "value=&"]
+        );
+        assert_eq!(
+            parse(r#"tool value=\&"#).unwrap().words,
+            ["tool", "value=&"]
+        );
+    }
+
+    #[test]
+    fn malformed_quotes_and_escapes_fail_locally() {
+        assert_eq!(
+            parse(r#"tool a="unfinished"#).unwrap_err(),
+            "unmatched double quote"
+        );
+        assert_eq!(
+            parse("tool a=unfinished\\").unwrap_err(),
+            "trailing backslash escapes no character"
+        );
+    }
+
+    #[test]
+    fn empty_and_unquoted_arguments_remain_compatible() {
+        assert_eq!(
+            parse("tool a=1 b=true").unwrap().words,
+            ["tool", "a=1", "b=true"]
+        );
+        assert_eq!(parse(r#"tool empty="""#).unwrap().words, ["tool", "empty="]);
+    }
+}

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -30,6 +30,7 @@
 
 mod alias;
 mod bench;
+mod command;
 mod config;
 mod editor;
 mod elicit;
@@ -1281,11 +1282,20 @@ async fn handle_line(
     };
     let line = command.as_str();
     let client = session.client();
-    let mut tokens: Vec<&str> = line.split_whitespace().collect();
-    let background = tokens.last() == Some(&"&");
-    if background {
-        tokens.pop();
-    }
+    let parsed = match command::parse(line) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            note_error();
+            if json_output() {
+                println!("{}", error_json(&e));
+            } else {
+                println!("{}: {e}", style::error_prefix());
+            }
+            return false;
+        }
+    };
+    let background = parsed.background;
+    let tokens: Vec<&str> = parsed.words.iter().map(String::as_str).collect();
     if tokens.is_empty() {
         return false;
     }
@@ -2608,6 +2618,31 @@ mod tests {
     fn error_json_is_a_valid_object() {
         let v: serde_json::Value = serde_json::from_str(&error_json("boom: it broke")).unwrap();
         assert_eq!(v["error"], "boom: it broke");
+    }
+
+    #[test]
+    fn quoted_task_arguments_reach_schema_coercion_intact() {
+        let parsed = command::parse(
+            r#"run.start instruction="Reply with exactly hello" mode=interactive &"#,
+        )
+        .unwrap();
+        let tokens: Vec<&str> = parsed.words[1..].iter().map(String::as_str).collect();
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "instruction": { "type": "string" },
+                "mode": { "type": "string" }
+            }
+        });
+
+        assert!(parsed.background);
+        assert_eq!(
+            parse_kv_args(&schema, &tokens),
+            serde_json::json!({
+                "instruction": "Reply with exactly hello",
+                "mode": "interactive"
+            })
+        );
     }
 
     // The persistent-history path relies on FileBackedHistory buffering saves

--- a/examples/mcp-repl/src/vars.rs
+++ b/examples/mcp-repl/src/vars.rs
@@ -62,11 +62,74 @@ pub fn route(line: &str) -> (Output, &str) {
         Some((name, rest)) => (Some(name.to_string()), rest),
         None => (None, line),
     };
-    let (command, filter) = match rest.split_once(" | ") {
+    let (command, filter) = match split_pipe(rest) {
         Some((cmd, path)) => (cmd.trim_end(), Some(path.trim().to_string())),
         None => (rest, None),
     };
     (Output { capture, filter }, command)
+}
+
+/// Find a routing pipe only at the command language's top level. Pipes inside
+/// quoted strings or JSON object/array arguments belong to the tool input.
+fn split_pipe(line: &str) -> Option<(&str, &str)> {
+    let bytes = line.as_bytes();
+    let mut quote = None;
+    let mut escaped = false;
+    let mut json_depth = 0usize;
+    let mut json_string = false;
+    let mut json_escaped = false;
+
+    for (index, &byte) in bytes.iter().enumerate() {
+        if json_depth > 0 {
+            if json_string {
+                if json_escaped {
+                    json_escaped = false;
+                } else if byte == b'\\' {
+                    json_escaped = true;
+                } else if byte == b'"' {
+                    json_string = false;
+                }
+            } else {
+                match byte {
+                    b'"' => json_string = true,
+                    b'{' | b'[' => json_depth += 1,
+                    b'}' | b']' => json_depth -= 1,
+                    _ => {}
+                }
+            }
+            continue;
+        }
+
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match quote {
+            Some(b'\'') => {
+                if byte == b'\'' {
+                    quote = None;
+                }
+            }
+            Some(b'"') => match byte {
+                b'\\' => escaped = true,
+                b'"' => quote = None,
+                _ => {}
+            },
+            Some(_) => unreachable!("only quote bytes are stored"),
+            None => match byte {
+                b'\\' => escaped = true,
+                b'\'' | b'"' => quote = Some(byte),
+                b'{' | b'[' => json_depth = 1,
+                b'|' if bytes.get(index.wrapping_sub(1)) == Some(&b' ')
+                    && bytes.get(index + 1) == Some(&b' ') =>
+                {
+                    return Some((&line[..index - 1], &line[index + 2..]));
+                }
+                _ => {}
+            },
+        }
+    }
+    None
 }
 
 /// `name = rest` where `name` is an identifier, distinguishing capture from
@@ -207,6 +270,17 @@ mod tests {
         // k=v args and alias definitions are not captures.
         assert!(route("get_crate name=serde").0.is_plain());
         assert!(route("query=serde").0.capture.is_none());
+    }
+
+    #[test]
+    fn route_ignores_pipes_inside_arguments() {
+        let (o, cmd) = route(r#"echo message="left | right""#);
+        assert!(o.is_plain());
+        assert_eq!(cmd, r#"echo message="left | right""#);
+
+        let (o, cmd) = route(r#"call echo {"message":"left | right"} | .content"#);
+        assert_eq!(o.filter.as_deref(), Some(".content"));
+        assert_eq!(cmd, r#"call echo {"message":"left | right"}"#);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace whitespace splitting with a quote-aware command parser
- preserve raw JSON object and array arguments while supporting shell-style quoting and escapes
- keep capture, pipe, alias, variable, and task background syntax compatible
- document the command quoting rules

Closes #1135

## Validation

- `cargo test -p mcp-repl`
- `cargo clippy -p mcp-repl --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- reproduced schema-coerced and raw JSON calls against `--demo --json`