### PR TITLE
feat(mcp-repl): add secure OAuth profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +106,137 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -264,6 +406,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,10 +446,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cc"
@@ -332,6 +511,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.6",
+ "inout",
 ]
 
 [[package]]
@@ -412,6 +601,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -735,6 +933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +1036,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +1076,26 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -984,6 +1239,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1121,6 +1389,27 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -1391,6 +1680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1561,6 +1860,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,7 +1951,10 @@ name = "mcp-repl"
 version = "0.1.8"
 dependencies = [
  "async-trait",
+ "base64 0.23.0",
  "clap",
+ "getrandom 0.4.3",
+ "keyring",
  "nu-ansi-term",
  "reedline",
  "serde",
@@ -1642,6 +1965,7 @@ dependencies = [
  "toml_edit",
  "tower-mcp",
  "tracing-subscriber",
+ "webbrowser",
 ]
 
 [[package]]
@@ -1649,6 +1973,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "micromap"
@@ -1673,6 +2006,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1769,6 +2108,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,6 +2174,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +2200,12 @@ dependencies = [
  "primeorder",
  "sha2 0.10.9",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -1865,6 +2268,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1872,6 +2286,20 @@ checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1905,6 +2333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2523,6 +2960,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2614,6 +3070,17 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3473,6 +3940,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3558,6 +4036,7 @@ checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -3730,6 +4209,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "webbrowser"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6eb50cc7b133f0c7720a64661fbd8e520b882f8ab9015deea5e00d5cd809c4"
+dependencies = [
+ "jni",
+ "log",
+ "ndk-context",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "url",
+ "web-sys",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3809,6 +4304,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-registry"
@@ -4040,6 +4548,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,3 +4718,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
+ "winnow",
+]

--- a/crates/tower-mcp/src/client/oauth_flow.rs
+++ b/crates/tower-mcp/src/client/oauth_flow.rs
@@ -995,8 +995,8 @@ impl OAuthAuthorizationFlow {
         };
 
         if let Some(token) = self.inner.token_store.load(&binding).await?
-            && token_is_valid(&token, self.inner.refresh_buffer)
             && scopes_are_covered(&scopes, &token.scopes)
+            && (token_is_valid(&token, self.inner.refresh_buffer) || token.refresh_token.is_some())
         {
             *self.inner.current.write().await = Some(ActiveToken {
                 binding,
@@ -1005,6 +1005,9 @@ impl OAuthAuthorizationFlow {
                 registration,
                 auth_method,
             });
+            if !token_is_valid(&token, self.inner.refresh_buffer) {
+                TokenProvider::get_token(self).await?;
+            }
             return Ok(OAuthAuthorizationStart::Authorized {
                 scopes: token.scopes,
             });
@@ -1785,12 +1788,16 @@ async fn prepare_redirect(
 
 async fn run_loopback_callback(
     listener: tokio::net::TcpListener,
-    sender: oneshot::Sender<String>,
+    mut sender: oneshot::Sender<String>,
     callback_base: String,
 ) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let Ok((mut stream, _)) = listener.accept().await else {
+    let accepted = tokio::select! {
+        _ = sender.closed() => return,
+        accepted = listener.accept() => accepted,
+    };
+    let Ok((mut stream, _)) = accepted else {
         return;
     };
     let mut bytes = vec![0_u8; 8192];
@@ -2329,6 +2336,64 @@ mod tests {
                 "resource".to_string(),
                 "https://mcp.example.com/mcp".to_string()
             )));
+    }
+
+    #[tokio::test]
+    async fn expired_persisted_token_refreshes_after_flow_rebuild() {
+        let http = MockOAuthHttp::new(RegistrationMode::Dynamic).expiring();
+        let tokens = MemoryOAuthTokenStore::new();
+        let registrations = super::super::oauth_authcode::MemoryOAuthClientRegistrationStore::new();
+        let first_handler = AutomaticAuthorizationHandler::default();
+
+        let first = flow_builder(http.clone(), dynamic_options(), first_handler)
+            .registration_store(registrations.clone())
+            .token_store(tokens.clone())
+            .refresh_buffer(Duration::ZERO)
+            .build()
+            .unwrap();
+        first.authorize(["challenge.scope"]).await.unwrap();
+
+        let restored_handler = AutomaticAuthorizationHandler::default();
+        let restored_calls = restored_handler.calls.clone();
+        let restored = flow_builder(http, dynamic_options(), restored_handler)
+            .registration_store(registrations)
+            .token_store(tokens)
+            .refresh_buffer(Duration::ZERO)
+            .build()
+            .unwrap();
+
+        let start = restored.begin(["challenge.scope"]).await.unwrap();
+        assert!(matches!(start, OAuthAuthorizationStart::Authorized { .. }));
+        assert_eq!(restored_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(restored.get_token().await.unwrap(), "refreshed-token");
+    }
+
+    #[tokio::test]
+    async fn dropped_loopback_attempt_releases_its_listener() {
+        let probe = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        let (_, receiver) = prepare_redirect(
+            &OAuthRedirectPolicy::loopback_at(port, "/callback"),
+            "state",
+        )
+        .await
+        .unwrap();
+        drop(receiver);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                match tokio::net::TcpListener::bind(("127.0.0.1", port)).await {
+                    Ok(listener) => break drop(listener),
+                    Err(_) => tokio::task::yield_now().await,
+                }
+            }
+        })
+        .await
+        .expect("dropped OAuth attempt kept its loopback port bound");
     }
 
     #[tokio::test]

--- a/examples/mcp-repl/Cargo.toml
+++ b/examples/mcp-repl/Cargo.toml
@@ -15,17 +15,21 @@ name = "mcp-repl"
 path = "src/main.rs"
 
 [dependencies]
-tower-mcp = { workspace = true, features = ["http-client", "protocol-2026-07-28"] }
+tower-mcp = { workspace = true, features = ["http-client", "oauth-client", "protocol-2026-07-28"] }
 async-trait.workspace = true
 tokio.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+base64.workspace = true
+getrandom.workspace = true
 toml = "1"
 toml_edit = "0.25"
 clap.workspace = true
 tracing-subscriber.workspace = true
 reedline = { version = "0.49", features = ["external_printer"] }
 nu-ansi-term = "0.50"
+keyring = "4.1"
+webbrowser = { version = "1.2", features = ["hardened"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/examples/mcp-repl/README.md
+++ b/examples/mcp-repl/README.md
@@ -69,6 +69,51 @@ mcp-repl --http https://internal.example/mcp --header "X-Api-Key: abc"
 `--bearer` and `--header` apply only to HTTP connections; they are ignored
 (with a warning) for the demo and stdio-child transports.
 
+For an MCP server using OAuth authorization-code + PKCE, create a named login
+without opening an MCP session:
+
+```bash
+# Discovers the protected resource and authorization server, opens the browser,
+# receives the redirect on an ephemeral loopback port, and saves the credentials.
+mcp-repl --login work --http https://mcp.example.com/mcp \
+  --oauth-scope openid --oauth-scope offline_access
+
+# Reuse its saved URL directly, retarget it with --http, or select it through
+# a server profile.
+mcp-repl --oauth work
+mcp-repl --oauth work --http https://mcp-alt.example.com/mcp
+
+# If automatic browser launch is unavailable, print the URL and wait for the
+# loopback redirect (remote use requires forwarding that loopback callback).
+mcp-repl --login work --http https://mcp.example.com/mcp --no-browser
+
+# Remove both profile metadata and credentials.
+mcp-repl --logout work
+```
+
+Login follows MCP protected-resource and authorization-server discovery,
+requires PKCE S256, tries an optional Client ID Metadata Document before
+Dynamic Client Registration, and requests refresh-token support when the
+server advertises it. Use
+`--oauth-client-id-metadata-document https://client.example/metadata.json` for
+CIMD or `--oauth-authorization-server ISSUER` to select one exact issuer when
+discovery advertises several.
+
+Only non-secret routing metadata is written to `config.toml`. Access tokens,
+refresh tokens, and dynamically registered client secrets are kept in macOS
+Keychain, Windows Credential Manager, or the Linux Secret Service through the
+platform credential store. If no secure store is available, mcp-repl fails
+closed; it never writes a plaintext credential fallback. A saved expired token
+is refreshed automatically. A failed refresh tells you to run `--login` again;
+an explicit login discards the unusable token while retaining reusable DCR
+registration.
+
+`--exec`/`--json` never starts an interactive authorization or opens a browser.
+It either restores/refreshes the saved credential or exits with an actionable
+`--login` command. Runtime insufficient-scope challenges are retried at most
+twice; interactive sessions can authorize the added scopes, while one-shot
+commands fail immediately with the same login guidance.
+
 ## Profiles
 
 A config file names servers so a connection is `mcp-repl <name>` instead of a
@@ -83,6 +128,15 @@ url = "https://cratesio-mcp.fly.dev/"
 bearer_env = "CRATESIO_TOKEN"      # read the token from the environment
 headers = { "X-Api-Key" = "abc" }
 
+[oauth.work]
+url = "https://mcp.example.com/mcp"
+scopes = ["openid", "offline_access"]
+
+[servers.work]
+transport = "http"
+oauth = "work"
+headers = { "X-Tenant" = "acme" }
+
 [servers.local]
 transport = "stdio"
 command = ["cargo", "run", "--example", "getting_started"]
@@ -95,10 +149,17 @@ mcp-repl cratesio                  # a bare name works too
 ```
 
 - `transport` is optional: a profile with a `url` is HTTP, one with a
-  `command` is stdio. A profile with both must say which.
+  `command` is stdio, and one with `oauth` is HTTP and may reuse that OAuth
+  profile's saved URL. A profile with both a URL/OAuth selection and a command
+  must say which.
 - Explicit flags override profile fields. `--http <url>` retargets the URL
   while keeping the profile's auth; `--bearer` replaces the profile's token;
   each `--header` overrides the profile header of the same name.
+- OAuth precedence is explicit static authorization (`--bearer` or
+  `--header Authorization`) first, then explicit `--oauth`, then a server
+  profile's `oauth`, then native/imported static credentials, and finally
+  `MCP_BEARER`. A server profile cannot combine `oauth` with `bearer`,
+  `bearer_env`, or an `Authorization` header; non-auth headers remain valid.
 - The bare-name form only resolves when the single positional matches a
   configured profile, so spawning a stdio server by bare name still works.
   Because everything after the first positional belongs to the spawned

--- a/examples/mcp-repl/src/config.rs
+++ b/examples/mcp-repl/src/config.rs
@@ -12,6 +12,14 @@
 //! bearer_env = "CRATESIO_TOKEN"
 //! headers = { "X-Api-Key" = "..." }
 //!
+//! [oauth.work]
+//! url = "https://mcp.example.com/mcp"
+//! scopes = ["openid", "offline_access"]
+//!
+//! [servers.work]
+//! transport = "http"
+//! oauth = "work"
+//!
 //! [servers.local]
 //! transport = "stdio"
 //! command = ["cargo", "run", "--example", "getting_started"]
@@ -39,6 +47,10 @@ use serde::Deserialize;
 pub struct Config {
     #[serde(default)]
     pub servers: BTreeMap<String, Profile>,
+    /// Non-secret metadata for named OAuth credential profiles. Tokens and
+    /// registered client secrets live in the operating-system credential store.
+    #[serde(default)]
+    pub oauth: BTreeMap<String, OAuthProfile>,
     /// Command aliases in effect against every server. See [`crate::alias`].
     #[serde(default)]
     pub aliases: BTreeMap<String, String>,
@@ -56,6 +68,8 @@ pub struct Profile {
     pub bearer: Option<String>,
     /// Name of the environment variable holding the bearer token.
     pub bearer_env: Option<String>,
+    /// Named entry in the top-level `[oauth]` table.
+    pub oauth: Option<String>,
     /// Extra headers sent with every request of an `http` profile.
     #[serde(default)]
     pub headers: BTreeMap<String, String>,
@@ -66,6 +80,21 @@ pub struct Profile {
     /// file-level `[aliases]` of the same name.
     #[serde(default)]
     pub aliases: BTreeMap<String, String>,
+}
+
+/// Non-secret OAuth metadata stored under `[oauth.<name>]`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OAuthProfile {
+    /// MCP protected-resource URL used when this profile was authorized.
+    pub url: String,
+    /// Initial scopes requested during login and tracked for escalation.
+    #[serde(default)]
+    pub scopes: Vec<String>,
+    /// Optional HTTPS Client ID Metadata Document URL (CIMD).
+    pub client_id_metadata_document: Option<String>,
+    /// Preferred authorization-server issuer when discovery advertises several.
+    pub authorization_server: Option<String>,
 }
 
 /// The transports a profile can name. `ws` and stateless HTTP are not
@@ -86,6 +115,7 @@ pub enum Connection {
         url: String,
         bearer: Option<String>,
         headers: Vec<(String, String)>,
+        oauth: Option<String>,
     },
     Stdio {
         command: Vec<String>,
@@ -130,13 +160,40 @@ impl Config {
     pub fn names(&self) -> Vec<&str> {
         self.servers.keys().map(String::as_str).collect()
     }
+
+    /// Resolve a named server, allowing an OAuth-only server profile to reuse
+    /// the protected-resource URL saved with its credential profile.
+    pub fn resolve_profile_with(
+        &self,
+        name: &str,
+        lookup: impl Fn(&str) -> Option<String>,
+    ) -> Result<Connection, String> {
+        let profile = self.profile(name)?;
+        let oauth_url = profile
+            .oauth
+            .as_deref()
+            .map(|oauth| {
+                self.oauth
+                    .get(oauth)
+                    .map(|metadata| metadata.url.as_str())
+                    .ok_or_else(|| {
+                        format!("server profile references unknown OAuth profile {oauth:?}")
+                    })
+            })
+            .transpose()?;
+        profile.resolve_with_oauth_url(lookup, oauth_url)
+    }
 }
 
 impl Profile {
     /// The transport this profile connects over: the declared one, else
     /// inferred from whichever of `url`/`command` is present.
     pub fn transport(&self) -> Result<Transport, String> {
-        match (self.transport, self.url.is_some(), !self.command.is_empty()) {
+        match (
+            self.transport,
+            self.url.is_some() || self.oauth.is_some(),
+            !self.command.is_empty(),
+        ) {
             (Some(t), _, _) => Ok(t),
             (None, true, false) => Ok(Transport::Http),
             (None, false, true) => Ok(Transport::Stdio),
@@ -170,15 +227,39 @@ impl Profile {
 
     /// Resolve into a [`Connection`], validating that the transport has the
     /// fields it needs.
+    #[cfg(test)]
     pub fn resolve_with(
         &self,
         lookup: impl Fn(&str) -> Option<String>,
     ) -> Result<Connection, String> {
+        self.resolve_with_oauth_url(lookup, None)
+    }
+
+    fn resolve_with_oauth_url(
+        &self,
+        lookup: impl Fn(&str) -> Option<String>,
+        oauth_url: Option<&str>,
+    ) -> Result<Connection, String> {
         match self.transport()? {
             Transport::Http => {
+                if self.oauth.is_some()
+                    && (self.bearer.is_some()
+                        || self.bearer_env.is_some()
+                        || self
+                            .headers
+                            .keys()
+                            .any(|name| name.eq_ignore_ascii_case("authorization")))
+                {
+                    return Err(
+                        "HTTP profile cannot combine `oauth` with `bearer`, `bearer_env`, or an \
+                         Authorization header"
+                            .to_string(),
+                    );
+                }
                 let url = self
                     .url
                     .clone()
+                    .or_else(|| oauth_url.map(str::to_string))
                     .ok_or("profile has `transport = \"http\"` but no `url`")?;
                 Ok(Connection::Http {
                     url,
@@ -188,6 +269,7 @@ impl Profile {
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect(),
+                    oauth: self.oauth.clone(),
                 })
             }
             Transport::Stdio => {
@@ -206,7 +288,13 @@ impl Profile {
     /// A one-line summary for `--list-servers`.
     pub fn summary(&self) -> String {
         match self.transport() {
-            Ok(Transport::Http) => format!("http   {}", self.url.as_deref().unwrap_or("(no url)")),
+            Ok(Transport::Http) => format!(
+                "http   {}",
+                self.url
+                    .as_deref()
+                    .or(self.oauth.as_deref())
+                    .unwrap_or("(no url)")
+            ),
             Ok(Transport::Stdio) => format!("stdio  {}", self.command.join(" ")),
             Err(e) => format!("(invalid: {e})"),
         }
@@ -276,8 +364,68 @@ command = ["cargo", "run", "--example", "getting_started"]
                 url: "https://cratesio-mcp.fly.dev/".to_string(),
                 bearer: Some("secret".to_string()),
                 headers: vec![("X-Api-Key".to_string(), "abc".to_string())],
+                oauth: None,
             }
         );
+    }
+
+    #[test]
+    fn oauth_metadata_and_server_selection_are_non_secret() {
+        let config = Config::parse(
+            r#"
+[oauth.work]
+url = "https://mcp.example/mcp"
+scopes = ["openid", "offline_access"]
+client_id_metadata_document = "https://client.example/metadata.json"
+authorization_server = "https://auth.example"
+
+[servers.work]
+oauth = "work"
+headers = { "X-Tenant" = "acme" }
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.oauth["work"].scopes, ["openid", "offline_access"]);
+        assert_eq!(
+            config.resolve_profile_with("work", env(&[])).unwrap(),
+            Connection::Http {
+                url: "https://mcp.example/mcp".to_string(),
+                bearer: None,
+                headers: vec![("X-Tenant".to_string(), "acme".to_string())],
+                oauth: Some("work".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_oauth_reference_is_an_actionable_error() {
+        let config = Config::parse("[servers.work]\noauth = \"missing\"\n").unwrap();
+        let error = config.resolve_profile_with("work", env(&[])).unwrap_err();
+        assert!(
+            error.contains("unknown OAuth profile \"missing\""),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn oauth_server_profile_rejects_ambiguous_static_auth() {
+        for auth in [
+            "bearer = \"secret\"",
+            "bearer_env = \"TOKEN\"",
+            "headers = { Authorization = \"Bearer secret\" }",
+        ] {
+            let source = format!(
+                "[servers.work]\nurl = \"https://mcp.example/mcp\"\noauth = \"work\"\n{auth}\n"
+            );
+            let error = Config::parse(&source)
+                .unwrap()
+                .profile("work")
+                .unwrap()
+                .resolve_with(env(&[("TOKEN", "secret")]))
+                .unwrap_err();
+            assert!(error.contains("cannot combine `oauth`"), "{error}");
+        }
     }
 
     #[test]

--- a/examples/mcp-repl/src/import_config.rs
+++ b/examples/mcp-repl/src/import_config.rs
@@ -251,6 +251,7 @@ fn resolve_entry(
                 url: expand(url, &workspace, lookup)?,
                 bearer: None,
                 headers,
+                oauth: None,
             })
         }
     }
@@ -398,6 +399,7 @@ mod tests {
                 url: "https://example/mcp".to_string(),
                 bearer: None,
                 headers: vec![("Authorization".to_string(), "Bearer secret".to_string())],
+                oauth: None,
             }
         );
     }

--- a/examples/mcp-repl/src/main.rs
+++ b/examples/mcp-repl/src/main.rs
@@ -16,6 +16,10 @@
 //! # Connect to a streamable HTTP server:
 //! cargo run -p mcp-repl -- --http http://127.0.0.1:3001/mcp
 //!
+//! # Authorize once, then reuse a secure OAuth profile:
+//! cargo run -p mcp-repl -- --login work --http https://mcp.example.com/mcp
+//! cargo run -p mcp-repl -- --oauth work --http https://mcp.example.com/mcp
+//!
 //! # Connect to a named profile from ~/.config/mcp-repl/config.toml:
 //! cargo run -p mcp-repl -- --server cratesio
 //! ```
@@ -38,6 +42,7 @@ mod exit_status;
 mod find;
 mod import_config;
 mod jobs;
+mod oauth_profile;
 mod output;
 mod sampling;
 mod schema_contract;
@@ -60,7 +65,8 @@ use nu_ansi_term::{Color, Style};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tower_mcp::client::{
     ChannelTransport, HttpClientConfig, HttpClientTransport, McpClient, McpClientBuilder,
-    NotificationHandler, StdioClientTransport,
+    NotificationHandler, OAuthAuthorizationFlow, OAuthAuthorizationStart, OAuthClientError,
+    OAuthScopeEscalationConfig, StdioClientTransport,
 };
 use tower_mcp::protocol::{
     Content, DiscoverResult, Implementation, InitializeResult, LogLevel, PromptDefinition,
@@ -151,6 +157,40 @@ struct Args {
     /// (repeatable). Split on the first colon.
     #[arg(long = "header", value_name = "NAME: VALUE")]
     headers: Vec<String>,
+
+    /// Use a named OAuth credential profile for this HTTP connection.
+    #[arg(long, value_name = "NAME")]
+    oauth: Option<String>,
+
+    /// Authorize and securely save a named OAuth profile, then exit without
+    /// opening an MCP session. Supply --http for a new profile.
+    #[arg(long, value_name = "NAME", conflicts_with = "logout")]
+    login: Option<String>,
+
+    /// Remove a named OAuth profile and its credentials, then exit without
+    /// opening an MCP session.
+    #[arg(long, value_name = "NAME", conflicts_with = "login")]
+    logout: Option<String>,
+
+    /// Initial OAuth scope to request during --login (repeatable). Existing
+    /// profile scopes are retained when this is omitted.
+    #[arg(long = "oauth-scope", value_name = "SCOPE")]
+    oauth_scopes: Vec<String>,
+
+    /// HTTPS Client ID Metadata Document URL to try before Dynamic Client
+    /// Registration during --login.
+    #[arg(long, value_name = "URL")]
+    oauth_client_id_metadata_document: Option<String>,
+
+    /// Exact authorization-server issuer to select when discovery advertises
+    /// more than one during --login.
+    #[arg(long, value_name = "ISSUER")]
+    oauth_authorization_server: Option<String>,
+
+    /// Print the authorization URL instead of launching a browser. The
+    /// loopback callback is still used.
+    #[arg(long)]
+    no_browser: bool,
 
     /// Run a command and exit instead of starting the interactive prompt.
     /// Repeatable; commands run in order against the same session, including
@@ -798,6 +838,23 @@ fn build_http_config_with_env(
     Ok(config)
 }
 
+fn selected_oauth_profile(
+    cli_oauth: Option<&str>,
+    profile_oauth: Option<&str>,
+    cli_bearer: bool,
+    cli_headers: &[String],
+) -> Option<String> {
+    let explicit_authorization = cli_bearer
+        || cli_headers.iter().any(|header| {
+            header
+                .split_once(':')
+                .is_some_and(|(name, _)| name.trim().eq_ignore_ascii_case("authorization"))
+        });
+    (!explicit_authorization)
+        .then(|| cli_oauth.or(profile_oauth).map(str::to_string))
+        .flatten()
+}
+
 fn demo_router() -> tower_mcp::McpRouter {
     use tower_mcp::extract::RawArgs;
     use tower_mcp::protocol::{CompleteResult, CompletionReference, ReadResourceResult};
@@ -1072,19 +1129,42 @@ fn watch_task(session: Arc<Session>, jobs: Arc<Jobs>, task_id: String, poll_inte
 /// keep reporting frames after a reconnect, and it declares the same
 /// capabilities as the startup client: a reconnect must not quietly leave the
 /// session less capable than it began.
+#[derive(Clone)]
+struct OAuthRuntime {
+    flow: OAuthAuthorizationFlow,
+    scopes: Vec<String>,
+}
+
+fn http_transport(
+    url: String,
+    config: HttpClientConfig,
+    oauth: Option<OAuthRuntime>,
+) -> HttpClientTransport {
+    let transport = HttpClientTransport::with_config(url, config);
+    match oauth {
+        Some(oauth) => transport.with_scope_aware_token_provider(
+            oauth.flow,
+            OAuthScopeEscalationConfig::new(oauth.scopes).max_attempts(2),
+        ),
+        None => transport,
+    }
+}
+
 fn http_connector(
     url: String,
     config: HttpClientConfig,
+    oauth: Option<OAuthRuntime>,
     make_handler: Arc<dyn Fn() -> ReplClientHandler + Send + Sync>,
     protocol: ProtocolMode,
 ) -> Connector {
     Box::new(move || {
-        let (url, config, handler) = (url.clone(), config.clone(), make_handler());
+        let (url, config, oauth, handler) =
+            (url.clone(), config.clone(), oauth.clone(), make_handler());
         Box::pin(async move {
             let client = client_builder(protocol)
                 .map_err(|error| tower_mcp::Error::Transport(error.to_string()))?
                 .connect(
-                    TracingTransport::new(HttpClientTransport::with_config(url, config)),
+                    TracingTransport::new(http_transport(url, config, oauth)),
                     handler,
                 )
                 .await?;
@@ -1106,6 +1186,158 @@ fn load_config(explicit: Option<&str>) -> config::Config {
             exit_with_error(ExitStatus::Usage, &e);
         }
     }
+}
+
+async fn handle_oauth_profile_action(
+    args: &Args,
+    profiles: &config::Config,
+    config_file: Option<&std::path::Path>,
+) -> bool {
+    let Some(name) = args.login.as_deref().or(args.logout.as_deref()) else {
+        if !args.oauth_scopes.is_empty()
+            || args.oauth_client_id_metadata_document.is_some()
+            || args.oauth_authorization_server.is_some()
+        {
+            exit_with_error(
+                ExitStatus::Usage,
+                "--oauth-scope, --oauth-client-id-metadata-document, and \
+                 --oauth-authorization-server apply only to --login",
+            );
+        }
+        return false;
+    };
+    oauth_profile::validate_name(name)
+        .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
+    if args.demo
+        || !args.command.is_empty()
+        || !args.exec.is_empty()
+        || args.json
+        || args.list_servers
+        || args.bearer.is_some()
+        || !args.headers.is_empty()
+        || args.oauth.is_some()
+    {
+        exit_with_error(
+            ExitStatus::Usage,
+            "--login/--logout are standalone credential operations; do not combine them with \
+             a command, --demo, --exec/--json, --list-servers, --bearer, --header, or --oauth",
+        );
+    }
+    let path = config_file.unwrap_or_else(|| {
+        exit_with_error(
+            ExitStatus::Usage,
+            "no config file location is available; set HOME/XDG_CONFIG_HOME or pass --config",
+        )
+    });
+
+    if args.logout.is_some() {
+        let store = oauth_profile::CredentialStore::keyring(name)
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Auth, &error));
+        store
+            .clear()
+            .await
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Auth, &error));
+        oauth_profile::remove_metadata(path, name)
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
+        println!("removed OAuth profile {name:?} and its stored credentials");
+        return true;
+    }
+
+    let existing = profiles.oauth.get(name).cloned().unwrap_or_default();
+    let server_url = args.server.as_deref().map(|server_name| {
+        let profile = profiles
+            .profile(server_name)
+            .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
+        match profile.transport() {
+            Ok(config::Transport::Http) => profile
+                .url
+                .clone()
+                .or_else(|| {
+                    profile
+                        .oauth
+                        .as_deref()
+                        .and_then(|oauth| profiles.oauth.get(oauth))
+                        .map(|metadata| metadata.url.clone())
+                })
+                .unwrap_or_else(|| {
+                    exit_with_error(
+                        ExitStatus::Usage,
+                        &format!("server profile {server_name:?} has no HTTP URL"),
+                    )
+                }),
+            Ok(config::Transport::Stdio) => exit_with_error(
+                ExitStatus::Usage,
+                &format!("server profile {server_name:?} is stdio; OAuth requires HTTP"),
+            ),
+            Err(error) => exit_with_error(ExitStatus::Usage, &error),
+        }
+    });
+    let url = args
+        .http
+        .clone()
+        .or(server_url)
+        .or_else(|| (!existing.url.is_empty()).then(|| existing.url.clone()))
+        .unwrap_or_else(|| {
+            exit_with_error(
+                ExitStatus::Usage,
+                "a new OAuth profile needs --http URL (or --server with an HTTP profile)",
+            )
+        });
+    let scopes = if args.oauth_scopes.is_empty() {
+        existing.scopes
+    } else {
+        args.oauth_scopes
+            .iter()
+            .flat_map(|scope| scope.split_ascii_whitespace())
+            .map(str::to_string)
+            .fold(Vec::new(), |mut scopes, scope| {
+                if !scope.is_empty() && !scopes.contains(&scope) {
+                    scopes.push(scope);
+                }
+                scopes
+            })
+    };
+    let metadata = config::OAuthProfile {
+        url: url.clone(),
+        scopes,
+        client_id_metadata_document: args
+            .oauth_client_id_metadata_document
+            .clone()
+            .or(existing.client_id_metadata_document),
+        authorization_server: args
+            .oauth_authorization_server
+            .clone()
+            .or(existing.authorization_server),
+    };
+    let (flow, store) = oauth_profile::build_flow(name, &url, &metadata, true, !args.no_browser)
+        .unwrap_or_else(|error| exit_with_error(ExitStatus::Auth, &error));
+    if let Err(error) = flow.authorize(metadata.scopes.clone()).await {
+        if matches!(error, OAuthClientError::TokenRequest(_)) {
+            store
+                .clear_tokens()
+                .await
+                .unwrap_or_else(|store_error| exit_with_error(ExitStatus::Auth, &store_error));
+            let (retry, _) =
+                oauth_profile::build_flow(name, &url, &metadata, true, !args.no_browser)
+                    .unwrap_or_else(|build_error| exit_with_error(ExitStatus::Auth, &build_error));
+            retry
+                .authorize(metadata.scopes.clone())
+                .await
+                .unwrap_or_else(|retry_error| {
+                    exit_with_error(ExitStatus::Auth, &retry_error.to_string())
+                });
+        } else {
+            exit_with_error(ExitStatus::Auth, &error.to_string());
+        }
+    }
+    if let Err(error) = oauth_profile::save_metadata(path, name, &metadata) {
+        let _ = store.clear().await;
+        exit_with_error(ExitStatus::Usage, &error);
+    }
+    println!(
+        "saved OAuth profile {name:?}; credentials are in the operating-system credential store"
+    );
+    true
 }
 
 /// `--list-servers`: the configured profiles, one per line.
@@ -1148,7 +1380,7 @@ fn resolve_profile(args: &Args, config: &config::Config) -> Option<(String, conf
              `bearer_env = \"VAR\"` so the token is not kept in the config file"
         );
     }
-    match profile.resolve_with(|var| std::env::var(var).ok()) {
+    match config.resolve_profile_with(&name, |var| std::env::var(var).ok()) {
         Ok(connection) => Some((name, connection)),
         Err(e) => {
             exit_with_error(ExitStatus::Usage, &format!("server profile {name:?}: {e}"));
@@ -1210,7 +1442,20 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
     // Server profiles are read up front: both --list-servers and profile
     // resolution need them before anything connects.
     let config_file = config::config_path(args.config.as_deref()).map(|(path, _)| path);
-    let profiles = load_config(args.config.as_deref());
+    let profiles = if args.login.is_some() || args.logout.is_some() {
+        config_file
+            .as_deref()
+            .map(|path| {
+                config::Config::load(path, false)
+                    .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error))
+            })
+            .unwrap_or_default()
+    } else {
+        load_config(args.config.as_deref())
+    };
+    if handle_oauth_profile_action(&args, &profiles, config_file.as_deref()).await {
+        return Ok(());
+    }
     if args.list_servers {
         print_servers(&profiles);
         return Ok(());
@@ -1293,19 +1538,39 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
         (
             Some(url),
             Some(config::Connection::Http {
-                bearer, headers, ..
+                bearer,
+                headers,
+                oauth,
+                ..
             }),
         ) => Some(config::Connection::Http {
             url,
             bearer,
             headers,
+            oauth,
         }),
         (Some(url), _) => Some(config::Connection::Http {
             url,
             bearer: None,
             headers: Vec::new(),
+            oauth: None,
         }),
         (None, Some(c)) => Some(c),
+        (None, None) if args.command.is_empty() && args.oauth.is_some() => {
+            let name = args.oauth.as_deref().expect("guarded above");
+            let metadata = profiles.oauth.get(name).unwrap_or_else(|| {
+                exit_with_error(
+                    ExitStatus::Usage,
+                    &format!("no OAuth profile named {name:?}; create it with --login"),
+                )
+            });
+            Some(config::Connection::Http {
+                url: metadata.url.clone(),
+                bearer: None,
+                headers: Vec::new(),
+                oauth: Some(name.to_string()),
+            })
+        }
         (None, None) if !args.command.is_empty() => Some(config::Connection::Stdio {
             command: args.command.clone(),
             env: std::collections::BTreeMap::new(),
@@ -1317,6 +1582,9 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
     let over_http = matches!(connection, Some(config::Connection::Http { .. }));
     if !over_http && (args.bearer.is_some() || !args.headers.is_empty()) {
         eprintln!("warning: --bearer/--header apply only to HTTP servers; ignoring them here");
+    }
+    if !over_http && args.oauth.is_some() {
+        exit_with_error(ExitStatus::Usage, "--oauth applies only to HTTP servers");
     }
     if let Some(name) = &profile_name
         && !quiet
@@ -1360,21 +1628,126 @@ async fn run(args: Args) -> tower_mcp::Result<()> {
                 url,
                 bearer,
                 headers,
+                oauth: profile_oauth,
             }) => {
-                let config =
-                    build_http_config(args.bearer.clone(), &args.headers, bearer, &headers)
-                        .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
+                let oauth_name = selected_oauth_profile(
+                    args.oauth.as_deref(),
+                    profile_oauth.as_deref(),
+                    args.bearer.is_some(),
+                    &args.headers,
+                );
+                let cli_authorization = oauth_name.is_none()
+                    && (args.bearer.is_some()
+                        || args.headers.iter().any(|header| {
+                            header.split_once(':').is_some_and(|(name, _)| {
+                                name.trim().eq_ignore_ascii_case("authorization")
+                            })
+                        }));
+                if cli_authorization && (args.oauth.is_some() || profile_oauth.is_some()) && !quiet
+                {
+                    eprintln!(
+                        "warning: explicit --bearer/--header Authorization takes precedence over OAuth"
+                    );
+                }
+                let profile_headers = if oauth_name.is_some() {
+                    headers
+                        .into_iter()
+                        .filter(|(name, _)| !name.eq_ignore_ascii_case("authorization"))
+                        .collect::<Vec<_>>()
+                } else {
+                    headers
+                };
+                let config = if oauth_name.is_some() {
+                    build_http_config_with_env(
+                        args.bearer.clone(),
+                        &args.headers,
+                        None,
+                        &profile_headers,
+                        None,
+                    )
+                } else {
+                    build_http_config(args.bearer.clone(), &args.headers, bearer, &profile_headers)
+                }
+                .unwrap_or_else(|error| exit_with_error(ExitStatus::Usage, &error));
+                let oauth = if let Some(name) = oauth_name {
+                    let metadata = profiles.oauth.get(&name).unwrap_or_else(|| {
+                        exit_with_error(
+                            ExitStatus::Usage,
+                            &format!(
+                                "no OAuth profile named {name:?}; create it with \
+                                 `mcp-repl --login {name} --http {url}`"
+                            ),
+                        )
+                    });
+                    let interactive = !one_shot && !args.json;
+                    let (flow, store) = oauth_profile::build_flow(
+                        &name,
+                        &url,
+                        metadata,
+                        interactive,
+                        interactive && !args.no_browser,
+                    )
+                    .unwrap_or_else(|error| exit_with_error(ExitStatus::Auth, &error));
+                    if interactive {
+                        flow.authorize(metadata.scopes.clone())
+                            .await
+                            .map_err(|error| {
+                                tower_mcp::Error::Transport(format!(
+                                    "OAuth authorization failed for profile {name:?}: {error}. \
+                                     Run `mcp-repl --login {name} --http {url}` to reauthorize"
+                                ))
+                            })?;
+                    } else {
+                        if !store.has_tokens().await.map_err(|error| {
+                            tower_mcp::Error::Transport(format!(
+                                "OAuth credential restore failed for profile {name:?}: {error}"
+                            ))
+                        })? {
+                            return Err(tower_mcp::Error::Transport(format!(
+                                "OAuth login required for profile {name:?}; run \
+                                 `mcp-repl --login {name} --http {url}` before using --exec/--json"
+                            )));
+                        }
+                        match flow.begin(metadata.scopes.clone()).await.map_err(|error| {
+                            tower_mcp::Error::Transport(format!(
+                                "OAuth credential restore failed for profile {name:?}: {error}. \
+                                 Run `mcp-repl --login {name} --http {url}` to reauthorize"
+                            ))
+                        })? {
+                            OAuthAuthorizationStart::Authorized { .. } => {}
+                            OAuthAuthorizationStart::Pending(_) => {
+                                return Err(tower_mcp::Error::Transport(format!(
+                                    "OAuth login required for profile {name:?}; run \
+                                     `mcp-repl --login {name} --http {url}` before using --exec/--json"
+                                )));
+                            }
+                            _ => {
+                                return Err(tower_mcp::Error::Transport(format!(
+                                    "OAuth login required for profile {name:?}; run \
+                                     `mcp-repl --login {name} --http {url}` before using --exec/--json"
+                                )));
+                            }
+                        }
+                    }
+                    Some(OAuthRuntime {
+                        flow,
+                        scopes: metadata.scopes.clone(),
+                    })
+                } else {
+                    None
+                };
                 if !args.no_reconnect {
                     connector = Some(http_connector(
                         url.clone(),
                         config.clone(),
+                        oauth.clone(),
                         make_handler.clone(),
                         args.protocol,
                     ));
                 }
                 builder
                     .connect(
-                        TracingTransport::new(HttpClientTransport::with_config(url, config)),
+                        TracingTransport::new(http_transport(url, config, oauth)),
                         make_handler(),
                     )
                     .await?
@@ -2976,6 +3349,42 @@ mod tests {
         }
     }
 
+    #[test]
+    fn oauth_cli_parses_standalone_and_connection_workflows() {
+        let login = Args::try_parse_from([
+            "mcp-repl",
+            "--login",
+            "work",
+            "--http",
+            "https://mcp.example/mcp",
+            "--oauth-scope",
+            "openid",
+            "--oauth-scope",
+            "offline_access",
+            "--no-browser",
+        ])
+        .unwrap();
+        assert_eq!(login.login.as_deref(), Some("work"));
+        assert_eq!(login.oauth_scopes, ["openid", "offline_access"]);
+        assert!(login.no_browser);
+
+        let connection = Args::try_parse_from([
+            "mcp-repl",
+            "--oauth",
+            "work",
+            "--http",
+            "https://mcp.example/mcp",
+            "--exec",
+            "tools",
+            "--json",
+        ])
+        .unwrap();
+        assert_eq!(connection.oauth.as_deref(), Some("work"));
+        assert_eq!(connection.exec, ["tools"]);
+
+        assert!(Args::try_parse_from(["mcp-repl", "--login", "work", "--logout", "work"]).is_err());
+    }
+
     #[tokio::test]
     async fn stable_selection_uses_initialize() {
         let client = client_builder(ProtocolMode::Stable)
@@ -3107,6 +3516,40 @@ mod tests {
     }
 
     #[test]
+    fn oauth_precedence_is_explicit_static_then_cli_then_server_profile() {
+        assert_eq!(
+            selected_oauth_profile(Some("cli"), Some("server"), false, &[]),
+            Some("cli".to_string())
+        );
+        assert_eq!(
+            selected_oauth_profile(None, Some("server"), false, &[]),
+            Some("server".to_string())
+        );
+        assert_eq!(
+            selected_oauth_profile(Some("cli"), Some("server"), true, &[]),
+            None
+        );
+        assert_eq!(
+            selected_oauth_profile(
+                Some("cli"),
+                Some("server"),
+                false,
+                &["authorization: Basic explicit".to_string()],
+            ),
+            None
+        );
+        assert_eq!(
+            selected_oauth_profile(
+                Some("cli"),
+                Some("server"),
+                false,
+                &["X-Tenant: acme".to_string()],
+            ),
+            Some("cli".to_string())
+        );
+    }
+
+    #[test]
     fn selected_authorization_header_beats_environment_bearer() {
         let selected_headers = [("authorization".to_string(), "Basic selected".to_string())];
         let cfg = build_http_config_with_env(
@@ -3134,6 +3577,22 @@ mod tests {
             cfg.headers.get("Authorization").map(String::as_str),
             Some("Bearer explicit-token")
         );
+    }
+
+    #[test]
+    fn explicit_oauth_suppresses_profile_and_environment_bearers() {
+        let selected = selected_oauth_profile(Some("work"), None, false, &[]);
+        assert_eq!(selected.as_deref(), Some("work"));
+
+        let cfg = build_http_config_with_env(
+            None,
+            &[],
+            selected.is_none().then(|| "profile-token".to_string()),
+            &[],
+            selected.is_none().then(|| "environment-token".to_string()),
+        )
+        .unwrap();
+        assert!(!cfg.headers.contains_key("Authorization"));
     }
 
     #[test]

--- a/examples/mcp-repl/src/oauth_profile.rs
+++ b/examples/mcp-repl/src/oauth_profile.rs
@@ -1,0 +1,853 @@
+//! Secure, named OAuth credentials for mcp-repl.
+//!
+//! The TOML config contains only routing and registration metadata. Access
+//! tokens, refresh tokens, and DCR client secrets are serialized into one
+//! profile record in the operating-system credential store.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+use toml_edit::{Array, DocumentMut, Item, Table, value};
+use tower_mcp::client::{
+    OAuthAuthorizationAction, OAuthAuthorizationFlow, OAuthAuthorizationHandler,
+    OAuthAuthorizationRequest, OAuthClientError, OAuthClientRegistration,
+    OAuthClientRegistrationOptions, OAuthClientRegistrationStore, OAuthDynamicClientRegistration,
+    OAuthRedirectPolicy, OAuthStoredToken, OAuthTokenBinding, OAuthTokenStore,
+};
+
+use crate::config::OAuthProfile;
+
+const KEYRING_SERVICE: &str = "mcp-repl/oauth";
+// Credential Manager stores passwords as UTF-16 in a 2,560-byte blob. Base64
+// of 768 raw bytes is 1,024 ASCII characters / 2,048 UTF-16 bytes, leaving
+// room below that platform limit. The other supported stores allow more.
+const KEYRING_CHUNK_BYTES: usize = 768;
+const MAX_KEYRING_CHUNKS: usize = 4096;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct KeyringManifest {
+    generation: String,
+    chunks: usize,
+}
+
+impl KeyringManifest {
+    fn parse(encoded: &str) -> Result<Self, String> {
+        let mut parts = encoded.split(':');
+        let (Some("v1"), Some(generation), Some(chunks), None) =
+            (parts.next(), parts.next(), parts.next(), parts.next())
+        else {
+            return Err("stored OAuth credential manifest is invalid".to_string());
+        };
+        if generation.is_empty()
+            || !generation
+                .chars()
+                .all(|character| character.is_ascii_hexdigit())
+        {
+            return Err("stored OAuth credential manifest has an invalid generation".to_string());
+        }
+        let chunks = chunks
+            .parse::<usize>()
+            .map_err(|_| "stored OAuth credential manifest has an invalid chunk count")?;
+        if chunks == 0 || chunks > MAX_KEYRING_CHUNKS {
+            return Err("stored OAuth credential manifest has an invalid chunk count".to_string());
+        }
+        Ok(Self {
+            generation: generation.to_string(),
+            chunks,
+        })
+    }
+
+    fn encode(&self) -> String {
+        format!("v1:{}:{}", self.generation, self.chunks)
+    }
+}
+
+fn new_generation() -> Result<String, String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes)
+        .map_err(|error| format!("cannot generate credential-store record id: {error}"))?;
+    Ok(bytes.iter().map(|byte| format!("{byte:02x}")).collect())
+}
+
+fn chunk_account(profile: &str, manifest: &KeyringManifest, index: usize) -> String {
+    format!("{profile}:{}:{index}", manifest.generation)
+}
+
+fn encode_chunks(secret: &str) -> Vec<String> {
+    secret
+        .as_bytes()
+        .chunks(KEYRING_CHUNK_BYTES)
+        .map(|chunk| base64::engine::general_purpose::STANDARD.encode(chunk))
+        .collect()
+}
+
+fn decode_chunks(chunks: impl IntoIterator<Item = String>) -> Result<String, String> {
+    let mut decoded = Vec::new();
+    for chunk in chunks {
+        decoded.extend(
+            base64::engine::general_purpose::STANDARD
+                .decode(chunk)
+                .map_err(|_| "stored OAuth credential chunk is invalid")?,
+        );
+    }
+    String::from_utf8(decoded)
+        .map_err(|_| "stored OAuth credential record is not UTF-8".to_string())
+}
+
+fn keyring_entry(account: &str) -> Result<keyring::v1::Entry, String> {
+    keyring::v1::Entry::new(KEYRING_SERVICE, account).map_err(|error| error.to_string())
+}
+
+fn delete_keyring_entry(account: &str) -> Result<(), String> {
+    match keyring_entry(account)?.delete_credential() {
+        Ok(()) | Err(keyring::v1::Error::NoEntry) => Ok(()),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn read_keyring_manifest(profile: &str) -> Result<Option<KeyringManifest>, String> {
+    match keyring_entry(profile)?.get_password() {
+        Ok(encoded) => KeyringManifest::parse(&encoded).map(Some),
+        Err(keyring::v1::Error::NoEntry) => Ok(None),
+        Err(error) => Err(error.to_string()),
+    }
+}
+
+fn delete_keyring_generation(profile: &str, manifest: &KeyringManifest) -> Result<(), String> {
+    let mut first_error = None;
+    for index in 0..manifest.chunks {
+        if let Err(error) = delete_keyring_entry(&chunk_account(profile, manifest, index))
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+#[async_trait]
+trait SecretBackend: Send + Sync {
+    async fn load(&self, profile: &str) -> Result<Option<String>, String>;
+    async fn save(&self, profile: &str, secret: &str) -> Result<(), String>;
+    async fn remove(&self, profile: &str) -> Result<(), String>;
+}
+
+#[derive(Debug, Default)]
+struct KeyringSecretBackend;
+
+impl KeyringSecretBackend {
+    fn check() -> Result<(), String> {
+        keyring::v1::Entry::store_status()
+            .as_ref()
+            .map_err(|error| {
+                format!(
+                    "the operating-system credential store is unavailable: {error}. \
+                 mcp-repl will not fall back to plaintext; use MCP_BEARER for a headless \
+                 environment or configure the platform credential service"
+                )
+            })
+            .copied()
+    }
+}
+
+#[async_trait]
+impl SecretBackend for KeyringSecretBackend {
+    async fn load(&self, profile: &str) -> Result<Option<String>, String> {
+        let profile = profile.to_string();
+        tokio::task::spawn_blocking(move || {
+            let Some(manifest) = read_keyring_manifest(&profile)? else {
+                return Ok(None);
+            };
+            let mut chunks = Vec::with_capacity(manifest.chunks);
+            for index in 0..manifest.chunks {
+                let account = chunk_account(&profile, &manifest, index);
+                let chunk = keyring_entry(&account)?.get_password().map_err(|error| {
+                    if matches!(error, keyring::v1::Error::NoEntry) {
+                        "stored OAuth credential record is incomplete".to_string()
+                    } else {
+                        error.to_string()
+                    }
+                })?;
+                chunks.push(chunk);
+            }
+            decode_chunks(chunks).map(Some)
+        })
+        .await
+        .map_err(|error| format!("credential-store worker failed: {error}"))?
+    }
+
+    async fn save(&self, profile: &str, secret: &str) -> Result<(), String> {
+        let profile = profile.to_string();
+        let secret = secret.to_string();
+        tokio::task::spawn_blocking(move || {
+            let previous = read_keyring_manifest(&profile)?;
+            let encoded_chunks = encode_chunks(&secret);
+            if encoded_chunks.is_empty() || encoded_chunks.len() > MAX_KEYRING_CHUNKS {
+                return Err("OAuth credential record is too large for the secure store".to_string());
+            }
+            let manifest = KeyringManifest {
+                generation: new_generation()?,
+                chunks: encoded_chunks.len(),
+            };
+            for (index, chunk) in encoded_chunks.iter().enumerate() {
+                let account = chunk_account(&profile, &manifest, index);
+                if let Err(error) = keyring_entry(&account)
+                    .and_then(|entry| entry.set_password(chunk).map_err(|error| error.to_string()))
+                {
+                    for cleanup in 0..index {
+                        let _ = delete_keyring_entry(&chunk_account(&profile, &manifest, cleanup));
+                    }
+                    return Err(error);
+                }
+            }
+            if let Err(error) = keyring_entry(&profile).and_then(|entry| {
+                entry
+                    .set_password(&manifest.encode())
+                    .map_err(|error| error.to_string())
+            }) {
+                let _ = delete_keyring_generation(&profile, &manifest);
+                return Err(error);
+            }
+            if let Some(previous) = previous {
+                delete_keyring_generation(&profile, &previous)?;
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|error| format!("credential-store worker failed: {error}"))?
+    }
+
+    async fn remove(&self, profile: &str) -> Result<(), String> {
+        let profile = profile.to_string();
+        tokio::task::spawn_blocking(move || {
+            if let Some(manifest) = read_keyring_manifest(&profile)? {
+                delete_keyring_generation(&profile, &manifest)?;
+            }
+            delete_keyring_entry(&profile)
+        })
+        .await
+        .map_err(|error| format!("credential-store worker failed: {error}"))?
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredToken {
+    binding: OAuthTokenBinding,
+    token: OAuthStoredToken,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct StoredRegistration {
+    issuer: String,
+    registration: OAuthClientRegistration,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+struct Secrets {
+    #[serde(default)]
+    tokens: Vec<StoredToken>,
+    #[serde(default)]
+    registrations: Vec<StoredRegistration>,
+}
+
+/// Both persistence traits share one encrypted/keychain record and one lock,
+/// so token refresh and DCR updates cannot overwrite one another in-process.
+#[derive(Clone)]
+pub struct CredentialStore {
+    profile: Arc<str>,
+    backend: Arc<dyn SecretBackend>,
+    lock: Arc<Mutex<()>>,
+}
+
+impl std::fmt::Debug for CredentialStore {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CredentialStore")
+            .field("profile", &self.profile)
+            .finish_non_exhaustive()
+    }
+}
+
+impl CredentialStore {
+    pub fn keyring(profile: &str) -> Result<Self, String> {
+        validate_name(profile)?;
+        KeyringSecretBackend::check()?;
+        Ok(Self::with_backend(profile, Arc::new(KeyringSecretBackend)))
+    }
+
+    fn with_backend(profile: &str, backend: Arc<dyn SecretBackend>) -> Self {
+        Self {
+            profile: Arc::from(profile),
+            backend,
+            lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    async fn load_secrets(&self) -> Result<Secrets, String> {
+        let Some(encoded) = self.backend.load(&self.profile).await? else {
+            return Ok(Secrets::default());
+        };
+        serde_json::from_str(&encoded)
+            .map_err(|error| format!("stored OAuth profile is invalid: {error}"))
+    }
+
+    async fn save_secrets(&self, secrets: &Secrets) -> Result<(), String> {
+        if secrets.tokens.is_empty() && secrets.registrations.is_empty() {
+            return self.backend.remove(&self.profile).await;
+        }
+        let encoded = serde_json::to_string(secrets)
+            .map_err(|error| format!("cannot encode OAuth credentials: {error}"))?;
+        self.backend.save(&self.profile, &encoded).await
+    }
+
+    pub async fn clear(&self) -> Result<(), String> {
+        let _guard = self.lock.lock().await;
+        self.backend.remove(&self.profile).await
+    }
+
+    pub async fn clear_tokens(&self) -> Result<(), String> {
+        let _guard = self.lock.lock().await;
+        let mut secrets = self.load_secrets().await?;
+        secrets.tokens.clear();
+        self.save_secrets(&secrets).await
+    }
+
+    pub async fn has_tokens(&self) -> Result<bool, String> {
+        let _guard = self.lock.lock().await;
+        self.load_secrets()
+            .await
+            .map(|secrets| !secrets.tokens.is_empty())
+    }
+}
+
+#[async_trait]
+impl OAuthTokenStore for CredentialStore {
+    async fn load(
+        &self,
+        binding: &OAuthTokenBinding,
+    ) -> Result<Option<OAuthStoredToken>, OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        self.load_secrets()
+            .await
+            .map(|secrets| {
+                secrets
+                    .tokens
+                    .into_iter()
+                    .find(|stored| stored.binding == *binding)
+                    .map(|stored| stored.token)
+            })
+            .map_err(OAuthClientError::TokenStore)
+    }
+
+    async fn save(
+        &self,
+        binding: &OAuthTokenBinding,
+        token: &OAuthStoredToken,
+    ) -> Result<(), OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        let mut secrets = self
+            .load_secrets()
+            .await
+            .map_err(OAuthClientError::TokenStore)?;
+        secrets.tokens.retain(|stored| stored.binding != *binding);
+        secrets.tokens.push(StoredToken {
+            binding: binding.clone(),
+            token: token.clone(),
+        });
+        self.save_secrets(&secrets)
+            .await
+            .map_err(OAuthClientError::TokenStore)
+    }
+
+    async fn remove(&self, binding: &OAuthTokenBinding) -> Result<(), OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        let mut secrets = self
+            .load_secrets()
+            .await
+            .map_err(OAuthClientError::TokenStore)?;
+        secrets.tokens.retain(|stored| stored.binding != *binding);
+        self.save_secrets(&secrets)
+            .await
+            .map_err(OAuthClientError::TokenStore)
+    }
+}
+
+#[async_trait]
+impl OAuthClientRegistrationStore for CredentialStore {
+    async fn load(
+        &self,
+        issuer: &str,
+    ) -> Result<Option<OAuthClientRegistration>, OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        self.load_secrets()
+            .await
+            .map(|secrets| {
+                secrets
+                    .registrations
+                    .into_iter()
+                    .find(|stored| stored.issuer == issuer)
+                    .map(|stored| stored.registration)
+            })
+            .map_err(OAuthClientError::CredentialStore)
+    }
+
+    async fn save(
+        &self,
+        issuer: &str,
+        registration: &OAuthClientRegistration,
+    ) -> Result<(), OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        let mut secrets = self
+            .load_secrets()
+            .await
+            .map_err(OAuthClientError::CredentialStore)?;
+        secrets
+            .registrations
+            .retain(|stored| stored.issuer != issuer);
+        secrets.registrations.push(StoredRegistration {
+            issuer: issuer.to_string(),
+            registration: registration.clone(),
+        });
+        self.save_secrets(&secrets)
+            .await
+            .map_err(OAuthClientError::CredentialStore)
+    }
+
+    async fn remove(&self, issuer: &str) -> Result<(), OAuthClientError> {
+        let _guard = self.lock.lock().await;
+        let mut secrets = self
+            .load_secrets()
+            .await
+            .map_err(OAuthClientError::CredentialStore)?;
+        secrets
+            .registrations
+            .retain(|stored| stored.issuer != issuer);
+        self.save_secrets(&secrets)
+            .await
+            .map_err(OAuthClientError::CredentialStore)
+    }
+}
+
+type BrowserOpener = dyn Fn(&str) -> Result<(), String> + Send + Sync;
+
+#[derive(Clone)]
+struct BrowserAuthorizationHandler {
+    profile: Arc<str>,
+    interactive: bool,
+    open_browser: bool,
+    opener: Arc<BrowserOpener>,
+}
+
+impl BrowserAuthorizationHandler {
+    fn new(profile: &str, interactive: bool, open_browser: bool) -> Self {
+        Self {
+            profile: Arc::from(profile),
+            interactive,
+            open_browser,
+            opener: Arc::new(|url| webbrowser::open(url).map_err(|error| error.to_string())),
+        }
+    }
+}
+
+#[async_trait]
+impl OAuthAuthorizationHandler for BrowserAuthorizationHandler {
+    async fn authorize(
+        &self,
+        request: OAuthAuthorizationRequest,
+    ) -> Result<OAuthAuthorizationAction, OAuthClientError> {
+        if !self.interactive {
+            return Err(OAuthClientError::Redirect(format!(
+                "interactive authorization is required; run `mcp-repl --login {} --http {}` first",
+                self.profile, request.resource
+            )));
+        }
+        if self.open_browser {
+            match (self.opener)(&request.authorization_url) {
+                Ok(()) => eprintln!("OAuth authorization opened in your browser."),
+                Err(error) => eprintln!("Could not open a browser ({error})."),
+            }
+        }
+        eprintln!(
+            "Authorize this client, then return here (waiting up to 5 minutes):\n{}",
+            request.authorization_url
+        );
+        Ok(OAuthAuthorizationAction::AwaitLoopback)
+    }
+}
+
+pub fn build_flow(
+    name: &str,
+    resource_url: &str,
+    metadata: &OAuthProfile,
+    interactive: bool,
+    open_browser: bool,
+) -> Result<(OAuthAuthorizationFlow, CredentialStore), String> {
+    let store = CredentialStore::keyring(name)?;
+    let mut options = OAuthClientRegistrationOptions::new().with_dynamic_registration(
+        OAuthDynamicClientRegistration::native("mcp-repl", std::iter::empty::<String>()),
+    );
+    if let Some(client_id) = &metadata.client_id_metadata_document {
+        options = options.with_client_id_metadata_document(client_id.clone());
+    }
+    let mut builder = OAuthAuthorizationFlow::builder(resource_url)
+        .redirect_policy(OAuthRedirectPolicy::loopback())
+        .registration_options(options)
+        .registration_store(store.clone())
+        .token_store(store.clone())
+        .authorization_handler(BrowserAuthorizationHandler::new(
+            name,
+            interactive,
+            open_browser,
+        ));
+    if let Some(issuer) = &metadata.authorization_server {
+        builder = builder.preferred_authorization_server(issuer.clone());
+    }
+    let flow = builder.build().map_err(|error| error.to_string())?;
+    Ok((flow, store))
+}
+
+pub fn validate_name(name: &str) -> Result<(), String> {
+    if name.is_empty()
+        || name.len() > 64
+        || !name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "._-".contains(character))
+    {
+        return Err(
+            "OAuth profile names must be 1-64 characters containing only ASCII letters, digits, \
+             `.`, `_`, or `-`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub fn save_metadata(path: &Path, name: &str, profile: &OAuthProfile) -> Result<(), String> {
+    validate_name(name)?;
+    edit_config(path, |document| {
+        if document.get("oauth").is_none() {
+            document["oauth"] = Item::Table(Table::new());
+        }
+        let oauth = document["oauth"]
+            .as_table_mut()
+            .ok_or("top-level `oauth` must be a table")?;
+        let mut table = Table::new();
+        table["url"] = value(&profile.url);
+        if !profile.scopes.is_empty() {
+            let mut scopes = Array::new();
+            for scope in &profile.scopes {
+                scopes.push(scope.as_str());
+            }
+            table["scopes"] = value(scopes);
+        }
+        if let Some(client_id) = &profile.client_id_metadata_document {
+            table["client_id_metadata_document"] = value(client_id);
+        }
+        if let Some(issuer) = &profile.authorization_server {
+            table["authorization_server"] = value(issuer);
+        }
+        oauth[name] = Item::Table(table);
+        Ok(())
+    })
+}
+
+pub fn remove_metadata(path: &Path, name: &str) -> Result<bool, String> {
+    validate_name(name)?;
+    let mut removed = false;
+    edit_config(path, |document| {
+        let Some(oauth) = document.get_mut("oauth") else {
+            return Ok(());
+        };
+        let table = oauth
+            .as_table_mut()
+            .ok_or("top-level `oauth` must be a table")?;
+        removed = table.remove(name).is_some();
+        if table.is_empty() {
+            document.remove("oauth");
+        }
+        Ok(())
+    })?;
+    Ok(removed)
+}
+
+fn edit_config(
+    path: &Path,
+    edit: impl FnOnce(&mut DocumentMut) -> Result<(), String>,
+) -> Result<(), String> {
+    let source = match std::fs::read_to_string(path) {
+        Ok(source) => source,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(format!("{}: {error}", path.display())),
+    };
+    let mut document = source
+        .parse::<DocumentMut>()
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    edit(&mut document)?;
+    write_atomic(path, &document.to_string())
+        .map_err(|error| format!("{}: {error}", path.display()))
+}
+
+fn write_atomic(path: &Path, contents: &str) -> Result<(), std::io::Error> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut temporary = path.as_os_str().to_owned();
+    temporary.push(".tmp");
+    let temporary = PathBuf::from(temporary);
+    std::fs::write(&temporary, contents)?;
+    std::fs::rename(temporary, path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::RwLock;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct MemoryBackend(RwLock<HashMap<String, String>>);
+
+    #[async_trait]
+    impl SecretBackend for MemoryBackend {
+        async fn load(&self, profile: &str) -> Result<Option<String>, String> {
+            Ok(self.0.read().unwrap().get(profile).cloned())
+        }
+
+        async fn save(&self, profile: &str, secret: &str) -> Result<(), String> {
+            self.0
+                .write()
+                .unwrap()
+                .insert(profile.to_string(), secret.to_string());
+            Ok(())
+        }
+
+        async fn remove(&self, profile: &str) -> Result<(), String> {
+            self.0.write().unwrap().remove(profile);
+            Ok(())
+        }
+    }
+
+    fn binding(resource: &str) -> OAuthTokenBinding {
+        OAuthTokenBinding {
+            resource: resource.to_string(),
+            issuer: "https://auth.example".to_string(),
+            client_id: "client".to_string(),
+        }
+    }
+
+    #[test]
+    fn secure_store_chunks_large_unicode_records_below_platform_limit() {
+        let secret = format!("{}{}", "jwt.".repeat(1200), "🔐".repeat(700));
+        let chunks = encode_chunks(&secret);
+        assert!(chunks.len() > 1);
+        assert!(chunks.iter().all(|chunk| chunk.len() <= 1024));
+        assert_eq!(decode_chunks(chunks).unwrap(), secret);
+
+        let manifest = KeyringManifest {
+            generation: "01abcdef".to_string(),
+            chunks: 7,
+        };
+        assert_eq!(
+            KeyringManifest::parse(&manifest.encode()).unwrap(),
+            manifest
+        );
+        assert!(KeyringManifest::parse("v1:bad:not-a-number").is_err());
+    }
+
+    #[test]
+    fn profile_names_are_bounded_for_platform_stores() {
+        assert!(validate_name("work-prod_1.example").is_ok());
+        assert!(validate_name(&"a".repeat(65)).is_err());
+        assert!(validate_name("contains/slash").is_err());
+    }
+
+    fn token(access_token: &str) -> OAuthStoredToken {
+        OAuthStoredToken {
+            access_token: access_token.to_string(),
+            refresh_token: Some("refresh-secret".to_string()),
+            expires_at: u64::MAX,
+            scopes: vec!["openid".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_bindings_and_issuers_share_one_secret_record() {
+        let backend = Arc::new(MemoryBackend::default());
+        let store = CredentialStore::with_backend("work", backend.clone());
+        OAuthTokenStore::save(&store, &binding("https://one/mcp"), &token("one"))
+            .await
+            .unwrap();
+        OAuthTokenStore::save(&store, &binding("https://two/mcp"), &token("two"))
+            .await
+            .unwrap();
+        let registration = OAuthClientRegistration::dynamically_registered(
+            "https://auth.example",
+            "client",
+            Some("client-secret".to_string()),
+        );
+        OAuthClientRegistrationStore::save(&store, "https://auth.example", &registration)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            OAuthTokenStore::load(&store, &binding("https://two/mcp"))
+                .await
+                .unwrap()
+                .unwrap()
+                .access_token,
+            "two"
+        );
+        assert!(
+            OAuthTokenStore::load(&store, &binding("https://other/mcp"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            OAuthClientRegistrationStore::load(&store, "https://auth.example")
+                .await
+                .unwrap()
+                .unwrap(),
+            registration
+        );
+
+        let encoded = backend.0.read().unwrap()["work"].clone();
+        assert!(encoded.contains("refresh-secret"));
+        assert!(encoded.contains("client-secret"));
+        assert!(!format!("{store:?}").contains("secret"));
+    }
+
+    #[tokio::test]
+    async fn clear_removes_every_secret_for_profile() {
+        let backend = Arc::new(MemoryBackend::default());
+        let store = CredentialStore::with_backend("work", backend.clone());
+        OAuthTokenStore::save(&store, &binding("https://one/mcp"), &token("one"))
+            .await
+            .unwrap();
+        store.clear().await.unwrap();
+        assert!(backend.0.read().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn clearing_tokens_preserves_dynamic_registration() {
+        let backend = Arc::new(MemoryBackend::default());
+        let store = CredentialStore::with_backend("work", backend);
+        OAuthTokenStore::save(&store, &binding("https://one/mcp"), &token("one"))
+            .await
+            .unwrap();
+        let registration = OAuthClientRegistration::dynamically_registered(
+            "https://auth.example",
+            "client",
+            Some("client-secret".to_string()),
+        );
+        OAuthClientRegistrationStore::save(&store, "https://auth.example", &registration)
+            .await
+            .unwrap();
+
+        assert!(store.has_tokens().await.unwrap());
+        store.clear_tokens().await.unwrap();
+        assert!(!store.has_tokens().await.unwrap());
+        assert!(
+            OAuthTokenStore::load(&store, &binding("https://one/mcp"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(
+            OAuthClientRegistrationStore::load(&store, "https://auth.example")
+                .await
+                .unwrap(),
+            Some(registration)
+        );
+    }
+
+    fn request() -> OAuthAuthorizationRequest {
+        OAuthAuthorizationRequest {
+            authorization_url: "https://auth.example/authorize?state=test".to_string(),
+            redirect_uri: "http://127.0.0.1:12345/callback".to_string(),
+            resource: "https://mcp.example/mcp".to_string(),
+            issuer: "https://auth.example".to_string(),
+            scopes: vec!["openid".to_string()],
+        }
+    }
+
+    #[tokio::test]
+    async fn browser_handler_has_an_automation_safe_seam() {
+        let opens = Arc::new(AtomicUsize::new(0));
+        let opener = {
+            let opens = opens.clone();
+            Arc::new(move |_url: &str| {
+                opens.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }) as Arc<BrowserOpener>
+        };
+        let headless = BrowserAuthorizationHandler {
+            profile: Arc::from("work"),
+            interactive: false,
+            open_browser: true,
+            opener: opener.clone(),
+        };
+        let error = headless.authorize(request()).await.unwrap_err();
+        assert!(error.to_string().contains("--login work"));
+        assert_eq!(opens.load(Ordering::SeqCst), 0);
+
+        let manual = BrowserAuthorizationHandler {
+            profile: Arc::from("work"),
+            interactive: true,
+            open_browser: false,
+            opener: opener.clone(),
+        };
+        assert!(matches!(
+            manual.authorize(request()).await.unwrap(),
+            OAuthAuthorizationAction::AwaitLoopback
+        ));
+        assert_eq!(opens.load(Ordering::SeqCst), 0);
+
+        let browser = BrowserAuthorizationHandler {
+            profile: Arc::from("work"),
+            interactive: true,
+            open_browser: true,
+            opener,
+        };
+        assert!(matches!(
+            browser.authorize(request()).await.unwrap(),
+            OAuthAuthorizationAction::AwaitLoopback
+        ));
+        assert_eq!(opens.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn metadata_round_trip_never_contains_credentials() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("config.toml");
+        std::fs::write(&path, "[aliases]\nt = \"tools\"\n").unwrap();
+        let profile = OAuthProfile {
+            url: "https://mcp.example/mcp".to_string(),
+            scopes: vec!["openid".to_string(), "offline_access".to_string()],
+            client_id_metadata_document: Some("https://client.example/metadata.json".to_string()),
+            authorization_server: Some("https://auth.example".to_string()),
+        };
+
+        save_metadata(&path, "work", &profile).unwrap();
+        let source = std::fs::read_to_string(&path).unwrap();
+        assert!(source.contains("[oauth.work]"));
+        assert!(source.contains("[aliases]"));
+        assert!(!source.contains("token"));
+        assert!(!source.contains("secret"));
+        assert_eq!(
+            crate::config::Config::parse(&source).unwrap().oauth["work"],
+            profile
+        );
+
+        assert!(remove_metadata(&path, "work").unwrap());
+        let source = std::fs::read_to_string(path).unwrap();
+        assert!(!source.contains("[oauth"));
+        assert!(source.contains("[aliases]"));
+    }
+}


### PR DESCRIPTION
Closes #1155

## Summary

- add standalone `--login`/`--logout` workflows and named `--oauth` profiles using the existing tower-mcp PKCE, discovery, CIMD, and DCR flow
- store access tokens, refresh tokens, and registered client secrets in the OS credential store; persist only non-secret routing metadata in TOML
- restore and refresh credentials across processes and reconnects, with interactive scope escalation and fail-closed automation behavior
- document and test server-profile integration and auth precedence

## Reusable client fixes

- refresh an expired persisted token when an OAuth flow is rebuilt after process restart
- cancel a dropped loopback authorization attempt so its listener is released

## Security and automation

- macOS Keychain, Windows Credential Manager, and Linux Secret Service through `keyring`
- versioned chunk manifests keep credential records within Windows payload limits without plaintext fallback
- `--exec` and `--json` never open a browser or begin interactive authorization
- explicit static CLI authorization wins, then explicit OAuth, server-profile OAuth, profile/imported static auth, and finally `MCP_BEARER`

## Verification

- `cargo test --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc -p tower-mcp -p tower-mcp-types -p tower-mcp-macros --no-deps --all-features`
- `rustup run 1.90 cargo check --all-targets --all-features`
- `cargo audit`
- workspace line coverage: 81.68% (CI floor: 80%)

OAuth fixture behavior remains covered by the tower-mcp mock HTTP tests; mcp-repl adds injected credential-store and browser-opener seams for deterministic local tests.