### PR TITLE
feat(channel): apply Tower layers to the in-process transport

### DIFF
--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -67,9 +67,11 @@ use crate::context::{NotificationReceiver, notification_channel};
 use crate::error::Result;
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{JsonRpcRequest, JsonRpcResponse, McpNotification};
-use crate::router::McpRouter;
+use crate::router::{McpRouter, RouterRequest, RouterResponse};
+use crate::transport::service::{CatchError, InjectAnnotations};
 #[cfg(feature = "stateless")]
 use crate::transport::stdio::{StdioSubscriptionInput, StdioSubscriptions};
+use tower_service::Service;
 
 use super::transport::ClientTransport;
 
@@ -119,10 +121,75 @@ impl ChannelTransport {
     /// handling flow through the same channel.
     ///
     /// [`HttpTransport::with_notifications`]: crate::transport::HttpTransport::with_notifications
-    pub fn with_notifications(
+    pub fn with_notifications(router: McpRouter, notification_rx: NotificationReceiver) -> Self {
+        let service = JsonRpcService::new(router.clone());
+        Self::spawn_with_service(router, service, notification_rx)
+    }
+
+    /// Create a channel transport whose dispatch runs through a Tower layer.
+    ///
+    /// The channel counterpart of [`StdioTransport::layer`]: the layer wraps
+    /// the router's dispatch service, so standard middleware (timeout, rate
+    /// limit, tracing, audit) observes every JSON-RPC request an
+    /// [`McpClient`](crate::client::McpClient) makes in-process, exactly as
+    /// it would over stdio or HTTP. Layers that produce errors are wrapped
+    /// with [`CatchError`] and tool-annotation injection is preserved.
+    ///
+    /// `subscriptions/listen` remains transport-owned on every transport and
+    /// does not pass through the layer (#1182 tracks that boundary).
+    ///
+    /// [`StdioTransport::layer`]: crate::transport::StdioTransport::layer
+    pub fn layer<L>(router: McpRouter, layer: L) -> Self
+    where
+        L: tower::Layer<McpRouter>,
+        L::Service: Service<RouterRequest, Response = RouterResponse> + Clone + Send + 'static,
+        <L::Service as Service<RouterRequest>>::Error: std::fmt::Display + Send,
+        <L::Service as Service<RouterRequest>>::Future: Send,
+    {
+        let (notification_tx, notification_rx) = notification_channel(64);
+        let router = router.with_notification_sender(notification_tx);
+        Self::layer_with_notifications(router, layer, notification_rx)
+    }
+
+    /// [`layer`](Self::layer) with a caller-owned notification receiver, the
+    /// layered counterpart of [`with_notifications`](Self::with_notifications).
+    pub fn layer_with_notifications<L>(
         router: McpRouter,
+        layer: L,
+        notification_rx: NotificationReceiver,
+    ) -> Self
+    where
+        L: tower::Layer<McpRouter>,
+        L::Service: Service<RouterRequest, Response = RouterResponse> + Clone + Send + 'static,
+        <L::Service as Service<RouterRequest>>::Error: std::fmt::Display + Send,
+        <L::Service as Service<RouterRequest>>::Future: Send,
+    {
+        let annotations = router.tool_annotations_map();
+        let wrapped = layer.layer(router.clone());
+        let service = InjectAnnotations::new(CatchError::new(wrapped), annotations);
+        Self::spawn_with_service(router, JsonRpcService::new(service), notification_rx)
+    }
+
+    /// Spawn the request and notification loops over an arbitrary dispatch
+    /// service.
+    ///
+    /// The router is retained alongside the service for transport metadata
+    /// only: server identity and tasks opt-in for subscription handling, and
+    /// the `notifications/initialized` forward. Requests dispatch through
+    /// `service`, never through the router directly, so a wrapping layer sees
+    /// every request.
+    fn spawn_with_service<S>(
+        router: McpRouter,
+        service: JsonRpcService<S>,
         mut notification_rx: NotificationReceiver,
-    ) -> Self {
+    ) -> Self
+    where
+        S: Service<RouterRequest, Response = RouterResponse, Error = std::convert::Infallible>
+            + Clone
+            + Send
+            + 'static,
+        S::Future: Send,
+    {
         let (request_tx, mut request_rx) = mpsc::channel::<String>(64);
         let (response_tx, response_rx) = mpsc::channel::<String>(64);
 
@@ -161,8 +228,6 @@ impl ChannelTransport {
                 }
             }
         });
