### PR TITLE
fix(proxy): stack repeated backend_layer calls instead of replacing

### DIFF
--- a/crates/tower-mcp/src/proxy/builder.rs
+++ b/crates/tower-mcp/src/proxy/builder.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::router::{RouterRequest, RouterResponse};
 use crate::transport::CatchError;
 
-use super::backend::{Backend, BackendService, ListChanged};
+use super::backend::{Backend, ListChanged};
 use super::service::{BackendEntry, McpProxy};
 
 /// A backend that was skipped during proxy construction.
@@ -279,6 +279,12 @@ impl McpProxyBuilder {
     /// Tower middleware (timeout, rate limit, concurrency limit, etc.) to
     /// be applied per-backend.
     ///
+    /// Repeated calls stack: each layer wraps the service composed so far,
+    /// so the layer added last sees a request first. In the example below a
+    /// request passes the timeout, then the rate limiter, then reaches the
+    /// backend, and a `ServiceBuilder` composing the same middleware in one
+    /// call remains equivalent.
+    ///
     /// Layers that produce errors (e.g., `TimeoutLayer`) are automatically
     /// wrapped with [`CatchError`] to convert errors into JSON-RPC error
     /// responses, maintaining the `Error = Infallible` contract.
@@ -287,10 +293,12 @@ impl McpProxyBuilder {
     ///
     /// ```rust,ignore
     /// use std::time::Duration;
+    /// use tower::limit::RateLimitLayer;
     /// use tower::timeout::TimeoutLayer;
     ///
     /// let proxy = McpProxy::builder("proxy", "1.0.0")
     ///     .backend("slow", transport).await
+    ///     .backend_layer(RateLimitLayer::new(50, Duration::from_secs(1)))
     ///     .backend_layer(TimeoutLayer::new(Duration::from_secs(30)))
     ///     .build()
     ///     .await?;
@@ -301,7 +309,7 @@ impl McpProxyBuilder {
     /// Panics if no backend has been added yet.
     pub fn backend_layer<L>(mut self, layer: L) -> Self
     where
-        L: Layer<BackendService> + Send + 'static,
+        L: Layer<BoxCloneService<RouterRequest, RouterResponse, Infallible>> + Send + 'static,
         L::Service: tower_service::Service<RouterRequest, Response = RouterResponse>
             + Clone
             + Send
@@ -314,9 +322,14 @@ impl McpProxyBuilder {
             .last_mut()
             .expect("backend_layer called before adding a backend");
 
-        // Get the base BackendService and apply the layer
-        let base = pending.backend.service();
-        let layered = layer.layer(base);
+        // Wrap the service composed so far, not the raw backend: starting
+        // from the base on every call silently discarded all but the most
+        // recent layer (#1173).
+        let current = pending
+            .custom_service
+            .take()
+            .unwrap_or_else(|| BoxCloneService::new(pending.backend.service()));
+        let layered = layer.layer(current);
         // Wrap with CatchError to convert middleware errors to JSON-RPC errors
         let caught = CatchError::new(layered);
         pending.custom_service = Some(BoxCloneService::new(caught));

--- a/crates/tower-mcp/src/proxy/tests.rs
+++ b/crates/tower-mcp/src/proxy/tests.rs
@@ -906,6 +906,187 @@ mod proxy_tests {
         }
     }
 
+    /// Records which layers a request passed through, in order.
+    #[derive(Clone)]
+    struct MarkerLayer {
+        tag: &'static str,
+        calls: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    #[derive(Clone)]
+    struct MarkerService<S> {
+        inner: S,
+        tag: &'static str,
+        calls: std::sync::Arc<std::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    impl<S> Layer<S> for MarkerLayer {
+        type Service = MarkerService<S>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            MarkerService {
+                inner,
+                tag: self.tag,
+                calls: self.calls.clone(),
+            }
+        }
+    }
+
+    impl<S> Service<RouterRequest> for MarkerService<S>
+    where
+        S: Service<RouterRequest>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        fn poll_ready(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, request: RouterRequest) -> Self::Future {
+            self.calls.lock().unwrap().push(self.tag);
+            self.inner.call(request)
+        }
+    }
+
+    /// Repeated `backend_layer` calls must stack rather than each replacing
+    /// the previous composition (#1173).
+    #[tokio::test]
+    async fn test_backend_layer_calls_stack() {
+        let calls = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let math_transport = ChannelTransport::new(math_router());
+
+        let mut proxy = McpProxy::builder("stack-proxy", "1.0.0")
+            .backend("math", math_transport)
+            .await
+            .backend_layer(MarkerLayer {
+                tag: "first",
+                calls: calls.clone(),
+            })
+            .backend_layer(MarkerLayer {
+                tag: "second",
+                calls: calls.clone(),
+            })
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        let resp = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
+                name: "math_add".to_string(),
+                arguments: json!({"a": 2, "b": 3}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await
+        .expect("layered call should succeed");
+
+        match resp {
+            McpResponse::CallTool(result) => assert_eq!(result.all_text(), "5"),
+            other => panic!("expected CallTool response, got: {:?}", other),
+        }
+
+        // Both layers fired, and the layer added last saw the request first.
+        assert_eq!(*calls.lock().unwrap(), vec!["second", "first"]);
+    }
+
+    /// Delays every call before delegating, standing in for the latency
+    /// injection that exposed #1173 downstream.
+    #[derive(Clone)]
+    struct DelayLayer(Duration);
+
+    #[derive(Clone)]
+    struct DelayService<S> {
+        inner: S,
+        delay: Duration,
+    }
+
+    impl<S> Layer<S> for DelayLayer {
+        type Service = DelayService<S>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            DelayService {
+                inner,
+                delay: self.0,
+            }
+        }
+    }
+
+    impl<S> Service<RouterRequest> for DelayService<S>
+    where
+        S: Service<RouterRequest> + Clone + Send + 'static,
+        S::Future: Send,
+        RouterRequest: Send,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<S::Response, S::Error>> + Send>,
+        >;
+
+        fn poll_ready(
+            &mut self,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, request: RouterRequest) -> Self::Future {
+            let delay = self.delay;
+            let mut inner = self.inner.clone();
+            Box::pin(async move {
+                tokio::time::sleep(delay).await;
+                inner.call(request).await
+            })
+        }
+    }
+
+    /// A timeout added after a latency layer must observe that latency: with
+    /// the pre-#1173 behavior the timeout replaced the delay and a stacked
+    /// 10ms budget let a 100ms path succeed.
+    #[tokio::test]
+    async fn test_backend_layer_timeout_observes_earlier_layer() {
+        let math_transport = ChannelTransport::new(math_router());
+
+        let mut proxy = McpProxy::builder("delay-timeout-proxy", "1.0.0")
+            .backend("math", math_transport)
+            .await
+            .backend_layer(DelayLayer(Duration::from_millis(100)))
+            .backend_layer(TimeoutLayer::new(Duration::from_millis(10)))
+            .build_strict()
+            .await
+            .expect("proxy should build");
+
+        let result = call_proxy(
+            &mut proxy,
+            McpRequest::CallTool(crate::protocol::CallToolParams {
+                input_responses: None,
+                request_state: None,
+                name: "math_add".to_string(),
+                arguments: json!({"a": 2, "b": 3}),
+                meta: None,
+                task: None,
+            }),
+        )
+        .await;
+
+        let err = result.expect_err("the timeout must observe the injected delay");
+        assert!(
+            err.message.to_lowercase().contains("timed out")
+                || err.message.to_lowercase().contains("timeout"),
+            "error should mention timeout, got: {}",
+            err.message
+        );
+    }
+
     #[tokio::test]
     async fn test_backend_layer_only_affects_target_backend() {
         let math_transport = ChannelTransport::new(math_router());


### PR DESCRIPTION
Fixes #1173.

## Bug

```text
Repro:    .backend_layer(a) then .backend_layer(b) on the same backend
Observed: only b applies; a is silently discarded
Expected: both apply
```

Each `backend_layer` call restarted from `pending.backend.service()` and overwrote `custom_service`, so only the most recently added layer was active. Downstream, mcp-proxy applies its per-backend resilience chain as successive calls, which collapsed to the last element (joshrotenberg/mcp-proxy#218).

## Fix

Wrap the service composed so far instead of the raw backend: the first call wraps the backend, each later call wraps the previous composition, and `CatchError` re-wraps at every step to keep `Error = Infallible`. The layer added last sees a request first, and the doc comment now states the order.

The generic bound moves from `Layer<BackendService>` to `Layer<BoxCloneService<RouterRequest, RouterResponse, Infallible>>` to make composition over the boxed stack expressible. Standard tower layers are generic over the inner service and compile unchanged; only a layer hand-written exclusively against `BackendService` would notice.

## Tests

- `test_backend_layer_calls_stack`: two marker layers both fire, in last-added-first order
- `test_backend_layer_timeout_observes_earlier_layer`: a 10ms timeout added after a 100ms delay layer times out; before the fix the timeout replaced the delay and the call succeeded (the downstream chaos+timeout evidence, in miniature)

Both new tests were verified to fail against the previous implementation. Existing single-layer tests are unchanged and pass.
