### PR TITLE
feat(transport): route subscriptions/listen through the middleware boundary

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -914,6 +914,10 @@ pub enum McpResponse {
     Pong(EmptyResult),
     /// SEP-2575 `server/discover` response.
     Discover(DiscoverResult),
+    /// Accepted filter from the pre-upgrade service pass of
+    /// `subscriptions/listen`; consumed by the owning transport, never
+    /// serialized as the request's wire response.
+    SubscriptionsAccepted(SubscriptionsAcceptedResult),
     /// SEP-2575 / SEP-2567 `subscriptions/listen` response.
     ///
     /// In practice the HTTP transport returns an SSE stream for this method
@@ -2113,6 +2117,22 @@ pub struct SubscriptionsListenParams {
         with = "crate::protocol::meta_object_serde"
     )]
     pub meta: Option<Value>,
+}
+
+/// Accepted-filter result of the pre-upgrade service pass for
+/// `subscriptions/listen` (SEP-2575).
+///
+/// This is not a wire result. Transports dispatch the listen request through
+/// the JSON-RPC service before upgrading the connection into a stream, so
+/// `Service<RouterRequest>` middleware observes accepted and rejected listens
+/// like any other request; the transport then consumes this result to
+/// register the stream and emit `notifications/subscriptions/acknowledged`.
+/// The request's eventual wire response remains the graceful-close
+/// [`SubscriptionsListenResult`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscriptionsAcceptedResult {
+    /// The notification types and task IDs the server agreed to honor.
+    pub notifications: SubscriptionFilter,
 }
 
 /// Graceful final result of the `subscriptions/listen` RPC.