-
-        let service = JsonRpcService::new(router.clone());
 
         tokio::spawn(async move {
             while let Some(raw_request) = request_rx.recv().await {

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -258,3 +258,153 @@ async fn final_subscription_listen_filters_channel_transport_notifications() {
     );
     subscription.cancel().await.expect("subscription cancel");
 }
+
+// =============================================================================
+// Layered dispatch (#1181)
+// =============================================================================
+
+mod layered {
+    use super::*;
+    use std::sync::Mutex;
+    use std::task::{Context, Poll};
+
+    use tower_mcp::router::{RouterRequest, RouterResponse};
+
+    /// Records the method name of every request that passes through.
+    #[derive(Clone)]
+    struct RecordingLayer {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[derive(Clone)]
+    struct RecordingService<S> {
+        inner: S,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> tower::Layer<S> for RecordingLayer {
+        type Service = RecordingService<S>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            RecordingService {
+                inner,
+                seen: self.seen.clone(),
+            }
+        }
+    }
+
+    impl<S> tower_service::Service<RouterRequest> for RecordingService<S>
+    where
+        S: tower_service::Service<RouterRequest, Response = RouterResponse>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, request: RouterRequest) -> Self::Future {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(request.inner.method_name().to_string());
+            self.inner.call(request)
+        }
+    }
+
+    /// The acceptance criterion of #1181: middleware on the in-process
+    /// transport observes the same requests it would see over stdio or HTTP.
+    #[tokio::test]
+    async fn layer_observes_requests_made_through_the_client() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let router = McpRouter::new()
+            .server_info("layered-channel", "1.0.0")
+            .tool(slow_tool("quick", 0));
+
+        let transport = ChannelTransport::layer(router, RecordingLayer { seen: seen.clone() });
+        let client = McpClient::connect(transport).await.expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+        client.list_tools().await.expect("list tools");
+        client
+            .call_tool("quick", serde_json::json!({}))
+            .await
+            .expect("call tool");
+
+        let observed = seen.lock().unwrap().clone();
+        assert_eq!(observed, vec!["initialize", "tools/list", "tools/call"]);
+    }
+
+    /// Middleware errors surface as JSON-RPC errors through CatchError, and a
+    /// budget generous enough for the handler lets the call through.
+    #[tokio::test]
+    async fn layer_errors_become_jsonrpc_errors() {
+        let router = McpRouter::new()
+            .server_info("layered-channel", "1.0.0")
+            .tool(slow_tool("slow", 200));
+
+        let transport = ChannelTransport::layer(
+            router,
+            tower::timeout::TimeoutLayer::new(Duration::from_millis(20)),
+        );
+        let client = McpClient::connect(transport).await.expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("fast requests pass the timeout layer");
+
+        let error = client
+            .call_tool("slow", serde_json::json!({}))
+            .await
+            .expect_err("the slow call must exceed the layer budget");
+        assert!(
+            error.to_string().to_lowercase().contains("timed out")
+                || error.to_string().to_lowercase().contains("timeout"),
+            "error should come from the timeout layer, got: {error}"
+        );
+    }
+
+    /// The layered constructor with a caller-owned notification channel keeps
+    /// host-pushed notifications flowing.
+    #[tokio::test]
+    async fn layered_transport_still_delivers_notifications() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (notif_tx, notif_rx) = notification_channel(64);
+        let router = McpRouter::new()
+            .server_info("layered-channel", "1.0.0")
+            .with_notification_sender(notif_tx.clone());
+
+        let (seen_tx, mut seen_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let handler = NotificationHandler::new().on_tools_changed(move || {
+            let _ = seen_tx.send(());
+        });
+
+        let transport = ChannelTransport::layer_with_notifications(
+            router,
+            RecordingLayer { seen: seen.clone() },
+            notif_rx,
+        );
+        let client = McpClient::connect_with_handler(transport, handler)
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        notif_tx
+            .send(ServerNotification::ToolsListChanged)
+            .await
+            .expect("push notification");
+        tokio::time::timeout(Duration::from_secs(2), seen_rx.recv())
+            .await
+            .expect("notification must arrive through the layered transport")
+            .expect("handler channel open");
+
+        assert_eq!(*seen.lock().unwrap(), vec!["initialize"]);
+    }
+}


### PR DESCRIPTION
Closes #1181.

## What changes

`ChannelTransport` hard-coded its dispatch to `JsonRpcService<McpRouter>`, so middleware that observes every request over stdio and HTTP was unreachable from `McpClient` integration tests and embedded applications using the in-process transport (the AgentWork ledger case, joshrotenberg/agent-work#71).

- The constructor body is split into a generic core over any `Service<RouterRequest, Response = RouterResponse, Error = Infallible>`; the transport handle stays non-generic because the channel loop erases the service type, so no `GenericChannelTransport` is needed
- `ChannelTransport::layer(router, l)` and `layer_with_notifications(router, l, rx)` follow the `StdioTransport::layer` recipe exactly: the layer wraps the router's dispatch, `CatchError` converts middleware errors to JSON-RPC errors, `InjectAnnotations` preserves tool-annotation injection
- The router is retained beside the service for transport metadata only (server identity and tasks opt-in for subscription handling, the `notifications/initialized` forward); every request dispatches through the wrapped service

All requests share the single `call_single` dispatch path, so a layer that observes `initialize` and `tools/call` observes discovery, resource, prompt, and task requests identically.

`subscriptions/listen` remains transport-owned, consistent with stdio and HTTP; #1182 tracks that observation boundary and the `layer()` docs point at it.

## Tests

- `layer_observes_requests_made_through_the_client`: a recording layer sees exactly `["initialize", "tools/list", "tools/call"]` for that client interaction, the acceptance criterion of #1181
- `layer_errors_become_jsonrpc_errors`: a 20ms `TimeoutLayer` over a 200ms tool surfaces as a JSON-RPC timeout error through `CatchError`, while initialize passes
- `layered_transport_still_delivers_notifications`: host-pushed notifications flow through the layered constructor, and the layer correctly sees only requests
- The pre-existing channel suite, including the final-protocol `subscriptions/listen` filter test, is untouched and green

One hazard found and fixed during the refactor: the original body constructed a second `JsonRpcService::new(router.clone())` inside the loop, which would have shadowed the injected service and silently bypassed the layer while still compiling. The recording test exists specifically so that regression cannot come back quietly.