### PR TITLE
feat(mcp-repl): import standard MCP server configs

### DIFF
--- a/crates/tower-mcp/src/client/stdio.rs
+++ b/crates/tower-mcp/src/client/stdio.rs
@@ -18,7 +18,7 @@
 use std::process::Stdio;
 
 use async_trait::async_trait;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
 use tokio::process::{Child, Command};
 
 use super::transport::ClientTransport;
@@ -33,7 +33,11 @@ use crate::error::{Error, Result};
 pub struct StdioClientTransport {
     child: Option<Child>,
     stdin: Option<tokio::process::ChildStdin>,
-    stdout: BufReader<tokio::process::ChildStdout>,
+    // `Lines::next_line` retains a partially read frame when its future is
+    // cancelled by the client's `select!` loop. A bare `read_line` future can
+    // discard those bytes while leaving the newline behind, turning a valid
+    // response into an empty frame when outgoing commands arrive concurrently.
+    stdout: Lines<BufReader<tokio::process::ChildStdout>>,
 }
 
 impl StdioClientTransport {
@@ -92,7 +96,7 @@ impl StdioClientTransport {
         Ok(Self {
             child: Some(child),
             stdin: Some(stdin),
-            stdout: BufReader::new(stdout),
+            stdout: BufReader::new(stdout).lines(),
         })
     }
 
@@ -121,7 +125,7 @@ impl StdioClientTransport {
         Ok(Self {
             child: Some(child),
             stdin: Some(stdin),
-            stdout: BufReader::new(stdout),
+            stdout: BufReader::new(stdout).lines(),
         })
     }
 }
