### PR TITLE
feat(protocol): enable 2026-07-28 by default on feature-compiled clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/joshrotenberg/tower-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/ci.yml)
 [![License](https://img.shields.io/crates/l/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp#license)
 [![MSRV](https://img.shields.io/crates/msrv/tower-mcp.svg)](https://github.com/joshrotenberg/tower-mcp)
-[![MCP](https://img.shields.io/badge/MCP-2025--11--25-blue)](https://modelcontextprotocol.io/specification/2025-11-25)
+[![MCP](https://img.shields.io/badge/MCP-2026--07--28_%7C_2025--11--25-blue)](https://modelcontextprotocol.io/specification/2026-07-28)
 [![Conformance](https://img.shields.io/badge/conformance-48%2F48_server_%7C_235_client_checks-brightgreen)](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml)
 
 Tower-native [Model Context Protocol](https://modelcontextprotocol.io) (MCP) implementation for Rust.
@@ -620,11 +620,11 @@ let router = McpRouter::new()
 
 ## Protocol Compliance
 
-tower-mcp targets the [MCP specification 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) with backward compatibility for `2025-03-26`. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
+tower-mcp implements the [MCP specification 2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28) behind the `protocol-2026-07-28` feature, alongside the session protocols [2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) and `2025-03-26` that every build carries. The [official MCP conformance test suite](https://github.com/modelcontextprotocol/conformance) runs in CI on every PR via [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml), currently passing:
 
-For application-facing guidance on the stable default, opt-in 2026-07-28
-implementation, compile-time features, runtime allowlists, interoperability,
-and upgrade policy, start with the [protocol-version guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/).
+For application-facing guidance on the 2026-07-28 implementation,
+compile-time features, runtime allowlists, interoperability, and upgrade
+policy, start with the [protocol-version guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/).
 
 - **Server (2025-11-25):** 48/48 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the server baseline is empty
 - **Client (2025-11-25):** all 18 scenarios green, 235 checks (`conformance@0.2.0-alpha.10`, `--suite all`); the client baseline is empty
@@ -633,11 +633,12 @@ and upgrade policy, start with the [protocol-version guide](https://docs.rs/towe
 
 Both protocol revisions run on the same harness pin so the results are directly comparable with each other and with rmcp's current conformance workflow. Because the suite is upstream-maintained and grows with the spec, these counts shift as scenarios are added or version-gated -- treat the green CI badge as the source of truth, not any single snapshot. The empty baselines make any new failure immediately visible.
 
-The released 2026-07-28 implementation is available through the opt-in
-`protocol-2026-07-28` feature. It covers sessionless dispatch,
-`server/discover`, `subscriptions/listen`, per-request metadata, response-cache
-hints, Multi Round-Trip Requests, and the final Tasks extension. The default
-runtime remains 2025-11-25, including for clients built with `full`.
+The 2026-07-28 implementation is compiled in by the `protocol-2026-07-28`
+feature and enabled by default once compiled, for servers and clients alike.
+It covers sessionless dispatch, `server/discover`, `subscriptions/listen`,
+per-request metadata, response-cache hints, Multi Round-Trip Requests, and the
+final Tasks extension. A feature-enabled build that should keep serving only
+the session protocols narrows itself with `ProtocolSupport::stable()`.
 
 Compile-time availability and runtime allowlists are separate. The
 [protocol-version guide](https://docs.rs/tower-mcp/latest/tower_mcp/guides/protocol_versions/) explains the constants,

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -202,17 +202,24 @@ pub const JSONRPC_VERSION: &str = "2.0";
 /// The latest protocol version enabled by default.
 pub const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
 
-/// Protocol versions enabled by default (newest first).
+/// Session protocol versions negotiable through `initialize` (newest first).
 ///
 /// During initialization, the server negotiates the protocol version with the
 /// client. The server picks the newest version that both sides support.
 /// If no common version exists, the connection is rejected.
+///
+/// `2026-07-28` is deliberately not in this list even though it is stable:
+/// it removed the `initialize` handshake, so it is never a valid outcome of
+/// session negotiation. Builds that compile it (the `protocol-2026-07-28`
+/// feature in `tower-mcp`) enable it through `ProtocolSupport`, which both
+/// clients and servers default to the full compiled set.
 ///
 /// ```rust
 /// use tower_mcp_types::protocol::{LATEST_PROTOCOL_VERSION, SUPPORTED_PROTOCOL_VERSIONS};
 ///
 /// assert_eq!(LATEST_PROTOCOL_VERSION, "2025-11-25");
 /// assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&"2025-03-26"));
+/// assert!(!SUPPORTED_PROTOCOL_VERSIONS.contains(&"2026-07-28"));
 /// ```
 pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-03-26"];
 

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -390,9 +390,12 @@ impl McpClientBuilder {
         Self {
             capabilities: ClientCapabilities::default(),
             roots: Vec::new(),
-            // Merely compiling an opt-in implementation must not move an existing
-            // client off the established initialize/session path.
-            protocol_support: ProtocolSupport::stable(),
+            // Every compiled implementation, matching servers (#1179). The
+            // entry point still selects the era: nothing calls `discover`
+            // implicitly, so compiling a feature never changes an existing
+            // client's wire behavior, it only removes the configuration step
+            // before `discover`.
+            protocol_support: ProtocolSupport::default(),
             max_mrtr_rounds: 8,
             cache_config: ClientCacheConfig::default(),
         }
@@ -432,9 +435,12 @@ impl McpClientBuilder {
 
     /// Set the exact ordered protocol versions enabled for this client.
     ///
-    /// The default is [`ProtocolSupport::stable`], even when the opt-in final
-    /// protocol implementation was compiled. Applications select
-    /// 2026-07-28 explicitly and then call `McpClient::discover`.
+    /// The default is [`ProtocolSupport::default`], every implementation
+    /// compiled into this build: with `protocol-2026-07-28` enabled the
+    /// client can call `McpClient::discover` without further configuration,
+    /// and without the feature only the stable session protocols exist.
+    /// Pass [`ProtocolSupport::stable`] to keep a feature-enabled build on
+    /// the session protocols only.
     pub fn protocol_support(mut self, support: ProtocolSupport) -> Self {
         self.protocol_support = support;
         self

--- a/crates/tower-mcp/src/guides/protocol_versions.rs
+++ b/crates/tower-mcp/src/guides/protocol_versions.rs
@@ -19,7 +19,7 @@ authoritative for protocol behavior:
 
 | Wire revision | Status in tower-mcp 0.18 | Compile-time switch | Lifecycle |
 |---|---|---|---|
-| `2026-07-28` | released, opt-in | `protocol-2026-07-28` | sessionless, per-request metadata, optional `server/discover` first |
+| `2026-07-28` | released, enabled when compiled | `protocol-2026-07-28` | sessionless, per-request metadata, optional `server/discover` first |
 | `2025-11-25` | stable default | always available | `initialize` session lifecycle |
 | `2025-03-26` | backward compatibility | always available | `initialize` session lifecycle |
 
@@ -82,15 +82,17 @@ fn main() -> Result<(), BoxError> {
 ```
 
 `ProtocolSupport::compiled()` enables the whole compiled set.
-`ProtocolSupport::stable()` excludes opt-in implementations even if they were
-compiled. `ProtocolSupport::default()` is the compiled set.
+`ProtocolSupport::stable()` narrows a build to the session protocols even
+when `protocol-2026-07-28` was compiled. `ProtocolSupport::default()` is the
+compiled set, for clients and servers alike.
 
 Two older constants have narrower meaning:
 
-- `LATEST_PROTOCOL_VERSION` is the preferred non-breaking default
+- `LATEST_PROTOCOL_VERSION` is the preferred session default
   (`2025-11-25`), not the newest published date.
-- `SUPPORTED_PROTOCOL_VERSIONS` is the stable compatibility set, not every
-  implementation that can be compiled.
+- `SUPPORTED_PROTOCOL_VERSIONS` is the session-negotiable set, the versions
+  `initialize` can produce. `2026-07-28` removed `initialize`, so it is
+  never in this list regardless of features.
 
 Use `COMPILED_PROTOCOL_VERSIONS` and `ProtocolSupport` for deployment policy.
 
@@ -163,8 +165,11 @@ the feature and runtime policy allow it; do not call the historical
 
 ## Configure a client
 
-Clients are stable by default, even in a build using `full`. This avoids a
-Cargo feature changing an application's first wire request.
+Clients default to every compiled implementation, matching servers. The entry
+point still selects the era: `initialize` starts a legacy session and
+`discover` starts the final lifecycle, so compiling a feature never changes an
+application's first wire request; it only removes the extra configuration step
+before `discover`.
 
 ### Stable client
 
@@ -178,6 +183,14 @@ client.initialize("my-client", "1.0.0").await?;
 version and session ID for later requests.
 
 ### Final client
+
+```rust,ignore
+let client = McpClient::connect(transport).await?;
+client.discover("my-client", "1.0.0").await?;
+```
+
+With `protocol-2026-07-28` compiled, no configuration is needed. To *refuse*
+the session protocols entirely, narrow the client instead:
 
 ```rust,ignore
 let support = ProtocolSupport::try_new(["2026-07-28"])?;

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -397,10 +397,10 @@
 //!     .stateless(StatelessConfig::new());
 //! ```
 //!
-//! The 2026-07-28 implementation is opt-in. Enable the
-//! `protocol-2026-07-28` Cargo feature to compile it, then use
-//! [`ProtocolSupport`] to narrow the versions enabled by an individual
-//! transport at runtime.
+//! The 2026-07-28 implementation is compiled in by the
+//! `protocol-2026-07-28` Cargo feature and enabled by default once compiled.
+//! Use [`ProtocolSupport`] to narrow the versions enabled by an individual
+//! client or transport at runtime.
 //!
 //! ### Router Composition
 //!
@@ -463,8 +463,9 @@
 //!
 //! ## MCP Specification
 //!
-//! This crate implements MCP 2025-11-25 by default and provides an opt-in
-//! implementation of the released 2026-07-28 specification:
+//! Every build implements the MCP 2025-11-25 and 2025-03-26 session
+//! protocols; the `protocol-2026-07-28` feature adds the released 2026-07-28
+//! specification, enabled by default once compiled:
 //! <https://modelcontextprotocol.io/specification/2026-07-28>
 //!
 //! Enable it with `protocol-2026-07-28`; the legacy `stateless` feature name

--- a/crates/tower-mcp/src/protocol_support.rs
+++ b/crates/tower-mcp/src/protocol_support.rs
@@ -12,7 +12,7 @@ use crate::protocol::SUPPORTED_PROTOCOL_VERSIONS;
 
 /// Protocol versions compiled into this build, in preference order.
 ///
-/// Enabling `protocol-2026-07-28` adds the released, opt-in implementation.
+/// Enabling `protocol-2026-07-28` adds the released implementation.
 /// The former `stateless` feature remains a compatibility alias and produces
 /// the same compiled set.
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
@@ -81,8 +81,8 @@ impl ProtocolSupport {
 
     /// Enable only the stable-by-default compatibility set.
     ///
-    /// This excludes opt-in protocol implementations even when their Cargo
-    /// features are compiled.
+    /// This narrows a build to the `initialize`-negotiable session protocols,
+    /// excluding 2026-07-28 even when its Cargo feature is compiled.
     pub fn stable() -> Self {
         Self {
             versions: SUPPORTED_PROTOCOL_VERSIONS


### PR DESCRIPTION
Closes #1179, with one deliberate deviation from the issue's checklist, explained below.

## What changes

- `McpClient` defaults to `ProtocolSupport::default()` (the compiled set), matching what HTTP/WebSocket servers have done since the allowlist landed. With `protocol-2026-07-28` compiled, `discover()` works with no configuration; without the feature, the compiled set is the stable set and nothing changes.
- `stable()` keeps its meaning as the explicit narrowing to the session protocols, and its docs now say that.
- README, the protocol-versions guide, and the crate docs reframe 2026-07-28 from released-but-opt-in to enabled-when-compiled. The README MCP badge now names both revisions.

No implicit behavior changes for existing clients: nothing calls `discover()` on its own, so the entry point (`initialize` vs `discover`) still selects the era, and compiling the feature never alters an application's first wire request.

## Deviation from the issue: `SUPPORTED_PROTOCOL_VERSIONS` is unchanged

The issue proposed adding `2026-07-28` to the constant plus a compiled-set intersection in `stable()`. Surveying the call sites showed the constant means something narrower than "supported": every functional use is legacy-session semantics -- `initialize` negotiation in the router, the jsonrpc version check, and SEP-1442 stateless validation. `2026-07-28` removed `initialize`, so it can never be a valid outcome of session negotiation; adding it would have made bare-router `initialize` accept a version the session path cannot deliver, and the intersection in `stable()` would have been a workaround for that self-inflicted problem. The constant's rustdoc now documents this boundary explicitly, and the promotion lands entirely in the `ProtocolSupport` defaults, where version policy actually lives.

## Validation

- Full workspace test suite with `--all-features`, default-features lib tests, and tower-mcp-types tests all pass; clippy and rustdoc clean
- Both conformance suites run on this PR as usual; empty baselines are the acceptance signal
- Pre-existing and unrelated: default-features doctests are broken on main (46 errors, `HttpClientTransport` without `http-client`); recorded on #1093