--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -194,10 +194,9 @@ impl ChannelTransport {
         let (response_tx, response_rx) = mpsc::channel::<String>(64);
 
         #[cfg(feature = "stateless")]
-        let subscriptions = Arc::new(StdMutex::new(StdioSubscriptions::new(
-            Some(router.implementation()),
-            router.final_tasks_enabled(),
-        )));
+        let subscriptions = Arc::new(StdMutex::new(StdioSubscriptions::new(Some(
+            router.implementation(),
+        ))));
 
         // Notification pump: serialize ServerNotifications into JSON-RPC
         // notification frames on the shared response stream.
@@ -243,17 +242,43 @@ impl ChannelTransport {
                 };
                 #[cfg(feature = "stateless")]
                 {
+                    // The registry lock is never held across an await: the
+                    // dispatch through the service happens between the
+                    // handle_input and complete_listen critical sections.
                     let handled = subscriptions
                         .lock()
                         .ok()
                         .map(|mut subscriptions| subscriptions.handle_input(&service, &parsed));
-                    if let Some(Ok(StdioSubscriptionInput::Handled(frames))) = handled {
-                        for frame in frames {
-                            if response_tx.send(frame).await.is_err() {
-                                return;
+                    match handled {
+                        Some(Ok(StdioSubscriptionInput::Handled(frames))) => {
+                            for frame in frames {
+                                if response_tx.send(frame).await.is_err() {
+                                    return;
+                                }
                             }
+                            continue;
                         }
-                        continue;
+                        Some(Ok(StdioSubscriptionInput::Dispatch(request))) => {
+                            let request_id = request.id.clone();
+                            let response = crate::transport::stdio::dispatch_listen_request(
+                                &mut service.clone(),
+                                *request,
+                                request_id.clone(),
+                            )
+                            .await;
+                            let frames = subscriptions.lock().ok().map(|mut subscriptions| {
+                                subscriptions.complete_listen(request_id, &response)
+                            });
+                            if let Some(Ok(frames)) = frames {
+                                for frame in frames {
+                                    if response_tx.send(frame).await.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
+                            continue;
+                        }
+                        _ => {}
                     }
                 }
                 if parsed.get("id").is_none() {

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3582,6 +3582,44 @@ impl McpRouter {
                 }
             }
 
+            #[cfg(feature = "stateless")]
+            McpRequest::SubscriptionsListen(params) => {
+                // The stream itself is transport-owned: transports dispatch
+                // the request here before upgrading the connection, so
+                // `Service<RouterRequest>` middleware observes accepted and
+                // rejected listens and the validation lives in one place
+                // (#1182). The response is consumed by the transport, never
+                // written to the wire.
+                if !is_final_protocol_request(&extensions) {
+                    // A legacy peer gets exactly what the old catch-all
+                    // produced for this method.
+                    return Err(Error::JsonRpc(JsonRpcError::method_not_found(
+                        "subscriptions/listen",
+                    )));
+                }
+                let Some(requested) = params.notifications else {
+                    return Err(Error::JsonRpc(JsonRpcError::invalid_params(
+                        "subscriptions/listen requires a notifications filter",
+                    )));
+                };
+                // SEP-2663: task status notifications require the declared
+                // extension, the same answer the three task methods give.
+                if requested.task_ids.is_some() && !client_declares_tasks(&extensions) {
+                    return Err(Error::JsonRpc(
+                        JsonRpcError::missing_required_client_capability(
+                            tasks_client_capabilities(),
+                        ),
+                    ));
+                }
+                let notifications = crate::transport::subscriptions::accepted_subscription_filter(
+                    requested,
+                    self.final_tasks_enabled(),
+                );
+                Ok(McpResponse::SubscriptionsAccepted(
+                    crate::protocol::SubscriptionsAcceptedResult { notifications },
+                ))
+            }
+
             McpRequest::Unknown { method, .. } => {
                 Err(Error::JsonRpc(JsonRpcError::method_not_found(&method)))
             }

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -274,21 +274,20 @@ use crate::error::{Error, JsonRpcError, Result};
 use crate::error::{ErrorCode, McpErrorCode};
 use crate::inspection::{McpDirection, McpProtocolRevision};
 use crate::jsonrpc::{JsonRpcService, apply_protocol_result_fields, inspect_runtime_value};
+#[cfg(feature = "stateless")]
+use crate::protocol::SubscriptionFilter;
 use crate::protocol::{
     ClientCapabilities, Implementation, JsonRpcMessage, JsonRpcNotification, JsonRpcRequest,
     JsonRpcResponse, LATEST_PROTOCOL_VERSION, McpNotification, PROTOCOL_VERSION_2026_07_28,
     RequestId,
 };
-#[cfg(feature = "stateless")]
-use crate::protocol::{SubscriptionFilter, SubscriptionsListenParams};
 use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{
     CatchError, InjectAnnotations, McpBoxService, ServiceFactory, identity_factory,
 };
 #[cfg(feature = "stateless")]
 use crate::transport::subscriptions::{
-    accepted_subscription_filter, subscription_complete_response, subscription_matches,
-    tagged_subscription_notification,
+    subscription_complete_response, subscription_matches, tagged_subscription_notification,
 };
 use crate::{ProtocolSupport, ProtocolSupportError};
 use tower::util::BoxCloneService;
@@ -1298,21 +1297,6 @@ impl SessionHandle {
     #[cfg(feature = "stateless")]
     pub fn close_subscriptions(&self) -> usize {
         self.modern_subscriptions.close_all()
-    }
-}
-
-#[cfg(feature = "stateless")]
-impl AppState {
-    /// Whether the served router opted into the Tasks extension.
-    ///
-    /// A boxed service is opaque here, so it reads as not enabled: the
-    /// acknowledgement then declines the task IDs rather than promising
-    /// notifications this transport cannot confirm anyone will send.
-    fn tasks_extension_enabled(&self) -> bool {
-        match &self.service_source {
-            ServiceSource::Router { router, .. } => router.final_tasks_enabled(),
-            ServiceSource::Service(_) => false,
-        }
     }
 }
 
@@ -4254,22 +4238,6 @@ fn stateless_sse_with_notifications(
         .into_response()
 }
 
-/// Whether a `subscriptions/listen` request declared the Tasks extension.
-///
-/// The listen handler runs ahead of the router, so it reads the per-request
-/// capabilities straight out of `_meta` rather than from request extensions.
-#[cfg(feature = "stateless")]
-fn listen_request_declares_tasks(parsed: &serde_json::Value) -> bool {
-    parsed
-        .get("params")
-        .and_then(crate::stateless::StatelessRequestMeta::from_params)
-        .and_then(|meta| meta.client_capabilities)
-        .and_then(|capabilities| capabilities.extensions)
-        .is_some_and(|declared| {
-            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
-        })
-}
-
 /// Serve the final, sessionless `subscriptions/listen` protocol over its
 /// owning POST response.
 #[cfg(feature = "stateless")]
@@ -4285,39 +4253,85 @@ async fn handle_modern_subscriptions_listen_sse(
             StatusCode::BAD_REQUEST,
         );
     };
-    let params = match parsed
-        .get("params")
-        .cloned()
-        .ok_or_else(|| JsonRpcError::invalid_params("subscriptions/listen requires params"))
-        .and_then(|value| {
-            serde_json::from_value::<SubscriptionsListenParams>(value)
-                .map_err(|error| JsonRpcError::invalid_params(error.to_string()))
-        }) {
-        Ok(params) => params,
+    let request: JsonRpcRequest = match serde_json::from_value(parsed.clone()) {
+        Ok(request) => request,
         Err(error) => {
-            return json_rpc_error_response_with_status(id, error, StatusCode::BAD_REQUEST);
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::invalid_request(format!("Invalid request: {error}")),
+                StatusCode::BAD_REQUEST,
+            );
         }
     };
-    let Some(requested) = params.notifications else {
-        return json_rpc_error_response_with_status(
-            id,
-            JsonRpcError::invalid_params("subscriptions/listen requires a notifications filter"),
-            StatusCode::BAD_REQUEST,
-        );
-    };
-    // SEP-2663: a client asking for task notifications must have declared the
-    // extension, on this request like every other final-protocol request.
-    if requested.task_ids.is_some() && !listen_request_declares_tasks(parsed) {
-        return json_rpc_error_response_with_status(
-            id,
-            JsonRpcError::missing_required_client_capability(
-                crate::router::tasks_client_capabilities(),
-            ),
-            StatusCode::BAD_REQUEST,
-        );
-    }
 
-    let accepted = accepted_subscription_filter(requested, state.tasks_extension_enabled());
+    // Dispatch the request through the per-request service before upgrading,
+    // so `Service<RouterRequest>` middleware observes accepted and rejected
+    // listens and the router owns validation and filter negotiation (#1182).
+    // The service response never reaches the wire: an error is returned as
+    // the reply, and a success carries the accepted filter this handler
+    // consumes to register the stream. The stream lifetime stays entirely
+    // transport-owned.
+    let service = match &state.service_source {
+        ServiceSource::Router { router, factory } => {
+            let ephemeral = router.with_fresh_session();
+            ephemeral.session().mark_initialized();
+            JsonRpcService::new(factory(ephemeral))
+        }
+        ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
+    };
+    let mut ext = crate::router::Extensions::new();
+    ext.insert(state.protocol_support.clone());
+    stash_per_request_meta(&request, &mut ext);
+    if ext
+        .get::<crate::stateless::StatelessRequestMeta>()
+        .is_none()
+    {
+        // This handler is only reached for effective-final requests, but the
+        // version can arrive via the HTTP header with no per-request `_meta`.
+        // Seed the meta so the router classifies the request correctly.
+        ext.insert(crate::stateless::StatelessRequestMeta {
+            protocol_version: Some(crate::protocol::PROTOCOL_VERSION_2026_07_28.to_string()),
+            ..Default::default()
+        });
+    }
+    let mut service = service.with_extensions(ext);
+
+    let response = match service.call_single(request).await {
+        Ok(response) => response,
+        Err(error) => {
+            return json_rpc_error_response_with_status(
+                id,
+                JsonRpcError::internal_error(error.to_string()),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            );
+        }
+    };
+    let accepted = match &response {
+        JsonRpcResponse::Result(result) => match result
+            .result
+            .get("notifications")
+            .cloned()
+            .map(serde_json::from_value::<SubscriptionFilter>)
+        {
+            Some(Ok(accepted)) => accepted,
+            _ => {
+                return json_rpc_error_response_with_status(
+                    id,
+                    JsonRpcError::internal_error(
+                        "subscriptions/listen produced an unrecognized service result",
+                    ),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                );
+            }
+        },
+        _ => {
+            // Rejected: middleware already observed the error; reply with it.
+            let mut resp = axum::Json(&response).into_response();
+            *resp.status_mut() = StatusCode::BAD_REQUEST;
+            return resp;
+        }
+    };
+
     let (rx, guard) = state
         .modern_subscriptions
         .register(subscription_id.clone(), accepted.clone());

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -9,7 +9,7 @@
 pub mod stdio;
 
 #[cfg(feature = "stateless")]
-mod subscriptions;
+pub(crate) mod subscriptions;
 
 #[cfg(feature = "http")]
 pub mod http;

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -45,7 +45,7 @@ use tower_service::Service;
 use crate::error::{Error, Result};
 use crate::jsonrpc::JsonRpcService;
 #[cfg(feature = "stateless")]
-use crate::protocol::{Implementation, SubscriptionFilter, SubscriptionsListenParams};
+use crate::protocol::{Implementation, SubscriptionFilter};
 use crate::protocol::{
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, JsonRpcResponseMessage,
     McpNotification, RequestId, notifications,
@@ -54,8 +54,8 @@ use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{CatchError, InjectAnnotations};
 #[cfg(feature = "stateless")]
 use crate::transport::subscriptions::{
-    accepted_subscription_filter, subscription_acknowledgment, subscription_complete_response,
-    subscription_matches, tagged_subscription_notification,
+    subscription_acknowledgment, subscription_complete_response, subscription_matches,
+    tagged_subscription_notification,
 };
 use crate::{ProtocolSupport, ProtocolSupportError};
 
@@ -112,37 +112,24 @@ pub(crate) struct StdioSubscriptions {
     active: HashMap<RequestId, SubscriptionFilter>,
     modern_mode: bool,
     server_info: Option<Implementation>,
-    /// Whether the served router opted into the Tasks extension. Captured at
-    /// startup because the listen handler only sees the generic service.
-    tasks_enabled: bool,
-}
-
-/// Whether a stdio `subscriptions/listen` request declared the Tasks
-/// extension in its per-request `_meta`.
-#[cfg(feature = "stateless")]
-fn stdio_request_declares_tasks(parsed: &serde_json::Value) -> bool {
-    parsed
-        .get("params")
-        .and_then(crate::stateless::StatelessRequestMeta::from_params)
-        .and_then(|meta| meta.client_capabilities)
-        .and_then(|capabilities| capabilities.extensions)
-        .is_some_and(|declared| {
-            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
-        })
 }
 
 #[cfg(feature = "stateless")]
 pub(crate) enum StdioSubscriptionInput {
     NotHandled,
     Handled(Vec<String>),
+    /// A modern listen request that passed the transport-owned checks.
+    /// Dispatch it through the JSON-RPC service (so middleware observes it
+    /// and the router validates and negotiates the filter), then hand the
+    /// response to [`StdioSubscriptions::complete_listen`].
+    Dispatch(Box<JsonRpcRequest>),
 }
 
 #[cfg(feature = "stateless")]
 impl StdioSubscriptions {
-    pub(crate) fn new(server_info: Option<Implementation>, tasks_enabled: bool) -> Self {
+    pub(crate) fn new(server_info: Option<Implementation>) -> Self {
         Self {
             server_info,
-            tasks_enabled,
             ..Self::default()
         }
     }
@@ -201,36 +188,12 @@ impl StdioSubscriptions {
             ]));
         }
 
-        let params = request
-            .params
-            .clone()
-            .ok_or_else(|| {
-                crate::error::JsonRpcError::invalid_params("subscriptions/listen requires params")
-            })
-            .and_then(|value| {
-                serde_json::from_value::<SubscriptionsListenParams>(value)
-                    .map_err(|error| crate::error::JsonRpcError::invalid_params(error.to_string()))
-            });
-        let params = match params {
-            Ok(params) => params,
-            Err(error) => {
-                let response = JsonRpcResponse::error(Some(request_id), error);
-                return Ok(StdioSubscriptionInput::Handled(vec![
-                    serde_json::to_string(&response)?,
-                ]));
-            }
-        };
-        let Some(requested) = params.notifications else {
-            let response = JsonRpcResponse::error(
-                Some(request_id),
-                crate::error::JsonRpcError::invalid_params(
-                    "subscriptions/listen requires a notifications filter",
-                ),
-            );
-            return Ok(StdioSubscriptionInput::Handled(vec![
-                serde_json::to_string(&response)?,
-            ]));
-        };
+        // Duplicate request ids are stream-registry state only this
+        // transport can see, so the check stays here, ahead of the service
+        // dispatch. Everything else about the request (params shape, the
+        // required filter, the SEP-2663 capability gate, filter negotiation)
+        // is the router's job, reached through the service so middleware
+        // observes the request (#1182).
         if self.active.contains_key(&request_id) {
             let response = JsonRpcResponse::error(
                 Some(request_id),
@@ -243,27 +206,47 @@ impl StdioSubscriptions {
             ]));
         }
 
-        // SEP-2663: asking for task notifications without declaring the
-        // extension is answered with the missing-capability error, the same
-        // way the three task methods answer it.
-        if requested.task_ids.is_some() && !stdio_request_declares_tasks(parsed) {
+        Ok(StdioSubscriptionInput::Dispatch(Box::new(request)))
+    }
+
+    /// Complete a listen request the caller dispatched through the service.
+    ///
+    /// An error response is emitted verbatim: middleware already observed
+    /// the rejection and the wire shape must match what the transport-owned
+    /// validation produced before #1182. A success response carries the
+    /// accepted filter, which registers the stream and becomes the
+    /// `notifications/subscriptions/acknowledged` frame.
+    pub(crate) fn complete_listen(
+        &mut self,
+        request_id: RequestId,
+        response: &JsonRpcResponse,
+    ) -> Result<Vec<String>> {
+        // `JsonRpcResponse` is non_exhaustive; anything that is not a
+        // success result is passed through verbatim like an error.
+        let JsonRpcResponse::Result(result) = response else {
+            return Ok(vec![serde_json::to_string(response)?]);
+        };
+        let result = &result.result;
+        let accepted = result
+            .get("notifications")
+            .cloned()
+            .map(serde_json::from_value::<SubscriptionFilter>)
+            .and_then(std::result::Result::ok);
+        let Some(accepted) = accepted else {
             let response = JsonRpcResponse::error(
                 Some(request_id),
-                crate::error::JsonRpcError::missing_required_client_capability(
-                    crate::router::tasks_client_capabilities(),
+                crate::error::JsonRpcError::internal_error(
+                    "subscriptions/listen produced an unrecognized service result",
                 ),
             );
-            return Ok(StdioSubscriptionInput::Handled(vec![
-                serde_json::to_string(&response)?,
-            ]));
-        }
+            return Ok(vec![serde_json::to_string(&response)?]);
+        };
 
-        let accepted = accepted_subscription_filter(requested, self.tasks_enabled);
         let acknowledgment = subscription_acknowledgment(request_id.clone(), accepted.clone());
         let acknowledgment = serde_json::to_string(&acknowledgment)?;
         self.modern_mode = true;
         self.active.insert(request_id, accepted);
-        Ok(StdioSubscriptionInput::Handled(vec![acknowledgment]))
+        Ok(vec![acknowledgment])
     }
 
     /// Route a subscription-scoped notification and suppress its untagged
@@ -373,6 +356,34 @@ fn handle_notification(router: &McpRouter, notification: JsonRpcNotification) ->
 }
 
 /// Serialize a server notification to a JSON-RPC notification string.
+/// Dispatch a validated `subscriptions/listen` request through the JSON-RPC
+/// service, converting a service-level failure into a JSON-RPC error response
+/// so [`StdioSubscriptions::complete_listen`] always receives an answer.
+#[cfg(feature = "stateless")]
+pub(crate) async fn dispatch_listen_request<S>(
+    service: &mut JsonRpcService<S>,
+    request: JsonRpcRequest,
+    request_id: crate::protocol::RequestId,
+) -> JsonRpcResponse
+where
+    S: tower_service::Service<
+            crate::router::RouterRequest,
+            Response = crate::router::RouterResponse,
+            Error = std::convert::Infallible,
+        > + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
+    match service.call_single(request).await {
+        Ok(response) => response,
+        Err(error) => JsonRpcResponse::error(
+            Some(request_id),
+            crate::error::JsonRpcError::internal_error(error.to_string()),
+        ),
+    }
+}
+
 pub(crate) fn serialize_notification(notification: &ServerNotification) -> Option<String> {
     match notification {
         ServerNotification::Progress(params) => {
@@ -602,7 +613,6 @@ impl StdioTransport {
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
-            tasks_enabled: self.router.final_tasks_enabled(),
             ..StdioSubscriptions::default()
         };
 
@@ -634,13 +644,29 @@ impl StdioTransport {
                             Ok(parsed) => parsed,
                             Err(_) => serde_json::Value::Null,
                         };
-                        if let StdioSubscriptionInput::Handled(frames) =
-                            subscriptions.handle_input(&self.service, &parsed)?
-                        {
-                            for frame in frames {
-                                write_line_to_stdout(&mut writer, &frame).await?;
+                        match subscriptions.handle_input(&self.service, &parsed)? {
+                            StdioSubscriptionInput::Handled(frames) => {
+                                for frame in frames {
+                                    write_line_to_stdout(&mut writer, &frame).await?;
+                                }
+                                continue;
                             }
-                            continue;
+                            StdioSubscriptionInput::Dispatch(request) => {
+                                let request_id = request.id.clone();
+                                let response = dispatch_listen_request(
+                                    &mut self.service,
+                                    *request,
+                                    request_id.clone(),
+                                )
+                                .await;
+                                for frame in
+                                    subscriptions.complete_listen(request_id, &response)?
+                                {
+                                    write_line_to_stdout(&mut writer, &frame).await?;
+                                }
+                                continue;
+                            }
+                            StdioSubscriptionInput::NotHandled => {}
                         }
                     }
 
@@ -970,14 +996,25 @@ where
         };
 
         #[cfg(feature = "stateless")]
-        if subscriptions_enabled
-            && let StdioSubscriptionInput::Handled(frames) =
-                subscriptions.handle_input(service, &parsed)?
-        {
-            for frame in frames {
-                write_line_to_stdout(writer, &frame).await?;
+        if subscriptions_enabled {
+            match subscriptions.handle_input(service, &parsed)? {
+                StdioSubscriptionInput::Handled(frames) => {
+                    for frame in frames {
+                        write_line_to_stdout(writer, &frame).await?;
+                    }
+                    return Ok(());
+                }
+                StdioSubscriptionInput::Dispatch(request) => {
+                    let request_id = request.id.clone();
+                    let response =
+                        dispatch_listen_request(service, *request, request_id.clone()).await;
+                    for frame in subscriptions.complete_listen(request_id, &response)? {
+                        write_line_to_stdout(writer, &frame).await?;
+                    }
+                    return Ok(());
+                }
+                StdioSubscriptionInput::NotHandled => {}
             }
-            return Ok(());
         }
         #[cfg(not(feature = "stateless"))]
         let _ = subscriptions_enabled;
@@ -1333,7 +1370,6 @@ impl BidirectionalStdioTransport {
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
-            tasks_enabled: self.router.final_tasks_enabled(),
             ..StdioSubscriptions::default()
         };
 
@@ -1449,13 +1485,23 @@ impl BidirectionalStdioTransport {
         }
 
         #[cfg(feature = "stateless")]
-        if let StdioSubscriptionInput::Handled(frames) =
-            subscriptions.handle_input(&self.service, &parsed)?
-        {
-            for frame in frames {
-                self.write_line(&frame, writer.clone()).await?;
+        match subscriptions.handle_input(&self.service, &parsed)? {
+            StdioSubscriptionInput::Handled(frames) => {
+                for frame in frames {
+                    self.write_line(&frame, writer.clone()).await?;
+                }
+                return Ok(());
             }
-            return Ok(());
+            StdioSubscriptionInput::Dispatch(request) => {
+                let request_id = request.id.clone();
+                let response =
+                    dispatch_listen_request(&mut self.service, *request, request_id.clone()).await;
+                for frame in subscriptions.complete_listen(request_id, &response)? {
+                    self.write_line(&frame, writer.clone()).await?;
+                }
+                return Ok(());
+            }
+            StdioSubscriptionInput::NotHandled => {}
         }
 
         // Check if it's a notification (no id field)

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -1200,3 +1200,168 @@ async fn bidi_transport_elicitation_round_trip() {
         .expect("elicitation round-trip over bidirectional stdio timed out (deadlock)");
     let _ = timeout(Duration::from_secs(2), handle).await;
 }
+
+// =============================================================================
+// Middleware observation of subscriptions/listen (#1182)
+// =============================================================================
+
+#[cfg(feature = "stateless")]
+mod listen_observation {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use std::task::{Context as TaskContext, Poll};
+
+    use tower_mcp::router::{RouterRequest, RouterResponse};
+
+    #[derive(Clone)]
+    struct RecordingLayer {
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[derive(Clone)]
+    struct RecordingService<S> {
+        inner: S,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl<S> tower::Layer<S> for RecordingLayer {
+        type Service = RecordingService<S>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            RecordingService {
+                inner,
+                seen: self.seen.clone(),
+            }
+        }
+    }
+
+    impl<S> tower_service::Service<RouterRequest> for RecordingService<S>
+    where
+        S: tower_service::Service<RouterRequest, Response = RouterResponse>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        fn poll_ready(&mut self, cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, request: RouterRequest) -> Self::Future {
+            self.seen
+                .lock()
+                .unwrap()
+                .push(request.inner.method_name().to_string());
+            self.inner.call(request)
+        }
+    }
+
+    async fn run_listen_exchange(request: serde_json::Value) -> (Vec<String>, serde_json::Value) {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let mut transport =
+            StdioTransport::new(subscription_router()).layer(RecordingLayer { seen: seen.clone() });
+        let control = transport.handle();
+        let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+        let task = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+        server_stdin_writer
+            .write_all(format!("{request}\n").as_bytes())
+            .await
+            .unwrap();
+        server_stdin_writer.flush().await.unwrap();
+        let mut reader = BufReader::new(server_stdout_reader);
+        let frame = timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("listen exchange reply");
+        control.shutdown().unwrap();
+        let _ = task.await;
+        let observed = seen.lock().unwrap().clone();
+        (observed, frame)
+    }
+
+    /// Before #1182 the transport intercepted `subscriptions/listen` ahead of
+    /// the service, so a layer advertised as covering all MCP requests never
+    /// saw subscription starts. Now the accepted listen passes through it.
+    #[tokio::test]
+    async fn middleware_observes_an_accepted_listen() {
+        let (observed, frame) = run_listen_exchange(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "observed",
+            "method": "subscriptions/listen",
+            "params": {
+                "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
+                "notifications": {"toolsListChanged": true}
+            }
+        }))
+        .await;
+
+        assert_eq!(observed, vec!["subscriptions/listen"]);
+        // The wire behavior is unchanged: the acknowledgment still arrives.
+        assert_eq!(frame["method"], "notifications/subscriptions/acknowledged");
+        assert_eq!(
+            frame["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+            "observed"
+        );
+        assert_eq!(frame["params"]["notifications"]["toolsListChanged"], true);
+    }
+
+    /// A rejected listen also passes through the layer, and the rejection
+    /// wire shape matches what the transport-owned validation produced
+    /// before: -32021 with the required extension named.
+    #[tokio::test]
+    async fn middleware_observes_a_rejected_listen() {
+        let (observed, frame) = run_listen_exchange(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "rejected",
+            "method": "subscriptions/listen",
+            "params": {
+                "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
+                "notifications": {"taskIds": ["task-1"]}
+            }
+        }))
+        .await;
+
+        assert_eq!(observed, vec!["subscriptions/listen"]);
+        assert_eq!(frame["id"], "rejected");
+        assert_eq!(frame["error"]["code"], -32021);
+        assert!(
+            frame["error"]["data"]["requiredCapabilities"]["extensions"]
+                ["io.modelcontextprotocol/tasks"]
+                .is_object(),
+            "the rejection must name the missing extension: {frame}"
+        );
+    }
+
+    /// A listen violating the wire schema (the required `notifications`
+    /// field missing) is rejected by protocol inspection inside the service,
+    /// before the middleware boundary. That matches every other method:
+    /// schema-invalid requests never become a `RouterRequest`, so middleware
+    /// does not observe them; semantic rejections (like -32021 above) do.
+    #[tokio::test]
+    async fn schema_rejections_stay_ahead_of_the_middleware_boundary() {
+        let (observed, frame) = run_listen_exchange(serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": "no-filter",
+            "method": "subscriptions/listen",
+            "params": {
+                "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
+            }
+        }))
+        .await;
+
+        assert!(observed.is_empty(), "schema rejections precede middleware");
+        assert_eq!(frame["id"], "no-filter");
+        assert_eq!(frame["error"]["code"], -32602);
+        assert!(
+            frame["error"]["message"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("required `notifications` field is missing"),
+            "the rejection must explain the missing filter: {frame}"
+        );
+    }
+}


### PR DESCRIPTION
Contract A of #1182, per the hybrid decision on the issue: the request half of the observation boundary. The close-only hook (terminal reason, stream duration) is the remaining half and lands separately.

## What changes

- The router handles `McpRequest::SubscriptionsListen`: required-filter validation, the SEP-2663 `-32021` capability gate, and filter negotiation move next to the capability state the router already owns (`final_tasks_enabled`, per-request client capabilities). The result is the new `SubscriptionsAccepted` shape, documented as never reaching the wire.
- All four transport paths (stdio, generic stdio, bidirectional stdio, HTTP) dispatch the listen request through their service before upgrading, so `Service<RouterRequest>` middleware observes accepted and rejected listens like any other method. The stdio family shares a `Dispatch` handoff from `StdioSubscriptions` plus `complete_listen`; HTTP uses the same ephemeral factory-built service as the stateless request path, so `HttpTransport::layer` stacks apply.
- Transport-local copies of the validation are deleted (`stdio_request_declares_tasks`, `listen_request_declares_tasks`, `AppState::tasks_extension_enabled`, the per-transport filter checks). The duplicate-request-id check stays transport-side because it is stream-registry state.
- The channel loop never holds the registry lock across an await: dispatch happens between the `handle_input` and `complete_listen` critical sections.

## Boundary decisions

- **Schema rejections stay ahead of middleware.** A listen missing the required `notifications` field is rejected by protocol inspection inside the service, exactly as schema-invalid requests are for every method; middleware observes semantic rejections, schema violations never become a `RouterRequest`. Pinned by test. The missing-filter message changes from the transport text to the inspection text (`required `notifications` field is missing`), same `-32602`.
- **Middleware observes validation time, not stream lifetime.** The service call returns before the upgrade; duration and terminal reason belong to the close hook.

## Tests

- New: `middleware_observes_an_accepted_listen`, `middleware_observes_a_rejected_listen` (a recording layer on `StdioTransport::layer` sees exactly `["subscriptions/listen"]` while the wire acknowledgment/-32021 shapes stay identical), and `schema_rejections_stay_ahead_of_the_middleware_boundary`
- Parity: all pre-existing listen suites pass unchanged across stdio (16 tests), HTTP (9, including the SEP-2663 task-gate cases), and channel (8), plus the full workspace with all features

Refs #1182