### PR TITLE
feat(tasks): prepare task state before execution

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -142,6 +142,8 @@ pub struct Task {
     pub poll_interval: u64,
     /// Human-readable status message
     pub status_message: Option<String>,
+    /// Protocol metadata retained across every task view.
+    pub meta: Option<serde_json::Value>,
     /// The result of the tool call (when completed)
     pub result: Option<CallToolResult>,
     /// Structured execution error (when failed).
@@ -192,6 +194,7 @@ impl Task {
             ttl: ttl.unwrap_or(DEFAULT_TTL_MS),
             poll_interval: DEFAULT_POLL_INTERVAL_MS,
             status_message: Some("Task started".to_string()),
+            meta: None,
             result: None,
             error: None,
             owner,
@@ -216,7 +219,7 @@ impl Task {
             poll_interval: Some(self.poll_interval),
             result: None,
             error: None,
-            meta: None,
+            meta: self.meta.clone(),
         }
     }
 
@@ -401,6 +404,24 @@ pub trait TaskStore: Send + Sync + 'static {
     /// Get task object by ID. Returns `None` if unknown.
     async fn get_task(&self, task_id: &str) -> Result<Option<TaskObject>>;
 
+    /// Persist protocol `_meta` for a task.
+    ///
+    /// The default preserves source compatibility for external stores. Stores
+    /// that want to support task preparation metadata must override it.
+    async fn set_task_meta(&self, task_id: &str, meta: serde_json::Value) -> Result<bool> {
+        let _ = (task_id, meta);
+        Ok(false)
+    }
+
+    /// Remove a task that could not finish initialization.
+    ///
+    /// The default preserves source compatibility for external stores. Stores
+    /// used with preparation callbacks should override it.
+    async fn discard_task(&self, task_id: &str) -> Result<bool> {
+        let _ = task_id;
+        Ok(false)
+    }
+
     /// Get a task's full snapshot (task object, result, error) by ID.
     async fn get_task_result(&self, task_id: &str) -> Result<Option<TaskSnapshot>>;
 
@@ -567,6 +588,26 @@ impl TaskStore for MemoryTaskStore {
         } else {
             None
         })
+    }
+
+    async fn set_task_meta(&self, task_id: &str, meta: serde_json::Value) -> Result<bool> {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(false);
+        };
+        let Some(task) = tasks.get_mut(task_id).filter(|task| !task.is_expired()) else {
+            return Ok(false);
+        };
+        task.meta = Some(meta);
+        Ok(true)
+    }
+
+    async fn discard_task(&self, task_id: &str) -> Result<bool> {
+        Ok(self
+            .tasks
+            .write()
+            .ok()
+            .and_then(|mut tasks| tasks.remove(task_id))
+            .is_some())
     }
 
     async fn task_owner(&self, task_id: &str) -> Result<Option<TaskOwner>> {

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -695,6 +695,20 @@ impl RequestContext {
         })
     }
 
+    /// Notify the client that a final-protocol task changed status.
+    ///
+    /// This is useful when a handler drives a task transition through a custom
+    /// [`crate::TaskStore`] path rather than through the router directly.
+    pub fn notify_task_status_changed(
+        &self,
+        params: crate::tasks::TaskStatusNotificationParams,
+    ) -> bool {
+        self.notification_tx.as_ref().is_some_and(|tx| {
+            tx.try_send(ServerNotification::FinalTaskStatusChanged(params))
+                .is_ok()
+        })
+    }
+
     /// Send a log message notification to the client
     ///
     /// This is a no-op if no notification sender is configured.

--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -1063,6 +1063,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
@@ -1191,6 +1192,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
@@ -1299,6 +1301,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -648,7 +648,10 @@ pub use router::{McpRouter, RouterRequest, RouterResponse, ToolAnnotationsMap};
 pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;
-pub use tool::{BoxToolService, GuardLayer, NoParams, Tool, ToolBuilder, ToolHandler, ToolRequest};
+pub use tool::{
+    BoxToolService, GuardLayer, NoParams, TaskContext, TaskPreparation, Tool, ToolBuilder,
+    ToolHandler, ToolRequest,
+};
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,
     SyncStdioTransport,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -65,6 +65,14 @@ fn task_store_error(e: TaskStoreError) -> Error {
     )))
 }
 
