### PR TITLE
fix(mcp-repl): redraw around child stderr

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,6 +2107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826c1fc22a2b1f14c3f6a80fc3d56adfbfb913d07f170bce4246700de7adfd50"
 dependencies = [
  "chrono",
+ "crossbeam",
  "crossterm",
  "fd-lock",
  "itertools",

--- a/crates/tower-mcp/src/client/stdio.rs
+++ b/crates/tower-mcp/src/client/stdio.rs
@@ -27,8 +27,9 @@ use crate::error::{Error, Result};
 /// Client transport that communicates with a subprocess via stdio.
 ///
 /// Spawns a child process and communicates using line-delimited JSON-RPC
-/// messages over stdin (write) and stdout (read). Stderr is inherited so
-/// server debug output appears in the client's terminal.
+/// messages over stdin (write) and stdout (read). By default stderr is
+/// inherited so server debug output appears in the client's terminal. A
+/// caller using [`Self::spawn_command`] may redirect or pipe it instead.
 pub struct StdioClientTransport {
     child: Option<Child>,
     stdin: Option<tokio::process::ChildStdin>,
@@ -53,8 +54,8 @@ impl StdioClientTransport {
     /// This allows setting environment variables, working directory, and
     /// other process configuration before spawning.
     ///
-    /// Stdin and stdout are automatically set to piped. Stderr is set to
-    /// inherited unless already configured.
+    /// Stdin and stdout are automatically set to piped. Stderr keeps the
+    /// [`Command`] configuration; its default is inherited.
     ///
     /// # Example
     ///
@@ -71,9 +72,7 @@ impl StdioClientTransport {
     /// # }
     /// ```
     pub async fn spawn_command(cmd: &mut Command) -> Result<Self> {
-        cmd.stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::inherit());
+        cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
 
         let mut child = cmd
             .spawn()
@@ -95,6 +94,15 @@ impl StdioClientTransport {
             stdin: Some(stdin),
             stdout: BufReader::new(stdout),
         })
+    }
+
+    /// Take the child's piped stderr handle, if the command configured one.
+    ///
+    /// This returns `None` when stderr is inherited, redirected elsewhere, or
+    /// has already been taken. It is useful for clients that need to integrate
+    /// server diagnostics with their own terminal or logging UI.
+    pub fn take_stderr(&mut self) -> Option<tokio::process::ChildStderr> {
+        self.child.as_mut()?.stderr.take()
     }
 
     /// Create from an existing child process.
@@ -250,6 +258,24 @@ mod tests {
 
         let received = transport.recv().await.unwrap();
         assert_eq!(received.as_deref(), Some("hello_from_test"));
+    }
+
+    #[tokio::test]
+    async fn test_spawn_command_preserves_piped_stderr() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "echo diagnostic >&2"]);
+        cmd.stderr(Stdio::piped());
+
+        let mut transport = StdioClientTransport::spawn_command(&mut cmd).await.unwrap();
+        let stderr = transport
+            .take_stderr()
+            .expect("spawn_command must not replace piped stderr");
+        let mut stderr = BufReader::new(stderr);
+        let mut line = String::new();
+        stderr.read_line(&mut line).await.unwrap();
+
+        assert_eq!(line.trim(), "diagnostic");
+        assert!(transport.take_stderr().is_none());
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/guides/client.rs
+++ b/crates/tower-mcp/src/guides/client.rs
@@ -68,7 +68,11 @@ async fn main() -> Result<(), BoxError> {
 ```
 
 Use `spawn_command` when you need environment variables, a working directory,
-or piped process settings. `spawn` is the compact convenience API.
+or redirected process settings. `spawn_command` always pipes stdin and stdout,
+but preserves your stderr configuration; call
+[`StdioClientTransport::take_stderr`](crate::client::StdioClientTransport::take_stderr)
+after requesting `Stdio::piped()` when your application needs to consume server
+diagnostics itself. `spawn` is the compact convenience API and inherits stderr.
 
 ### Stable lifecycle over HTTP
 

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -24,5 +24,5 @@ toml = "1"
 toml_edit = "0.25"
 clap.workspace = true
 tracing-subscriber.workspace = true
-reedline = "0.49"
+reedline = { version = "0.49", features = ["external_printer"] }
 nu-ansi-term = "0.50"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -227,6 +227,12 @@ Progress and log notifications print inline as they arrive, and
 dynamic servers (see the `dynamic_capabilities` example) grow and shrink the
 REPL's vocabulary live.
 
+For a spawned stdio server, child diagnostics remain visible but are read from
+the child's stderr and passed through reedline's external printer. Logs that
+arrive while you are typing therefore appear above a cleanly redrawn prompt
+instead of splitting the current input. In `--exec` mode they remain on stderr,
+so `--json` stdout contains only command results.
+
 ## bench
 
 The `[142ms]` annotation answers "how slow was that call". `bench` answers

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -15,8 +15,8 @@ use std::time::Duration;
 
 use nu_ansi_term::{Color, Style};
 use reedline::{
-    ColumnarMenu, Completer, DefaultHinter, Emacs, FileBackedHistory, Highlighter, KeyCode,
-    KeyModifiers, MenuBuilder, Prompt, PromptEditMode, PromptHistorySearch,
+    ColumnarMenu, Completer, DefaultHinter, Emacs, ExternalPrinter, FileBackedHistory, Highlighter,
+    KeyCode, KeyModifiers, MenuBuilder, Prompt, PromptEditMode, PromptHistorySearch,
     PromptHistorySearchStatus, Reedline, ReedlineEvent, ReedlineMenu, Signal, Span, StyledText,
     Suggestion, default_emacs_keybindings,
 };
@@ -582,6 +582,7 @@ pub fn spawn_readline_thread(
     line_tx: tokio::sync::mpsc::Sender<String>,
     ack_rx: std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    external_printer: ExternalPrinter<String>,
     persist_history: bool,
 ) {
     std::thread::spawn(move || {
@@ -598,6 +599,7 @@ pub fn spawn_readline_thread(
             &line_tx,
             &ack_rx,
             at_prompt,
+            external_printer,
             persist_history,
         );
     });
@@ -651,6 +653,7 @@ fn run_interactive(
     line_tx: &tokio::sync::mpsc::Sender<String>,
     ack_rx: &std::sync::mpsc::Receiver<()>,
     at_prompt: Arc<AtomicBool>,
+    external_printer: ExternalPrinter<String>,
     persist_history: bool,
 ) {
     let completer = ReplCompleter::new(surface.clone(), session, aliases.clone(), runtime);
@@ -675,6 +678,7 @@ fn run_interactive(
         .with_hinter(Box::new(
             DefaultHinter::default().with_style(Style::new().fg(Color::DarkGray)),
         ))
+        .with_external_printer(external_printer)
         .with_ansi_colors(style::colors_enabled());
 
     // Persist history across sessions (up to 1000 entries) so up-arrow recalls

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -35,6 +35,7 @@ mod config;
 mod editor;
 mod elicit;
 mod find;
+mod output;
 mod sampling;
 mod session;
 mod style;
@@ -51,6 +52,7 @@ use std::time::Duration;
 use clap::{Parser, ValueEnum};
 use nu_ansi_term::{Color, Style};
 
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tower_mcp::client::{
     ChannelTransport, HttpClientConfig, HttpClientTransport, McpClient, McpClientBuilder,
     NotificationHandler, StdioClientTransport,
@@ -63,6 +65,7 @@ use tower_mcp::{ProtocolSupport, ProtocolSupportError};
 
 use alias::Aliases;
 use elicit::ReplClientHandler;
+use output::AsyncOutput;
 use session::{Connector, Session, is_not_initialized, is_session_lost};
 use style::{json_pretty, paint, tag, task_status_style};
 use wire::{TracingTransport, wire};
@@ -834,7 +837,10 @@ fn demo_router() -> tower_mcp::McpRouter {
 /// The notification callbacks: log and progress messages print inline,
 /// `list_changed` notifications nudge the event loop to refresh the surface.
 /// Built per client, since a reconnect installs a new one.
-fn notification_handler(refresh_tx: tokio::sync::mpsc::UnboundedSender<()>) -> NotificationHandler {
+fn notification_handler(
+    refresh_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    output: AsyncOutput,
+) -> NotificationHandler {
     let t = refresh_tx.clone();
     let r = refresh_tx.clone();
     let p = refresh_tx;
@@ -848,40 +854,63 @@ fn notification_handler(refresh_tx: tokio::sync::mpsc::UnboundedSender<()>) -> N
         .on_prompts_changed(move || {
             let _ = p.send(());
         })
-        .on_progress(|p| {
-            let pct = match (p.progress, p.total) {
-                (done, Some(total)) if total > 0.0 => {
-                    format!(" {:.0}%", 100.0 * done / total)
-                }
-                _ => String::new(),
-            };
-            println!(
-                "{} {}",
-                tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
-                p.message.as_deref().unwrap_or("")
-            );
+        .on_progress({
+            let output = output.clone();
+            move |p| {
+                let pct = match (p.progress, p.total) {
+                    (done, Some(total)) if total > 0.0 => {
+                        format!(" {:.0}%", 100.0 * done / total)
+                    }
+                    _ => String::new(),
+                };
+                output.line(format!(
+                    "{} {}",
+                    tag(Style::new().fg(Color::Cyan), &format!("progress{pct}")),
+                    p.message.as_deref().unwrap_or("")
+                ));
+            }
         })
         // A subscribed resource changed. Printed inline like progress and log
         // lines; the content is not re-read, since a `read` may be expensive and
         // the point is to know it moved.
-        .on_resource_updated(|uri| {
-            let known = if subscribe::contains(&uri) {
-                String::new()
-            } else {
-                format!(" {}", paint(Style::new().dimmed(), "(not subscribed here)"))
-            };
-            println!(
-                "{} {uri}{known}",
-                tag(Style::new().fg(Color::Cyan), "resource updated")
-            );
+        .on_resource_updated({
+            let output = output.clone();
+            move |uri| {
+                let known = if subscribe::contains(&uri) {
+                    String::new()
+                } else {
+                    format!(" {}", paint(Style::new().dimmed(), "(not subscribed here)"))
+                };
+                output.line(format!(
+                    "{} {uri}{known}",
+                    tag(Style::new().fg(Color::Cyan), "resource updated")
+                ));
+            }
         })
-        .on_log_message(|m| {
-            println!(
+        .on_log_message(move |m| {
+            output.line(format!(
                 "{} {}",
                 tag(log_level_style(m.level), &format!("log {}", m.level)),
                 m.data
-            );
+            ));
         })
+}
+
+/// Forward complete child stderr lines through the prompt-safe output sink.
+fn forward_child_stderr(stderr: tokio::process::ChildStderr, output: AsyncOutput) {
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        loop {
+            match lines.next_line().await {
+                Ok(Some(line)) => output.line(line),
+                Ok(None) => break,
+                Err(error) => {
+                    output.line(format!("warning: reading server stderr failed: {error}"));
+                    break;
+                }
+            }
+        }
+    });
 }
 
 /// The recipe for rebuilding an `--http` connection: a brand new transport
@@ -1019,6 +1048,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // handler declines form requests during that window instead of
     // fighting over raw-mode stdin.
     let at_prompt = Arc::new(AtomicBool::new(false));
+    let async_output = AsyncOutput::new(at_prompt.clone(), !one_shot);
 
     // Notifications print inline and trigger surface refreshes.
     let (refresh_tx, mut refresh_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1028,8 +1058,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     let make_handler: Arc<dyn Fn() -> ReplClientHandler + Send + Sync> = {
         let refresh_tx = refresh_tx.clone();
         let at_prompt = at_prompt.clone();
+        let async_output = async_output.clone();
         Arc::new(move || {
-            ReplClientHandler::new(notification_handler(refresh_tx.clone()), at_prompt.clone())
+            ReplClientHandler::new(
+                notification_handler(refresh_tx.clone(), async_output.clone()),
+                at_prompt.clone(),
+            )
         })
     };
     drop(refresh_tx);
@@ -1139,8 +1173,13 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                     .await?
             }
             Some(config::Connection::Stdio { command }) => {
-                let cmd_args: Vec<&str> = command[1..].iter().map(|s| s.as_str()).collect();
-                let transport = StdioClientTransport::spawn(&command[0], &cmd_args).await?;
+                let mut cmd = tokio::process::Command::new(&command[0]);
+                cmd.args(&command[1..]);
+                cmd.stderr(std::process::Stdio::piped());
+                let mut transport = StdioClientTransport::spawn_command(&mut cmd).await?;
+                if let Some(stderr) = transport.take_stderr() {
+                    forward_child_stderr(stderr, async_output.clone());
+                }
                 builder
                     .connect(TracingTransport::new(transport), make_handler())
                     .await?
@@ -1206,6 +1245,9 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         line_tx,
         ack_rx,
         at_prompt,
+        async_output
+            .external_printer()
+            .expect("interactive sessions have an external printer"),
         !args.no_history,
     );
 
@@ -1215,9 +1257,9 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         tokio::select! {
             Some(()) = refresh_rx.recv() => {
                 let fresh = fetch_surface(&session.client()).await;
-                println!("{} {} tools, {} prompts, {} resources",
+                async_output.line(format!("{} {} tools, {} prompts, {} resources",
                     tag(Style::new().fg(Color::Cyan), "surface changed"),
-                    fresh.tools.len(), fresh.prompts.len(), fresh.resources.len());
+                    fresh.tools.len(), fresh.prompts.len(), fresh.resources.len()));
                 *surface.write().unwrap() = fresh;
             }
             maybe_line = line_rx.recv() => {

--- a/examples/mcp-repl/src/output.rs
+++ b/examples/mcp-repl/src/output.rs
@@ -1,0 +1,68 @@
+//! Prompt-safe output for asynchronous server diagnostics.
+//!
+//! While reedline owns the terminal, output goes through its external printer
+//! so the active input is cleared and redrawn. At startup, during a command,
+//! and in `--exec` mode, diagnostics stay on stderr.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use reedline::ExternalPrinter;
+
+/// Shared destination for output that can arrive independently of a command.
+#[derive(Clone)]
+pub struct AsyncOutput {
+    at_prompt: Arc<AtomicBool>,
+    printer: Option<ExternalPrinter<String>>,
+}
+
+impl AsyncOutput {
+    /// Build a sink, with a reedline printer only for interactive sessions.
+    pub fn new(at_prompt: Arc<AtomicBool>, interactive: bool) -> Self {
+        Self {
+            at_prompt,
+            printer: interactive.then(|| ExternalPrinter::new(1024)),
+        }
+    }
+
+    /// Clone the printer that the editor must install, when interactive.
+    pub fn external_printer(&self) -> Option<ExternalPrinter<String>> {
+        self.printer.clone()
+    }
+
+    /// Print one logical line without disturbing an active prompt.
+    pub fn line(&self, line: impl Into<String>) {
+        let line = line.into();
+        if self.at_prompt.load(Ordering::SeqCst)
+            && let Some(printer) = &self.printer
+            && printer.print(line.clone()).is_ok()
+        {
+            return;
+        }
+        eprintln!("{line}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_prompt_uses_reedline_external_printer() {
+        let at_prompt = Arc::new(AtomicBool::new(true));
+        let output = AsyncOutput::new(at_prompt, true);
+
+        output.line("server diagnostic");
+
+        assert_eq!(
+            output.external_printer().unwrap().get_line().as_deref(),
+            Some("server diagnostic")
+        );
+    }
+
+    #[test]
+    fn non_interactive_output_has_no_printer() {
+        let output = AsyncOutput::new(Arc::new(AtomicBool::new(false)), false);
+        assert!(output.external_printer().is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- preserve caller-configured stderr in `StdioClientTransport::spawn_command` and expose piped stderr with `take_stderr`
- pipe stdio server diagnostics in mcp-repl and forward complete lines through Reedline external printing while the prompt is active
- route asynchronous progress, logs, resource updates, and surface refreshes through the same prompt-safe sink
- keep non-interactive diagnostics on stderr so `--exec --json` stdout stays clean

Closes #1136

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p tower-mcp -p mcp-repl --no-deps --all-features`
- real stdio child check confirmed verbose child logs on stderr and valid JSON-only stdout