### PR TITLE
feat(mcp-repl): surface task status transitions

### DIFF
--- a/crates/tower-mcp/src/client/handler.rs
+++ b/crates/tower-mcp/src/client/handler.rs
@@ -59,7 +59,9 @@ use async_trait::async_trait;
 use crate::protocol::{
     CreateMessageParams, CreateMessageResult, ElicitRequestParams, ElicitResult, ListRootsResult,
     LogLevel, LoggingMessageParams, ProgressParams, RequestId, SubscriptionFilter,
+    TaskStatusParams,
 };
+use crate::tasks::TaskStatusNotificationParams;
 use tower_mcp_types::JsonRpcError;
 
 /// Notification sent from the server to the client.
@@ -84,6 +86,10 @@ pub enum ServerNotification {
     ToolsListChanged,
     /// The list of available prompts has changed.
     PromptsListChanged,
+    /// A legacy task changed status (`notifications/tasks`).
+    TaskStatusChanged(TaskStatusParams),
+    /// A final-protocol task changed status (`notifications/tasks`).
+    FinalTaskStatusChanged(TaskStatusNotificationParams),
     /// The server acknowledged a `subscriptions/listen` stream.
     SubscriptionAcknowledged {
         /// JSON-RPC request ID that identifies the subscription.
@@ -181,6 +187,8 @@ impl ClientHandler for () {}
 type ProgressCallback = Box<dyn Fn(ProgressParams) + Send + Sync>;
 type LogMessageCallback = Box<dyn Fn(LoggingMessageParams) + Send + Sync>;
 type ResourceUpdatedCallback = Box<dyn Fn(String) + Send + Sync>;
+type TaskStatusCallback = Box<dyn Fn(TaskStatusParams) + Send + Sync>;
+type FinalTaskStatusCallback = Box<dyn Fn(TaskStatusNotificationParams) + Send + Sync>;
 type SimpleCallback = Box<dyn Fn() + Send + Sync>;
 
 /// Callback-based handler for server notifications.
@@ -210,6 +218,8 @@ pub struct NotificationHandler {
     on_resources_changed: Option<SimpleCallback>,
     on_tools_changed: Option<SimpleCallback>,
     on_prompts_changed: Option<SimpleCallback>,
+    on_task_status_changed: Option<TaskStatusCallback>,
+    on_final_task_status_changed: Option<FinalTaskStatusCallback>,
 }
 
 impl NotificationHandler {
@@ -222,6 +232,8 @@ impl NotificationHandler {
             on_resources_changed: None,
             on_tools_changed: None,
             on_prompts_changed: None,
+            on_task_status_changed: None,
+            on_final_task_status_changed: None,
         }
     }
 
@@ -297,6 +309,24 @@ impl NotificationHandler {
         self
     }
 
+    /// Register a callback for legacy task status notifications.
+    pub fn on_task_status_changed(
+        mut self,
+        f: impl Fn(TaskStatusParams) + Send + Sync + 'static,
+    ) -> Self {
+        self.on_task_status_changed = Some(Box::new(f));
+        self
+    }
+
+    /// Register a callback for final-protocol task status notifications.
+    pub fn on_final_task_status_changed(
+        mut self,
+        f: impl Fn(TaskStatusNotificationParams) + Send + Sync + 'static,
+    ) -> Self {
+        self.on_final_task_status_changed = Some(Box::new(f));
+        self
+    }
+
     fn dispatch_notification(&self, notification: ServerNotification) {
         match notification {
             ServerNotification::Progress(params) => {
@@ -329,6 +359,16 @@ impl NotificationHandler {
                     cb();
                 }
             }
+            ServerNotification::TaskStatusChanged(params) => {
+                if let Some(cb) = &self.on_task_status_changed {
+                    cb(params);
+                }
+            }
+            ServerNotification::FinalTaskStatusChanged(params) => {
+                if let Some(cb) = &self.on_final_task_status_changed {
+                    cb(params);
+                }
+            }
             // Preserve the existing callback API for subscription-delivered
             // events while custom ClientHandler implementations can inspect
             // the wrapper and correlate concurrent streams.
@@ -357,6 +397,14 @@ impl std::fmt::Debug for NotificationHandler {
             .field("on_resources_changed", &self.on_resources_changed.is_some())
             .field("on_tools_changed", &self.on_tools_changed.is_some())
             .field("on_prompts_changed", &self.on_prompts_changed.is_some())
+            .field(
+                "on_task_status_changed",
+                &self.on_task_status_changed.is_some(),
+            )
+            .field(
+                "on_final_task_status_changed",
+                &self.on_final_task_status_changed.is_some(),
+            )
             .finish()
     }
 }
@@ -469,6 +517,52 @@ mod tests {
         assert_eq!(tools_count.load(Ordering::SeqCst), 1);
         assert_eq!(resources_count.load(Ordering::SeqCst), 1);
         assert_eq!(prompts_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_notification_handler_task_status_changed() {
+        let legacy_count = Arc::new(AtomicUsize::new(0));
+        let final_count = Arc::new(AtomicUsize::new(0));
+        let legacy = legacy_count.clone();
+        let final_ = final_count.clone();
+        let handler = NotificationHandler::new()
+            .on_task_status_changed(move |params| {
+                assert_eq!(params.task_id, "legacy-task");
+                legacy.fetch_add(1, Ordering::SeqCst);
+            })
+            .on_final_task_status_changed(move |params| {
+                assert_eq!(params.task.task_id(), "final-task");
+                final_.fetch_add(1, Ordering::SeqCst);
+            });
+
+        handler
+            .on_notification(ServerNotification::TaskStatusChanged(TaskStatusParams {
+                task_id: "legacy-task".into(),
+                status: crate::protocol::TaskStatus::Completed,
+                status_message: None,
+                created_at: "2026-08-02T00:00:00Z".into(),
+                last_updated_at: "2026-08-02T00:00:01Z".into(),
+                ttl: None,
+                poll_interval: None,
+                meta: None,
+            }))
+            .await;
+        handler
+            .on_notification(ServerNotification::FinalTaskStatusChanged(
+                TaskStatusNotificationParams {
+                    task: crate::tasks::DetailedTask::cancelled(crate::tasks::TaskMetadata::new(
+                        "final-task",
+                        "2026-08-02T00:00:00Z",
+                        "2026-08-02T00:00:01Z",
+                        None,
+                    )),
+                    meta: None,
+                },
+            ))
+            .await;
+
+        assert_eq!(legacy_count.load(Ordering::SeqCst), 1);
+        assert_eq!(final_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -104,7 +104,7 @@ use crate::protocol::{
     RequestOutcome, ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability,
     SamplingCapability, SubscriptionFilter, SubscriptionsAcknowledgedParams,
     SubscriptionsListenParams, SubscriptionsListenResult, TaskObject, TaskRequestParams,
-    ToolDefinition, UpdateTaskParams, notifications,
+    TaskStatusParams, ToolDefinition, UpdateTaskParams, notifications,
 };
 use response_cache::{CacheLookup, ClientResponseCache};
 use tower_mcp_types::JsonRpcError;
@@ -2827,6 +2827,38 @@ fn parse_server_notification(
         notifications::RESOURCES_LIST_CHANGED => ServerNotification::ResourcesListChanged,
         notifications::TOOLS_LIST_CHANGED => ServerNotification::ToolsListChanged,
         notifications::PROMPTS_LIST_CHANGED => ServerNotification::PromptsListChanged,
+        notifications::TASK_STATUS_CHANGED => {
+            let is_final = params
+                .as_ref()
+                .and_then(serde_json::Value::as_object)
+                .is_some_and(|params| params.contains_key("ttlMs"));
+            match (is_final, params.clone()) {
+                (true, Some(params)) => {
+                    match serde_json::from_value::<crate::tasks::TaskStatusNotificationParams>(
+                        params.clone(),
+                    ) {
+                        Ok(params) => ServerNotification::FinalTaskStatusChanged(params),
+                        Err(_) => ServerNotification::Unknown {
+                            method: method.to_string(),
+                            params: Some(params),
+                        },
+                    }
+                }
+                (false, Some(params)) => {
+                    match serde_json::from_value::<TaskStatusParams>(params.clone()) {
+                        Ok(params) => ServerNotification::TaskStatusChanged(params),
+                        Err(_) => ServerNotification::Unknown {
+                            method: method.to_string(),
+                            params: Some(params),
+                        },
+                    }
+                }
+                (_, None) => ServerNotification::Unknown {
+                    method: method.to_string(),
+                    params: None,
+                },
+            }
+        }
         _ => ServerNotification::Unknown {
             method: method.to_string(),
             params: params.clone(),
@@ -4308,6 +4340,52 @@ mod tests {
                 subscription_id: RequestId::Number(7),
                 reason: Some(reason),
             } if reason == "done"
+        ));
+
+        let notification = parse_server_notification(
+            notifications::TASK_STATUS_CHANGED,
+            Some(serde_json::json!({
+                "taskId": "legacy-task",
+                "status": "completed",
+                "createdAt": "2026-08-02T00:00:00Z",
+                "lastUpdatedAt": "2026-08-02T00:00:01Z",
+                "ttl": null
+            })),
+        );
+        assert!(matches!(
+            notification,
+            ServerNotification::TaskStatusChanged(TaskStatusParams {
+                task_id,
+                status: crate::protocol::TaskStatus::Completed,
+                ..
+            }) if task_id == "legacy-task"
+        ));
+
+        let notification = parse_server_notification(
+            notifications::TASK_STATUS_CHANGED,
+            Some(serde_json::json!({
+                "taskId": "final-task",
+                "status": "cancelled",
+                "createdAt": "2026-08-02T00:00:00Z",
+                "lastUpdatedAt": "2026-08-02T00:00:01Z",
+                "ttlMs": null,
+                "_meta": {
+                    "io.modelcontextprotocol/subscriptionId": "task-stream"
+                }
+            })),
+        );
+        assert!(matches!(
+            notification,
+            ServerNotification::Subscription {
+                subscription_id: RequestId::String(id),
+                notification,
+            } if id == "task-stream"
+                && matches!(
+                    notification.as_ref(),
+                    ServerNotification::FinalTaskStatusChanged(params)
+                        if params.task.task_id() == "final-task"
+                            && params.task.status() == crate::protocol::TaskStatus::Cancelled
+                )
         ));
     }
 

--- a/crates/tower-mcp/src/guides/client.rs
+++ b/crates/tower-mcp/src/guides/client.rs
@@ -161,6 +161,9 @@ async fn main() -> Result<(), BoxError> {
         .on_progress(|progress| {
             eprintln!("{}", progress.message.as_deref().unwrap_or("working"));
         })
+        .on_task_status_changed(|task| {
+            eprintln!("task {} is {}", task.task_id, task.status);
+        })
         .on_tools_changed(|| eprintln!("tool list changed"));
 
     let transport = StdioClientTransport::spawn("my-mcp-server", &[]).await?;
@@ -170,6 +173,11 @@ async fn main() -> Result<(), BoxError> {
     Ok(())
 }
 ```
+
+`on_task_status_changed` receives the legacy 2025-11-25 task shape;
+`on_final_task_status_changed` receives the status-specific final Tasks
+extension shape. Custom `ClientHandler` implementations can instead match the
+corresponding `ServerNotification` variants directly.
 
 Implement `ClientHandler` when the server may request roots, sampling, or
 elicitation. Pair the implementation with the matching builder call:

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -215,12 +215,23 @@ Task-capable tools support shell-style backgrounding (SEP-2663):
 ```text
 demo> slow_add a=2 b=3 &
 [task task-1] started
-demo> jobs
-task-1  slow_add  working
-demo> wait task-1
+[task task-1] completed  run `task task-1` for details
+demo> task task-1
 task task-1  status=completed
 5
 ```
+
+The REPL tracks only tasks it started and consumes both legacy and final typed
+task-status notifications, deduplicating repeated transitions. A final client
+opens a task-scoped `subscriptions/listen` stream; a bounded per-task poller
+remains authoritative for stable servers and for unavailable or dropped final
+notifications. It honors the server's suggested interval, ends at a terminal
+state, and gives up after three consecutive read failures. `jobs`, `task`,
+`wait`, and `cancel` remain the authoritative manual controls.
+
+Automatic transition lines are interactive-only. `--exec` and `--json`
+suppress them for deterministic scripted output; explicit task commands still
+return their normal text or JSON results.
 
 Progress and log notifications print inline as they arrive, and
 `list_changed` notifications refresh the command table mid-session, so

--- a/examples/mcp-repl/src/jobs.rs
+++ b/examples/mcp-repl/src/jobs.rs
@@ -1,0 +1,310 @@
+//! Background task registry and notification reconciliation.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use nu_ansi_term::Style;
+use tower_mcp::protocol::{TaskObject, TaskStatus, TaskStatusParams};
+use tower_mcp::tasks::TaskStatusNotificationParams;
+
+use crate::output::AsyncOutput;
+use crate::style::{paint, tag, task_status_style};
+
+const MAX_PENDING_NOTIFICATIONS: usize = 128;
+
+/// A task started by this REPL.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Job {
+    pub task_id: String,
+    pub tool: String,
+    pub status: TaskStatus,
+    pub status_message: Option<String>,
+}
+
+#[derive(Clone)]
+struct PendingStatus {
+    status: TaskStatus,
+    status_message: Option<String>,
+}
+
+#[derive(Default)]
+struct State {
+    jobs: Vec<Job>,
+    pending: HashMap<String, PendingStatus>,
+}
+
+struct Transition {
+    task_id: String,
+    status: TaskStatus,
+    status_message: Option<String>,
+}
+
+/// Shared tasks started by the REPL.
+pub struct Jobs {
+    state: Mutex<State>,
+    output: AsyncOutput,
+    announce: bool,
+}
+
+impl Jobs {
+    pub fn new(output: AsyncOutput, announce: bool) -> Self {
+        Self {
+            state: Mutex::new(State::default()),
+            output,
+            announce,
+        }
+    }
+
+    /// Record a task returned by a background tool call. If its notification
+    /// raced ahead of the response, reconcile and announce that newer state.
+    pub fn register(
+        &self,
+        task_id: String,
+        tool: String,
+        status: TaskStatus,
+        status_message: Option<String>,
+    ) {
+        let transition = {
+            let mut state = self.state.lock().unwrap();
+            let pending = state.pending.remove(&task_id);
+            state.jobs.push(Job {
+                task_id: task_id.clone(),
+                tool,
+                status,
+                status_message,
+            });
+            pending.and_then(|pending| {
+                apply_status(
+                    &mut state.jobs,
+                    &task_id,
+                    pending.status,
+                    pending.status_message,
+                )
+            })
+        };
+        self.announce(transition);
+    }
+
+    /// Observe a legacy task notification.
+    pub fn observe_legacy(&self, params: TaskStatusParams) {
+        self.observe(params.task_id, params.status, params.status_message);
+    }
+
+    /// Observe a final-protocol task notification.
+    pub fn observe_final(&self, params: TaskStatusNotificationParams) {
+        self.observe(
+            params.task.task_id().to_string(),
+            params.task.status(),
+            params.task.metadata().status_message.clone(),
+        );
+    }
+
+    /// Observe a status fetched by the bounded per-task polling fallback.
+    pub fn observe_task(&self, task: &TaskObject) {
+        self.observe(
+            task.task_id.clone(),
+            task.status,
+            task.status_message.clone(),
+        );
+    }
+
+    /// Silently refresh a known task after an explicit `jobs`, `task`, or
+    /// `wait` request. Manual commands render their own authoritative output.
+    pub fn sync(&self, task_id: &str, status: TaskStatus, status_message: Option<String>) {
+        let mut state = self.state.lock().unwrap();
+        if let Some(job) = state.jobs.iter_mut().find(|job| job.task_id == task_id) {
+            job.status = status;
+            job.status_message = status_message;
+        }
+    }
+
+    pub fn list(&self) -> Vec<Job> {
+        self.state.lock().unwrap().jobs.clone()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.state.lock().unwrap().jobs.is_empty()
+    }
+
+    pub fn is_terminal(&self, task_id: &str) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .jobs
+            .iter()
+            .find(|job| job.task_id == task_id)
+            .is_some_and(|job| job.status.is_terminal())
+    }
+
+    pub fn automatic_updates_enabled(&self) -> bool {
+        self.announce
+    }
+
+    fn observe(&self, task_id: String, status: TaskStatus, status_message: Option<String>) {
+        let transition = {
+            let mut state = self.state.lock().unwrap();
+            if let Some(transition) =
+                apply_status(&mut state.jobs, &task_id, status, status_message.clone())
+            {
+                Some(transition)
+            } else if state.jobs.iter().any(|job| job.task_id == task_id) {
+                None
+            } else {
+                if state.pending.len() >= MAX_PENDING_NOTIFICATIONS
+                    && !state.pending.contains_key(&task_id)
+                    && let Some(evicted) = state.pending.keys().next().cloned()
+                {
+                    state.pending.remove(&evicted);
+                }
+                state.pending.insert(
+                    task_id,
+                    PendingStatus {
+                        status,
+                        status_message,
+                    },
+                );
+                None
+            }
+        };
+        self.announce(transition);
+    }
+
+    fn announce(&self, transition: Option<Transition>) {
+        if !self.announce {
+            return;
+        }
+        let Some(transition) = transition else {
+            return;
+        };
+        let status = transition.status.to_string();
+        let mut line = format!(
+            "{} {}",
+            tag(Style::new(), &format!("task {}", transition.task_id)),
+            paint(task_status_style(transition.status), &status)
+        );
+        if let Some(message) = transition
+            .status_message
+            .filter(|message| !message.is_empty())
+        {
+            line.push_str(&format!(" — {message}"));
+        }
+        if transition.status.is_terminal() || transition.status == TaskStatus::InputRequired {
+            line.push_str(&format!(
+                "  {}",
+                paint(
+                    Style::new().dimmed(),
+                    &format!("run `task {}` for details", transition.task_id)
+                )
+            ));
+        }
+        self.output.line(line);
+    }
+}
+
+fn apply_status(
+    jobs: &mut [Job],
+    task_id: &str,
+    status: TaskStatus,
+    status_message: Option<String>,
+) -> Option<Transition> {
+    let job = jobs.iter_mut().find(|job| job.task_id == task_id)?;
+    if job.status == status {
+        job.status_message = status_message;
+        return None;
+    }
+    job.status = status;
+    job.status_message = status_message.clone();
+    Some(Transition {
+        task_id: task_id.to_string(),
+        status,
+        status_message,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    use super::*;
+
+    fn fixture() -> (Jobs, reedline::ExternalPrinter<String>) {
+        let output = AsyncOutput::new(Arc::new(AtomicBool::new(true)), true);
+        let printer = output.external_printer().unwrap();
+        (Jobs::new(output, true), printer)
+    }
+
+    #[test]
+    fn tracked_transitions_print_once() {
+        let (jobs, printer) = fixture();
+        jobs.register(
+            "task-1".into(),
+            "slow_add".into(),
+            TaskStatus::Working,
+            None,
+        );
+        assert!(printer.get_line().is_none());
+
+        jobs.observe_legacy(TaskStatusParams {
+            task_id: "task-1".into(),
+            status: TaskStatus::Completed,
+            status_message: Some("done".into()),
+            created_at: "2026-08-02T00:00:00Z".into(),
+            last_updated_at: "2026-08-02T00:00:01Z".into(),
+            ttl: None,
+            poll_interval: None,
+            meta: None,
+        });
+        let line = printer.get_line().unwrap();
+        assert!(line.contains("[task task-1]"));
+        assert!(line.contains("completed"));
+        assert!(line.contains("task task-1"));
+
+        jobs.observe("task-1".into(), TaskStatus::Completed, None);
+        assert!(printer.get_line().is_none(), "replay must be deduplicated");
+    }
+
+    #[test]
+    fn notification_that_wins_the_creation_race_is_reconciled() {
+        let (jobs, printer) = fixture();
+        jobs.observe("task-race".into(), TaskStatus::Failed, Some("boom".into()));
+        assert!(printer.get_line().is_none(), "unknown tasks stay silent");
+
+        jobs.register("task-race".into(), "run".into(), TaskStatus::Working, None);
+        let line = printer.get_line().unwrap();
+        assert!(line.contains("failed"));
+        assert!(line.contains("boom"));
+        assert_eq!(jobs.list()[0].status, TaskStatus::Failed);
+    }
+
+    #[test]
+    fn input_failed_and_cancelled_transitions_are_visible() {
+        let (jobs, printer) = fixture();
+        for (id, status) in [
+            ("input", TaskStatus::InputRequired),
+            ("failed", TaskStatus::Failed),
+            ("cancelled", TaskStatus::Cancelled),
+        ] {
+            jobs.register(id.into(), "run".into(), TaskStatus::Working, None);
+            jobs.observe(id.into(), status, None);
+            let line = printer.get_line().unwrap();
+            assert!(line.contains(&status.to_string()), "{line}");
+            assert!(line.contains(&format!("task {id}")), "{line}");
+        }
+    }
+
+    #[test]
+    fn one_shot_policy_suppresses_automatic_lines() {
+        let output = AsyncOutput::new(Arc::new(AtomicBool::new(true)), true);
+        let printer = output.external_printer().unwrap();
+        let jobs = Jobs::new(output, false);
+        jobs.register(
+            "task-1".into(),
+            "slow_add".into(),
+            TaskStatus::Working,
+            None,
+        );
+        jobs.observe("task-1".into(), TaskStatus::Cancelled, None);
+        assert!(printer.get_line().is_none());
+    }
+}

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -35,6 +35,7 @@ mod config;
 mod editor;
 mod elicit;
 mod find;
+mod jobs;
 mod output;
 mod sampling;
 mod session;
@@ -59,12 +60,14 @@ use tower_mcp::client::{
 };
 use tower_mcp::protocol::{
     Content, DiscoverResult, Implementation, InitializeResult, LogLevel, PromptDefinition,
-    ResourceDefinition, ResourceTemplateDefinition, ServerCapabilities, TaskObject, ToolDefinition,
+    ResourceDefinition, ResourceTemplateDefinition, ServerCapabilities, SubscriptionFilter,
+    TaskObject, ToolDefinition,
 };
 use tower_mcp::{ProtocolSupport, ProtocolSupportError};
 
 use alias::Aliases;
 use elicit::ReplClientHandler;
+use jobs::Jobs;
 use output::AsyncOutput;
 use session::{Connector, Session, is_not_initialized, is_session_lost};
 use style::{json_pretty, paint, tag, task_status_style};
@@ -197,6 +200,10 @@ fn json_output() -> bool {
 
 fn note_error() {
     HAD_ERROR.store(true, Ordering::Relaxed);
+}
+
+fn automatic_task_updates(one_shot: bool, json: bool) -> bool {
+    !one_shot && !json
 }
 
 /// A one-line JSON error object for `--json` mode.
@@ -411,10 +418,14 @@ async fn establish_connection(
 }
 
 fn client_builder(protocol: ProtocolMode) -> Result<McpClientBuilder, ProtocolSupportError> {
-    Ok(McpClient::builder()
+    let builder = McpClient::builder()
         .protocol_support(protocol.support()?)
         .with_elicitation()
-        .with_sampling())
+        .with_sampling();
+    Ok(match protocol {
+        ProtocolMode::Stable => builder,
+        ProtocolMode::Final => builder.with_tasks(),
+    })
 }
 
 /// The connection banner: server identity, negotiated protocol, and any
@@ -730,6 +741,7 @@ fn demo_router() -> tower_mcp::McpRouter {
 
     tower_mcp::McpRouter::new()
         .server_info("mcp-repl-demo", env!("CARGO_PKG_VERSION"))
+        .with_tasks()
         .prompt(
             PromptBuilder::new("greet")
                 .description("Generate a greeting (name tab-completes via the server)")
@@ -840,6 +852,7 @@ fn demo_router() -> tower_mcp::McpRouter {
 fn notification_handler(
     refresh_tx: tokio::sync::mpsc::UnboundedSender<()>,
     output: AsyncOutput,
+    jobs: Arc<Jobs>,
 ) -> NotificationHandler {
     let t = refresh_tx.clone();
     let r = refresh_tx.clone();
@@ -854,6 +867,11 @@ fn notification_handler(
         .on_prompts_changed(move || {
             let _ = p.send(());
         })
+        .on_task_status_changed({
+            let jobs = jobs.clone();
+            move |params| jobs.observe_legacy(params)
+        })
+        .on_final_task_status_changed(move |params| jobs.observe_final(params))
         .on_progress({
             let output = output.clone();
             move |p| {
@@ -907,6 +925,69 @@ fn forward_child_stderr(stderr: tokio::process::ChildStderr, output: AsyncOutput
                 Err(error) => {
                     output.line(format!("warning: reading server stderr failed: {error}"));
                     break;
+                }
+            }
+        }
+    });
+}
+
+/// Watch one task until it reaches a terminal state. Final clients open a
+/// task-scoped `subscriptions/listen` stream for immediate notifications; the
+/// bounded polling loop remains authoritative for stable servers and for a
+/// final notification that is unavailable or dropped.
+fn watch_task(session: Arc<Session>, jobs: Arc<Jobs>, task_id: String, poll_interval: Option<u64>) {
+    if !jobs.automatic_updates_enabled() || jobs.is_terminal(&task_id) {
+        return;
+    }
+    tokio::spawn(async move {
+        let client = session.client();
+        let _subscription =
+            if client.selected_protocol_version().await.as_deref() == Some("2026-07-28") {
+                match client
+                    .listen_subscriptions(SubscriptionFilter {
+                        task_ids: Some(vec![task_id.clone()]),
+                        ..Default::default()
+                    })
+                    .await
+                {
+                    Ok(mut handle) => match handle.acknowledged().await {
+                        Ok(accepted)
+                            if accepted
+                                .task_ids
+                                .as_ref()
+                                .is_some_and(|ids| ids.iter().any(|id| id == &task_id)) =>
+                        {
+                            Some(handle)
+                        }
+                        _ => None,
+                    },
+                    Err(_) => None,
+                }
+            } else {
+                None
+            };
+        let mut interval_ms = poll_interval.unwrap_or(1000).clamp(50, 30_000);
+        let mut consecutive_errors = 0;
+        loop {
+            tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+            if jobs.is_terminal(&task_id) {
+                break;
+            }
+            match session.client().task_get(&task_id).await {
+                Ok(task) => {
+                    consecutive_errors = 0;
+                    interval_ms = task.poll_interval.unwrap_or(1000).clamp(50, 30_000);
+                    let terminal = task.status.is_terminal();
+                    jobs.observe_task(&task);
+                    if terminal {
+                        break;
+                    }
+                }
+                Err(_) => {
+                    consecutive_errors += 1;
+                    if consecutive_errors >= 3 {
+                        break;
+                    }
                 }
             }
         }
@@ -1049,6 +1130,13 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // fighting over raw-mode stdin.
     let at_prompt = Arc::new(AtomicBool::new(false));
     let async_output = AsyncOutput::new(at_prompt.clone(), !one_shot);
+    // Automatic task transitions are an interactive convenience. `--exec`
+    // and `--json` retain deterministic output; their manual task commands
+    // remain authoritative.
+    let jobs = Arc::new(Jobs::new(
+        async_output.clone(),
+        automatic_task_updates(one_shot, args.json),
+    ));
 
     // Notifications print inline and trigger surface refreshes.
     let (refresh_tx, mut refresh_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
@@ -1059,9 +1147,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         let refresh_tx = refresh_tx.clone();
         let at_prompt = at_prompt.clone();
         let async_output = async_output.clone();
+        let jobs = jobs.clone();
         Arc::new(move || {
             ReplClientHandler::new(
-                notification_handler(refresh_tx.clone(), async_output.clone()),
+                notification_handler(refresh_tx.clone(), async_output.clone(), jobs.clone()),
                 at_prompt.clone(),
             )
         })
@@ -1220,9 +1309,8 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     // One-shot: run each --exec command in order, then exit non-zero if any
     // errored. No editor, no event loop.
     if one_shot {
-        let mut jobs: Vec<(String, String)> = Vec::new();
         for cmd in &args.exec {
-            if handle_line(&session, &surface, &aliases, &mut jobs, cmd.trim()).await {
+            if handle_line(&session, &surface, &aliases, &jobs, cmd.trim()).await {
                 break;
             }
         }
@@ -1251,8 +1339,6 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         !args.no_history,
     );
 
-    let mut jobs: Vec<(String, String)> = Vec::new();
-
     loop {
         tokio::select! {
             Some(()) = refresh_rx.recv() => {
@@ -1264,7 +1350,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             }
             maybe_line = line_rx.recv() => {
                 let Some(line) = maybe_line else { break };
-                let quit = handle_line(&session, &surface, &aliases, &mut jobs, line.trim()).await;
+                let quit = handle_line(&session, &surface, &aliases, &jobs, line.trim()).await;
                 let _ = ack_tx.send(());
                 if quit {
                     break;
@@ -1279,7 +1365,7 @@ async fn handle_line(
     session: &Arc<Session>,
     surface: &Arc<RwLock<Surface>>,
     aliases: &Arc<RwLock<Aliases>>,
-    jobs: &mut Vec<(String, String)>,
+    jobs: &Arc<Jobs>,
     line: &str,
 ) -> bool {
     if line.is_empty() {
@@ -1642,13 +1728,18 @@ async fn handle_line(
             if jobs.is_empty() {
                 println!("no background tasks");
             }
-            for (id, tool) in jobs.iter() {
-                match client.task_get(id).await {
-                    Ok(task) => println!(
-                        "{id}  {tool}  {}",
-                        paint(task_status_style(task.status), &task.status.to_string())
-                    ),
-                    Err(_) => println!("{id}  {tool}  (gone)"),
+            for job in jobs.list() {
+                match client.task_get(&job.task_id).await {
+                    Ok(task) => {
+                        jobs.sync(&job.task_id, task.status, task.status_message.clone());
+                        println!(
+                            "{}  {}  {}",
+                            job.task_id,
+                            job.tool,
+                            paint(task_status_style(task.status), &task.status.to_string())
+                        );
+                    }
+                    Err(_) => println!("{}  {}  (gone)", job.task_id, job.tool),
                 }
             }
         }
@@ -1673,12 +1764,16 @@ async fn handle_line(
             };
             match outcome {
                 Ok(task) if json_output() => {
+                    jobs.sync(id, task.status, task.status_message.clone());
                     println!(
                         "{}",
                         json_pretty(&serde_json::to_value(&task).unwrap_or_default())
                     );
                 }
-                Ok(task) => render_task(&task),
+                Ok(task) => {
+                    jobs.sync(id, task.status, task.status_message.clone());
+                    render_task(&task);
+                }
                 Err(e) => {
                     note_error();
                     if json_output() {
@@ -2255,7 +2350,7 @@ fn describe(surface: &Surface, name: &str) {
 async fn run_tool(
     session: &Arc<Session>,
     surface: &Arc<RwLock<Surface>>,
-    jobs: &mut Vec<(String, String)>,
+    jobs: &Arc<Jobs>,
     name: &str,
     arguments: serde_json::Value,
     background: bool,
@@ -2269,6 +2364,8 @@ async fn run_tool(
         .await
         {
             Ok(created) => {
+                let task_id = created.task.task_id.clone();
+                let poll_interval = created.task.poll_interval;
                 if json_output() {
                     println!(
                         "{}",
@@ -2283,7 +2380,13 @@ async fn run_tool(
                         )
                     );
                 }
-                jobs.push((created.task.task_id, name.to_string()));
+                jobs.register(
+                    created.task.task_id,
+                    name.to_string(),
+                    created.task.status,
+                    created.task.status_message,
+                );
+                watch_task(session.clone(), jobs.clone(), task_id, poll_interval);
             }
             Err(e) => {
                 note_error();
@@ -2556,6 +2659,11 @@ mod tests {
         assert!(
             sent[0]["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"].is_object()
         );
+        assert!(
+            sent[0]["params"]["_meta"]["io.modelcontextprotocol/clientCapabilities"]["extensions"]
+                [tower_mcp::protocol::TASKS_EXTENSION_ID]
+                .is_object()
+        );
         assert_eq!(
             sent[0]["params"]["_meta"]["io.modelcontextprotocol/clientInfo"]["name"],
             "mcp-repl"
@@ -2663,6 +2771,14 @@ mod tests {
     }
 
     #[test]
+    fn automatic_task_updates_are_interactive_text_only() {
+        assert!(automatic_task_updates(false, false));
+        assert!(!automatic_task_updates(true, false));
+        assert!(!automatic_task_updates(true, true));
+        assert!(!automatic_task_updates(false, true));
+    }
+
+    #[test]
     fn quoted_task_arguments_reach_schema_coercion_intact() {
         let parsed = command::parse(
             r#"run.start instruction="Reply with exactly hello" mode=interactive &"#,
@@ -2719,6 +2835,43 @@ mod tests {
             .unwrap();
         client.initialize("mcp-repl-test", "0").await.unwrap();
         client
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn bundled_slow_task_announces_completion_without_manual_polling() {
+        let session = Arc::new(Session::new(demo_client().await, None));
+        let surface = Arc::new(RwLock::new(Surface::default()));
+        let output = AsyncOutput::new(Arc::new(AtomicBool::new(true)), true);
+        let printer = output.external_printer().unwrap();
+        let jobs = Arc::new(Jobs::new(output, true));
+
+        run_tool(
+            &session,
+            &surface,
+            &jobs,
+            "slow_add",
+            serde_json::json!({ "a": 2, "b": 3 }),
+            true,
+            &vars::Output::default(),
+        )
+        .await;
+
+        let line = tokio::time::timeout(Duration::from_secs(6), async {
+            loop {
+                if let Some(line) = printer.get_line() {
+                    break line;
+                }
+                tokio::time::sleep(Duration::from_millis(25)).await;
+            }
+        })
+        .await
+        .expect("the task watcher should observe slow_add completion");
+
+        assert!(line.contains("completed"), "{line}");
+        assert_eq!(
+            jobs.list()[0].status,
+            tower_mcp::protocol::TaskStatus::Completed
+        );
     }
 
     /// A session whose connector builds a fresh demo client, counting how


### PR DESCRIPTION
## Summary
- parse legacy and final task notifications into typed client callbacks
- track only REPL-started tasks, reconcile creation races, and deduplicate replayed transitions
- use final task-scoped subscriptions with server-paced per-task polling as a stable-protocol and delivery fallback
- print redraw-safe interactive transitions while preserving deterministic `--exec` and `--json` output
- opt the final REPL and bundled demo into the Tasks extension and document the behavior

Closes #1137

## Validation
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p tower-mcp -p mcp-repl --no-deps --all-features`
- `cargo fmt --all -- --check`
- final-protocol demo one-shot JSON task creation