### PR TITLE
fix(mcp-repl): subscribe to final surface changes

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -236,7 +236,13 @@ return their normal text or JSON results.
 Progress and log notifications print inline as they arrive, and
 `list_changed` notifications refresh the command table mid-session, so
 dynamic servers (see the `dynamic_capabilities` example) grow and shrink the
-REPL's vocabulary live.
+REPL's vocabulary live. Stable connections receive those notifications on
+their ordinary transport. An interactive final connection opens one
+`subscriptions/listen` stream for tool, prompt, and resource list changes
+after its initial surface fetch, validates the server's acknowledged subset,
+and reopens the stream after a reconnect or unexpected ending with bounded
+backoff. `--exec` never opens this background stream, preserving deterministic
+one-shot output.
 
 For a spawned stdio server, child diagnostics remain visible but are read from
 the child's stderr and passed through reedline's external printer. Logs that

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -41,6 +41,7 @@ mod sampling;
 mod session;
 mod style;
 mod subscribe;
+mod surface_subscription;
 mod vars;
 mod wire;
 
@@ -1320,6 +1321,14 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
             0
         });
     }
+
+    // Final list-change notifications are subscription-scoped. Start the
+    // long-lived stream only for an interactive final connection, after the
+    // initial surface fetch; stable notifications already arrive directly,
+    // and one-shot output must remain deterministic.
+    let _surface_subscription = (args.protocol == ProtocolMode::Final).then(|| {
+        surface_subscription::SurfaceSubscription::start(session.clone(), async_output.clone())
+    });
 
     // Readline runs on its own thread; lines cross into async via channels.
     let (line_tx, mut line_rx) = tokio::sync::mpsc::channel::<String>(1);

