### PR TITLE
ci(mcp-repl): prepare standalone lifecycle

### DIFF
--- a/.github/workflows/mcp-repl.yml
+++ b/.github/workflows/mcp-repl.yml
@@ -1,0 +1,64 @@
+name: mcp-repl
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/mcp-repl.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/tower-mcp/**"
+      - "crates/tower-mcp-types/**"
+      - "examples/Cargo.toml"
+      - "examples/mcp-repl/**"
+      - "examples/mcp_repl_fixture.rs"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/mcp-repl.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "crates/tower-mcp/**"
+      - "crates/tower-mcp-types/**"
+      - "examples/Cargo.toml"
+      - "examples/mcp-repl/**"
+      - "examples/mcp_repl_fixture.rs"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  current-main:
+    name: Current tower-mcp
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: Format
+        run: cargo fmt -p mcp-repl -- --check
+      - name: Lint
+        run: cargo clippy -p mcp-repl --all-targets --all-features -- -D warnings
+      - name: Test
+        run: cargo test -p mcp-repl --all-targets --all-features
+      - name: Documentation
+        run: cargo doc -p mcp-repl --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
+  released-tower-mcp:
+    name: Released tower-mcp package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Verify publishable package
+        run: cargo package -p mcp-repl

--- a/examples/mcp-repl/src/lib.rs
+++ b/examples/mcp-repl/src/lib.rs
@@ -50,6 +50,7 @@ mod exit_status;
 mod find;
 pub mod import_config;
 mod jobs;
+pub mod lifecycle;
 pub mod oauth_profile;
 mod output;
 mod sampling;

--- a/examples/mcp-repl/src/lifecycle.rs
+++ b/examples/mcp-repl/src/lifecycle.rs
@@ -1,0 +1,86 @@
+//! Project lifecycle and extraction guide.
+//!
+//! `mcp-repl` is independently versioned and published even though its source
+//! currently lives in the tower-mcp workspace. This guide records the release
+//! contract and the work required before moving it to a standalone repository.
+//! It is a plan, not authorization to perform the move.
+//!
+//! # Supported boundaries
+//!
+//! The application lives in the `mcp_repl` library and the binary is only a
+//! thin call to [`crate::run_cli`]. The deliberately reusable seams are:
+//!
+//! - [`crate::config`] for native server and alias profiles;
+//! - [`crate::import_config`] for explicit imports from standard MCP JSON
+//!   configuration files; and
+//! - [`crate::oauth_profile`] for non-secret OAuth profile metadata and secure
+//!   credential-store access.
+//!
+//! Terminal editing, rendering, and command dispatch remain private. A related
+//! tool such as `mcp2md` should not depend on all of `mcp-repl` merely to reuse
+//! configuration: that would also couple it to the interactive terminal stack.
+//! Keep such a tool independent unless real duplication justifies extracting a
+//! narrow configuration or connection crate used by both projects.
+//!
+//! # Compatibility and release lanes
+//!
+//! The path-scoped `mcp-repl` workflow owns the package's checks independently
+//! from the rest of the workspace:
+//!
+//! ```text
+//! cargo fmt -p mcp-repl -- --check
+//! cargo clippy -p mcp-repl --all-targets --all-features -- -D warnings
+//! cargo test -p mcp-repl --all-targets --all-features
+//! RUSTDOCFLAGS=-Dwarnings cargo doc -p mcp-repl --no-deps --all-features
+//! ```
+//!
+//! Those commands test the workspace's current `tower-mcp`, which is the main
+//! compatibility lane. `cargo package -p mcp-repl` creates and verifies the
+//! normalized publishable package. In that package, Cargo replaces the
+//! workspace path dependency with the declared crates.io version, so this is
+//! also the released-framework compatibility lane. A tower-mcp version change
+//! must be published before that package lane can pass.
+//!
+//! While the package remains in this workspace, the repository's release-plz
+//! workflow owns crates.io publication, tags, GitHub releases, and changelog
+//! updates. Do not publish the same version manually in parallel. Before an
+//! extraction, let the final workspace release finish and start the new
+//! repository at the next version. Copy and dry-run the release workflow before
+//! enabling its registry credential.
+//!
+//! # Extraction checklist
+//!
+//! Perform history rewriting only in a disposable clone. A starting point is:
+//!
+//! ```text
+//! git filter-repo \
+//!   --path examples/mcp-repl/ \
+//!   --path LICENSE-APACHE \
+//!   --path LICENSE-MIT \
+//!   --path-rename examples/mcp-repl/:
+//! git log --follow -- src/lib.rs
+//! ```
+//!
+//! Before making the new repository authoritative:
+//!
+//! 1. Move or reproduce the black-box fixture currently located at
+//!    `examples/mcp_repl_fixture.rs`; it intentionally is not part of the
+//!    published package today.
+//! 2. Replace workspace-inherited package fields and dependencies with explicit
+//!    standalone manifest values, then run all checks and `cargo package` from
+//!    the extracted repository.
+//! 3. Carry over the licenses, contribution and security policy, code-owner and
+//!    dependency-update settings, supported Rust version, and the path-scoped
+//!    quality workflow.
+//! 4. Transfer open mcp-repl issues when possible. Otherwise recreate them with
+//!    bidirectional links, leave a migration notice in tower-mcp, and update
+//!    repository links in the README, Cargo manifest, crates.io, docs.rs, and
+//!    release notes.
+//! 5. Confirm the maintainers and crates.io owners who will handle releases and
+//!    security reports. Publish the new repository's security contact before
+//!    changing the crate's canonical repository URL.
+//! 6. Verify tags, changelog history, and `git log --follow` before archiving the
+//!    old source location or closing the extraction tracker.
+//!
+//! Until those steps are complete, source, issue triage, release notes, and
+//! security reporting remain owned by the tower-mcp repository.

--- a/examples/mcp-repl/tests/e2e.rs
+++ b/examples/mcp-repl/tests/e2e.rs
@@ -682,9 +682,10 @@ async fn exercise_interactive_final_task(http: &HttpFixture) {
         .expect("write task command");
     wait_for_file(&http.subscription_file, "final subscription").await;
     // The subscription is immediate, while the bounded task poller remains a
-    // fallback. Leave enough room for either path to observe completion before
-    // asking the editor thread to exit.
-    tokio::time::sleep(Duration::from_millis(1_500)).await;
+    // fallback. The fixture advertises a two-second poll interval, so leave a
+    // full extra second for the fallback to observe completion before asking
+    // the editor thread to exit.
+    tokio::time::sleep(Duration::from_millis(3_000)).await;
     stdin
         .write_all(b"jobs\nquit\n")
         .await


### PR DESCRIPTION
## Summary

- add a path-scoped mcp-repl workflow that independently owns formatting, linting, tests, and rustdoc against the current workspace
- add a package lane that verifies the normalized crate against the released tower-mcp dependency
- publish a rustdoc lifecycle guide covering supported reuse boundaries, release ownership, history-preserving extraction, issue/security handoff, and the remaining standalone blockers

## Verification

- `actionlint .github/workflows/mcp-repl.yml`
- `cargo fmt -p mcp-repl -- --check`
- `cargo clippy -p mcp-repl --all-targets --all-features -- -D warnings`
- `cargo test -p mcp-repl --all-targets --all-features` (155 unit tests plus black-box E2E)
- `RUSTDOCFLAGS=-Dwarnings cargo doc -p mcp-repl --no-deps --all-features`
- `cargo package -p mcp-repl --allow-dirty`

Part of #1156. This prepares extraction but deliberately does not move the repository.