### PR TITLE
feat(mcp-repl): validate schema snapshots

### DIFF
--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -486,6 +486,53 @@ enough, the message points at `help` as before.
 - Prompts: the argument table (name, required/optional, description).
 - Resources and templates: URI, name, MIME type, size, and description.
 
+## Schema snapshots and compatibility checks
+
+Tool and prompt definitions can be saved as versioned, canonical JSON
+contracts. Snapshots intentionally omit descriptions, icons, annotations, and
+other presentation metadata: a documentation edit should not break a caller.
+
+```text
+demo> snapshot add add.schema.json
+saved tool "add" schema snapshot to add.schema.json
+demo> validate add.schema.json compatible
+tool "add" is compatible under compatible validation
+```
+
+Without a path, `snapshot <name>` prints the canonical JSON. Use
+`snapshot tool:<name>` or `snapshot prompt:<name>` when both namespaces expose
+the same name. `validate <path> [strict|compatible|ignore]` reads a snapshot
+and compares it with the advertised surface without invoking anything:
+
+- `strict` requires the entire canonical contract to match.
+- `compatible` protects existing callers: removed or retyped inputs, newly
+  required inputs, removed or retyped expected outputs, and prompt argument
+  breaks fail. Additive optional inputs/arguments and additive outputs pass;
+  input widening and output narrowing (for example, integer output replacing
+  number output) also pass.
+- `ignore` loads the snapshot but deliberately skips enforcement, which is
+  useful while rolling out contracts in automation.
+
+Nested object/array schemas and local JSON Schema references such as
+`#/$defs/filter` are followed recursively. External references are rejected
+because validation is offline and must not fetch code or schemas implicitly.
+Changes to complex `anyOf`, `oneOf`, `allOf`, or `not` compositions are treated
+conservatively as incompatible.
+
+Repeat `--schema-contract <path>` to enforce snapshots before matching tool
+calls, task-augmented calls, benchmarks, or prompt retrievals. The default is
+compatible mode; `--schema-mode strict|compatible|ignore` changes it:
+
+```bash
+mcp-repl --schema-contract add.schema.json \
+  --schema-mode compatible --http https://example/mcp
+```
+
+A successful preflight is silent. An incompatible preflight sends no MCP
+request, returns status 1, and explains every finding. Under `--json` the
+validation report is the command's single NDJSON value, so the scripting
+framing contract is preserved.
+
 ## Output rendering
 
 - JSON output (schema dumps, `info` capabilities, non-text content) is
@@ -547,8 +594,10 @@ task-augmented tool call returns its task-creation result. Surface list commands
 return convenience arrays of their protocol definitions (without pagination
 wrappers). REPL-only commands use documented convenience values or envelopes:
 `find` and `subscriptions` return arrays; `describe` returns
-`{"kind": ..., "definition": ...}`; and `help`, `bench`, `jobs`, aliases,
-`wire`, `last`, `refresh`, `info`, `vars`, `unset`, and `quit` return objects.
+`{"kind": ..., "definition": ...}`; `snapshot` returns its canonical contract
+or a file acknowledgement; `validate` returns its compatibility report; and
+`help`, `bench`, `jobs`, aliases, `wire`, `last`, `refresh`, `info`, `vars`,
+`unset`, and `quit` return objects.
 
 JSON errors also stay on stdout so they occupy that command's one output line:
 

--- a/examples/mcp-repl/src/editor.rs
+++ b/examples/mcp-repl/src/editor.rs
@@ -369,7 +369,7 @@ impl Completer for ReplCompleter {
                     }
                 }
             }