@@ -150,18 +154,12 @@ impl ClientTransport for StdioClientTransport {
     }
 
     async fn recv(&mut self) -> Result<Option<String>> {
-        let mut line = String::new();
-        let bytes = self
+        let line = self
             .stdout
-            .read_line(&mut line)
+            .next_line()
             .await
             .map_err(|e| Error::Transport(format!("Failed to read: {}", e)))?;
-
-        if bytes == 0 {
-            return Ok(None); // EOF
-        }
-
-        Ok(Some(line.trim().to_string()))
+        Ok(line.map(|line| line.trim().to_string()))
     }
 
     fn is_connected(&self) -> bool {
@@ -237,6 +235,24 @@ mod tests {
         // Should get None (EOF) since `true` produces no output and exits
         let result = transport.recv().await.unwrap();
         assert_eq!(result, None);
+    }
+
+    #[tokio::test]
+    async fn line_reader_preserves_partial_frame_when_receive_is_cancelled() {
+        let (mut writer, reader) = tokio::io::duplex(256);
+        let mut lines = BufReader::new(reader).lines();
+        let frame = r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#;
+
+        writer.write_all(frame.as_bytes()).await.unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), lines.next_line())
+                .await
+                .is_err(),
+            "a partial frame must remain pending until its newline arrives"
+        );
+
+        writer.write_all(b"\n").await.unwrap();
+        assert_eq!(lines.next_line().await.unwrap().as_deref(), Some(frame));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -594,7 +594,11 @@ impl StdioTransport {
         R: tokio::io::AsyncRead + Unpin + Send,
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
-        let mut reader = BufReader::new(reader);
+        // Keep the line buffer across cancelled `select!` branches. Tokio's
+        // `read_line` future can discard a partial JSON frame when a
+        // notification or control message wins the race; `next_line` stores
+        // that partial frame in `Lines` until the following poll.
+        let mut lines = BufReader::new(reader).lines();
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
@@ -605,20 +609,17 @@ impl StdioTransport {
         tracing::info!("Stdio transport started, waiting for input");
 
         loop {
-            let mut line = String::new();
-
             tokio::select! {
                 // Handle incoming messages from stdin
-                result = reader.read_line(&mut line) => {
-                    let bytes_read = result.map_err(|e| {
+                result = lines.next_line() => {
+                    let line = result.map_err(|e| {
                         Error::Transport(format!("Failed to read from stdin: {}", e))
                     })?;
-
-                    if bytes_read == 0 {
+                    let Some(line) = line else {
                         // EOF
                         tracing::info!("Stdin closed, shutting down");
                         break;
-                    }
+                    };
 
                     let trimmed = clean_input_line(&line);
                     if trimmed.is_empty() {
@@ -851,27 +852,24 @@ where
         R: tokio::io::AsyncRead + Unpin + Send,
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
-        let mut reader = BufReader::new(reader);
+        let mut lines = BufReader::new(reader).lines();
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions::default();
 
         tracing::info!("Generic stdio transport started, waiting for input");
 
         loop {
-            let mut line = String::new();
-
             // Use select! if we have a notification receiver, otherwise just read
             if let Some(ref mut notif_rx) = self.notification_rx {
                 tokio::select! {
-                    result = reader.read_line(&mut line) => {
-                        let bytes_read = result.map_err(|e| {
+                    result = lines.next_line() => {
+                        let line = result.map_err(|e| {
                             Error::Transport(format!("Failed to read from stdin: {}", e))
                         })?;
-
-                        if bytes_read == 0 {
+                        let Some(line) = line else {
                             tracing::info!("Stdin closed, shutting down");
                             break;
-                        }
+                        };
 
                         Self::process_input(
                             &mut self.service,
@@ -911,14 +909,14 @@ where
                 }
             } else {
                 tokio::select! {
-                    result = reader.read_line(&mut line) => {
-                        let bytes_read = result.map_err(|e| {
+                    result = lines.next_line() => {
+                        let line = result.map_err(|e| {
                             Error::Transport(format!("Failed to read from stdin: {}", e))
                         })?;
-                        if bytes_read == 0 {
+                        let Some(line) = line else {
                             tracing::info!("Stdin closed, shutting down");
                             break;
-                        }
+                        };
                         Self::process_input(
                             &mut self.service,
                             &line,
@@ -1331,7 +1329,7 @@ impl BidirectionalStdioTransport {
         W: tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
         let writer = Arc::new(Mutex::new(writer));
-        let mut reader = BufReader::new(reader);
+        let mut lines = BufReader::new(reader).lines();
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
@@ -1342,19 +1340,16 @@ impl BidirectionalStdioTransport {
         tracing::info!("Bidirectional stdio transport started, waiting for input");
 
         loop {
-            let mut line = String::new();
-
             tokio::select! {
                 // Handle incoming messages from stdin
-                result = reader.read_line(&mut line) => {
-                    let bytes_read = result.map_err(|e| {
+                result = lines.next_line() => {
+                    let line = result.map_err(|e| {
                         Error::Transport(format!("Failed to read from stdin: {}", e))
                     })?;
-
-                    if bytes_read == 0 {
+                    let Some(line) = line else {
                         tracing::info!("Stdin closed, shutting down");
                         break;
-                    }
+                    };
 
                     let trimmed = clean_input_line(&line);
                     if trimmed.is_empty() {

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -163,6 +163,55 @@ async fn stdio_transport_loop_continues_after_parse_error() {
     );
 }
 
+/// A control or notification branch may win `select!` while stdin holds only
+/// part of a JSON frame. The line reader must retain that prefix until the
+/// newline arrives instead of discarding it and parsing only the suffix.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn stdio_transport_preserves_partial_frame_when_read_is_cancelled() {
+    let mut transport = StdioTransport::new(router());
+    let control = transport.handle();
+    let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    server_stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":42,")
+        .await
+        .unwrap();
+    server_stdin_writer.flush().await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // An unknown subscription is deliberately a no-op, but receiving this
+    // control message forces the competing branch to win once.
+    control
+        .close_subscription(tower_mcp::protocol::RequestId::Number(999))
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    server_stdin_writer
+        .write_all(b"\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    drop(server_stdin_writer);
+
+    let frames = read_n_frames(BufReader::new(server_stdout_reader), 1).await;
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(frames.len(), 1, "expected one response: {frames:?}");
+    assert_eq!(frames[0]["id"], 42, "the request prefix was lost");
+    assert!(
+        frames[0].get("result").is_some(),
+        "unexpected frame: {frames:?}"
+    );
+}
+
 /// Test 3: closing the writer side of the input stream (EOF) cleanly
 /// terminates the loop -- `run_with_streams` returns `Ok(())`.
 #[tokio::test]

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -22,6 +22,9 @@ cargo run -p mcp-repl -- cargo run --example getting_started
 # Connect to a streamable HTTP server:
 cargo run -p mcp-repl -- --http http://127.0.0.1:3001/mcp
 
+# Import one named server from a repository or client JSON config:
+cargo run -p mcp-repl -- path/to/.mcp.json:server-name
+
 # Opt into the final, sessionless 2026-07-28 lifecycle:
 cargo run -p mcp-repl -- --protocol 2026-07-28 --http http://127.0.0.1:3001/mcp
 ```
@@ -107,6 +110,70 @@ mcp-repl cratesio                  # a bare name works too
 - An unknown profile name errors with the list of known names, and a missing
   `--config` file is an error. A missing file at the default location is not:
   profiles are opt-in.
+
+### Importing standard MCP configs
+
+An explicit `PATH:ENTRY` selector imports a named server from the common JSON
+format used by repository `.mcp.json` files, VS Code, Claude, Cursor, and other
+MCP clients. Both `mcpServers` and `servers` roots are accepted; automatic
+file discovery is deliberately deferred so the selected source is always
+visible in the command:
+
+```bash
+mcp-repl .mcp.json:local
+mcp-repl .vscode/mcp.json:remote
+mcp-repl --server "$HOME/Library/Application Support/Claude/claude_desktop_config.json:github"
+```
+
+```json
+{
+  "mcpServers": {
+    "local": {
+      "command": "cargo",
+      "args": ["run", "--manifest-path", "${workspaceFolder}/server/Cargo.toml"],
+      "env": { "API_TOKEN": "${env:HOST_API_TOKEN}" },
+      "cwd": "${workspaceFolder}"
+    }
+  },
+  "servers": {
+    "remote": {
+      "type": "http",
+      "url": "${env:MCP_URL}",
+      "headers": { "Authorization": "Bearer ${env:MCP_TOKEN}" }
+    }
+  }
+}
+```
+
+- `stdio` entries preserve `command`, ordered `args`, `env`, and `cwd`.
+  Relative working directories resolve from the config's workspace directory
+  (the parent of `.vscode` for `.vscode/mcp.json`, otherwise the file's
+  directory). The child inherits the current environment, with imported `env`
+  values overriding matching keys.
+- `http` and `streamable-http` entries preserve `url` and `headers`. Legacy
+  `sse` entries are rejected because mcp-repl connects with Streamable HTTP.
+- `${env:NAME}` and `${NAME}` read the launching environment;
+  `${workspaceFolder}`, `${workspaceFolderBasename}`, and `${userHome}` are
+  also supported. A missing variable is an error. `${input:...}` is rejected
+  with guidance because an imported interactive input has no portable value
+  outside the client that defined it.
+- Precedence is explicit flags first, then the imported entry, then native
+  profiles when no import was selected. `--http` can retarget an imported HTTP
+  entry while retaining its headers; `--bearer` and repeated `--header` values
+  override imported authentication. `MCP_BEARER` remains the final bearer
+  fallback when no selected configuration or flag supplies one.
+- Unknown entries list available names in sorted order. Entries with both a
+  command and URL, conflicting transport declarations, missing required
+  fields, or transport-specific fields on the wrong transport are refused.
+- **Trust boundary:** selecting an imported `stdio` entry executes its command
+  directly with the declared arguments, environment, and working directory.
+  Treat the JSON file as executable code and review files from repositories or
+  people you do not trust. mcp-repl never invokes a shell for the entry and
+  does not print imported environment or header values, but literal secrets in
+  the source file are still secrets at rest.
+- Native global aliases remain available for imported connections. Imported
+  files do not define mcp-repl aliases, so aliases created while using one are
+  global.
 
 ### Reconnecting
 

--- a/examples/mcp-repl/src/config.rs
+++ b/examples/mcp-repl/src/config.rs
@@ -89,6 +89,8 @@ pub enum Connection {
     },
     Stdio {
         command: Vec<String>,
+        env: BTreeMap<String, String>,
+        cwd: Option<PathBuf>,
     },
 }
 
@@ -194,6 +196,8 @@ impl Profile {
                 }
                 Ok(Connection::Stdio {
                     command: self.command.clone(),
+                    env: BTreeMap::new(),
+                    cwd: None,
                 })
             }
         }
@@ -293,6 +297,8 @@ command = ["cargo", "run", "--example", "getting_started"]
                     "--example".to_string(),
                     "getting_started".to_string(),
                 ],
+                env: BTreeMap::new(),
+                cwd: None,
             }
         );
     }

--- a/examples/mcp-repl/src/import_config.rs
+++ b/examples/mcp-repl/src/import_config.rs
@@ -1,0 +1,477 @@
+//! Import named servers from the common JSON configuration used by MCP
+//! clients such as Claude, Cursor, and VS Code.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::config::Connection;
+
+/// An explicit `PATH:ENTRY` selector recognized by the CLI.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Selector {
+    pub path: PathBuf,
+    pub entry: String,
+}
+
+/// A resolved imported server plus its display label.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ImportedConnection {
+    pub selector: Selector,
+    pub connection: Connection,
+}
+
+impl ImportedConnection {
+    pub fn label(&self) -> String {
+        format!("{}:{}", self.selector.path.display(), self.selector.entry)
+    }
+}
+
+/// Recognize an explicit JSON config selector without stealing ordinary
+/// executable names containing `:`. A `.json` suffix is explicit even when
+/// the file is missing, so the user gets a file error rather than attempting
+/// to spawn the whole selector as a command.
+pub fn parse_selector(value: &str) -> Option<Result<Selector, String>> {
+    let (path, entry) = value.rsplit_once(':')?;
+    let path = PathBuf::from(path);
+    let looks_like_json = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("json"));
+    if !looks_like_json && !path.exists() {
+        return None;
+    }
+    if path.as_os_str().is_empty() {
+        return Some(Err("import selector has an empty file path".to_string()));
+    }
+    if entry.is_empty() {
+        return Some(Err(format!(
+            "import selector for {} has an empty entry name",
+            path.display()
+        )));
+    }
+    Some(Ok(Selector {
+        path,
+        entry: entry.to_string(),
+    }))
+}
+
+/// Read and resolve one selected server. Environment values are supplied by
+/// the caller so tests never mutate the process environment.
+pub fn load_with(
+    selector: Selector,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<ImportedConnection, String> {
+    let source = std::fs::read_to_string(&selector.path)
+        .map_err(|error| format!("{}: {error}", selector.path.display()))?;
+    let path = std::fs::canonicalize(&selector.path)
+        .map_err(|error| format!("{}: {error}", selector.path.display()))?;
+    let connection = parse_document(&source, &path, &selector.entry, &lookup)?;
+    Ok(ImportedConnection {
+        selector: Selector {
+            path,
+            entry: selector.entry,
+        },
+        connection,
+    })
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Document {
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: BTreeMap<String, Entry>,
+    #[serde(default)]
+    servers: BTreeMap<String, Entry>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct Entry {
+    #[serde(rename = "type")]
+    kind: Option<String>,
+    transport: Option<String>,
+    command: Option<String>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    cwd: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ImportedTransport {
+    Http,
+    Stdio,
+}
+
+fn parse_document(
+    source: &str,
+    path: &Path,
+    selected: &str,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<Connection, String> {
+    let document: Document = serde_json::from_str(source)
+        .map_err(|error| format!("{}: invalid MCP JSON config: {error}", path.display()))?;
+    let mut entries = document.mcp_servers;
+    for (name, entry) in document.servers {
+        if entries.insert(name.clone(), entry).is_some() {
+            return Err(format!(
+                "{} defines server {name:?} in both `mcpServers` and `servers`",
+                path.display()
+            ));
+        }
+    }
+    let entry = entries.get(selected).ok_or_else(|| {
+        let available = entries.keys().cloned().collect::<Vec<_>>();
+        if available.is_empty() {
+            format!(
+                "{} has no entries under `mcpServers` or `servers`",
+                path.display()
+            )
+        } else {
+            format!(
+                "{} has no server named {selected:?}; available servers: {}",
+                path.display(),
+                available.join(", ")
+            )
+        }
+    })?;
+    resolve_entry(entry, path, selected, lookup)
+}
+
+fn resolve_entry(
+    entry: &Entry,
+    path: &Path,
+    name: &str,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<Connection, String> {
+    let workspace = workspace_folder(path);
+    let declared = match (&entry.kind, &entry.transport) {
+        (Some(kind), Some(transport)) => {
+            let kind = parse_transport(kind)?;
+            let transport = parse_transport(transport)?;
+            if kind != transport {
+                return Err(format!(
+                    "server {name:?} has conflicting `type` and `transport` values"
+                ));
+            }
+            Some(kind)
+        }
+        (Some(kind), None) | (None, Some(kind)) => Some(parse_transport(kind)?),
+        (None, None) => None,
+    };
+    let has_command = entry.command.is_some();
+    let has_url = entry.url.is_some();
+    let transport = match (declared, has_command, has_url) {
+        (Some(transport), _, _) => transport,
+        (None, true, false) => ImportedTransport::Stdio,
+        (None, false, true) => ImportedTransport::Http,
+        (None, true, true) => {
+            return Err(format!(
+                "server {name:?} sets both `command` and `url`; add `type` to choose a transport"
+            ));
+        }
+        (None, false, false) => {
+            return Err(format!(
+                "server {name:?} has neither `command` nor `url`, so its transport cannot be inferred"
+            ));
+        }
+    };
+
+    match transport {
+        ImportedTransport::Stdio => {
+            if entry.url.is_some() || !entry.headers.is_empty() {
+                return Err(format!(
+                    "stdio server {name:?} also sets HTTP-only `url` or `headers`"
+                ));
+            }
+            let command = entry
+                .command
+                .as_deref()
+                .ok_or_else(|| format!("stdio server {name:?} has no `command`"))?;
+            let mut command_and_args = Vec::with_capacity(entry.args.len() + 1);
+            command_and_args.push(expand(command, &workspace, lookup)?);
+            for argument in &entry.args {
+                command_and_args.push(expand(argument, &workspace, lookup)?);
+            }
+            if command_and_args[0].is_empty() {
+                return Err(format!("stdio server {name:?} has an empty `command`"));
+            }
+            let env = entry
+                .env
+                .iter()
+                .map(|(key, value)| {
+                    expand(value, &workspace, lookup).map(|value| (key.clone(), value))
+                })
+                .collect::<Result<BTreeMap<_, _>, _>>()?;
+            let cwd = entry
+                .cwd
+                .as_deref()
+                .map(|cwd| expand(cwd, &workspace, lookup))
+                .transpose()?
+                .map(PathBuf::from)
+                .map(|cwd| {
+                    if cwd.is_absolute() {
+                        cwd
+                    } else {
+                        workspace.join(cwd)
+                    }
+                });
+            Ok(Connection::Stdio {
+                command: command_and_args,
+                env,
+                cwd,
+            })
+        }
+        ImportedTransport::Http => {
+            if entry.command.is_some()
+                || !entry.args.is_empty()
+                || !entry.env.is_empty()
+                || entry.cwd.is_some()
+            {
+                return Err(format!(
+                    "HTTP server {name:?} also sets stdio-only `command`, `args`, `env`, or `cwd`"
+                ));
+            }
+            let url = entry
+                .url
+                .as_deref()
+                .ok_or_else(|| format!("HTTP server {name:?} has no `url`"))?;
+            let headers = entry
+                .headers
+                .iter()
+                .map(|(key, value)| {
+                    expand(value, &workspace, lookup).map(|value| (key.clone(), value))
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Ok(Connection::Http {
+                url: expand(url, &workspace, lookup)?,
+                bearer: None,
+                headers,
+            })
+        }
+    }
+}
+
+fn parse_transport(value: &str) -> Result<ImportedTransport, String> {
+    match value.to_ascii_lowercase().replace(['-', '_'], "").as_str() {
+        "stdio" => Ok(ImportedTransport::Stdio),
+        "http" | "streamablehttp" => Ok(ImportedTransport::Http),
+        "sse" => Err(
+            "transport `sse` is not supported; mcp-repl requires Streamable HTTP (`http`)"
+                .to_string(),
+        ),
+        _ => Err(format!(
+            "unsupported imported transport {value:?}; expected `stdio` or `http`"
+        )),
+    }
+}
+
+fn workspace_folder(config_path: &Path) -> PathBuf {
+    let parent = config_path.parent().unwrap_or_else(|| Path::new("."));
+    if parent.file_name().is_some_and(|name| name == ".vscode") {
+        parent.parent().unwrap_or(parent).to_path_buf()
+    } else {
+        parent.to_path_buf()
+    }
+}
+
+fn expand(
+    input: &str,
+    workspace: &Path,
+    lookup: &impl Fn(&str) -> Option<String>,
+) -> Result<String, String> {
+    let mut rendered = String::new();
+    let mut rest = input;
+    while let Some(start) = rest.find("${") {
+        rendered.push_str(&rest[..start]);
+        let after_open = &rest[start + 2..];
+        let Some(end) = after_open.find('}') else {
+            return Err("unterminated `${...}` substitution in imported config".to_string());
+        };
+        let variable = &after_open[..end];
+        let replacement = match variable {
+            "workspaceFolder" => workspace.to_string_lossy().into_owned(),
+            "workspaceFolderBasename" => workspace
+                .file_name()
+                .map(|name| name.to_string_lossy().into_owned())
+                .unwrap_or_default(),
+            "userHome" => lookup("HOME")
+                .or_else(|| lookup("USERPROFILE"))
+                .ok_or_else(|| {
+                    "`${userHome}` requires the HOME or USERPROFILE environment variable"
+                        .to_string()
+                })?,
+            variable if variable.starts_with("input:") => {
+                return Err(format!(
+                    "`${{{variable}}}` requires interactive client input, which mcp-repl cannot import; use an environment variable instead"
+                ));
+            }
+            variable => {
+                let variable = variable.strip_prefix("env:").unwrap_or(variable);
+                if variable.is_empty() {
+                    return Err(
+                        "imported config contains an empty environment substitution".to_string()
+                    );
+                }
+                lookup(variable).ok_or_else(|| {
+                    format!("imported config requires environment variable {variable:?}, but it is unset")
+                })?
+            }
+        };
+        rendered.push_str(&replacement);
+        rest = &after_open[end + 1..];
+    }
+    rendered.push_str(rest);
+    Ok(rendered)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> + use<> {
+        let values: BTreeMap<String, String> = pairs
+            .iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect();
+        move |key| values.get(key).cloned()
+    }
+
+    #[test]
+    fn parses_claude_stdio_shape_with_workspace_and_environment() {
+        let source = r#"{
+          "mcpServers": {
+            "local": {
+              "command": "${workspaceFolder}/bin/server",
+              "args": ["--repo", "${workspaceFolderBasename}"],
+              "env": {"API_TOKEN": "${env:HOST_TOKEN}"},
+              "cwd": "work"
+            }
+          }
+        }"#;
+        let resolved = parse_document(
+            source,
+            Path::new("/repo/.mcp.json"),
+            "local",
+            &env(&[("HOST_TOKEN", "secret")]),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved,
+            Connection::Stdio {
+                command: vec![
+                    "/repo/bin/server".to_string(),
+                    "--repo".to_string(),
+                    "repo".to_string(),
+                ],
+                env: BTreeMap::from([("API_TOKEN".to_string(), "secret".to_string())]),
+                cwd: Some(PathBuf::from("/repo/work")),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_vscode_http_shape_and_uses_workspace_parent() {
+        let source = r#"{
+          "servers": {
+            "remote": {
+              "type": "streamable-http",
+              "url": "${env:MCP_URL}",
+              "headers": {"Authorization": "Bearer ${TOKEN}"}
+            }
+          }
+        }"#;
+        let resolved = parse_document(
+            source,
+            Path::new("/repo/.vscode/mcp.json"),
+            "remote",
+            &env(&[("MCP_URL", "https://example/mcp"), ("TOKEN", "secret")]),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved,
+            Connection::Http {
+                url: "https://example/mcp".to_string(),
+                bearer: None,
+                headers: vec![("Authorization".to_string(), "Bearer secret".to_string())],
+            }
+        );
+    }
+
+    #[test]
+    fn missing_entry_lists_sorted_names() {
+        let error = parse_document(
+            r#"{"mcpServers":{"z":{"command":"z"},"a":{"command":"a"}}}"#,
+            Path::new("/repo/.mcp.json"),
+            "missing",
+            &env(&[]),
+        )
+        .unwrap_err();
+        assert!(error.contains("a, z"), "{error}");
+    }
+
+    #[test]
+    fn rejects_ambiguous_and_unsupported_transports() {
+        let ambiguous = parse_document(
+            r#"{"mcpServers":{"x":{"command":"x","url":"https://example"}}}"#,
+            Path::new("/repo/.mcp.json"),
+            "x",
+            &env(&[]),
+        )
+        .unwrap_err();
+        assert!(ambiguous.contains("both"), "{ambiguous}");
+
+        let sse = parse_document(
+            r#"{"servers":{"x":{"type":"sse","url":"https://example"}}}"#,
+            Path::new("/repo/mcp.json"),
+            "x",
+            &env(&[]),
+        )
+        .unwrap_err();
+        assert!(sse.contains("Streamable HTTP"), "{sse}");
+    }
+
+    #[test]
+    fn missing_substitutions_name_the_variable_without_leaking_values() {
+        let error = parse_document(
+            r#"{
+              "mcpServers": {
+                "x": {
+                  "command": "server",
+                  "args": ["${env:MISSING}"],
+                  "env": {"LITERAL_SECRET": "do-not-print-me"}
+                }
+              }
+            }"#,
+            Path::new("/repo/.mcp.json"),
+            "x",
+            &env(&[]),
+        )
+        .unwrap_err();
+        assert!(error.contains("MISSING"), "{error}");
+        assert!(!error.contains("do-not-print-me"), "{error}");
+    }
+
+    #[test]
+    fn interactive_input_substitutions_are_actionable_errors() {
+        let error = expand("${input:token}", Path::new("/repo"), &env(&[])).unwrap_err();
+        assert!(error.contains("interactive"), "{error}");
+        assert!(error.contains("environment variable"), "{error}");
+    }
+
+    #[test]
+    fn selector_recognition_does_not_steal_ordinary_commands() {
+        assert!(parse_selector("registry:serve").is_none());
+        assert_eq!(
+            parse_selector("path/to/.mcp.json:server").unwrap().unwrap(),
+            Selector {
+                path: PathBuf::from("path/to/.mcp.json"),
+                entry: "server".to_string(),
+            }
+        );
+    }
+}

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -36,6 +36,7 @@ mod editor;
 mod elicit;
 mod exit_status;
 mod find;
+mod import_config;
 mod jobs;
 mod output;
 mod sampling;
@@ -119,8 +120,9 @@ struct Args {
     #[arg(long, conflicts_with_all = ["http", "command", "server"])]
     demo: bool,
 
-    /// Connect using the named `[servers.<name>]` profile from the config
-    /// file. A bare positional that matches a profile name works too.
+    /// Connect using a native profile name, or import `PATH.json:ENTRY` from a
+    /// standard MCP JSON config. Either selector also works as a lone
+    /// positional.
     #[arg(long, value_name = "NAME")]
     server: Option<String>,
 
@@ -745,14 +747,34 @@ fn build_http_config(
     profile_bearer: Option<String>,
     profile_headers: &[(String, String)],
 ) -> Result<HttpClientConfig, String> {
+    build_http_config_with_env(
+        bearer,
+        headers,
+        profile_bearer,
+        profile_headers,
+        std::env::var("MCP_BEARER").ok(),
+    )
+}
+
+fn build_http_config_with_env(
+    bearer: Option<String>,
+    headers: &[String],
+    profile_bearer: Option<String>,
+    profile_headers: &[(String, String)],
+    env_bearer: Option<String>,
+) -> Result<HttpClientConfig, String> {
     let mut config = HttpClientConfig::default();
     for (name, value) in profile_headers {
         config = config.header(name.as_str(), value.as_str());
     }
-    if let Some(token) = bearer
-        .or(profile_bearer)
-        .or_else(|| std::env::var("MCP_BEARER").ok())
-    {
+    let selected_has_authorization = profile_headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+    if let Some(token) = bearer.or(profile_bearer).or_else(|| {
+        (!selected_has_authorization)
+            .then_some(env_bearer)
+            .flatten()
+    }) {
         config = config.bearer_token(token);
     }
     for raw in headers {
@@ -1122,6 +1144,27 @@ fn resolve_profile(args: &Args, config: &config::Config) -> Option<(String, conf
     }
 }
 
+/// Resolve an explicit `PATH:ENTRY` selector from `--server` or a lone
+/// positional. Imported JSON is intentionally opt-in; ordinary commands and
+/// native profile names retain their existing interpretation.
+fn resolve_import(args: &Args) -> Option<import_config::ImportedConnection> {
+    let candidate = match args.server.as_deref() {
+        Some(server) => server,
+        None => match args.command.as_slice() {
+            [only] => only,
+            _ => return None,
+        },
+    };
+    let selector = match import_config::parse_selector(candidate)? {
+        Ok(selector) => selector,
+        Err(error) => exit_with_error(ExitStatus::Usage, &error),
+    };
+    Some(
+        import_config::load_with(selector, |variable| std::env::var(variable).ok())
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error)),
+    )
+}
+
 fn log_level_style(level: LogLevel) -> Style {
     match level {
         LogLevel::Emergency | LogLevel::Alert | LogLevel::Critical | LogLevel::Error => {
@@ -1160,7 +1203,12 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
         print_servers(&profiles);
         return Ok(());
     }
-    let profile = resolve_profile(&args, &profiles);
+    let imported = resolve_import(&args);
+    let profile = if imported.is_none() {
+        resolve_profile(&args, &profiles)
+    } else {
+        None
+    };
     // --exec runs commands and exits; suppress the banner and surface listing
     // unless --verbose, so scripted output is only the command results.
     let one_shot = !args.exec.is_empty();
@@ -1204,12 +1252,13 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
     // otherwise.
     sampling::init(sampling::resolve(args.sampling, one_shot));
 
-    // Explicit flags override profile fields: --http retargets a profile's URL
-    // while keeping its auth, and --bearer/--header are layered on in
-    // build_http_config.
-    let (profile_name, connection) = match profile {
-        Some((name, c)) => (Some(name), Some(c)),
-        None => (None, None),
+    // Explicit flags override imported or native profile fields: --http
+    // retargets the URL while keeping HTTP auth, and --bearer/--header are
+    // layered on in build_http_config.
+    let (profile_name, import_label, connection) = match (imported, profile) {
+        (Some(imported), _) => (None, Some(imported.label()), Some(imported.connection)),
+        (None, Some((name, connection))) => (Some(name), None, Some(connection)),
+        (None, None) => (None, None, None),
     };
 
     // Aliases come from the same file as the profiles: the global table plus
@@ -1244,6 +1293,8 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
         (None, Some(c)) => Some(c),
         (None, None) if !args.command.is_empty() => Some(config::Connection::Stdio {
             command: args.command.clone(),
+            env: std::collections::BTreeMap::new(),
+            cwd: None,
         }),
         (None, None) => None,
     };
@@ -1258,6 +1309,13 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
         println!(
             "{}",
             tag(Style::new().fg(Color::Cyan), &format!("profile {name}"))
+        );
+    } else if let Some(label) = &import_label
+        && !quiet
+    {
+        println!(
+            "{}",
+            tag(Style::new().fg(Color::Cyan), &format!("import {label}"))
         );
     }
 
@@ -1306,9 +1364,13 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
                     )
                     .await?
             }
-            Some(config::Connection::Stdio { command }) => {
+            Some(config::Connection::Stdio { command, env, cwd }) => {
                 let mut cmd = tokio::process::Command::new(&command[0]);
                 cmd.args(&command[1..]);
+                cmd.envs(env);
+                if let Some(cwd) = cwd {
+                    cmd.current_dir(cwd);
+                }
                 cmd.stderr(std::process::Stdio::piped());
                 let mut transport = StdioClientTransport::spawn_command(&mut cmd).await?;
                 if let Some(stderr) = transport.take_stderr() {
@@ -2820,6 +2882,36 @@ mod tests {
         assert_eq!(
             cfg.headers.get("X-Kept").map(String::as_str),
             Some("profile")
+        );
+    }
+
+    #[test]
+    fn selected_authorization_header_beats_environment_bearer() {
+        let selected_headers = [("authorization".to_string(), "Basic selected".to_string())];
+        let cfg = build_http_config_with_env(
+            None,
+            &[],
+            None,
+            &selected_headers,
+            Some("ambient-token".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.headers.get("authorization").map(String::as_str),
+            Some("Basic selected")
+        );
+
+        let cfg = build_http_config_with_env(
+            Some("explicit-token".into()),
+            &[],
+            None,
+            &selected_headers,
+            Some("ambient-token".into()),
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.headers.get("Authorization").map(String::as_str),
+            Some("Bearer explicit-token")
         );
     }
 

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -1422,7 +1422,13 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
                 break;
             }
         }
-        std::process::exit(exit_status::current().code());
+        let status = exit_status::current().code();
+        drop(client);
+        let session = Arc::try_unwrap(session).unwrap_or_else(|_| {
+            panic!("one-shot MCP session is still shared after all commands completed")
+        });
+        session.shutdown().await?;
+        std::process::exit(status);
     }
 
     // Final list-change notifications are subscription-scoped. Start the

--- a/examples/mcp-repl/src/session.rs
+++ b/examples/mcp-repl/src/session.rs
@@ -82,6 +82,22 @@ impl Session {
         self.generation_tx.subscribe()
     }
 
+    /// Close the live client and its transport once the session is no longer
+    /// shared by command work. One-shot mode uses this before applying its
+    /// process exit status so stdio children see EOF and are reaped cleanly.
+    pub async fn shutdown(self) -> Result<(), tower_mcp::Error> {
+        let client = self
+            .client
+            .into_inner()
+            .expect("session client lock poisoned");
+        let client = Arc::try_unwrap(client).map_err(|_| {
+            tower_mcp::Error::Transport(
+                "cannot shut down an MCP session while its client is still in use".to_string(),
+            )
+        })?;
+        client.shutdown().await
+    }
+
     /// Rebuild the connection, unless another caller already did so since
     /// `seen` was read. Returns `Ok(())` either way; the caller should
     /// re-read [`Session::client`] afterwards.

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -8,9 +8,12 @@ use tempfile::TempDir;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{Child, Command};
 
-const CASE_TIMEOUT: Duration = Duration::from_secs(20);
+// Each process normally finishes in well under a second, but beta and Windows
+// runners can be CPU-starved while the all-target workspace job is active.
+// Keep hangs bounded without treating scheduler stalls as product failures.
+const CASE_TIMEOUT: Duration = Duration::from_secs(60);
 const BUILD_TIMEOUT: Duration = Duration::from_secs(180);
-const SUITE_TIMEOUT: Duration = Duration::from_secs(300);
+const SUITE_TIMEOUT: Duration = Duration::from_secs(600);
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -350,6 +350,93 @@ async fn exercise_json_contract(fixture: &Path, temp: &TempDir) {
     assert_eq!(values[0]["kind"], "auth");
 }
 
+async fn exercise_imported_stdio_config(fixture: &Path, temp: &TempDir) {
+    let workspace = temp.path().join("import-workspace");
+    let cwd = workspace.join("work");
+    std::fs::create_dir_all(&cwd).expect("create imported fixture cwd");
+    let config = workspace.join(".mcp.json");
+    std::fs::write(
+        &config,
+        serde_json::json!({
+            "mcpServers": {
+                "fixture": {
+                    "command": fixture,
+                    "env": {
+                        "MCP_REPL_IMPORTED_VALUE": "${env:MCP_REPL_HOST_VALUE}"
+                    },
+                    "cwd": "${workspaceFolder}/work"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write imported stdio config");
+    let exit_file = temp.path().join("import-stdio.exit");
+    let selector = format!("{}:fixture", config.display());
+    let mut command = repl_command();
+    command
+        .args(["--json", "--exec", "process_info", &selector])
+        .env("MCP_REPL_HOST_VALUE", "from-host")
+        .env("MCP_REPL_FIXTURE_EXIT_FILE", &exit_file);
+    let output = run(command, "imported stdio config", CASE_TIMEOUT).await;
+    assert_success(&output, "imported stdio config");
+    assert_eq!(
+        wait_for_file(&exit_file, "imported stdio fixture shutdown").await,
+        "clean"
+    );
+    let values = json_lines(&output, "imported stdio config");
+    assert_eq!(values.len(), 1);
+    let process: serde_json::Value = serde_json::from_str(
+        values[0]
+            .pointer("/content/0/text")
+            .and_then(serde_json::Value::as_str)
+            .expect("process_info text result"),
+    )
+    .expect("process_info JSON");
+    assert_eq!(process["imported"], "from-host");
+    assert_eq!(
+        PathBuf::from(process["cwd"].as_str().expect("process cwd"))
+            .canonicalize()
+            .expect("canonical process cwd"),
+        cwd.canonicalize().expect("canonical expected cwd")
+    );
+}
+
+async fn exercise_imported_http_config(http: &HttpFixture, temp: &TempDir) {
+    let config = temp.path().join("vscode-mcp.json");
+    std::fs::write(
+        &config,
+        serde_json::json!({
+            "servers": {
+                "fixture": {
+                    "type": "http",
+                    "url": "http://127.0.0.1:1/"
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write imported HTTP config");
+    let selector = format!("{}:fixture", config.display());
+    let mut command = repl_command();
+    command.args([
+        "--json",
+        "--exec",
+        "add a=20 b=22",
+        "--http",
+        &http.url,
+        &selector,
+    ]);
+    let output = run(command, "imported HTTP config", CASE_TIMEOUT).await;
+    assert_success(&output, "imported HTTP config");
+    let values = json_lines(&output, "imported HTTP config");
+    assert_eq!(values.len(), 1);
+    assert_eq!(
+        values[0].pointer("/content/0/text"),
+        Some(&serde_json::json!("42"))
+    );
+}
+
 async fn exercise_stdio(fixture: &Path, temp: &TempDir) {
     let stable = run_stdio(
         fixture,
@@ -455,6 +542,8 @@ async fn exercise_interactive_final_task(http: &HttpFixture) {
 async fn exercise_http(fixture: &Path, temp: &TempDir) {
     let http = HttpFixture::start(fixture, temp).await;
 
+    exercise_imported_http_config(&http, temp).await;
+
     let stable = run_http(
         &http.url,
         "stable HTTP",
@@ -505,6 +594,7 @@ async fn published_cli_covers_transports_and_protocol_lifecycles() {
         let temp = TempDir::new().expect("temporary fixture directory");
         let fixture = build_fixture().await;
         exercise_json_contract(&fixture, &temp).await;
+        exercise_imported_stdio_config(&fixture, &temp).await;
         exercise_stdio(&fixture, &temp).await;
         exercise_http(&fixture, &temp).await;
     })

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -1,5 +1,6 @@
 //! Black-box coverage for the published `mcp-repl` process boundary.
 
+use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 use std::process::Output;
 use std::time::Duration;
@@ -23,18 +24,46 @@ fn workspace_root() -> PathBuf {
 }
 
 async fn run(mut command: Command, label: &str, timeout: Duration) -> Output {
+    // Capture through files rather than `Child::wait_with_output`. On Windows,
+    // a server grandchild can retain an inherited pipe handle after mcp-repl
+    // exits, which makes waiting for pipe EOF look like a hung parent process.
+    let mut stdout = tempfile::tempfile().expect("create stdout capture");
+    let mut stderr = tempfile::tempfile().expect("create stderr capture");
     command
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
+        .stdout(stdout.try_clone().expect("clone stdout capture"))
+        .stderr(stderr.try_clone().expect("clone stderr capture"))
         .kill_on_drop(true);
-    let child = command
+    let mut child = command
         .spawn()
         .unwrap_or_else(|error| panic!("spawn {label}: {error}"));
-    tokio::time::timeout(timeout, child.wait_with_output())
-        .await
-        .unwrap_or_else(|_| panic!("{label} exceeded {timeout:?}"))
-        .unwrap_or_else(|error| panic!("wait for {label}: {error}"))
+    let status = match tokio::time::timeout(timeout, child.wait()).await {
+        Ok(result) => result.unwrap_or_else(|error| panic!("wait for {label}: {error}")),
+        Err(_) => {
+            let _ = child.kill().await;
+            let stdout = read_capture(&mut stdout, label, "stdout");
+            let stderr = read_capture(&mut stderr, label, "stderr");
+            panic!(
+                "{label} exceeded {timeout:?}\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&stdout),
+                String::from_utf8_lossy(&stderr)
+            );
+        }
+    };
+    Output {
+        status,
+        stdout: read_capture(&mut stdout, label, "stdout"),
+        stderr: read_capture(&mut stderr, label, "stderr"),
+    }
+}
+
+fn read_capture(file: &mut std::fs::File, label: &str, stream: &str) -> Vec<u8> {
+    file.rewind()
+        .unwrap_or_else(|error| panic!("rewind {label} {stream}: {error}"));
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)
+        .unwrap_or_else(|error| panic!("read {label} {stream}: {error}"));
+    bytes
 }
 
 fn assert_success(output: &Output, label: &str) {

--- a/examples/mcp_repl_fixture.rs
+++ b/examples/mcp_repl_fixture.rs
@@ -71,6 +71,21 @@ fn fixture_router() -> McpRouter {
                 })
                 .build(),
         )
+        .tool(
+            ToolBuilder::new("process_info")
+                .description("Report deterministic process environment for import tests")
+                .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                    let cwd = std::env::current_dir()
+                        .expect("fixture current directory")
+                        .to_string_lossy()
+                        .into_owned();
+                    let imported = std::env::var("MCP_REPL_IMPORTED_VALUE").ok();
+                    Ok(CallToolResult::text(
+                        serde_json::json!({ "cwd": cwd, "imported": imported }).to_string(),
+                    ))
+                })
+                .build(),
+        )
         .resource(
             ResourceBuilder::new("fixture://guide")
                 .name("Fixture Guide")


### PR DESCRIPTION
Closes #1153.

## Summary

- accept explicit `PATH.json:ENTRY` selectors from `--server` or the lone positional argument
- import both common `mcpServers` and VS Code-style `servers` roots
- preserve stdio commands, ordered args, environment overrides, and working directories
- preserve Streamable HTTP URLs and headers, with explicit CLI auth/URL overrides
- expand environment, workspace-folder, workspace-basename, and user-home variables with actionable errors for missing or interactive substitutions
- reject ambiguous, conflicting, malformed, and legacy SSE entries with sorted discovery errors
- document precedence, secret handling, aliases, and the imported-stdio trust boundary
- verify imported stdio environment/cwd and imported HTTP retargeting at the binary boundary
- close one-shot clients gracefully and capture process output through temporary files so Windows cannot confuse an inherited grandchild pipe with a hung mcp-repl process
- make every stdio reader cancellation-safe: persistent line buffers now preserve partial JSON frames when a competing request, notification, or control branch wins `select!`

## Windows CI root cause

The trace showed `tools/list` request 2 turn into an empty incoming frame while responses 3–5 arrived normally. Tokio documents `read_line` as cancellation-unsafe. The client message loop and all three server stdio loops were creating a fresh `read_line` future inside `select!`; a competing branch could consume part of a JSON frame, cancel that future, discard the prefix, and leave only its newline. Switching to persistent `Lines::next_line` state fixes the lost frame rather than increasing timeouts. Client- and server-side partial-frame regression tests reproduce the cancellation boundary.

## Auth precedence

Explicit `--bearer` and `--header` flags win. Imported/native credentials are next. Ambient `MCP_BEARER` is only a final fallback and does not overwrite a selected `Authorization` header.

## Tests

- `cargo test -p mcp-repl`
- three consecutive `cargo test -p mcp-repl --test e2e --all-features` runs after the cancellation-safety fix
- focused client and server partial-frame cancellation regressions
- `cargo clippy -p tower-mcp -p mcp-repl --all-targets --all-features -- -D warnings`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features --doc`