+async fn discard_unprepared_task(store: &Arc<dyn TaskStore>, task_id: &str) {
+    if !matches!(store.discard_task(task_id).await, Ok(true)) {
+        let _ = store
+            .cancel_task(task_id, Some("task preparation failed"))
+            .await;
+    }
+}
+
 /// Whether this request is using the final, stateless 2026-07-28 lifecycle.
 ///
 /// Stable sessionful requests retain the crate's legacy task behavior; final
@@ -2266,10 +2274,10 @@ impl McpRouter {
 
     /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
     async fn final_get_task(&self, task_id: &str) -> Result<McpResponse> {
-        let detailed = self.detailed_task(task_id).await?;
-        Ok(McpResponse::FinalGetTask(crate::tasks::GetTaskResult::new(
-            detailed,
-        )))
+        let (detailed, meta) = self.detailed_task(task_id).await?;
+        let mut result = crate::tasks::GetTaskResult::new(detailed);
+        result.meta = meta;
+        Ok(McpResponse::FinalGetTask(result))
     }
 
     /// Build the complete status-discriminated view of a task.
@@ -2277,7 +2285,13 @@ impl McpRouter {
     /// Both `tasks/get` and `notifications/tasks` render a task through this
     /// one path, which is what makes a pushed notification identical to the
     /// poll response a client would have received at that moment.
-    async fn detailed_task(&self, task_id: &str) -> Result<crate::tasks::DetailedTask> {
+    async fn detailed_task(
+        &self,
+        task_id: &str,
+    ) -> Result<(
+        crate::tasks::DetailedTask,
+        Option<serde_json::Map<String, serde_json::Value>>,
+    )> {
         let (task, result, error) = self
             .inner
             .task_store
@@ -2295,7 +2309,8 @@ impl McpRouter {
         metadata.status_message = task.status_message.clone();
         metadata.poll_interval_ms = task.poll_interval;
 
-        Ok(match task.status {
+        let meta = task.meta.and_then(|value| value.as_object().cloned());
+        let detailed = match task.status {
             TaskStatus::Working => crate::tasks::DetailedTask::working(metadata),
             TaskStatus::InputRequired => {
                 // Every request still awaiting a response, not just the most
@@ -2339,7 +2354,8 @@ impl McpRouter {
             // `TaskStatus` is non_exhaustive. Report an unrecognized status as
             // working rather than inventing a terminal state.
             _ => crate::tasks::DetailedTask::working(metadata),
-        })
+        };
+        Ok((detailed, meta))
     }
 
     /// Push the current state of a task to subscribed listen streams.
@@ -2355,7 +2371,7 @@ impl McpRouter {
             return;
         }
 
-        let detailed = match self.detailed_task(task_id).await {
+        let (detailed, meta) = match self.detailed_task(task_id).await {
             Ok(detailed) => detailed,
             Err(error) => {
                 tracing::debug!(
@@ -2371,7 +2387,7 @@ impl McpRouter {
         let notification = ServerNotification::FinalTaskStatusChanged(
             crate::tasks::TaskStatusNotificationParams {
                 task: detailed,
-                meta: None,
+                meta,
             },
         );
 
@@ -2750,8 +2766,45 @@ impl McpRouter {
                         &extensions,
                     );
 
-                    // Spawn the task execution in the background
                     let task_store = self.inner.task_store.clone();
+                    let task_context = crate::tool::TaskContext::new(task_id.clone());
+                    let mut ctx = ctx;
+                    ctx.extensions_mut().insert(task_context.clone());
+                    let preparation = match tool
+                        .prepare_task(task_context, params.arguments.clone())
+                        .await
+                    {
+                        Ok(preparation) => preparation,
+                        Err(error) => {
+                            discard_unprepared_task(&task_store, &task_id).await;
+                            return Err(error);
+                        }
+                    };
+                    if let Some(meta) = preparation.meta {
+                        let value = serde_json::Value::Object(meta);
+                        if let Err(error) = crate::protocol::validate_meta_object(&value) {
+                            discard_unprepared_task(&task_store, &task_id).await;
+                            return Err(Error::invalid_params(format!(
+                                "Invalid task metadata: {error}"
+                            )));
+                        }
+                        let persisted = match task_store.set_task_meta(&task_id, value).await {
+                            Ok(persisted) => persisted,
+                            Err(error) => {
+                                discard_unprepared_task(&task_store, &task_id).await;
+                                return Err(task_store_error(error));
+                            }
+                        };
+                        if !persisted {
+                            discard_unprepared_task(&task_store, &task_id).await;
+                            return Err(Error::JsonRpc(JsonRpcError::internal_error(
+                                "Task store could not persist preparation metadata",
+                            )));
+                        }
+                    }
+                    ctx.extensions_mut().merge(&preparation.extensions);
+
+                    // Spawn the task execution in the background
                     let tool = tool.clone();
                     let arguments = params.arguments;
                     let task_id_clone = task_id.clone();
@@ -2824,12 +2877,11 @@ impl McpRouter {
                         );
                         metadata.status_message = task.status_message.clone();
                         metadata.poll_interval_ms = task.poll_interval;
-                        return Ok(McpResponse::FinalCreateTask(
-                            crate::tasks::CreateTaskResult::new(crate::tasks::Task::new(
-                                metadata,
-                                task.status,
-                            )),
-                        ));
+                        let mut result = crate::tasks::CreateTaskResult::new(
+                            crate::tasks::Task::new(metadata, task.status),
+                        );
+                        result.meta = task.meta.and_then(|value| value.as_object().cloned());
+                        return Ok(McpResponse::FinalCreateTask(result));
                     }
                     Ok(McpResponse::CreateTask(CreateTaskResult::new(task)))
                 } else {
@@ -3986,6 +4038,14 @@ mod tests {
                     .handler(|input: AddInput| async move {
                         Ok(CallToolResult::text(format!("{}", input.a + input.b)))
                     })
+                    .task_preparation(|task, _input| async move {
+                        let mut meta = serde_json::Map::new();
+                        meta.insert(
+                            "dev.tower-mcp/owner-test".to_string(),
+                            serde_json::json!({"taskId": task.task_id()}),
+                        );
+                        Ok(crate::TaskPreparation::new().with_meta(meta))
+                    })
                     .build(),
             )
             .with_tasks();
@@ -4016,6 +4076,10 @@ mod tests {
         assert!(wire["ttlMs"].is_number() || wire["ttlMs"].is_null());
         assert!(wire.get("ttl").is_none(), "legacy field name leaked");
         let task_id = created.task.metadata.task_id.clone();
+        assert_eq!(
+            created.meta.as_ref().unwrap()["dev.tower-mcp/owner-test"]["taskId"],
+            task_id
+        );
 
         // tasks/get returns a status-discriminated DetailedTask.
         let McpResponse::FinalGetTask(fetched) = router

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -43,7 +43,7 @@ use pin_project_lite::pin_project;
 use schemars::{JsonSchema, Schema, SchemaGenerator};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use serde_json::Value;
+use serde_json::{Map, Value};
 #[cfg(feature = "stateless")]
 use tower::ServiceExt;
 use tower::util::BoxCloneService;
@@ -52,7 +52,7 @@ use tower_service::Service;
 #[cfg(feature = "stateless")]
 use tokio::sync::Mutex;
 
-use crate::context::RequestContext;
+use crate::context::{Extensions, RequestContext};
 use crate::error::{Error, Result, ResultExt};
 use crate::protocol::{
     CallToolResult, ClientCapabilities, RequestOutcome, TaskSupportMode, ToolAnnotations,
@@ -458,6 +458,100 @@ pub(crate) fn ensure_object_schema(mut schema: Value) -> Value {
 /// A boxed future for tool handlers
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// Identity allocated for one task-backed tool execution.
+///
+/// The same value is supplied to task preparation and inserted into the
+/// background handler's request extensions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskContext {
+    task_id: String,
+}
+
+impl TaskContext {
+    pub(crate) fn new(task_id: String) -> Self {
+        Self { task_id }
+    }
+
+    /// The server-generated task identifier.
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+}
+
+/// Metadata and application state produced before task execution begins.
+#[derive(Debug, Clone, Default)]
+pub struct TaskPreparation {
+    pub(crate) meta: Option<Map<String, Value>>,
+    pub(crate) extensions: Extensions,
+}
+
+impl TaskPreparation {
+    /// Create an empty preparation result.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Attach protocol `_meta` to every view of this task.
+    pub fn with_meta(mut self, meta: Map<String, Value>) -> Self {
+        self.meta = Some(meta);
+        self
+    }
+
+    /// Make application state available to the background handler through
+    /// [`crate::extract::Extension`].
+    pub fn with_extension<T: Send + Sync + 'static>(mut self, value: T) -> Self {
+        self.extensions.insert(value);
+        self
+    }
+}
+
+pub(crate) trait TaskPreparer: Send + Sync {
+    fn prepare(
+        &self,
+        context: TaskContext,
+        arguments: Value,
+    ) -> BoxFuture<'_, Result<TaskPreparation>>;
+}
+
+impl<F, Fut> TaskPreparer for F
+where
+    F: Fn(TaskContext, Value) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<TaskPreparation>> + Send + 'static,
+{
+    fn prepare(
+        &self,
+        context: TaskContext,
+        arguments: Value,
+    ) -> BoxFuture<'_, Result<TaskPreparation>> {
+        Box::pin((self)(context, arguments))
+    }
+}
+
+struct TypedTaskPreparer<I, F> {
+    prepare: F,
+    _phantom: std::marker::PhantomData<I>,
+}
+
+impl<I, F, Fut> TaskPreparer for TypedTaskPreparer<I, F>
+where
+    I: DeserializeOwned + Send + Sync + 'static,
+    F: Fn(TaskContext, I) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<TaskPreparation>> + Send + 'static,
+{
+    fn prepare(
+        &self,
+        context: TaskContext,
+        arguments: Value,
+    ) -> BoxFuture<'_, Result<TaskPreparation>> {
+        let input = serde_json::from_value(arguments)
+            .map_err(|error| Error::invalid_params(format!("Invalid input: {error}")));
+        match input {
+            Ok(input) => Box::pin((self.prepare)(context, input)),
+            Err(error) => Box::pin(async move { Err(error) }),
+        }
+    }
+}
+
 /// Tool handler trait - the core abstraction for tool execution
 pub trait ToolHandler: Send + Sync {
     /// Execute the tool with the given arguments
@@ -675,6 +769,8 @@ pub struct Tool {
     /// Client capabilities required to invoke this tool in the modern
     /// per-request protocol.
     pub(crate) required_client_capabilities: Option<ClientCapabilities>,
+    /// Optional callback run after task allocation and before task execution.
+    pub(crate) task_preparer: Option<Arc<dyn TaskPreparer>>,
     /// The boxed service that executes the tool
     pub(crate) service: Option<BoxToolService>,
     #[cfg(feature = "stateless")]
@@ -719,6 +815,7 @@ impl Clone for Tool {
             meta: self.meta.clone(),
             task_support: self.task_support,
             required_client_capabilities: self.required_client_capabilities.clone(),
+            task_preparer: self.task_preparer.clone(),
             service: self.service.clone(),
             #[cfg(feature = "stateless")]
             mrtr_handler: self.mrtr_handler.clone(),
@@ -848,6 +945,44 @@ impl Tool {
         self.required_client_capabilities.as_ref()
     }
 
+    /// Add a preparation callback for task-backed invocations.
+    ///
+    /// The callback runs exactly once after task ID allocation and before the
+    /// initial task response. It is skipped for synchronous calls.
+    pub fn with_task_preparation<F, Fut>(mut self, prepare: F) -> Self
+    where
+        F: Fn(TaskContext, Value) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<TaskPreparation>> + Send + 'static,
+    {
+        self.task_preparer = Some(Arc::new(prepare));
+        self
+    }
+
+    /// Add a typed preparation callback to an already-built tool.
+    pub fn with_typed_task_preparation<I, F, Fut>(mut self, prepare: F) -> Self
+    where
+        I: DeserializeOwned + Send + Sync + 'static,
+        F: Fn(TaskContext, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<TaskPreparation>> + Send + 'static,
+    {
+        self.task_preparer = Some(Arc::new(TypedTaskPreparer {
+            prepare,
+            _phantom: std::marker::PhantomData,
+        }));
+        self
+    }
+
+    pub(crate) async fn prepare_task(
+        &self,
+        context: TaskContext,
+        arguments: Value,
+    ) -> Result<TaskPreparation> {
+        match self.task_preparer.as_ref() {
+            Some(prepare) => prepare.prepare(context, arguments).await,
+            None => Ok(TaskPreparation::default()),
+        }
+    }
+
     /// Apply a guard to this built tool.
     ///
     /// The guard runs before the handler and can short-circuit with an error.
@@ -938,6 +1073,7 @@ impl Tool {
             meta: self.meta.clone(),
             task_support: self.task_support,
             required_client_capabilities: self.required_client_capabilities.clone(),
+            task_preparer: self.task_preparer.clone(),
             service: self.service.clone(),
             #[cfg(feature = "stateless")]
             mrtr_handler: self.mrtr_handler.clone(),
@@ -974,6 +1110,7 @@ impl Tool {
             meta: None,
             task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
@@ -1006,6 +1143,7 @@ impl Tool {
             meta: None,
             task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: None,
             mrtr_handler: Some(Arc::new(handler)),
             input_schema,
@@ -1368,6 +1506,7 @@ impl ToolBuilder {
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            task_preparer: None,
             handler,
             _phantom: std::marker::PhantomData,
         }
@@ -1619,6 +1758,7 @@ pub struct ToolBuilderWithHandler<I, F> {
     icons: Option<Vec<ToolIcon>>,
     annotations: Option<ToolAnnotations>,
     task_support: TaskSupportMode,
+    task_preparer: Option<Arc<dyn TaskPreparer>>,
     handler: F,
     _phantom: std::marker::PhantomData<I>,
 }
@@ -1772,6 +1912,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
@@ -1820,7 +1961,7 @@ where
 {
     /// Build the tool.
     pub fn build(self) -> Tool {
-        Tool::from_handler(
+        let mut tool = Tool::from_handler(
             self.name,
             self.title,
             self.description,
@@ -1833,7 +1974,22 @@ where
                 handler: self.handler,
                 _phantom: std::marker::PhantomData,
             },
-        )
+        );
+        tool.task_preparer = self.task_preparer;
+        tool
+    }
+
+    /// Add a typed preparation step for task-backed invocations.
+    pub fn task_preparation<P, PrepareFuture>(mut self, prepare: P) -> Self
+    where
+        P: Fn(TaskContext, I) -> PrepareFuture + Send + Sync + 'static,
+        PrepareFuture: Future<Output = Result<TaskPreparation>> + Send + 'static,
+    {
+        self.task_preparer = Some(Arc::new(TypedTaskPreparer {
+            prepare,
+            _phantom: std::marker::PhantomData,
+        }));
+        self
     }
 
     /// Apply a Tower layer (middleware) to this tool.
@@ -1871,6 +2027,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            task_preparer: self.task_preparer,
             handler: self.handler,
             layer,
             _phantom: std::marker::PhantomData,
@@ -1983,6 +2140,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: None,
             service: None,
             mrtr_handler: Some(Arc::new(ServiceMrtrToolHandler {
                 service: Mutex::new(service),
@@ -2037,6 +2195,7 @@ pub struct ToolBuilderWithLayer<I, F, L> {
     icons: Option<Vec<ToolIcon>>,
     annotations: Option<ToolAnnotations>,
     task_support: TaskSupportMode,
+    task_preparer: Option<Arc<dyn TaskPreparer>>,
     handler: F,
     layer: L,
     _phantom: std::marker::PhantomData<I>,
@@ -2082,6 +2241,7 @@ where
             meta: None,
             task_support: self.task_support,
             required_client_capabilities: None,
+            task_preparer: self.task_preparer,
             service: Some(service),
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
@@ -2106,6 +2266,7 @@ where
             icons: self.icons,
             annotations: self.annotations,
             task_support: self.task_support,
+            task_preparer: self.task_preparer,
             handler: self.handler,
             layer: tower::layer::util::Stack::new(layer, self.layer),
             _phantom: std::marker::PhantomData,

--- a/crates/tower-mcp/tests/task_preparation.rs
+++ b/crates/tower-mcp/tests/task_preparation.rs
@@ -1,0 +1,204 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::{Map, json};
+use tokio::sync::mpsc;
+use tower_mcp::client::{ChannelTransport, McpClient, NotificationHandler};
+use tower_mcp::extract::{Extension, Json};
+use tower_mcp::protocol::TaskStatus;
+use tower_mcp::schemars::JsonSchema;
+use tower_mcp::{
+    CallToolResult, McpRouter, ProtocolSupport, TaskContext, TaskPreparation, TaskStore,
+    TaskSupportMode, ToolBuilder,
+};
+
+const PREPARED_META: &str = "dev.tower-mcp/prepared";
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct Input {
+    value: u64,
+}
+
+#[derive(Debug, Clone)]
+struct PreparedState {
+    task_id: String,
+    doubled: u64,
+}
+
+#[tokio::test]
+async fn preparation_metadata_and_state_follow_the_entire_task_lifecycle() {
+    let preparation_count = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::new(AtomicUsize::new(0));
+    let prepare_calls = preparation_count.clone();
+    let handler_calls = handler_count.clone();
+
+    let tool = ToolBuilder::new("prepared")
+        .task_support(TaskSupportMode::Required)
+        .extractor_handler(
+            (),
+            move |Extension(prepared): Extension<PreparedState>,
+                  Extension(task): Extension<TaskContext>,
+                  Json(input): Json<Input>| {
+                let handler_calls = handler_calls.clone();
+                async move {
+                    handler_calls.fetch_add(1, Ordering::SeqCst);
+                    assert_eq!(task.task_id(), prepared.task_id);
+                    assert_eq!(prepared.doubled, input.value * 2);
+                    tokio::time::sleep(Duration::from_millis(25)).await;
+                    Ok(CallToolResult::json(json!({
+                        "task_id": prepared.task_id,
+                        "doubled": prepared.doubled
+                    })))
+                }
+            },
+        )
+        .build()
+        .with_task_preparation(move |task, arguments| {
+            let prepare_calls = prepare_calls.clone();
+            async move {
+                prepare_calls.fetch_add(1, Ordering::SeqCst);
+                let input: Input = serde_json::from_value(arguments)
+                    .map_err(|error| tower_mcp::Error::invalid_params(error.to_string()))?;
+                let state = PreparedState {
+                    task_id: task.task_id().to_string(),
+                    doubled: input.value * 2,
+                };
+                let mut meta = Map::new();
+                meta.insert(
+                    PREPARED_META.to_string(),
+                    json!({"taskId": task.task_id(), "doubled": state.doubled}),
+                );
+                Ok(TaskPreparation::new().with_meta(meta).with_extension(state))
+            }
+        });
+    let router = McpRouter::new()
+        .server_info("task-preparation-test", "1.0.0")
+        .tool(tool)
+        .with_tasks();
+
+    let (notification_tx, mut notification_rx) = mpsc::unbounded_channel();
+    let handler = NotificationHandler::new().on_final_task_status_changed(move |notification| {
+        let _ = notification_tx.send(notification);
+    });
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect(ChannelTransport::new(router), handler)
+        .await
+        .expect("connect");
+    client
+        .discover("task-preparation-client", "1.0.0")
+        .await
+        .expect("discover");
+
+    let created = client
+        .call_tool_as_task("prepared", json!({"value": 21}), None)
+        .await
+        .expect("task creation");
+    let initial_meta = created.meta.as_ref().expect("initial task metadata");
+    assert_eq!(initial_meta[PREPARED_META]["doubled"], 42);
+    assert_eq!(initial_meta[PREPARED_META]["taskId"], created.task.task_id);
+
+    let polled = client
+        .task_get(&created.task.task_id)
+        .await
+        .expect("tasks/get");
+    assert_eq!(
+        polled.meta.as_ref().unwrap()[PREPARED_META],
+        initial_meta[PREPARED_META]
+    );
+
+    let done = tokio::time::timeout(
+        Duration::from_secs(5),
+        client.task_wait(&created.task.task_id),
+    )
+    .await
+    .expect("task wait timeout")
+    .expect("task wait");
+    assert_eq!(done.status, TaskStatus::Completed);
+    assert_eq!(
+        done.meta.as_ref().unwrap()[PREPARED_META],
+        initial_meta[PREPARED_META]
+    );
+    assert_eq!(
+        done.result
+            .as_ref()
+            .unwrap()
+            .structured_content
+            .as_ref()
+            .unwrap()["doubled"],
+        42
+    );
+
+    let notification = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let notification = notification_rx.recv().await.expect("notification stream");
+            if notification.task.task_id() == created.task.task_id {
+                return notification;
+            }
+        }
+    })
+    .await
+    .expect("task notification timeout");
+    assert_eq!(
+        notification.meta.as_ref().unwrap()[PREPARED_META],
+        initial_meta[PREPARED_META]
+    );
+    assert_eq!(preparation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(handler_count.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn preparation_error_discards_the_task_and_skips_background_execution() {
+    let preparation_count = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::new(AtomicUsize::new(0));
+    let prepare_calls = preparation_count.clone();
+    let handler_calls = handler_count.clone();
+    let store = Arc::new(tower_mcp::MemoryTaskStore::new());
+
+    let tool = ToolBuilder::new("rejected")
+        .task_support(TaskSupportMode::Required)
+        .handler(move |_input: Input| {
+            let handler_calls = handler_calls.clone();
+            async move {
+                handler_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CallToolResult::text("should not run"))
+            }
+        })
+        .task_preparation(move |_task, _input| {
+            let prepare_calls = prepare_calls.clone();
+            async move {
+                prepare_calls.fetch_add(1, Ordering::SeqCst);
+                Err::<TaskPreparation, _>(tower_mcp::Error::Internal(
+                    "preparation rejected".to_string(),
+                ))
+            }
+        })
+        .build();
+    let router = McpRouter::new()
+        .server_info("task-preparation-test", "1.0.0")
+        .tool(tool)
+        .task_store(store.clone())
+        .with_tasks();
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect_simple(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client
+        .discover("task-preparation-client", "1.0.0")
+        .await
+        .expect("discover");
+
+    let error = client
+        .call_tool_as_task("rejected", json!({"value": 1}), None)
+        .await
+        .expect_err("preparation must reject the call");
+    assert!(error.to_string().contains("preparation rejected"));
+    assert_eq!(preparation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(handler_count.load(Ordering::SeqCst), 0);
+    assert!(store.list_tasks(None).await.unwrap().is_empty());
+}

--- a/crates/tower-mcp/tests/task_preparation.rs
+++ b/crates/tower-mcp/tests/task_preparation.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "stateless")]
+
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;


### PR DESCRIPTION
## Summary

- allocate and expose a `TaskContext` before a task-backed tool starts
- add raw and typed preparation callbacks that can attach protocol `_meta` and handler extensions
- persist prepared metadata across create, get, wait, and notification views
- clean up task records when preparation or metadata persistence fails
- keep external task stores source-compatible through default trait methods

## Why

Task-backed integrations need the server-generated task ID before background execution so they can establish durable correlation metadata and application state without maintaining a parallel lifecycle outside tower-mcp.

Closes #1141

## Validation

- `cargo test -p tower-mcp --all-features`
- `cargo clippy -p tower-mcp --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p tower-mcp --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`