### PR TITLE
feat(client): support final subscriptions over ChannelTransport

### DIFF
--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -60,11 +60,16 @@
 use async_trait::async_trait;
 use tokio::sync::mpsc;
 
+#[cfg(feature = "stateless")]
+use std::sync::{Arc, Mutex as StdMutex};
+
 use crate::context::{NotificationReceiver, notification_channel};
 use crate::error::Result;
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse, McpNotification};
 use crate::router::McpRouter;
+#[cfg(feature = "stateless")]
+use crate::transport::stdio::{StdioSubscriptionInput, StdioSubscriptions};
 
 use super::transport::ClientTransport;
 
@@ -121,11 +126,34 @@ impl ChannelTransport {
         let (request_tx, mut request_rx) = mpsc::channel::<String>(64);
         let (response_tx, response_rx) = mpsc::channel::<String>(64);
 
+        #[cfg(feature = "stateless")]
+        let subscriptions = Arc::new(StdMutex::new(StdioSubscriptions::new(
+            Some(router.implementation()),
+            router.final_tasks_enabled(),
+        )));
+
         // Notification pump: serialize ServerNotifications into JSON-RPC
         // notification frames on the shared response stream.
         let notification_out = response_tx.clone();
+        #[cfg(feature = "stateless")]
+        let notification_subscriptions = subscriptions.clone();
         tokio::spawn(async move {
             while let Some(notification) = notification_rx.recv().await {
+                #[cfg(feature = "stateless")]
+                {
+                    let frames = notification_subscriptions
+                        .lock()
+                        .ok()
+                        .and_then(|subscriptions| subscriptions.route_notification(&notification));
+                    if let Some(frames) = frames {
+                        for frame in frames {
+                            if notification_out.send(frame).await.is_err() {
+                                return;
+                            }
+                        }
+                        continue;
+                    }
+                }
                 if let Some(json) = crate::transport::stdio::serialize_notification(&notification)
                     && notification_out.send(json).await.is_err()
                 {
@@ -148,6 +176,21 @@ impl ChannelTransport {
                         continue;
                     }
                 };
+                #[cfg(feature = "stateless")]
+                {
+                    let handled = subscriptions
+                        .lock()
+                        .ok()
+                        .map(|mut subscriptions| subscriptions.handle_input(&service, &parsed));
+                    if let Some(Ok(StdioSubscriptionInput::Handled(frames))) = handled {
+                        for frame in frames {
+                            if response_tx.send(frame).await.is_err() {
+                                return;
+                            }
+                        }
+                        continue;
+                    }
+                }
                 if parsed.get("id").is_none() {
                     if parsed.get("method").and_then(|m| m.as_str())
                         == Some("notifications/initialized")

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -108,7 +108,7 @@ fn stdio_control_channel() -> (
 
 #[cfg(feature = "stateless")]
 #[derive(Default)]
-struct StdioSubscriptions {
+pub(crate) struct StdioSubscriptions {
     active: HashMap<RequestId, SubscriptionFilter>,
     modern_mode: bool,
     server_info: Option<Implementation>,
@@ -132,14 +132,22 @@ fn stdio_request_declares_tasks(parsed: &serde_json::Value) -> bool {
 }
 
 #[cfg(feature = "stateless")]
-enum StdioSubscriptionInput {
+pub(crate) enum StdioSubscriptionInput {
     NotHandled,
     Handled(Vec<String>),
 }
 
 #[cfg(feature = "stateless")]
 impl StdioSubscriptions {
-    fn handle_input<S>(
+    pub(crate) fn new(server_info: Option<Implementation>, tasks_enabled: bool) -> Self {
+        Self {
+            server_info,
+            tasks_enabled,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn handle_input<S>(
         &mut self,
         service: &JsonRpcService<S>,
         parsed: &serde_json::Value,
@@ -260,7 +268,10 @@ impl StdioSubscriptions {
 
     /// Route a subscription-scoped notification and suppress its untagged
     /// form whenever at least one final subscription is active.
-    fn route_notification(&self, notification: &ServerNotification) -> Option<Vec<String>> {
+    pub(crate) fn route_notification(
+        &self,
+        notification: &ServerNotification,
+    ) -> Option<Vec<String>> {
         if !self.modern_mode
             || !matches!(
                 notification,

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -165,3 +165,58 @@ async fn default_constructor_delivers_router_notifications() {
         .expect("handler channel closed");
     assert!(msg.contains("hello from the tool"), "got: {msg}");
 }
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_subscription_listen_filters_channel_transport_notifications() {
+    use tower_mcp::ProtocolSupport;
+    use tower_mcp::protocol::SubscriptionFilter;
+
+    let (notification_tx, notification_rx) = notification_channel(64);
+    let router = McpRouter::new()
+        .server_info("channel-test", "1.0.0")
+        .with_notification_sender(notification_tx.clone());
+    let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel();
+    let handler = NotificationHandler::new().on_resource_updated(move |uri| {
+        let _ = seen_tx.send(uri);
+    });
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .connect(
+            ChannelTransport::with_notifications(router, notification_rx),
+            handler,
+        )
+        .await
+        .expect("connect");
+    client
+        .discover("channel-subscription-test", "1.0.0")
+        .await
+        .expect("discover");
+
+    let mut subscription = client
+        .listen_subscriptions(SubscriptionFilter {
+            resource_subscriptions: Some(vec!["test://watched".to_string()]),
+            ..Default::default()
+        })
+        .await
+        .expect("subscriptions/listen");
+    let accepted = subscription.acknowledged().await.expect("acknowledgment");
+    assert_eq!(
+        accepted.resource_subscriptions,
+        Some(vec!["test://watched".to_string()])
+    );
+
+    notification_tx
+        .send(ServerNotification::ResourceUpdated {
+            uri: "test://watched".to_string(),
+        })
+        .await
+        .expect("notification send");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), seen_rx.recv())
+            .await
+            .expect("notification timeout"),
+        Some("test://watched".to_string())
+    );
+    subscription.cancel().await.expect("subscription cancel");
+}


### PR DESCRIPTION
## Summary

- reuse the final stdio subscription state machine in `ChannelTransport`
- handle `subscriptions/listen` acknowledgements and cancellation in process
- route matching notifications through subscription-scoped frames
- preserve existing stable notification delivery
- cover final resource subscription delivery with an integration test

## Why

In-process clients should be able to exercise the final MCP subscription lifecycle with the same semantics as wire transports. This makes `ChannelTransport` suitable for realistic final-protocol integration tests and embedded deployments.

Closes #1142

## Validation

- `cargo test -p tower-mcp --all-features --test channel_transport`
- `cargo test -p tower-mcp --all-features transport::stdio::tests`
- `cargo clippy -p tower-mcp --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p tower-mcp --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`