-            "describe" => {
+            "describe" | "snapshot" => {
                 out.extend(Self::complete_describe_word(&surface, word, span));
             }
             "unalias" => {

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -40,6 +40,7 @@ mod import_config;
 mod jobs;
 mod output;
 mod sampling;
+mod schema_contract;
 mod session;
 mod style;
 mod subscribe;
@@ -168,6 +169,15 @@ struct Args {
     #[arg(long)]
     verbose: bool,
 
+    /// Validate matching tools and prompts before invocation using this saved
+    /// schema snapshot (repeatable).
+    #[arg(long = "schema-contract", value_name = "PATH")]
+    schema_contracts: Vec<std::path::PathBuf>,
+
+    /// Enforcement used by --schema-contract snapshots.
+    #[arg(long, value_enum, default_value = "compatible")]
+    schema_mode: schema_contract::ValidationMode,
+
     /// How to answer a server's `sampling/createMessage` request: `prompt`
     /// shows it and reads the assistant message on stdin, `canned` answers
     /// with a fixed placeholder, `decline` refuses. Defaults to `prompt`
@@ -267,6 +277,8 @@ pub const BUILTINS: &[(&str, &str)] = &[
     ("templates", "list resource templates"),
     ("find", "search the surface by keyword"),
     ("describe", "show schemas and metadata for a name"),
+    ("snapshot", "export a tool or prompt schema contract"),
+    ("validate", "compare the surface with a schema snapshot"),
     ("read", "read a resource"),
     ("subscribe", "watch a resource for updates"),
     ("unsubscribe", "stop watching a resource"),
@@ -1203,6 +1215,9 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
         print_servers(&profiles);
         return Ok(());
     }
+    let schema_contracts =
+        schema_contract::ContractSet::load(&args.schema_contracts, args.schema_mode)
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
     let imported = resolve_import(&args);
     let profile = if imported.is_none() {
         resolve_profile(&args, &profiles)
@@ -1418,7 +1433,16 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
     // errored. No editor, no event loop.
     if one_shot {
         for cmd in &args.exec {
-            if handle_line(&session, &surface, &aliases, &jobs, cmd.trim()).await {
+            if handle_line(
+                &session,
+                &surface,
+                &aliases,
+                &jobs,
+                &schema_contracts,
+                cmd.trim(),
+            )
+            .await
+            {
                 break;
             }
         }
@@ -1468,7 +1492,15 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
             }
             maybe_line = line_rx.recv() => {
                 let Some(line) = maybe_line else { break };
-                let quit = handle_line(&session, &surface, &aliases, &jobs, line.trim()).await;
+                let quit = handle_line(
+                    &session,
+                    &surface,
+                    &aliases,
+                    &jobs,
+                    &schema_contracts,
+                    line.trim(),
+                )
+                .await;
                 let _ = ack_tx.send(());
                 if quit {
                     break;
@@ -1484,6 +1516,7 @@ async fn handle_line(
     surface: &Arc<RwLock<Surface>>,
     aliases: &Arc<RwLock<Aliases>>,
     jobs: &Arc<Jobs>,
+    schema_contracts: &schema_contract::ContractSet,
     line: &str,
 ) -> bool {
     if line.is_empty() {
@@ -1565,6 +1598,8 @@ async fn handle_line(
             println!("  tools | prompts | resources | templates   list the server surface");
             println!("  find <keyword>                            search the surface");
             println!("  describe <name>                           schemas and metadata");
+            println!("  snapshot <name> [path]                    export a schema contract");
+            println!("  validate <path> [mode]                    check a schema contract");
             println!("  read <uri>                                read a resource");
             println!("  subscribe <uri> | unsubscribe <uri>       watch a resource for updates");
             println!("  subscriptions                             list active subscriptions");
@@ -1715,6 +1750,90 @@ async fn handle_line(
                 describe(&surface, name);
             }
         }
+        "snapshot" => {
+            let Some(name) = rest.first() else {
+                command_error("usage: snapshot <tool|prompt> [path]");
+                return false;
+            };
+            if rest.len() > 2 {
+                command_error("usage: snapshot <tool|prompt> [path]");
+                return false;
+            }
+            let snapshot = {
+                let surface = surface.read().unwrap();
+                schema_contract::Snapshot::from_surface(&surface.tools, &surface.prompts, name)
+            };
+            let snapshot = match snapshot {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    report_error(ExitStatus::Usage, &error);
+                    return false;
+                }
+            };
+            let Some(snapshot) = snapshot else {
+                report_error(
+                    ExitStatus::NoMatch,
+                    &format!("no tool or prompt named `{name}`"),
+                );
+                return false;
+            };
+            if let Some(path) = rest.get(1) {
+                let path = std::path::Path::new(path);
+                match snapshot.write(path) {
+                    Ok(()) if json_output() => print_json(&serde_json::json!({
+                        "kind": snapshot.kind,
+                        "name": snapshot.name,
+                        "path": path,
+                    })),
+                    Ok(()) => println!(
+                        "saved {} {:?} schema snapshot to {}",
+                        snapshot.kind,
+                        snapshot.name,
+                        path.display()
+                    ),
+                    Err(error) => report_error(ExitStatus::Usage, &error),
+                }
+            } else if json_output() {
+                print_json(&snapshot.canonical_value());
+            } else {
+                print!("{}", snapshot.to_pretty_json());
+            }
+        }
+        "validate" => {
+            let Some(path) = rest.first() else {
+                command_error("usage: validate <snapshot-path> [strict|compatible|ignore]");
+                return false;
+            };
+            if rest.len() > 2 {
+                command_error("usage: validate <snapshot-path> [strict|compatible|ignore]");
+                return false;
+            }
+            let mode = match rest.get(1) {
+                Some(mode) => match schema_contract::ValidationMode::from_str(mode, true) {
+                    Ok(mode) => mode,
+                    Err(_) => {
+                        command_error(
+                            "validation mode must be `strict`, `compatible`, or `ignore`",
+                        );
+                        return false;
+                    }
+                },
+                None => schema_contracts.mode(),
+            };
+            let snapshot = match schema_contract::Snapshot::load(std::path::Path::new(path)) {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    report_error(ExitStatus::Usage, &error);
+                    return false;
+                }
+            };
+            let current = {
+                let surface = surface.read().unwrap();
+                snapshot.matching_surface(&surface.tools, &surface.prompts)
+            };
+            let report = schema_contract::validate(&snapshot, current.as_ref(), mode);
+            render_validation_report(&report, true);
+        }
         "read" => {
             let Some(uri) = rest.first() else {
                 command_error("usage: read <uri>");
@@ -1784,6 +1903,9 @@ async fn handle_line(
                 command_error("usage: prompt <name> [k=v...]");
                 return false;
             };
+            if !enforce_prompt_contract(schema_contracts, surface, name) {
+                return false;
+            }
             let mut prompt_args = HashMap::new();
             for t in &rest[1..] {
                 if let Some((k, v)) = t.split_once('=') {
@@ -1833,10 +1955,20 @@ async fn handle_line(
                     return false;
                 }
             };
-            run_tool(session, surface, jobs, name, arguments, background, &output).await;
+            run_tool(
+                session,
+                surface,
+                jobs,
+                schema_contracts,
+                name,
+                arguments,
+                background,
+                &output,
+            )
+            .await;
         }
         "bench" => {
-            handle_bench(&client, surface, rest, background).await;
+            handle_bench(&client, surface, schema_contracts, rest, background).await;
         }
         "jobs" => {
             if json_output() {
@@ -2085,7 +2217,14 @@ async fn handle_line(
             };
             let arguments = parse_kv_args(&schema, rest);
             run_tool(
-                session, surface, jobs, tool_name, arguments, background, &output,
+                session,
+                surface,
+                jobs,
+                schema_contracts,
+                tool_name,
+                arguments,
+                background,
+                &output,
             )
             .await;
         }
@@ -2100,6 +2239,7 @@ async fn handle_line(
 async fn handle_bench(
     client: &Arc<McpClient>,
     surface: &Arc<RwLock<Surface>>,
+    schema_contracts: &schema_contract::ContractSet,
     rest: &[&str],
     background: bool,
 ) {
@@ -2127,6 +2267,9 @@ async fn handle_bench(
         command_error(&format!("no tool named `{}` (try `tools`)", plan.tool));
         return;
     };
+    if !enforce_tool_contract(schema_contracts, surface, &plan.tool) {
+        return;
+    }
     let arg_tokens: Vec<&str> = plan.args.iter().map(String::as_str).collect();
     let arguments = parse_kv_args(&schema, &arg_tokens);
 
@@ -2361,6 +2504,73 @@ fn command_error(message: &str) {
     report_error(ExitStatus::Usage, message);
 }
 
+/// Render a compatibility report. Pre-invocation checks stay silent on
+/// success so one JSON command still emits exactly one JSON value.
+fn render_validation_report(
+    report: &schema_contract::ValidationReport,
+    render_success: bool,
+) -> bool {
+    if report.compatible && !render_success {
+        return true;
+    }
+    if !report.compatible {
+        note_error(ExitStatus::NoMatch);
+    }
+    if json_output() {
+        print_json(&serde_json::to_value(report).unwrap_or_default());
+    } else if report.compatible {
+        println!(
+            "{} {:?} is compatible under {} validation",
+            report.kind, report.name, report.mode
+        );
+    } else {
+        println!(
+            "{} {:?} is incompatible under {} validation:",
+            report.kind, report.name, report.mode
+        );
+        for issue in &report.issues {
+            println!("  {} [{}] {}", issue.path, issue.code, issue.message);
+        }
+    }
+    report.compatible
+}
+
+fn enforce_tool_contract(
+    contracts: &schema_contract::ContractSet,
+    surface: &Arc<RwLock<Surface>>,
+    name: &str,
+) -> bool {
+    let report = {
+        let surface = surface.read().unwrap();
+        surface
+            .tools
+            .iter()
+            .find(|definition| definition.name == name)
+            .and_then(|definition| contracts.check_tool(definition))
+    };
+    report
+        .as_ref()
+        .is_none_or(|report| render_validation_report(report, false))
+}
+
+fn enforce_prompt_contract(
+    contracts: &schema_contract::ContractSet,
+    surface: &Arc<RwLock<Surface>>,
+    name: &str,
+) -> bool {
+    let report = {
+        let surface = surface.read().unwrap();
+        surface
+            .prompts
+            .iter()
+            .find(|definition| definition.name == name)
+            .and_then(|definition| contracts.check_prompt(definition))
+    };
+    report
+        .as_ref()
+        .is_none_or(|report| render_validation_report(report, false))
+}
+
 fn describe_value(surface: &Surface, name: &str) -> Option<serde_json::Value> {
     surface
         .tools
@@ -2529,15 +2739,20 @@ fn describe(surface: &Surface, name: &str) {
     println!("nothing on the surface named `{name}` (try `tools`, `prompts`, `resources`)");
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_tool(
     session: &Arc<Session>,
     surface: &Arc<RwLock<Surface>>,
     jobs: &Arc<Jobs>,
+    schema_contracts: &schema_contract::ContractSet,
     name: &str,
     arguments: serde_json::Value,
     background: bool,
     output: &vars::Output,
 ) {
+    if !enforce_tool_contract(schema_contracts, surface, name) {
+        return;
+    }
     if background {
         match with_reconnect(session, surface, |c| {
             let arguments = arguments.clone();
@@ -3037,11 +3252,13 @@ mod tests {
         let output = AsyncOutput::new(Arc::new(AtomicBool::new(true)), true);
         let printer = output.external_printer().unwrap();
         let jobs = Arc::new(Jobs::new(output, true));
+        let schema_contracts = schema_contract::ContractSet::default();
 
         run_tool(
             &session,
             &surface,
             &jobs,
+            &schema_contracts,
             "slow_add",
             serde_json::json!({ "a": 2, "b": 3 }),
             true,

--- a/examples/mcp-repl/src/schema_contract.rs
+++ b/examples/mcp-repl/src/schema_contract.rs
@@ -1,0 +1,1358 @@
+//! Saved compatibility contracts for tool schemas and prompt arguments.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower_mcp::protocol::{PromptDefinition, ToolDefinition};
+
+const FORMAT_VERSION: u32 = 1;
+
+/// How closely the current server definition must match a saved snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationMode {
+    /// Require a byte-independent canonical JSON match.
+    Strict,
+    /// Allow changes that preserve existing callers and consumers.
+    #[default]
+    Compatible,
+    /// Load the contract but do not enforce it.
+    Ignore,
+}
+
+impl std::fmt::Display for ValidationMode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Strict => formatter.write_str("strict"),
+            Self::Compatible => formatter.write_str("compatible"),
+            Self::Ignore => formatter.write_str("ignore"),
+        }
+    }
+}
+
+/// Surface definition represented by a snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContractKind {
+    Tool,
+    Prompt,
+}
+
+impl std::fmt::Display for ContractKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tool => formatter.write_str("tool"),
+            Self::Prompt => formatter.write_str("prompt"),
+        }
+    }
+}
+
+fn string_type() -> String {
+    "string".to_string()
+}
+
+/// Prompt arguments are strings in MCP. Keeping the type explicit makes a
+/// future protocol change (or a hand-edited incompatible snapshot) visible.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PromptArgumentContract {
+    pub name: String,
+    #[serde(rename = "type", default = "string_type")]
+    pub value_type: String,
+    #[serde(default)]
+    pub required: bool,
+}
+
+/// Versioned, metadata-free schema contract for one tool or prompt.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct Snapshot {
+    pub format_version: u32,
+    pub kind: ContractKind,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub input_schema: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub arguments: Vec<PromptArgumentContract>,
+}
+
+impl Snapshot {
+    pub fn tool(definition: &ToolDefinition) -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            kind: ContractKind::Tool,
+            name: definition.name.clone(),
+            input_schema: Some(definition.input_schema.clone()),
+            output_schema: definition.output_schema.clone(),
+            arguments: Vec::new(),
+        }
+    }
+
+    pub fn prompt(definition: &PromptDefinition) -> Self {
+        Self {
+            format_version: FORMAT_VERSION,
+            kind: ContractKind::Prompt,
+            name: definition.name.clone(),
+            input_schema: None,
+            output_schema: None,
+            arguments: definition
+                .arguments
+                .iter()
+                .map(|argument| PromptArgumentContract {
+                    name: argument.name.clone(),
+                    value_type: string_type(),
+                    required: argument.required,
+                })
+                .collect(),
+        }
+    }
+
+    pub fn from_surface(
+        tools: &[ToolDefinition],
+        prompts: &[PromptDefinition],
+        selector: &str,
+    ) -> Result<Option<Self>, String> {
+        if let Some(name) = selector.strip_prefix("tool:") {
+            return Ok(tools
+                .iter()
+                .find(|definition| definition.name == name)
+                .map(Self::tool));
+        }
+        if let Some(name) = selector.strip_prefix("prompt:") {
+            return Ok(prompts
+                .iter()
+                .find(|definition| definition.name == name)
+                .map(Self::prompt));
+        }
+        let tool = tools.iter().find(|definition| definition.name == selector);
+        let prompt = prompts
+            .iter()
+            .find(|definition| definition.name == selector);
+        match (tool, prompt) {
+            (Some(_), Some(_)) => Err(format!(
+                "both a tool and prompt are named {selector:?}; use `tool:{selector}` or `prompt:{selector}`"
+            )),
+            (Some(definition), None) => Ok(Some(Self::tool(definition))),
+            (None, Some(definition)) => Ok(Some(Self::prompt(definition))),
+            (None, None) => Ok(None),
+        }
+    }
+
+    pub fn matching_surface(
+        &self,
+        tools: &[ToolDefinition],
+        prompts: &[PromptDefinition],
+    ) -> Option<Self> {
+        match self.kind {
+            ContractKind::Tool => tools
+                .iter()
+                .find(|definition| definition.name == self.name)
+                .map(Self::tool),
+            ContractKind::Prompt => prompts
+                .iter()
+                .find(|definition| definition.name == self.name)
+                .map(Self::prompt),
+        }
+    }
+
+    fn validate_shape(&self) -> Result<(), String> {
+        if self.format_version != FORMAT_VERSION {
+            return Err(format!(
+                "unsupported schema snapshot formatVersion {}; expected {FORMAT_VERSION}",
+                self.format_version
+            ));
+        }
+        if self.name.is_empty() {
+            return Err("schema snapshot has an empty name".to_string());
+        }
+        match self.kind {
+            ContractKind::Tool if self.input_schema.is_none() => {
+                Err("tool schema snapshot has no inputSchema".to_string())
+            }
+            ContractKind::Tool if !self.arguments.is_empty() => {
+                Err("tool schema snapshot unexpectedly contains prompt arguments".to_string())
+            }
+            ContractKind::Prompt if self.input_schema.is_some() || self.output_schema.is_some() => {
+                Err("prompt schema snapshot unexpectedly contains tool schemas".to_string())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Canonical JSON sorts every object key and the scalar arrays whose JSON
+    /// Schema order is semantically irrelevant.
+    pub fn canonical_value(&self) -> Value {
+        canonicalize(
+            serde_json::to_value(self).expect("schema snapshot serialization is infallible"),
+            None,
+        )
+    }
+
+    pub fn to_pretty_json(&self) -> String {
+        let mut rendered = serde_json::to_string_pretty(&self.canonical_value())
+            .expect("canonical schema snapshot serialization is infallible");
+        rendered.push('\n');
+        rendered
+    }
+
+    pub fn write(&self, path: &Path) -> Result<(), String> {
+        std::fs::write(path, self.to_pretty_json())
+            .map_err(|error| format!("{}: {error}", path.display()))
+    }
+
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let source = std::fs::read_to_string(path)
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        let snapshot: Self = serde_json::from_str(&source)
+            .map_err(|error| format!("{}: invalid schema snapshot: {error}", path.display()))?;
+        snapshot
+            .validate_shape()
+            .map_err(|error| format!("{}: {error}", path.display()))?;
+        Ok(snapshot)
+    }
+}
+
+fn canonicalize(value: Value, parent_key: Option<&str>) -> Value {
+    match value {
+        Value::Object(object) => {
+            let sorted = object
+                .into_iter()
+                .map(|(key, value)| {
+                    let value = canonicalize(value, Some(&key));
+                    (key, value)
+                })
+                .collect::<BTreeMap<_, _>>();
+            Value::Object(sorted.into_iter().collect())
+        }
+        Value::Array(values) if matches!(parent_key, Some("required" | "enum" | "type")) => {
+            let mut values = values
+                .into_iter()
+                .map(|value| canonicalize(value, None))
+                .collect::<Vec<_>>();
+            values.sort_by_key(Value::to_string);
+            Value::Array(values)
+        }
+        Value::Array(values) => Value::Array(
+            values
+                .into_iter()
+                .map(|value| canonicalize(value, None))
+                .collect(),
+        ),
+        value => value,
+    }
+}
+
+/// One stable, machine-readable compatibility finding.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationIssue {
+    pub path: String,
+    pub code: String,
+    pub message: String,
+}
+
+/// Result returned by both explicit validation and pre-invocation checks.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationReport {
+    pub compatible: bool,
+    pub mode: ValidationMode,
+    pub kind: ContractKind,
+    pub name: String,
+    pub issues: Vec<ValidationIssue>,
+}
+
+impl ValidationReport {
+    fn new(snapshot: &Snapshot, mode: ValidationMode, issues: Vec<ValidationIssue>) -> Self {
+        Self {
+            compatible: issues.is_empty(),
+            mode,
+            kind: snapshot.kind,
+            name: snapshot.name.clone(),
+            issues,
+        }
+    }
+}
+
+fn issue(path: impl Into<String>, code: &str, message: impl Into<String>) -> ValidationIssue {
+    ValidationIssue {
+        path: path.into(),
+        code: code.to_string(),
+        message: message.into(),
+    }
+}
+
+/// Compare a saved contract with the current definition of the same name.
+pub fn validate(
+    expected: &Snapshot,
+    current: Option<&Snapshot>,
+    mode: ValidationMode,
+) -> ValidationReport {
+    if mode == ValidationMode::Ignore {
+        return ValidationReport::new(expected, mode, Vec::new());
+    }
+    let Some(current) = current else {
+        return ValidationReport::new(
+            expected,
+            mode,
+            vec![issue(
+                "$",
+                "definition_removed",
+                format!(
+                    "{} {:?} is no longer advertised",
+                    expected.kind, expected.name
+                ),
+            )],
+        );
+    };
+    if expected.kind != current.kind || expected.name != current.name {
+        return ValidationReport::new(
+            expected,
+            mode,
+            vec![issue(
+                "$",
+                "identity_changed",
+                format!(
+                    "expected {} {:?}, found {} {:?}",
+                    expected.kind, expected.name, current.kind, current.name
+                ),
+            )],
+        );
+    }
+    if mode == ValidationMode::Strict {
+        let issues = (expected.canonical_value() != current.canonical_value())
+            .then(|| {
+                issue(
+                    "$",
+                    "definition_changed",
+                    "current definition does not exactly match the canonical snapshot",
+                )
+            })
+            .into_iter()
+            .collect();
+        return ValidationReport::new(expected, mode, issues);
+    }
+
+    let mut issues = Vec::new();
+    match expected.kind {
+        ContractKind::Tool => compare_tools(expected, current, &mut issues),
+        ContractKind::Prompt => compare_prompts(expected, current, &mut issues),
+    }
+    ValidationReport::new(expected, mode, issues)
+}
+
+fn compare_tools(expected: &Snapshot, current: &Snapshot, issues: &mut Vec<ValidationIssue>) {
+    let expected_input = expected
+        .input_schema
+        .as_ref()
+        .expect("validated tool snapshot input");
+    let current_input = current
+        .input_schema
+        .as_ref()
+        .expect("current tool snapshot input");
+    compare_schema(
+        expected_input,
+        current_input,
+        expected_input,
+        current_input,
+        Direction::Input,
+        "$.inputSchema",
+        issues,
+        &mut HashSet::new(),
+    );
+
+    match (&expected.output_schema, &current.output_schema) {
+        (Some(expected_output), Some(current_output)) => compare_schema(
+            expected_output,
+            current_output,
+            expected_output,
+            current_output,
+            Direction::Output,
+            "$.outputSchema",
+            issues,
+            &mut HashSet::new(),
+        ),
+        (Some(_), None) => issues.push(issue(
+            "$.outputSchema",
+            "output_schema_removed",
+            "tool no longer advertises its expected output schema",
+        )),
+        (None, _) => {}
+    }
+}
+
+fn compare_prompts(expected: &Snapshot, current: &Snapshot, issues: &mut Vec<ValidationIssue>) {
+    let current_arguments = current
+        .arguments
+        .iter()
+        .map(|argument| (argument.name.as_str(), argument))
+        .collect::<BTreeMap<_, _>>();
+    let expected_required = expected
+        .arguments
+        .iter()
+        .filter(|argument| argument.required)
+        .map(|argument| argument.name.as_str())
+        .collect::<BTreeSet<_>>();
+
+    for argument in &expected.arguments {
+        let path = format!("$.arguments.{}", argument.name);
+        let Some(current) = current_arguments.get(argument.name.as_str()) else {
+            issues.push(issue(
+                path,
+                "argument_removed",
+                format!("prompt argument {:?} was removed", argument.name),
+            ));
+            continue;
+        };
+        if argument.value_type != current.value_type {
+            issues.push(issue(
+                &path,
+                "argument_retyped",
+                format!(
+                    "prompt argument {:?} changed type from {:?} to {:?}",
+                    argument.name, argument.value_type, current.value_type
+                ),
+            ));
+        }
+        if !argument.required && current.required {
+            issues.push(issue(
+                path,
+                "argument_newly_required",
+                format!("prompt argument {:?} is now required", argument.name),
+            ));
+        }
+    }
+    for argument in &current.arguments {
+        if argument.required && !expected_required.contains(argument.name.as_str()) {
+            let existed = expected
+                .arguments
+                .iter()
+                .any(|expected| expected.name == argument.name);
+            if !existed {
+                issues.push(issue(
+                    format!("$.arguments.{}", argument.name),
+                    "argument_newly_required",
+                    format!("new prompt argument {:?} is required", argument.name),
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum Direction {
+    Input,
+    Output,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_schema(
+    expected_root: &Value,
+    current_root: &Value,
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+    seen: &mut HashSet<(usize, usize, Direction)>,
+) {
+    let expected = match resolve_local_ref(expected_root, expected) {
+        Ok(value) => value,
+        Err(message) => {
+            issues.push(issue(path, "invalid_expected_ref", message));
+            return;
+        }
+    };
+    let current = match resolve_local_ref(current_root, current) {
+        Ok(value) => value,
+        Err(message) => {
+            issues.push(issue(path, "invalid_current_ref", message));
+            return;
+        }
+    };
+    if expected.is_boolean() || current.is_boolean() {
+        let expected_class = schema_class(expected);
+        let current_class = schema_class(current);
+        let compatible = match direction {
+            Direction::Input => {
+                matches!(expected_class, SchemaClass::None)
+                    || matches!(current_class, SchemaClass::Any)
+                    || expected_class == current_class
+            }
+            Direction::Output => {
+                matches!(expected_class, SchemaClass::Any)
+                    || matches!(current_class, SchemaClass::None)
+                    || expected_class == current_class
+            }
+        };
+        if !compatible {
+            issues.push(issue(
+                path,
+                "boolean_schema_changed",
+                format!("{} boolean schema changed incompatibly", direction.label()),
+            ));
+        }
+        return;
+    }
+    let pair = (
+        expected as *const Value as usize,
+        current as *const Value as usize,
+        direction,
+    );
+    if !seen.insert(pair) {
+        return;
+    }
+
+    compare_types(expected, current, direction, path, issues);
+    compare_allowed_values(expected, current, direction, path, issues);
+    compare_constraints(expected, current, direction, path, issues);
+    compare_object(
+        expected_root,
+        current_root,
+        expected,
+        current,
+        direction,
+        path,
+        issues,
+        seen,
+    );
+    compare_array(
+        expected_root,
+        current_root,
+        expected,
+        current,
+        direction,
+        path,
+        issues,
+        seen,
+    );
+
+    for keyword in [
+        "anyOf",
+        "oneOf",
+        "allOf",
+        "not",
+        "prefixItems",
+        "contains",
+        "dependentRequired",
+        "propertyNames",
+        "patternProperties",
+    ] {
+        if expected.get(keyword).map(canonical_ref) != current.get(keyword).map(canonical_ref) {
+            issues.push(issue(
+                format!("{path}.{keyword}"),
+                "schema_composition_changed",
+                format!("JSON Schema keyword {keyword:?} changed"),
+            ));
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SchemaClass {
+    Any,
+    None,
+    Concrete,
+}
+
+fn schema_class(schema: &Value) -> SchemaClass {
+    match schema {
+        Value::Bool(true) => SchemaClass::Any,
+        Value::Bool(false) => SchemaClass::None,
+        _ => SchemaClass::Concrete,
+    }
+}
+
+fn canonical_ref(value: &Value) -> Value {
+    canonicalize(value.clone(), None)
+}
+
+fn resolve_local_ref<'a>(root: &'a Value, value: &'a Value) -> Result<&'a Value, String> {
+    let mut value = value;
+    let mut visited = HashSet::new();
+    for _ in 0..64 {
+        let Some(reference) = value.get("$ref").and_then(Value::as_str) else {
+            return Ok(value);
+        };
+        if !reference.starts_with('#') {
+            return Err(format!(
+                "external JSON Schema reference {reference:?} cannot be compared offline"
+            ));
+        }
+        if !visited.insert(reference.to_string()) {
+            return Ok(value);
+        }
+        let pointer = reference.strip_prefix('#').unwrap_or_default();
+        value = root
+            .pointer(pointer)
+            .ok_or_else(|| format!("unresolved local JSON Schema reference {reference:?}"))?;
+    }
+    Err("JSON Schema reference chain exceeds 64 entries".to_string())
+}
+
+fn schema_types(schema: &Value) -> Option<BTreeSet<&str>> {
+    match schema.get("type") {
+        Some(Value::String(value)) => Some(BTreeSet::from([value.as_str()])),
+        Some(Value::Array(values)) => Some(values.iter().filter_map(Value::as_str).collect()),
+        _ => schema
+            .get("const")
+            .map(|value| BTreeSet::from([json_type(value)]))
+            .or_else(|| {
+                schema
+                    .get("enum")
+                    .and_then(Value::as_array)
+                    .map(|values| values.iter().map(json_type).collect())
+            }),
+    }
+}
+
+fn json_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn accepts_type(allowed: &BTreeSet<&str>, candidate: &str) -> bool {
+    allowed.contains(candidate) || (candidate == "integer" && allowed.contains("number"))
+}
+
+fn compare_types(
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let expected_types = schema_types(expected);
+    let current_types = schema_types(current);
+    let compatible = match (direction, &expected_types, &current_types) {
+        (_, None, None) => true,
+        (Direction::Input, Some(_), None) => true,
+        (Direction::Input, None, Some(_)) => false,
+        (Direction::Input, Some(expected), Some(current)) => expected
+            .iter()
+            .all(|candidate| accepts_type(current, candidate)),
+        (Direction::Output, None, Some(_)) => true,
+        (Direction::Output, Some(_), None) => false,
+        (Direction::Output, Some(expected), Some(current)) => current
+            .iter()
+            .all(|candidate| accepts_type(expected, candidate)),
+    };
+    if !compatible {
+        issues.push(issue(
+            format!("{path}.type"),
+            "schema_retyped",
+            format!(
+                "schema type changed incompatibly from {} to {}",
+                type_label(expected_types.as_ref()),
+                type_label(current_types.as_ref())
+            ),
+        ));
+    }
+}
+
+fn type_label(types: Option<&BTreeSet<&str>>) -> String {
+    types
+        .map(|types| types.iter().copied().collect::<Vec<_>>().join(" | "))
+        .unwrap_or_else(|| "any".to_string())
+}
+
+fn allowed_values(schema: &Value) -> Option<BTreeSet<String>> {
+    if let Some(value) = schema.get("const") {
+        return Some(BTreeSet::from([canonical_ref(value).to_string()]));
+    }
+    schema.get("enum").and_then(Value::as_array).map(|values| {
+        values
+            .iter()
+            .map(|value| canonical_ref(value).to_string())
+            .collect()
+    })
+}
+
+fn compare_allowed_values(
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let expected = allowed_values(expected);
+    let current = allowed_values(current);
+    let compatible = match (direction, &expected, &current) {
+        (_, None, None) => true,
+        (Direction::Input, Some(_), None) => true,
+        (Direction::Input, None, Some(_)) => false,
+        (Direction::Input, Some(expected), Some(current)) => expected.is_subset(current),
+        (Direction::Output, None, Some(_)) => true,
+        (Direction::Output, Some(_), None) => false,
+        (Direction::Output, Some(expected), Some(current)) => current.is_subset(expected),
+    };
+    if !compatible {
+        issues.push(issue(
+            path,
+            "allowed_values_changed",
+            "enum/const values changed incompatibly",
+        ));
+    }
+}
+
+fn compare_constraints(
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    for keyword in [
+        "minimum",
+        "exclusiveMinimum",
+        "minLength",
+        "minItems",
+        "minProperties",
+        "minContains",
+    ] {
+        compare_bound(expected, current, direction, path, keyword, true, issues);
+    }
+    for keyword in [
+        "maximum",
+        "exclusiveMaximum",
+        "maxLength",
+        "maxItems",
+        "maxProperties",
+        "maxContains",
+    ] {
+        compare_bound(expected, current, direction, path, keyword, false, issues);
+    }
+    for keyword in ["pattern", "format", "multipleOf", "uniqueItems"] {
+        let expected_value = constraint_value(expected, keyword);
+        let current_value = constraint_value(current, keyword);
+        let compatible = match (direction, &expected_value, &current_value) {
+            (_, None, None) => true,
+            (Direction::Input, Some(_), None) => true,
+            (Direction::Input, None, Some(_)) => false,
+            (Direction::Input, Some(expected), Some(current)) => expected == current,
+            (Direction::Output, None, Some(_)) => true,
+            (Direction::Output, Some(_), None) => false,
+            (Direction::Output, Some(expected), Some(current)) => expected == current,
+        };
+        if !compatible {
+            issues.push(issue(
+                format!("{path}.{keyword}"),
+                "schema_constraint_changed",
+                format!(
+                    "{} constraint {keyword:?} changed incompatibly",
+                    direction.label()
+                ),
+            ));
+        }
+    }
+}
+
+fn constraint_value(schema: &Value, keyword: &str) -> Option<Value> {
+    let value = schema.get(keyword)?;
+    if keyword == "uniqueItems" && value == &Value::Bool(false) {
+        None
+    } else {
+        Some(canonical_ref(value))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_bound(
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    keyword: &str,
+    lower: bool,
+    issues: &mut Vec<ValidationIssue>,
+) {
+    let expected_value = bound_value(expected, keyword);
+    let current_value = bound_value(current, keyword);
+    let compatible = match (direction, expected_value, current_value, lower) {
+        (_, None, None, _) => true,
+        (Direction::Input, Some(_), None, _) => true,
+        (Direction::Input, None, Some(_), _) => false,
+        (Direction::Input, Some(expected), Some(current), true) => current <= expected,
+        (Direction::Input, Some(expected), Some(current), false) => current >= expected,
+        (Direction::Output, None, Some(_), _) => true,
+        (Direction::Output, Some(_), None, _) => false,
+        (Direction::Output, Some(expected), Some(current), true) => current >= expected,
+        (Direction::Output, Some(expected), Some(current), false) => current <= expected,
+    };
+    if !compatible {
+        issues.push(issue(
+            format!("{path}.{keyword}"),
+            "schema_constraint_changed",
+            format!(
+                "{} constraint {keyword:?} changed incompatibly",
+                direction.label()
+            ),
+        ));
+    }
+}
+
+fn bound_value(schema: &Value, keyword: &str) -> Option<f64> {
+    let value = schema.get(keyword).and_then(Value::as_f64)?;
+    if matches!(keyword, "minLength" | "minItems" | "minProperties") && value == 0.0 {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_object(
+    expected_root: &Value,
+    current_root: &Value,
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+    seen: &mut HashSet<(usize, usize, Direction)>,
+) {
+    let expected_properties = expected.get("properties").and_then(Value::as_object);
+    let current_properties = current.get("properties").and_then(Value::as_object);
+    let expected_required = required(expected);
+    let current_required = required(current);
+
+    for (name, expected_property) in expected_properties.into_iter().flatten() {
+        let property_path = format!("{path}.properties.{name}");
+        let Some(current_property) = current_properties.and_then(|properties| properties.get(name))
+        else {
+            issues.push(issue(
+                property_path,
+                match direction {
+                    Direction::Input => "input_removed",
+                    Direction::Output => "output_removed",
+                },
+                format!("{} property {name:?} was removed", direction.label()),
+            ));
+            continue;
+        };
+        compare_schema(
+            expected_root,
+            current_root,
+            expected_property,
+            current_property,
+            direction,
+            &property_path,
+            issues,
+            seen,
+        );
+    }
+
+    match direction {
+        Direction::Input => {
+            for name in current_required.difference(&expected_required) {
+                issues.push(issue(
+                    format!("{path}.properties.{name}"),
+                    "input_newly_required",
+                    format!("input property {name:?} is newly required"),
+                ));
+            }
+        }
+        Direction::Output => {
+            for name in expected_required.difference(&current_required) {
+                issues.push(issue(
+                    format!("{path}.properties.{name}"),
+                    "required_output_no_longer_guaranteed",
+                    format!("output property {name:?} is no longer required"),
+                ));
+            }
+        }
+    }
+
+    compare_additional_properties(
+        expected_root,
+        current_root,
+        expected,
+        current,
+        direction,
+        path,
+        issues,
+        seen,
+    );
+}
+
+impl Direction {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Input => "input",
+            Self::Output => "output",
+        }
+    }
+}
+
+fn required(schema: &Value) -> BTreeSet<String> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+enum AdditionalProperties<'a> {
+    Any,
+    None,
+    Schema(&'a Value),
+}
+
+fn additional_properties(schema: &Value) -> AdditionalProperties<'_> {
+    match schema.get("additionalProperties") {
+        Some(Value::Bool(false)) => AdditionalProperties::None,
+        Some(Value::Object(object)) if object.is_empty() => AdditionalProperties::Any,
+        Some(value @ Value::Object(_)) => AdditionalProperties::Schema(value),
+        _ => AdditionalProperties::Any,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_additional_properties(
+    expected_root: &Value,
+    current_root: &Value,
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+    seen: &mut HashSet<(usize, usize, Direction)>,
+) {
+    let expected = additional_properties(expected);
+    let current = additional_properties(current);
+    let incompatible = match (direction, expected, current) {
+        (Direction::Input, AdditionalProperties::Any, AdditionalProperties::Any)
+        | (Direction::Input, AdditionalProperties::None, _)
+        | (Direction::Input, AdditionalProperties::Schema(_), AdditionalProperties::Any)
+        | (Direction::Output, AdditionalProperties::Any, _)
+        | (Direction::Output, AdditionalProperties::None, AdditionalProperties::None)
+        | (Direction::Output, AdditionalProperties::Schema(_), AdditionalProperties::None) => false,
+        (_, AdditionalProperties::Schema(expected), AdditionalProperties::Schema(current)) => {
+            compare_schema(
+                expected_root,
+                current_root,
+                expected,
+                current,
+                direction,
+                &format!("{path}.additionalProperties"),
+                issues,
+                seen,
+            );
+            false
+        }
+        _ => true,
+    };
+    if incompatible {
+        issues.push(issue(
+            format!("{path}.additionalProperties"),
+            "additional_properties_changed",
+            format!(
+                "{} additionalProperties changed incompatibly",
+                direction.label()
+            ),
+        ));
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compare_array(
+    expected_root: &Value,
+    current_root: &Value,
+    expected: &Value,
+    current: &Value,
+    direction: Direction,
+    path: &str,
+    issues: &mut Vec<ValidationIssue>,
+    seen: &mut HashSet<(usize, usize, Direction)>,
+) {
+    match (expected.get("items"), current.get("items"), direction) {
+        (Some(expected), Some(current), _) => compare_schema(
+            expected_root,
+            current_root,
+            expected,
+            current,
+            direction,
+            &format!("{path}.items"),
+            issues,
+            seen,
+        ),
+        (None, Some(_), Direction::Input) | (Some(_), None, Direction::Output) => {
+            issues.push(issue(
+                format!("{path}.items"),
+                "array_items_changed",
+                format!("{} array items became less compatible", direction.label()),
+            ));
+        }
+        _ => {}
+    }
+}
+
+/// Preloaded snapshots selected with repeated `--schema-contract` flags.
+#[derive(Default)]
+pub struct ContractSet {
+    mode: ValidationMode,
+    snapshots: BTreeMap<(ContractKind, String), (PathBuf, Snapshot)>,
+}
+
+impl ContractSet {
+    pub fn load(paths: &[PathBuf], mode: ValidationMode) -> Result<Self, String> {
+        let mut snapshots = BTreeMap::new();
+        for path in paths {
+            let snapshot = Snapshot::load(path)?;
+            let key = (snapshot.kind, snapshot.name.clone());
+            if let Some((previous, _)) = snapshots.insert(key, (path.clone(), snapshot)) {
+                return Err(format!(
+                    "{} duplicates schema contract {}",
+                    path.display(),
+                    previous.display()
+                ));
+            }
+        }
+        Ok(Self { mode, snapshots })
+    }
+
+    pub fn mode(&self) -> ValidationMode {
+        self.mode
+    }
+
+    pub fn check_tool(&self, definition: &ToolDefinition) -> Option<ValidationReport> {
+        self.snapshots
+            .get(&(ContractKind::Tool, definition.name.clone()))
+            .map(|(_, expected)| validate(expected, Some(&Snapshot::tool(definition)), self.mode))
+    }
+
+    pub fn check_prompt(&self, definition: &PromptDefinition) -> Option<ValidationReport> {
+        self.snapshots
+            .get(&(ContractKind::Prompt, definition.name.clone()))
+            .map(|(_, expected)| validate(expected, Some(&Snapshot::prompt(definition)), self.mode))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_mcp::protocol::{PromptArgument, ToolDefinition};
+
+    fn tool(name: &str, input: Value, output: Option<Value>) -> Snapshot {
+        Snapshot::tool(&ToolDefinition {
+            name: name.to_string(),
+            title: None,
+            description: None,
+            input_schema: input,
+            output_schema: output,
+            icons: None,
+            annotations: None,
+            execution: None,
+            meta: None,
+        })
+    }
+
+    fn prompt(arguments: &[(&str, bool)]) -> Snapshot {
+        Snapshot::prompt(&PromptDefinition {
+            name: "greet".to_string(),
+            title: None,
+            description: None,
+            icons: None,
+            arguments: arguments
+                .iter()
+                .map(|(name, required)| PromptArgument {
+                    name: (*name).to_string(),
+                    description: None,
+                    required: *required,
+                })
+                .collect(),
+            meta: None,
+        })
+    }
+
+    #[test]
+    fn canonical_export_sorts_schema_keys_and_unordered_scalar_arrays() {
+        let snapshot = tool(
+            "x",
+            serde_json::json!({
+                "required": ["z", "a"],
+                "properties": {
+                    "z": {"type": ["null", "string"]},
+                    "a": {"type": "integer"}
+                },
+                "type": "object"
+            }),
+            None,
+        );
+        let rendered = snapshot.to_pretty_json();
+        assert!(rendered.find("formatVersion").unwrap() < rendered.find("inputSchema").unwrap());
+        assert!(rendered.find("\"a\"").unwrap() < rendered.find("\"z\"").unwrap());
+        assert!(rendered.find("\"null\"").unwrap() < rendered.find("\"string\"").unwrap());
+        assert!(rendered.ends_with('\n'));
+    }
+
+    #[test]
+    fn compatible_tool_allows_additive_optional_input_and_output() {
+        let expected = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"]
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"count": {"type": "number"}},
+                "required": ["count"]
+            })),
+        );
+        let current = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"}
+                },
+                "required": ["query"]
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                    "next": {"type": "string"}
+                },
+                "required": ["count", "next"]
+            })),
+        );
+        assert!(validate(&expected, Some(&current), ValidationMode::Compatible).compatible);
+    }
+
+    #[test]
+    fn compatible_tool_reports_removed_retyped_and_newly_required_fields() {
+        let expected = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "limit": {"type": "integer"}
+                }
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                    "label": {"type": "string"}
+                },
+                "required": ["count", "label"]
+            })),
+        );
+        let current = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "number"},
+                    "page": {"type": "integer"}
+                },
+                "required": ["query", "page"]
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"count": {"type": "string"}},
+                "required": ["count"]
+            })),
+        );
+        let report = validate(&expected, Some(&current), ValidationMode::Compatible);
+        let codes = report
+            .issues
+            .iter()
+            .map(|issue| issue.code.as_str())
+            .collect::<BTreeSet<_>>();
+        assert!(!report.compatible);
+        assert!(codes.contains("input_removed"));
+        assert!(codes.contains("input_newly_required"));
+        assert!(codes.contains("schema_retyped"));
+        assert!(codes.contains("output_removed"));
+        assert!(codes.contains("required_output_no_longer_guaranteed"));
+    }
+
+    #[test]
+    fn compatible_tool_applies_constraints_in_the_safe_direction() {
+        let expected = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {"query": {"type": "string", "maxLength": 20}}
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"score": {"type": "number", "minimum": 0}}
+            })),
+        );
+        let breaking = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {"query": {"type": "string", "maxLength": 10}}
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"score": {"type": "number", "minimum": -1}}
+            })),
+        );
+        let report = validate(&expected, Some(&breaking), ValidationMode::Compatible);
+        assert_eq!(
+            report
+                .issues
+                .iter()
+                .filter(|issue| issue.code == "schema_constraint_changed")
+                .count(),
+            2
+        );
+
+        let safe = tool(
+            "x",
+            serde_json::json!({
+                "type": "object",
+                "properties": {"query": {"type": "string", "maxLength": 30}}
+            }),
+            Some(serde_json::json!({
+                "type": "object",
+                "properties": {"score": {"type": "number", "minimum": 1}}
+            })),
+        );
+        assert!(validate(&expected, Some(&safe), ValidationMode::Compatible).compatible);
+    }
+
+    #[test]
+    fn boolean_schemas_follow_input_and_output_variance() {
+        let expected = tool("x", Value::Bool(true), Some(Value::Bool(true)));
+        let input_narrowed = tool("x", Value::Bool(false), Some(Value::Bool(true)));
+        assert!(!validate(&expected, Some(&input_narrowed), ValidationMode::Compatible).compatible);
+
+        let output_narrowed = tool("x", Value::Bool(true), Some(Value::Bool(false)));
+        assert!(
+            validate(
+                &expected,
+                Some(&output_narrowed),
+                ValidationMode::Compatible
+            )
+            .compatible
+        );
+    }
+
+    #[test]
+    fn nested_local_references_are_compared_recursively() {
+        let expected = tool(
+            "x",
+            serde_json::json!({
+                "$defs": {
+                    "filter": {
+                        "type": "object",
+                        "properties": {"term": {"type": "string"}}
+                    }
+                },
+                "type": "object",
+                "properties": {"filter": {"$ref": "#/$defs/filter"}}
+            }),
+            None,
+        );
+        let current = tool(
+            "x",
+            serde_json::json!({
+                "$defs": {
+                    "filter": {
+                        "type": "object",
+                        "properties": {"term": {"type": "number"}}
+                    }
+                },
+                "type": "object",
+                "properties": {"filter": {"$ref": "#/$defs/filter"}}
+            }),
+            None,
+        );
+        let report = validate(&expected, Some(&current), ValidationMode::Compatible);
+        assert!(!report.compatible);
+        assert!(report.issues.iter().any(|issue| {
+            issue.code == "schema_retyped"
+                && issue.path == "$.inputSchema.properties.filter.properties.term.type"
+        }));
+    }
+
+    #[test]
+    fn prompt_validation_allows_optional_additions_and_rejects_breaks() {
+        let expected = prompt(&[("name", false), ("tone", true)]);
+        let additive = prompt(&[("name", false), ("tone", false), ("language", false)]);
+        assert!(validate(&expected, Some(&additive), ValidationMode::Compatible).compatible);
+
+        let breaking = prompt(&[("name", true), ("language", true)]);
+        let report = validate(&expected, Some(&breaking), ValidationMode::Compatible);
+        assert!(!report.compatible);
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.code == "argument_removed")
+        );
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.code == "argument_newly_required")
+        );
+
+        let mut retyped = expected.clone();
+        retyped.arguments[0].value_type = "number".to_string();
+        let report = validate(&expected, Some(&retyped), ValidationMode::Compatible);
+        assert!(
+            report
+                .issues
+                .iter()
+                .any(|issue| issue.code == "argument_retyped")
+        );
+    }
+
+    #[test]
+    fn strict_and_ignore_modes_are_explicit() {
+        let expected = prompt(&[("name", false)]);
+        let current = prompt(&[("name", false), ("tone", false)]);
+        assert!(!validate(&expected, Some(&current), ValidationMode::Strict).compatible);
+        assert!(validate(&expected, None, ValidationMode::Ignore).compatible);
+    }
+
+    #[test]
+    fn snapshot_round_trip_and_contract_set_are_file_backed() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("greet.schema.json");
+        let expected = prompt(&[("name", true)]);
+        expected.write(&path).unwrap();
+        assert_eq!(Snapshot::load(&path).unwrap(), expected);
+
+        let set = ContractSet::load(&[path], ValidationMode::Compatible).unwrap();
+        let definition = PromptDefinition {
+            name: "greet".to_string(),
+            title: None,
+            description: None,
+            icons: None,
+            arguments: vec![PromptArgument {
+                name: "name".to_string(),
+                description: None,
+                required: true,
+            }],
+            meta: None,
+        };
+        assert!(set.check_prompt(&definition).unwrap().compatible);
+    }
+}

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -434,6 +434,135 @@ async fn exercise_imported_stdio_config(fixture: &Path, temp: &TempDir) {
     );
 }
 
