### PR TITLE
fix: repair repository MCP server commands

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,14 +2,14 @@
   "mcpServers": {
     "tower-mcp-example": {
       "command": "cargo",
-      "args": ["run", "-p", "tower-mcp", "--example", "getting_started"],
+      "args": ["run", "-p", "tower-mcp-examples", "--example", "getting_started"],
       "env": {
         "RUST_LOG": "tower_mcp=debug"
       }
     },
     "weather": {
       "command": "cargo",
-      "args": ["run", "-p", "tower-mcp", "--example", "weather_server"],
+      "args": ["run", "-p", "tower-mcp-examples", "--example", "weather_server"],
       "env": {
         "RUST_LOG": "tower_mcp=info"
       }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ Resources: `project://Cargo.toml`, `project://src/main.rs`, `project://state.jso
 
 1. Read `examples/README.md` for an index of all examples
 2. Read the `source://getting_started.rs` resource to see how a server is built
-3. Run any example: `cargo run --example getting_started`
+3. Run any example: `cargo run -p tower-mcp-examples --example getting_started`
 
 ## Development
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -47,6 +47,10 @@ stateless = ["tower-mcp/stateless"]
 # package preserves `cargo run --example ...` while keeping release archives
 # focused on the library crates.
 
+[[test]]
+name = "repository_mcp_config"
+path = "repository_mcp_config.rs"
+
 # --- Getting started ---
 [[example]]
 name = "getting_started"

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,44 +18,44 @@ For a guided path, see
 
 ```bash
 # Stdio examples (no feature flags needed)
-cargo run --example getting_started
-cargo run --example middleware
-cargo run --example rate_limiting
+cargo run -p tower-mcp-examples --example getting_started
+cargo run -p tower-mcp-examples --example middleware
+cargo run -p tower-mcp-examples --example rate_limiting
 
 # HTTP transport
-cargo run --example http_server --features http
+cargo run -p tower-mcp-examples --example http_server --features http
 
 # Typed MCP Apps server (stdio)
-cargo run --example mcp_apps --features mcp-apps
+cargo run -p tower-mcp-examples --example mcp_apps --features mcp-apps
 
 # Embed MCP inside an existing axum app
-cargo run --example axum_embedding --features http
+cargo run -p tower-mcp-examples --example axum_embedding --features http
 
 # WebSocket transport
-cargo run --example websocket_server --features websocket
+cargo run -p tower-mcp-examples --example websocket_server --features websocket
 
 # Clients (start http_server first, or run stateless_http_client standalone)
-cargo run --example http_client --features http-client
-cargo run --example http_sse_client --features http
-cargo run --example stateless_http_client --features "http,http-client,protocol-2026-07-28"
+cargo run -p tower-mcp-examples --example http_client --features http-client
+cargo run -p tower-mcp-examples --example http_sse_client --features http
+cargo run -p tower-mcp-examples --example stateless_http_client --features "http,http-client,protocol-2026-07-28"
 
 # Released 2026-07-28 discovery and Tasks extension
-cargo run --example server_discover --features "http,protocol-2026-07-28"
-cargo run --example tasks --features protocol-2026-07-28
+cargo run -p tower-mcp-examples --example server_discover --features "http,protocol-2026-07-28"
+cargo run -p tower-mcp-examples --example tasks --features protocol-2026-07-28
 
 # OAuth resource server and clients (see the published OAuth guide for configuration)
-cargo run --example http_auth --features jwks -- --auth jwks
-cargo run --example oauth_client --features oauth-client -- --mode authorization-code
-cargo run --example oauth_client --features oauth-client -- --mode credentials
+cargo run -p tower-mcp-examples --example http_auth --features jwks -- --auth jwks
+cargo run -p tower-mcp-examples --example oauth_client --features oauth-client -- --mode authorization-code
+cargo run -p tower-mcp-examples --example oauth_client --features oauth-client -- --mode credentials
 
 # Dynamic capabilities
-cargo run --example dynamic_capabilities --features dynamic-tools
+cargo run -p tower-mcp-examples --example dynamic_capabilities --features dynamic-tools
 
 # Testing
-cargo run --example testing --features testing
+cargo run -p tower-mcp-examples --example testing --features testing
 
 # Macros
-cargo run --example tool_macro --features macros
+cargo run -p tower-mcp-examples --example tool_macro --features macros
 ```
 
 ## Example Index

--- a/examples/repository_mcp_config.rs
+++ b/examples/repository_mcp_config.rs
@@ -1,0 +1,105 @@
+//! Guards the checked-in MCP client configuration against Cargo target drift.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::process::Command;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct McpConfig {
+    #[serde(rename = "mcpServers")]
+    servers: BTreeMap<String, McpServer>,
+}
+
+#[derive(Deserialize)]
+struct McpServer {
+    command: String,
+    args: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct CargoMetadata {
+    packages: Vec<CargoPackage>,
+}
+
+#[derive(Deserialize)]
+struct CargoPackage {
+    name: String,
+    targets: Vec<CargoTarget>,
+}
+
+#[derive(Deserialize)]
+struct CargoTarget {
+    name: String,
+    kind: Vec<String>,
+}
+
+fn value_after<'a>(args: &'a [String], flags: &[&str]) -> Option<&'a str> {
+    args.windows(2)
+        .find(|pair| flags.contains(&pair[0].as_str()))
+        .map(|pair| pair[1].as_str())
+}
+
+#[test]
+fn configured_cargo_servers_name_existing_packages_and_targets() {
+    let workspace = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("examples package must live under the workspace root");
+    let config: McpConfig = serde_json::from_slice(
+        &std::fs::read(workspace.join(".mcp.json")).expect("read repository .mcp.json"),
+    )
+    .expect("parse repository .mcp.json");
+
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+    let output = Command::new(cargo)
+        .args(["metadata", "--format-version", "1", "--no-deps"])
+        .current_dir(workspace)
+        .output()
+        .expect("run cargo metadata");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let metadata: CargoMetadata =
+        serde_json::from_slice(&output.stdout).expect("parse cargo metadata");
+
+    for (server_name, server) in config.servers {
+        assert_eq!(
+            server.command, "cargo",
+            "repository server {server_name:?} needs an explicit validator for its command"
+        );
+        assert_eq!(
+            server.args.first().map(String::as_str),
+            Some("run"),
+            "repository server {server_name:?} must use `cargo run`"
+        );
+        let package_name = value_after(&server.args, &["-p", "--package"])
+            .unwrap_or_else(|| panic!("repository server {server_name:?} must select a package"));
+        let package = metadata
+            .packages
+            .iter()
+            .find(|package| package.name == package_name)
+            .unwrap_or_else(|| {
+                panic!("repository server {server_name:?} names missing package {package_name:?}")
+            });
+
+        if let Some(example_name) = value_after(&server.args, &["--example"]) {
+            assert!(
+                package.targets.iter().any(|target| {
+                    target.name == example_name && target.kind.iter().any(|kind| kind == "example")
+                }),
+                "repository server {server_name:?} names missing example {example_name:?} in package {package_name:?}"
+            );
+        } else {
+            assert!(
+                package
+                    .targets
+                    .iter()
+                    .any(|target| target.kind.iter().any(|kind| kind == "bin")),
+                "repository server {server_name:?} names package {package_name:?} without a binary target"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Closes #1157

## Summary

- point the getting-started and weather MCP entries at their actual `tower-mcp-examples` package
- keep the already-correct `codegen-mcp` package selection
- make AGENTS.md and every runnable command in the example index package-explicit
- add a regression test that validates every Cargo-backed `.mcp.json` package and target against `cargo metadata`

## Smoke tests

Each checked-in entry completed initialize, tools/list, and clean stdio shutdown through mcp-repl:

- `mcp-repl --json -e tools .mcp.json:tower-mcp-example`
- `mcp-repl --json -e tools .mcp.json:weather`
- `mcp-repl --json -e tools .mcp.json:codegen-mcp`

## Verification

- `cargo test -p tower-mcp-examples --test repository_mcp_config`
- `cargo clippy -p tower-mcp-examples --test repository_mcp_config -- -D warnings`
- `cargo fmt --all -- --check`