### PR TITLE
test(mcp-repl): add binary transport E2E coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,6 +1636,7 @@ dependencies = [
  "reedline",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "toml_edit",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -161,6 +161,14 @@ name = "stateless_http_client"
 path = "stateless_http_client.rs"
 required-features = ["http", "http-client", "protocol-2026-07-28"]
 
+# Repository-only process fixture used by mcp-repl's black-box tests. It is
+# kept in this unpublished package so the published CLI does not gain a test
+# binary or fixture source.
+[[example]]
+name = "mcp_repl_fixture"
+path = "mcp_repl_fixture.rs"
+required-features = ["http", "protocol-2026-07-28"]
+
 # --- Sampling and bidirectional ---
 [[example]]
 name = "sampling_server"

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -26,3 +26,6 @@ clap.workspace = true
 tracing-subscriber.workspace = true
 reedline = { version = "0.49", features = ["external_printer"] }
 nu-ansi-term = "0.50"
+
+[dev-dependencies]
+tempfile = "3"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -506,6 +506,14 @@ Capture and filtering currently act on tool-call results.
   mcp-probe is a debugging platform you inspect a server with; mcp-repl is a
   shell you drive one from.
 
+## Testing
+
+`cargo test -p mcp-repl` includes a black-box process suite in addition to the
+unit tests. It builds a repository-only MCP fixture, launches the published
+`mcp-repl` binary, and covers stdio and ephemeral localhost HTTP with both the
+stable and exact `2026-07-28` lifecycles. The cases are network-independent,
+bounded by per-process and suite timeouts, and assert fixture cleanup.
+
 ## Notes
 
 - Tab completion for prompt argument values and resource template variables

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -1,0 +1,326 @@
+//! Black-box coverage for the published `mcp-repl` process boundary.
+
+use std::path::{Path, PathBuf};
+use std::process::Output;
+use std::time::Duration;
+
+use tempfile::TempDir;
+use tokio::io::AsyncWriteExt;
+use tokio::process::{Child, Command};
+
+const CASE_TIMEOUT: Duration = Duration::from_secs(20);
+const SUITE_TIMEOUT: Duration = Duration::from_secs(90);
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("workspace root")
+}
+
+async fn run(mut command: Command, label: &str, timeout: Duration) -> Output {
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let child = command
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn {label}: {error}"));
+    tokio::time::timeout(timeout, child.wait_with_output())
+        .await
+        .unwrap_or_else(|_| panic!("{label} exceeded {timeout:?}"))
+        .unwrap_or_else(|error| panic!("wait for {label}: {error}"))
+}
+
+fn assert_success(output: &Output, label: &str) {
+    assert!(
+        output.status.success(),
+        "{label} failed with {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+async fn build_fixture() -> PathBuf {
+    let mut command = Command::new(env!("CARGO"));
+    command.current_dir(workspace_root()).args([
+        "build",
+        "--quiet",
+        "-p",
+        "tower-mcp-examples",
+        "--example",
+        "mcp_repl_fixture",
+        "--features",
+        "http,protocol-2026-07-28",
+    ]);
+    let output = run(command, "fixture build", Duration::from_secs(60)).await;
+    assert_success(&output, "fixture build");
+
+    let test_binary = std::env::current_exe().expect("current test executable");
+    let profile_dir = test_binary
+        .parent()
+        .and_then(Path::parent)
+        .expect("target profile directory");
+    let fixture = profile_dir
+        .join("examples")
+        .join(format!("mcp_repl_fixture{}", std::env::consts::EXE_SUFFIX));
+    assert!(
+        fixture.is_file(),
+        "fixture was not built at {}",
+        fixture.display()
+    );
+    fixture
+}
+
+fn repl_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_mcp-repl"));
+    command.current_dir(workspace_root());
+    command
+}
+
+async fn wait_for_file(path: &Path, label: &str) -> String {
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            match std::fs::read_to_string(path) {
+                Ok(contents) => break contents,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(error) => panic!("read {label}: {error}"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("timed out waiting for {label}"))
+}
+
+async fn run_stdio(fixture: &Path, temp: &TempDir, case: &str, repl_args: &[&str]) -> Output {
+    let exit_file = temp.path().join(format!("{case}.exit"));
+    let mut command = repl_command();
+    command
+        .args(repl_args)
+        .arg(fixture)
+        .env("MCP_REPL_FIXTURE_EXIT_FILE", &exit_file);
+    let output = run(command, case, CASE_TIMEOUT).await;
+    assert_eq!(
+        wait_for_file(&exit_file, "stdio fixture shutdown").await,
+        "clean",
+        "mcp-repl left its stdio child running"
+    );
+    output
+}
+
+struct HttpFixture {
+    child: Option<Child>,
+    url: String,
+    subscription_file: PathBuf,
+}
+
+impl HttpFixture {
+    async fn start(fixture: &Path, temp: &TempDir) -> Self {
+        let ready_file = temp.path().join("http.ready");
+        let subscription_file = temp.path().join("http.subscription");
+        let mut command = Command::new(fixture);
+        command
+            .arg("--http")
+            .env("MCP_REPL_FIXTURE_READY_FILE", &ready_file)
+            .env("MCP_REPL_FIXTURE_SUBSCRIPTION_FILE", &subscription_file)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true);
+        let child = command.spawn().expect("spawn HTTP fixture");
+        let url = wait_for_file(&ready_file, "HTTP fixture readiness").await;
+        Self {
+            child: Some(child),
+            url,
+            subscription_file,
+        }
+    }
+
+    async fn shutdown(mut self) {
+        let mut child = self.child.take().expect("HTTP fixture child");
+        child.start_kill().expect("stop HTTP fixture");
+        tokio::time::timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("HTTP fixture did not exit")
+            .expect("wait for HTTP fixture");
+    }
+}
+
+impl Drop for HttpFixture {
+    fn drop(&mut self) {
+        if let Some(child) = &mut self.child {
+            let _ = child.start_kill();
+        }
+    }
+}
+
+async fn run_http(url: &str, case: &str, repl_args: &[&str]) -> Output {
+    let mut command = repl_command();
+    command.args(repl_args).args(["--http", url]);
+    run(command, case, CASE_TIMEOUT).await
+}
+
+async fn exercise_stdio(fixture: &Path, temp: &TempDir) {
+    let stable = run_stdio(
+        fixture,
+        temp,
+        "stable-stdio",
+        &[
+            "--protocol",
+            "stable",
+            "--verbose",
+            "--exec",
+            "add a=20 b=22",
+        ],
+    )
+    .await;
+    assert_success(&stable, "stable stdio");
+    let stdout = String::from_utf8_lossy(&stable.stdout);
+    let stderr = String::from_utf8_lossy(&stable.stderr);
+    assert!(stdout.contains("protocol 2025-11-25"), "{stdout}");
+    assert!(stdout.contains("42"), "{stdout}");
+    assert!(stderr.contains("mcp-repl fixture ready"), "{stderr}");
+
+    let final_ = run_stdio(
+        fixture,
+        temp,
+        "final-stdio",
+        &[
+            "--protocol",
+            "2026-07-28",
+            "--verbose",
+            "--exec",
+            "add a=20 b=22",
+            "--exec",
+            "prompt greet name=Ada",
+            "--exec",
+            "read fixture://guide",
+        ],
+    )
+    .await;
+    assert_success(&final_, "final stdio");
+    let stdout = String::from_utf8_lossy(&final_.stdout);
+    assert!(stdout.contains("protocol 2026-07-28"), "{stdout}");
+    assert!(stdout.contains("42"), "{stdout}");
+    assert!(stdout.contains("Please greet Ada warmly."), "{stdout}");
+    assert!(stdout.contains("fixture resource body"), "{stdout}");
+
+    let error = run_stdio(
+        fixture,
+        temp,
+        "json-error",
+        &["--json", "--exec", "no_such_command"],
+    )
+    .await;
+    assert!(!error.status.success(), "unknown command should fail");
+    let stdout = String::from_utf8_lossy(&error.stdout);
+    let stderr = String::from_utf8_lossy(&error.stderr);
+    assert!(stdout.contains("\"error\""), "{stdout}");
+    assert!(!stdout.contains("fixture ready"), "{stdout}");
+    assert!(stderr.contains("mcp-repl fixture ready"), "{stderr}");
+}
+
+async fn exercise_interactive_final_task(http: &HttpFixture) {
+    let mut command = repl_command();
+    command
+        .args([
+            "--protocol",
+            "2026-07-28",
+            "--no-history",
+            "--color",
+            "never",
+            "--http",
+            &http.url,
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    let mut child = command.spawn().expect("spawn interactive final mcp-repl");
+    let mut stdin = child.stdin.take().expect("interactive stdin");
+    stdin
+        .write_all(b"slow_add a=2 b=3 &\n")
+        .await
+        .expect("write task command");
+    wait_for_file(&http.subscription_file, "final subscription").await;
+    // The subscription is immediate, while the bounded task poller remains a
+    // fallback. Leave enough room for either path to observe completion before
+    // asking the editor thread to exit.
+    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    stdin
+        .write_all(b"jobs\nquit\n")
+        .await
+        .expect("write task status and quit commands");
+    drop(stdin);
+    let output = tokio::time::timeout(CASE_TIMEOUT, child.wait_with_output())
+        .await
+        .expect("interactive final case timed out")
+        .expect("wait for interactive final case");
+    assert_success(&output, "interactive final task");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("started"), "{stdout}");
+    assert!(stdout.contains("completed"), "{stdout}");
+}
+
+async fn exercise_http(fixture: &Path, temp: &TempDir) {
+    let http = HttpFixture::start(fixture, temp).await;
+
+    let stable = run_http(
+        &http.url,
+        "stable HTTP",
+        &[
+            "--protocol",
+            "stable",
+            "--verbose",
+            "--exec",
+            "prompt greet name=Grace",
+            "--exec",
+            "announce",
+        ],
+    )
+    .await;
+    assert_success(&stable, "stable HTTP");
+    let stdout = String::from_utf8_lossy(&stable.stdout);
+    let stderr = String::from_utf8_lossy(&stable.stderr);
+    assert!(stdout.contains("protocol 2025-11-25"), "{stdout}");
+    assert!(stdout.contains("Please greet Grace warmly."), "{stdout}");
+    assert!(stderr.contains("fixture announcement"), "{stderr}");
+
+    let final_ = run_http(
+        &http.url,
+        "final HTTP",
+        &[
+            "--protocol",
+            "2026-07-28",
+            "--json",
+            "--exec",
+            "add a=40 b=2",
+            "--exec",
+            "read fixture://guide",
+        ],
+    )
+    .await;
+    assert_success(&final_, "final HTTP");
+    let stdout = String::from_utf8_lossy(&final_.stdout);
+    assert!(stdout.contains("42"), "{stdout}");
+    assert!(stdout.contains("fixture resource body"), "{stdout}");
+
+    exercise_interactive_final_task(&http).await;
+    http.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn published_cli_covers_transports_and_protocol_lifecycles() {
+    tokio::time::timeout(SUITE_TIMEOUT, async {
+        let temp = TempDir::new().expect("temporary fixture directory");
+        let fixture = build_fixture().await;
+        exercise_stdio(&fixture, &temp).await;
+        exercise_http(&fixture, &temp).await;
+    })
+    .await
+    .expect("mcp-repl E2E suite exceeded its job-level timeout");
+}

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -55,6 +55,7 @@ async fn build_fixture() -> PathBuf {
         "mcp_repl_fixture",
         "--features",
         "http,protocol-2026-07-28",
+        "--message-format=json-render-diagnostics",
     ]);
     // Coverage and beta jobs may need to compile the repository-only fixture
     // with a distinct target configuration. Keep that budget independent of
@@ -62,14 +63,20 @@ async fn build_fixture() -> PathBuf {
     let output = run(command, "fixture build", BUILD_TIMEOUT).await;
     assert_success(&output, "fixture build");
 
-    let test_binary = std::env::current_exe().expect("current test executable");
-    let profile_dir = test_binary
-        .parent()
-        .and_then(Path::parent)
-        .expect("target profile directory");
-    let fixture = profile_dir
-        .join("examples")
-        .join(format!("mcp_repl_fixture{}", std::env::consts::EXE_SUFFIX));
+    // The outer test runner may select a different target directory (notably
+    // cargo-llvm-cov). Cargo's artifact record is authoritative; deriving the
+    // fixture path from the integration-test executable only works when both
+    // Cargo invocations happen to share a target directory.
+    let fixture = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+        .find_map(|message| {
+            (message["reason"] == "compiler-artifact"
+                && message["target"]["name"] == "mcp_repl_fixture")
+                .then(|| message["executable"].as_str().map(PathBuf::from))
+                .flatten()
+        })
+        .expect("Cargo did not report the mcp_repl_fixture executable");
     assert!(
         fixture.is_file(),
         "fixture was not built at {}",

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -9,7 +9,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 
 const CASE_TIMEOUT: Duration = Duration::from_secs(20);
-const SUITE_TIMEOUT: Duration = Duration::from_secs(90);
+const BUILD_TIMEOUT: Duration = Duration::from_secs(180);
+const SUITE_TIMEOUT: Duration = Duration::from_secs(300);
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -55,7 +56,10 @@ async fn build_fixture() -> PathBuf {
         "--features",
         "http,protocol-2026-07-28",
     ]);
-    let output = run(command, "fixture build", Duration::from_secs(60)).await;
+    // Coverage and beta jobs may need to compile the repository-only fixture
+    // with a distinct target configuration. Keep that budget independent of
+    // the much tighter timeout used to detect hung mcp-repl processes.
+    let output = run(command, "fixture build", BUILD_TIMEOUT).await;
     assert_success(&output, "fixture build");
 
     let test_binary = std::env::current_exe().expect("current test executable");

--- a/examples/mcp_repl_fixture.rs
+++ b/examples/mcp_repl_fixture.rs
@@ -94,7 +94,11 @@ fn env_path(name: &str) -> Option<PathBuf> {
 
 fn write_marker(name: &str, contents: impl AsRef<[u8]>) {
     if let Some(path) = env_path(name) {
-        std::fs::write(path, contents).expect("write fixture marker");
+        // Publish markers atomically so the test never observes the empty
+        // file between create/truncate and the content write on a busy host.
+        let pending = path.with_extension("pending");
+        std::fs::write(&pending, contents).expect("write pending fixture marker");
+        std::fs::rename(pending, path).expect("publish fixture marker");
     }
 }
 

--- a/examples/mcp_repl_fixture.rs
+++ b/examples/mcp_repl_fixture.rs
@@ -1,0 +1,134 @@
+//! Deterministic process fixture for `mcp-repl`'s black-box tests.
+//!
+//! This is intentionally an example in the unpublished examples package,
+//! rather than another binary in the published `mcp-repl` crate. With no
+//! arguments it serves stdio. `--http` binds an ephemeral localhost port and
+//! writes the resulting URL to `MCP_REPL_FIXTURE_READY_FILE`.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::{
+    CallToolResult, HttpTransport, McpRouter, PromptBuilder, ProtocolSupport, ResourceBuilder,
+    StdioTransport, TaskSupportMode, ToolBuilder,
+    extract::{Context, RawArgs},
+    protocol::{LogLevel, LoggingMessageParams},
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+fn fixture_router() -> McpRouter {
+    McpRouter::new()
+        .server_info("mcp-repl-fixture", "1.0.0")
+        .with_tasks()
+        .tool(
+            ToolBuilder::new("add")
+                .description("Add two integers")
+                .handler(|input: AddInput| async move {
+                    Ok(CallToolResult::text((input.a + input.b).to_string()))
+                })
+                .build(),
+        )
+        .tool(
+            ToolBuilder::new("slow_add")
+                .description("Add two integers in a final-protocol task")
+                .task_support(TaskSupportMode::Optional)
+                .handler(|input: AddInput| async move {
+                    tokio::time::sleep(Duration::from_millis(250)).await;
+                    Ok(CallToolResult::text((input.a + input.b).to_string()))
+                })
+                .build(),
+        )
+        .tool(
+            ToolBuilder::new("announce")
+                .description("Emit a deterministic server log notification")
+                .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
+                    ctx.send_log(LoggingMessageParams::new(
+                        LogLevel::Info,
+                        serde_json::json!("fixture announcement"),
+                    ));
+                    // Let the notification frame reach the client before the
+                    // one-shot process receives its terminal tool response.
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok(CallToolResult::text("announced"))
+                })
+                .build(),
+        )
+        .resource(
+            ResourceBuilder::new("fixture://guide")
+                .name("Fixture Guide")
+                .description("A deterministic resource for process tests")
+                .mime_type("text/plain")
+                .text("fixture resource body"),
+        )
+        .prompt(
+            PromptBuilder::new("greet")
+                .description("Generate a deterministic greeting request")
+                .required_arg("name", "The person to greet")
+                .handler(|args| async move {
+                    let name = args.get("name").map(String::as_str).unwrap_or("World");
+                    Ok(tower_mcp::GetPromptResult::user_message(format!(
+                        "Please greet {name} warmly."
+                    )))
+                })
+                .build(),
+        )
+}
+
+fn protocol_support() -> ProtocolSupport {
+    ProtocolSupport::try_new(["2025-11-25", "2026-07-28"]).expect("fixture protocols are compiled")
+}
+
+fn env_path(name: &str) -> Option<PathBuf> {
+    std::env::var_os(name).map(PathBuf::from)
+}
+
+fn write_marker(name: &str, contents: impl AsRef<[u8]>) {
+    if let Some(path) = env_path(name) {
+        std::fs::write(path, contents).expect("write fixture marker");
+    }
+}
+
+async fn observe_subscription(request: Request, next: Next) -> Response {
+    if request
+        .headers()
+        .get("mcp-method")
+        .and_then(|value| value.to_str().ok())
+        == Some("subscriptions/listen")
+    {
+        write_marker("MCP_REPL_FIXTURE_SUBSCRIPTION_FILE", b"seen");
+    }
+    next.run(request).await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), tower_mcp::BoxError> {
+    eprintln!("mcp-repl fixture ready");
+    if std::env::args().any(|arg| arg == "--http") {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let url = format!("http://{}/", listener.local_addr()?);
+        write_marker("MCP_REPL_FIXTURE_READY_FILE", &url);
+        let app = HttpTransport::new(fixture_router())
+            .protocol_support(protocol_support())
+            .disable_origin_validation()
+            .into_router()
+            .layer(axum::middleware::from_fn(observe_subscription));
+        axum::serve(listener, app).await?;
+    } else {
+        StdioTransport::new(fixture_router())
+            .protocol_support(protocol_support())
+            .run()
+            .await?;
+        write_marker("MCP_REPL_FIXTURE_EXIT_FILE", b"clean");
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes #1151.

## Summary

- add a black-box integration suite that launches the built `mcp-repl` binary
- cover stdio and ephemeral localhost Streamable HTTP without public network dependencies
- exercise stable `2025-11-25` and exact final `2026-07-28` lifecycles
- cover discovery, schema-coerced tool calls, prompts, resources, errors, JSON stdout/stderr separation, notifications, final tasks, and `subscriptions/listen`
- assert stdio child EOF/shutdown and explicitly terminate/wait for the HTTP fixture
- bound every process plus the overall suite with timeouts
- keep the deterministic server fixture in the unpublished examples package rather than the published CLI crate

## Tests

- `cargo test -p mcp-repl`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`