+async fn exercise_schema_contracts(fixture: &Path, temp: &TempDir) {
+    let snapshot_path = temp.path().join("add.schema.json");
+    let snapshot_command = format!("snapshot add '{}'", snapshot_path.display());
+    let exported = run_stdio(
+        fixture,
+        temp,
+        "schema-export",
+        &["--json", "--exec", &snapshot_command],
+    )
+    .await;
+    assert_success(&exported, "schema snapshot export");
+    let snapshot: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&snapshot_path).expect("read exported schema snapshot"),
+    )
+    .expect("exported schema snapshot JSON");
+    assert_eq!(snapshot["formatVersion"], 1);
+    assert_eq!(snapshot["kind"], "tool");
+    assert_eq!(snapshot["name"], "add");
+
+    let validate_command = format!("validate '{}' strict", snapshot_path.display());
+    let validated = run_stdio(
+        fixture,
+        temp,
+        "schema-validate",
+        &["--json", "--exec", &validate_command],
+    )
+    .await;
+    assert_success(&validated, "strict schema validation");
+    let values = json_lines(&validated, "strict schema validation");
+    assert_eq!(values.len(), 1);
+    assert_eq!(values[0]["compatible"], true);
+    assert_eq!(values[0]["mode"], "strict");
+
+    let mut incompatible = snapshot;
+    incompatible["inputSchema"]["properties"]["a"]["type"] = serde_json::json!("string");
+    std::fs::write(
+        &snapshot_path,
+        serde_json::to_string_pretty(&incompatible).unwrap(),
+    )
+    .expect("write incompatible schema snapshot");
+    let snapshot_path = snapshot_path.to_string_lossy().into_owned();
+    let blocked = run_stdio(
+        fixture,
+        temp,
+        "schema-preflight",
+        &[
+            "--json",
+            "--schema-contract",
+            &snapshot_path,
+            "--exec",
+            "add a=20 b=22",
+        ],
+    )
+    .await;
+    assert_status(&blocked, 1, "incompatible schema preflight");
+    let values = json_lines(&blocked, "incompatible schema preflight");
+    assert_eq!(values.len(), 1, "the blocked tool must not emit a result");
+    assert_eq!(values[0]["compatible"], false);
+    assert!(
+        values[0]["issues"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|issue| issue["code"] == "schema_retyped")
+    );
+
+    let human_validate = format!("validate '{}' compatible", snapshot_path);
+    let explained = run_stdio(
+        fixture,
+        temp,
+        "schema-human-report",
+        &["--exec", &human_validate],
+    )
+    .await;
+    assert_status(&explained, 1, "human schema validation");
+    let stdout = String::from_utf8_lossy(&explained.stdout);
+    assert!(stdout.contains("incompatible"), "{stdout}");
+    assert!(stdout.contains("schema_retyped"), "{stdout}");
+    assert!(
+        stdout.contains("$.inputSchema.properties.a.type"),
+        "{stdout}"
+    );
+
+    let prompt_path = temp.path().join("greet.schema.json");
+    let snapshot_prompt = format!("snapshot prompt:greet '{}'", prompt_path.display());
+    let exported = run_stdio(
+        fixture,
+        temp,
+        "prompt-schema-export",
+        &["--json", "--exec", &snapshot_prompt],
+    )
+    .await;
+    assert_success(&exported, "prompt schema snapshot export");
+    let mut prompt_snapshot: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(&prompt_path).expect("read prompt schema snapshot"),
+    )
+    .expect("prompt schema snapshot JSON");
+    prompt_snapshot["arguments"][0]["required"] = serde_json::json!(false);
+    std::fs::write(
+        &prompt_path,
+        serde_json::to_string_pretty(&prompt_snapshot).unwrap(),
+    )
+    .expect("write incompatible prompt snapshot");
+    let prompt_path = prompt_path.to_string_lossy().into_owned();
+    let blocked = run_stdio(
+        fixture,
+        temp,
+        "prompt-schema-preflight",
+        &[
+            "--json",
+            "--schema-contract",
+            &prompt_path,
+            "--exec",
+            "prompt greet name=Ada",
+        ],
+    )
+    .await;
+    assert_status(&blocked, 1, "incompatible prompt schema preflight");
+    let values = json_lines(&blocked, "incompatible prompt schema preflight");
+    assert_eq!(values.len(), 1, "the blocked prompt must not emit a result");
+    assert!(
+        values[0]["issues"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|issue| issue["code"] == "argument_newly_required")
+    );
+}
+
 async fn exercise_imported_http_config(http: &HttpFixture, temp: &TempDir) {
     let config = temp.path().join("vscode-mcp.json");
     std::fs::write(
@@ -626,6 +755,7 @@ async fn published_cli_covers_transports_and_protocol_lifecycles() {
         let temp = TempDir::new().expect("temporary fixture directory");
         let fixture = build_fixture().await;
         exercise_json_contract(&fixture, &temp).await;
+        exercise_schema_contracts(&fixture, &temp).await;
         exercise_imported_stdio_config(&fixture, &temp).await;
         exercise_stdio(&fixture, &temp).await;
         exercise_http(&fixture, &temp).await;


### PR DESCRIPTION
Closes #1154.

## Summary

- add canonical, versioned, metadata-free snapshots for tools and prompts
- add interactive `snapshot <name> [path]` and `validate <path> [strict|compatible|ignore]` commands
- add repeatable startup enforcement through `--schema-contract PATH` and `--schema-mode`
- enforce selected contracts before direct, raw, background, benchmark, and prompt invocations
- emit stable JSON validation reports with non-zero status and actionable human explanations
- compare nested object/array schemas, required fields, types, enum/const values, numeric/string/array constraints, and `additionalProperties`
- implement compatibility variance for input and output schemas, including integer-as-number subtype handling and boolean schemas
- resolve local `$ref` values offline with cycle protection; reject external references
- conservatively require exact matches for complex compositions that cannot be proven compatible
- document snapshot workflows, CI usage, mode semantics, and pre-invocation enforcement

## Compatibility policy

For tool inputs, a compatible server accepts every value the snapshot promised: optional additions are allowed, but removed/retyped fields, newly required inputs, or tighter constraints fail. For expected tool outputs, the current server must continue producing values allowed by the snapshot: additive optional output fields are allowed, while removed/retyped expected fields and looser incompatible output constraints fail. Prompt compatibility applies the input-side policy to prompt arguments.

## Tests

- 142 mcp-repl unit tests, including compatible/strict/ignore behavior, nested local references, constraints, boolean schemas, canonicalization, and file-backed contract sets
- binary E2E coverage for snapshot export, strict and compatible validation, JSON reports/exit status, and pre-invocation blocking
- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --all-features --doc`
