### PR TITLE
feat(prompts): initialize dynamic catalogs lazily

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -399,6 +399,9 @@ struct AutoInstructionsConfig {
 #[cfg(all(feature = "http", feature = "stateless"))]
 type ModernNotificationSink = Arc<dyn Fn(&ServerNotification) -> bool + Send + Sync + 'static>;
 
+#[cfg(feature = "dynamic-tools")]
+type PromptInitializer = Arc<dyn Fn() -> Result<()> + Send + Sync + 'static>;
+
 /// Inner configuration that is shared across clones
 #[derive(Clone)]
 struct McpRouterInner {
@@ -479,6 +482,9 @@ struct McpRouterInner {
     /// Dynamic prompts registry for runtime prompt (de)registration
     #[cfg(feature = "dynamic-tools")]
     dynamic_prompts: Option<Arc<DynamicPromptsInner>>,
+    /// Lazily populates the dynamic prompt registry before list/get access.
+    #[cfg(feature = "dynamic-tools")]
+    prompt_initializer: Option<PromptInitializer>,
     /// Dynamic resources registry for runtime resource (de)registration
     #[cfg(feature = "dynamic-tools")]
     dynamic_resources: Option<Arc<DynamicResourcesInner>>,
@@ -613,6 +619,8 @@ impl McpRouter {
                 dynamic_tools: None,
                 #[cfg(feature = "dynamic-tools")]
                 dynamic_prompts: None,
+                #[cfg(feature = "dynamic-tools")]
+                prompt_initializer: None,
                 #[cfg(feature = "dynamic-tools")]
                 dynamic_resources: None,
                 #[cfg(feature = "dynamic-tools")]
@@ -758,6 +766,20 @@ impl McpRouter {
         let inner_dyn = Arc::new(DynamicPromptsInner::new());
         Arc::make_mut(&mut self.inner).dynamic_prompts = Some(inner_dyn.clone());
         (self, DynamicPromptRegistry::new(inner_dyn))
+    }
+
+    /// Run an initializer before each `prompts/list` or `prompts/get` access.
+    ///
+    /// This supports prompt definitions backed by an application-owned lazy
+    /// catalog. The initializer should populate the registry returned by
+    /// [`Self::with_dynamic_prompts`] and implement its own caching.
+    #[cfg(feature = "dynamic-tools")]
+    pub fn dynamic_prompt_initializer<F>(mut self, initializer: F) -> Self
+    where
+        F: Fn() -> Result<()> + Send + Sync + 'static,
+    {
+        Arc::make_mut(&mut self.inner).prompt_initializer = Some(Arc::new(initializer));
+        self
     }
 
     /// Enable dynamic resource registration and return a registry handle.
@@ -3204,6 +3226,10 @@ impl McpRouter {
             }
 
             McpRequest::ListPrompts(params) => {
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(initializer) = &self.inner.prompt_initializer {
+                    initializer()?;
+                }
                 let disabled = self.inner.disabled_prompts.read().unwrap().clone();
                 let is_visible = |p: &Prompt| -> bool {
                     !disabled.contains(&p.name)
@@ -3250,6 +3276,10 @@ impl McpRouter {
             }
 
             McpRequest::GetPrompt(params) => {
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(initializer) = &self.inner.prompt_initializer {
+                    initializer()?;
+                }
                 // Disabled prompts are reported as if they don't exist.
                 if self
                     .inner

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -9,6 +9,11 @@ use tower_mcp::context::{ServerNotification, notification_channel};
 use tower_mcp::extract::RawArgs;
 use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
 
+#[cfg(feature = "dynamic-tools")]
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "dynamic-tools")]
+use tower_mcp::PromptBuilder;
+
 fn slow_tool(name: &str, delay_ms: u64) -> tower_mcp::Tool {
     ToolBuilder::new(name)
         .description("Sleeps, then answers")
@@ -118,6 +123,39 @@ async fn concurrent_requests_do_not_serialize() {
         slow_elapsed >= Duration::from_millis(500),
         "slow call should actually be slow, took {slow_elapsed:?}"
     );
+}
+
+#[cfg(feature = "dynamic-tools")]
+#[tokio::test]
+async fn dynamic_prompt_initializer_runs_only_when_prompts_are_accessed() {
+    let calls = Arc::new(AtomicU64::new(0));
+    let (router, prompts) = McpRouter::new()
+        .server_info("lazy-prompts", "1.0.0")
+        .with_dynamic_prompts();
+    let initializer_calls = calls.clone();
+    let router = router.dynamic_prompt_initializer(move || {
+        initializer_calls.fetch_add(1, Ordering::SeqCst);
+        if !prompts.contains("lazy") {
+            prompts.register(PromptBuilder::new("lazy").user_message("loaded"));
+        }
+        Ok(())
+    });
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("test", "1.0.0").await.unwrap();
+    client.list_tools().await.unwrap();
+    client.list_resources().await.unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+    let listed = client.list_prompts().await.unwrap();
+    assert_eq!(listed.prompts[0].name, "lazy");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    let loaded = client.get_prompt("lazy", None).await.unwrap();
+    assert_eq!(loaded.messages.len(), 1);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
 }
 
 /// The default constructor also delivers router-emitted notifications (the


### PR DESCRIPTION
## Summary

- add an optional dynamic prompt initializer to `McpRouter`
- invoke it immediately before `prompts/list` and `prompts/get`
- leave caching and registry population under application control
- avoid loading prompt catalogs for unrelated tools and resources operations
- cover access-triggered initialization with an in-process integration test

## Why

Applications with owned or expensive prompt catalogs should not need to populate tower-mcp's dynamic registry during startup when no client ever accesses prompts.

Closes #1143

## Validation

- `cargo test -p tower-mcp --all-features --test channel_transport dynamic_prompt_initializer_runs_only_when_prompts_are_accessed`
- `cargo test -p tower-mcp --all-features router::tests`
- `cargo clippy -p tower-mcp --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p tower-mcp --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`