--- a/examples/mcp-repl/src/session.rs
+++ b/examples/mcp-repl/src/session.rs
@@ -41,6 +41,10 @@ pub struct Session {
     /// and finds N+1 after taking the lock knows someone else already
     /// reconnected and skips its own attempt.
     generation: AtomicU64,
+    /// Wakes long-lived work tied to the current client so it can move to the
+    /// replacement immediately. Polling the atomic would leave an old final
+    /// subscription alive until its transport happened to close.
+    generation_tx: tokio::sync::watch::Sender<u64>,
 }
 
 impl Session {
@@ -48,11 +52,13 @@ impl Session {
     /// for stdio children and the in-process demo router: there, a dropped
     /// session means the server itself is gone.
     pub fn new(client: McpClient, connector: Option<Connector>) -> Self {
+        let (generation_tx, _) = tokio::sync::watch::channel(0);
         Self {
             client: RwLock::new(Arc::new(client)),
             connector,
             reconnecting: tokio::sync::Mutex::new(()),
             generation: AtomicU64::new(0),
+            generation_tx,
         }
     }
 
@@ -68,6 +74,12 @@ impl Session {
 
     pub fn generation(&self) -> u64 {
         self.generation.load(Ordering::Acquire)
+    }
+
+    /// Observe successful reconnects. Long-lived requests should reopen on
+    /// the client corresponding to each new generation.
+    pub fn subscribe_generation(&self) -> tokio::sync::watch::Receiver<u64> {
+        self.generation_tx.subscribe()
     }
 
     /// Rebuild the connection, unless another caller already did so since
@@ -88,7 +100,8 @@ impl Session {
         tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         let fresh = connector().await?;
         *self.client.write().unwrap() = Arc::new(fresh);
-        self.generation.fetch_add(1, Ordering::AcqRel);
+        let generation = self.generation.fetch_add(1, Ordering::AcqRel) + 1;
+        self.generation_tx.send_replace(generation);
         Ok(())
     }
 }

--- a/examples/mcp-repl/src/surface_subscription.rs
+++ b/examples/mcp-repl/src/surface_subscription.rs
@@ -1,0 +1,380 @@
+//! Final-protocol subscription that keeps the interactive command surface live.
+//!
+//! Stable connections receive ordinary `list_changed` notifications. The
+//! final protocol delivers those notifications only through a long-lived
+//! `subscriptions/listen` request, so the interactive REPL owns one stream
+//! for tools, prompts, and resources. A session reconnect invalidates that
+//! stream even when its old transport has not closed yet; unexpected endings
+//! retry with bounded exponential backoff.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tower_mcp::protocol::SubscriptionFilter;
+
+use crate::output::AsyncOutput;
+use crate::session::Session;
+
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Owns the background subscription task for one interactive REPL session.
+/// Dropping it stops the task and best-effort cancels its active stream.
+pub struct SurfaceSubscription {
+    shutdown_tx: tokio::sync::watch::Sender<bool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl SurfaceSubscription {
+    pub fn start(session: Arc<Session>, output: AsyncOutput) -> Self {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let task = tokio::spawn(run(session, output, shutdown_rx));
+        Self { shutdown_tx, task }
+    }
+}
+
+impl Drop for SurfaceSubscription {
+    fn drop(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        self.task.abort();
+    }
+}
+
+fn requested_filter() -> SubscriptionFilter {
+    SubscriptionFilter {
+        tools_list_changed: Some(true),
+        prompts_list_changed: Some(true),
+        resources_list_changed: Some(true),
+        ..Default::default()
+    }
+}
+
+fn honored_names(filter: &SubscriptionFilter) -> Vec<&'static str> {
+    let mut names = Vec::new();
+    if filter.tools_list_changed == Some(true) {
+        names.push("tools");
+    }
+    if filter.prompts_list_changed == Some(true) {
+        names.push("prompts");
+    }
+    if filter.resources_list_changed == Some(true) {
+        names.push("resources");
+    }
+    names
+}
+
+fn missing_names(filter: &SubscriptionFilter) -> Vec<&'static str> {
+    let mut names = Vec::new();
+    if filter.tools_list_changed != Some(true) {
+        names.push("tools");
+    }
+    if filter.prompts_list_changed != Some(true) {
+        names.push("prompts");
+    }
+    if filter.resources_list_changed != Some(true) {
+        names.push("resources");
+    }
+    names
+}
+
+async fn wait_before_retry(
+    delay: Duration,
+    generations: &mut tokio::sync::watch::Receiver<u64>,
+    shutdown: &mut tokio::sync::watch::Receiver<bool>,
+) -> bool {
+    tokio::select! {
+        _ = tokio::time::sleep(delay) => true,
+        changed = generations.changed() => changed.is_ok(),
+        _ = shutdown.changed() => false,
+    }
+}
+
+async fn run(
+    session: Arc<Session>,
+    output: AsyncOutput,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) {
+    let mut generations = session.subscribe_generation();
+    let mut backoff = INITIAL_BACKOFF;
+    let mut last_acknowledgment_warning = None;
+
+    'subscribe: loop {
+        if *shutdown.borrow() {
+            return;
+        }
+
+        // Mark the current generation observed before opening work on its
+        // client. A concurrent reconnect either wakes `changed()` below or is
+        // caught by the atomic comparison before an ending is retried.
+        let generation = session.generation();
+        generations.borrow_and_update();
+        let client = session.client();
+
+        let opened = tokio::select! {
+            result = client.listen_subscriptions(requested_filter()) => result,
+            changed = generations.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+                continue 'subscribe;
+            },
+            _ = shutdown.changed() => return,
+        };
+        let mut handle = match opened {
+            Ok(handle) => handle,
+            Err(error) => {
+                output.line(format!(
+                    "warning: final surface subscription could not open: {error}; retrying in {}s",
+                    backoff.as_secs()
+                ));
+                if !wait_before_retry(backoff, &mut generations, &mut shutdown).await {
+                    return;
+                }
+                backoff = backoff.saturating_mul(2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        let accepted = tokio::select! {
+            result = handle.acknowledged() => match result {
+                Ok(accepted) => accepted,
+                Err(error) => {
+                    output.line(format!(
+                        "warning: final surface subscription ended before acknowledgment: {error}; retrying in {}s",
+                        backoff.as_secs()
+                    ));
+                    if !wait_before_retry(backoff, &mut generations, &mut shutdown).await {
+                        return;
+                    }
+                    backoff = backoff.saturating_mul(2).min(MAX_BACKOFF);
+                    continue 'subscribe;
+                }
+            },
+            changed = generations.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+                continue 'subscribe;
+            },
+            _ = shutdown.changed() => return,
+        };
+
+        let honored = honored_names(&accepted);
+        let missing = missing_names(&accepted);
+        if honored.is_empty() {
+            output.line(
+                "warning: server declined tools, prompts, and resources list-change notifications; final surface auto-refresh is disabled"
+            );
+            let _ = handle.cancel().await;
+            return;
+        }
+        if !missing.is_empty() {
+            let warning = format!(
+                "warning: server accepted final surface notifications for {}; {} will not refresh automatically",
+                honored.join(", "),
+                missing.join(", ")
+            );
+            if last_acknowledgment_warning.as_deref() != Some(warning.as_str()) {
+                output.line(warning.clone());
+                last_acknowledgment_warning = Some(warning);
+            }
+        } else {
+            last_acknowledgment_warning = None;
+        }
+        backoff = INITIAL_BACKOFF;
+
+        let ended = tokio::select! {
+            result = handle.wait() => Some(result),
+            changed = generations.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+                None
+            },
+            _ = shutdown.changed() => return,
+        };
+        let Some(ended) = ended else {
+            continue;
+        };
+
+        // If reconnect won a race with stream completion, move straight to
+        // the replacement client rather than sleeping first.
+        if session.generation() != generation {
+            generations.borrow_and_update();
+            continue;
+        }
+
+        let reason = match ended {
+            Ok(_) => "the server completed it".to_string(),
+            Err(error) => error.to_string(),
+        };
+        output.line(format!(
+            "warning: final surface subscription ended ({reason}); retrying in {}s",
+            backoff.as_secs()
+        ));
+        if !wait_before_retry(backoff, &mut generations, &mut shutdown).await {
+            return;
+        }
+        backoff = backoff.saturating_mul(2).min(MAX_BACKOFF);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use tower_mcp::client::{ChannelTransport, ClientTransport, McpClient, NotificationHandler};
+    use tower_mcp::context::{ServerNotification, notification_channel};
+    use tower_mcp::{McpRouter, ProtocolSupport, ToolBuilder};
+
+    use crate::session::Connector;
+
+    struct CountingTransport {
+        inner: ChannelTransport,
+        listens: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl ClientTransport for CountingTransport {
+        async fn send(&mut self, message: &str) -> tower_mcp::Result<()> {
+            let value: serde_json::Value = serde_json::from_str(message)?;
+            if value.get("method").and_then(|method| method.as_str())
+                == Some("subscriptions/listen")
+            {
+                self.listens.fetch_add(1, Ordering::SeqCst);
+            }
+            self.inner.send(message).await
+        }
+
+        async fn recv(&mut self) -> tower_mcp::Result<Option<String>> {
+            self.inner.recv().await
+        }
+
+        fn is_connected(&self) -> bool {
+            self.inner.is_connected()
+        }
+
+        async fn close(&mut self) -> tower_mcp::Result<()> {
+            self.inner.close().await
+        }
+    }
+
+    fn router() -> McpRouter {
+        McpRouter::new()
+            .server_info("subscription-test", "1.0.0")
+            .tool(
+                ToolBuilder::new("ping")
+                    .description("Return pong")
+                    .handler(|_: serde_json::Value| async {
+                        Ok(tower_mcp::CallToolResult::text("pong"))
+                    })
+                    .build(),
+            )
+    }
+
+    async fn final_client(listens: Arc<AtomicUsize>, handler: NotificationHandler) -> McpClient {
+        let transport = CountingTransport {
+            inner: ChannelTransport::new(router()),
+            listens,
+        };
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect(transport, handler)
+            .await
+            .unwrap();
+        client.discover("mcp-repl-test", "0").await.unwrap();
+        client
+    }
+
+    async fn wait_for_listens(listens: &AtomicUsize, expected: usize) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while listens.load(Ordering::SeqCst) < expected {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("surface subscription was not opened");
+    }
+
+    #[test]
+    fn acknowledgment_reports_only_honored_notification_classes() {
+        let accepted = SubscriptionFilter {
+            tools_list_changed: Some(true),
+            resources_list_changed: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(honored_names(&accepted), ["tools", "resources"]);
+        assert_eq!(missing_names(&accepted), ["prompts"]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn open_surface_stream_allows_requests_and_routes_notifications() {
+        let listens = Arc::new(AtomicUsize::new(0));
+        let (notification_tx, notification_rx) = notification_channel(8);
+        let router = router().with_notification_sender(notification_tx.clone());
+        let (changed_tx, mut changed_rx) = tokio::sync::mpsc::unbounded_channel();
+        let handler = NotificationHandler::new().on_tools_changed(move || {
+            let _ = changed_tx.send(());
+        });
+        let transport = CountingTransport {
+            inner: ChannelTransport::with_notifications(router, notification_rx),
+            listens: listens.clone(),
+        };
+        let client = McpClient::builder()
+            .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+            .connect(transport, handler)
+            .await
+            .unwrap();
+        client.discover("mcp-repl-test", "0").await.unwrap();
+
+        let mut subscription = client
+            .listen_subscriptions(requested_filter())
+            .await
+            .unwrap();
+        let accepted = subscription.acknowledged().await.unwrap();
+        assert!(missing_names(&accepted).is_empty());
+
+        let tools = tokio::time::timeout(Duration::from_secs(1), client.list_all_tools())
+            .await
+            .expect("ordinary request was blocked by subscription")
+            .unwrap();
+        assert_eq!(tools.len(), 1);
+
+        notification_tx
+            .send(ServerNotification::ToolsListChanged)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), changed_rx.recv())
+            .await
+            .expect("subscription notification was not routed")
+            .expect("notification handler closed");
+        subscription.cancel().await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn reconnect_reopens_the_surface_stream_on_the_fresh_client() {
+        let listens = Arc::new(AtomicUsize::new(0));
+        let connector_listens = listens.clone();
+        let connector: Connector = Box::new(move || {
+            let listens = connector_listens.clone();
+            Box::pin(async move { Ok(final_client(listens, NotificationHandler::new()).await) })
+        });
+        let session = Arc::new(Session::new(
+            final_client(listens.clone(), NotificationHandler::new()).await,
+            Some(connector),
+        ));
+        let output = AsyncOutput::new(Arc::new(std::sync::atomic::AtomicBool::new(false)), false);
+        let subscription = SurfaceSubscription::start(session.clone(), output);
+
+        wait_for_listens(&listens, 1).await;
+        assert_eq!(listens.load(Ordering::SeqCst), 1);
+        session.reconnect(0).await.unwrap();
+        wait_for_listens(&listens, 2).await;
+        assert_eq!(listens.load(Ordering::SeqCst), 2);
+        assert_eq!(session.generation(), 1);
+
+        drop(subscription);
+    }
+}


### PR DESCRIPTION
Closes #1149.

## Summary

- open one interactive `subscriptions/listen` stream for final-protocol tool, prompt, and resource list changes after the initial surface fetch
- validate the acknowledgement and report only notification classes the server actually honored
- keep the stream alive, cancel it on shutdown, and retry unexpected endings with bounded exponential backoff
- notify long-lived session work on reconnect so the old stream is dropped and a fresh stream opens on the replacement client
- keep stable connections and `--exec` behavior unchanged
- document the stable/final delivery difference

## Tests

- verifies the final surface stream coexists with ordinary list requests and routes list-change notifications
- verifies reconnect opens exactly one replacement stream on the fresh client
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`