### PR TITLE
feat(transport): observe the terminal half of subscriptions/listen streams

### DIFF
--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -194,9 +194,10 @@ impl ChannelTransport {
         let (response_tx, response_rx) = mpsc::channel::<String>(64);
 
         #[cfg(feature = "stateless")]
-        let subscriptions = Arc::new(StdMutex::new(StdioSubscriptions::new(Some(
-            router.implementation(),
-        ))));
+        let subscriptions = Arc::new(StdMutex::new(
+            StdioSubscriptions::new(Some(router.implementation()))
+                .with_observer(router.subscription_observer()),
+        ));
 
         // Notification pump: serialize ServerNotifications into JSON-RPC
         // notification frames on the shared response stream.
@@ -335,6 +336,13 @@ impl ChannelTransport {
                     // the task simply ends.
                     let _ = response_out.send(json).await;
                 });
+            }
+
+            // The client dropped its sender: any registered streams die with
+            // the transport and cannot receive a terminal frame.
+            #[cfg(feature = "stateless")]
+            if let Ok(mut subscriptions) = subscriptions.lock() {
+                subscriptions.drain_disconnected();
             }
         });
 

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -658,6 +658,11 @@ pub use transport::{
     SyncStdioTransport,
 };
 
+#[cfg(feature = "stateless")]
+pub use transport::subscriptions::{
+    SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver,
+};
+
 #[cfg(feature = "http")]
 pub use transport::{HttpTransport, SessionHandle, SessionInfo};
 

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -440,6 +440,9 @@ struct McpRouterInner {
     /// can publish after the transport attaches its subscription registry.
     #[cfg(all(feature = "http", feature = "stateless"))]
     modern_notification_sink: Arc<RwLock<Option<ModernNotificationSink>>>,
+    #[cfg(feature = "stateless")]
+    subscription_observer:
+        Arc<RwLock<Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>>>>,
     /// Handle for sending requests to the client (for sampling, etc.)
     client_requester: Option<ClientRequesterHandle>,
     /// Task store for async operations
@@ -605,6 +608,8 @@ impl McpRouter {
                 notification_tx: None,
                 #[cfg(all(feature = "http", feature = "stateless"))]
                 modern_notification_sink: Arc::new(RwLock::new(None)),
+                #[cfg(feature = "stateless")]
+                subscription_observer: Arc::new(RwLock::new(None)),
                 client_requester: None,
                 task_store: Arc::new(MemoryTaskStore::new()),
                 subscriptions: Arc::new(RwLock::new(HashSet::new())),
@@ -886,6 +891,35 @@ impl McpRouter {
         }
         inner.notification_tx = Some(tx);
         self
+    }
+
+    /// Observe the terminal half of `subscriptions/listen` streams.
+    ///
+    /// Every transport built from this router reports stream closes (reason
+    /// and duration) through the observer. The request half of the boundary
+    /// is ordinary `Service<RouterRequest>` middleware; see
+    /// [`SubscriptionObserver`](crate::transport::subscriptions::SubscriptionObserver) for how the two compose.
+    #[cfg(feature = "stateless")]
+    pub fn with_subscription_observer(
+        self,
+        observer: Arc<dyn crate::transport::subscriptions::SubscriptionObserver>,
+    ) -> Self {
+        if let Ok(mut slot) = self.inner.subscription_observer.write() {
+            *slot = Some(observer);
+        }
+        self
+    }
+
+    /// The attached close observer, if any.
+    #[cfg(feature = "stateless")]
+    pub(crate) fn subscription_observer(
+        &self,
+    ) -> Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>> {
+        self.inner
+            .subscription_observer
+            .read()
+            .ok()
+            .and_then(|slot| slot.clone())
     }
 
     /// Attach the transport-lifetime final subscription notification path.

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1355,6 +1355,7 @@ struct ModernSubscription {
     subscription_id: RequestId,
     filter: SubscriptionFilter,
     tx: mpsc::UnboundedSender<String>,
+    started: std::time::Instant,
 }
 
 /// Process-local registry for sessionless final-protocol subscriptions.
@@ -1366,15 +1367,34 @@ struct ModernSubscriptionRegistry {
     next_key: AtomicU64,
     subscriptions: std::sync::Mutex<HashMap<u64, ModernSubscription>>,
     server_info: Option<Implementation>,
+    observer: Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>>,
 }
 
 #[cfg(feature = "stateless")]
 impl ModernSubscriptionRegistry {
-    fn new(server_info: Option<Implementation>) -> Self {
+    fn new(
+        server_info: Option<Implementation>,
+        observer: Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>>,
+    ) -> Self {
         Self {
             next_key: AtomicU64::new(0),
             subscriptions: std::sync::Mutex::new(HashMap::new()),
             server_info,
+            observer,
+        }
+    }
+
+    fn observe_close(
+        &self,
+        subscription: &ModernSubscription,
+        reason: crate::transport::subscriptions::SubscriptionCloseReason,
+    ) {
+        if let Some(observer) = &self.observer {
+            observer.on_close(crate::transport::subscriptions::SubscriptionClose {
+                subscription_id: subscription.subscription_id.clone(),
+                reason,
+                duration: subscription.started.elapsed(),
+            });
         }
     }
 
@@ -1391,6 +1411,7 @@ impl ModernSubscriptionRegistry {
                 subscription_id,
                 filter,
                 tx,
+                started: std::time::Instant::now(),
             },
         );
         (
@@ -1424,13 +1445,23 @@ impl ModernSubscriptionRegistry {
             "Routing final-protocol subscription notification"
         );
         subscriptions.retain(|_, subscription| {
-            if subscription_matches(notification, &subscription.filter)
+            let keep = if subscription_matches(notification, &subscription.filter)
                 && let Some(json) =
                     tagged_subscription_notification(notification, &subscription.subscription_id)
             {
-                return subscription.tx.send(json).is_ok();
+                subscription.tx.send(json).is_ok()
+            } else {
+                !subscription.tx.is_closed()
+            };
+            if !keep {
+                // Detected here rather than at guard drop: the entry is
+                // removed exactly once, so the close is reported exactly once.
+                self.observe_close(
+                    subscription,
+                    crate::transport::subscriptions::SubscriptionCloseReason::Disconnected,
+                );
             }
-            !subscription.tx.is_closed()
+            keep
         });
         true
     }
@@ -1450,6 +1481,10 @@ impl ModernSubscriptionRegistry {
         };
         let count = subscriptions.len();
         for subscription in subscriptions {
+            self.observe_close(
+                &subscription,
+                crate::transport::subscriptions::SubscriptionCloseReason::Drained,
+            );
             let response = subscription_complete_response(
                 subscription.subscription_id,
                 self.server_info.clone(),
@@ -1465,7 +1500,7 @@ impl ModernSubscriptionRegistry {
 #[cfg(feature = "stateless")]
 impl Default for ModernSubscriptionRegistry {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(None, None)
     }
 }
 
@@ -1478,11 +1513,18 @@ struct ModernSubscriptionGuard {
 #[cfg(feature = "stateless")]
 impl Drop for ModernSubscriptionGuard {
     fn drop(&mut self) {
-        self.registry
+        let removed = self
+            .registry
             .subscriptions
             .lock()
             .unwrap()
             .remove(&self.key);
+        if let Some(subscription) = removed {
+            self.registry.observe_close(
+                &subscription,
+                crate::transport::subscriptions::SubscriptionCloseReason::Disconnected,
+            );
+        }
     }
 }
 
@@ -2257,6 +2299,10 @@ impl HttpTransport {
                     Some(router.implementation())
                 }
                 _ => None,
+            },
+            match &self.service_source {
+                ServiceSource::Router { router, .. } => router.subscription_observer(),
+                ServiceSource::Service(_) => None,
             },
         ));
 
@@ -4898,6 +4944,63 @@ mod tests {
         let before = serde_json::to_value(&legacy).unwrap();
         apply_protocol_result_fields(&mut legacy, "resources/read", "2025-11-25");
         assert_eq!(serde_json::to_value(legacy).unwrap(), before);
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "stateless")]
+    async fn modern_subscription_registry_reports_closes() {
+        use crate::transport::subscriptions::{
+            SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver,
+        };
+
+        #[derive(Default)]
+        struct RecordingObserver {
+            closes: std::sync::Mutex<Vec<SubscriptionClose>>,
+        }
+        impl SubscriptionObserver for RecordingObserver {
+            fn on_close(&self, close: SubscriptionClose) {
+                self.closes.lock().unwrap().push(close);
+            }
+        }
+
+        let observer = Arc::new(RecordingObserver::default());
+        let registry = Arc::new(ModernSubscriptionRegistry::new(
+            None,
+            Some(observer.clone()),
+        ));
+
+        // A dropped guard is a client disconnect.
+        let (_rx, guard) = registry.register(
+            RequestId::String("disconnects".into()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+        );
+        drop(guard);
+
+        // A drained registry is a graceful server-side close.
+        let (_rx2, guard2) = registry.register(
+            RequestId::String("drains".into()),
+            SubscriptionFilter::default(),
+        );
+        assert_eq!(registry.close_all(), 1);
+        // The entry is already gone, so the later guard drop must not
+        // produce a second record.
+        drop(guard2);
+
+        let closes = observer.closes.lock().unwrap();
+        assert_eq!(closes.len(), 2, "one record per stream: {closes:?}");
+        assert_eq!(
+            closes[0].subscription_id,
+            RequestId::String("disconnects".into())
+        );
+        assert_eq!(closes[0].reason, SubscriptionCloseReason::Disconnected);
+        assert_eq!(
+            closes[1].subscription_id,
+            RequestId::String("drains".into())
+        );
+        assert_eq!(closes[1].reason, SubscriptionCloseReason::Drained);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -54,8 +54,8 @@ use crate::router::{McpRouter, RouterRequest, RouterResponse};
 use crate::transport::service::{CatchError, InjectAnnotations};
 #[cfg(feature = "stateless")]
 use crate::transport::subscriptions::{
-    subscription_acknowledgment, subscription_complete_response, subscription_matches,
-    tagged_subscription_notification,
+    SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver, subscription_acknowledgment,
+    subscription_complete_response, subscription_matches, tagged_subscription_notification,
 };
 use crate::{ProtocolSupport, ProtocolSupportError};
 
@@ -109,9 +109,17 @@ fn stdio_control_channel() -> (
 #[cfg(feature = "stateless")]
 #[derive(Default)]
 pub(crate) struct StdioSubscriptions {
-    active: HashMap<RequestId, SubscriptionFilter>,
+    active: HashMap<RequestId, ActiveSubscription>,
     modern_mode: bool,
     server_info: Option<Implementation>,
+    observer: Option<Arc<dyn SubscriptionObserver>>,
+}
+
+/// One registered listen stream: the accepted filter and when it started.
+#[cfg(feature = "stateless")]
+struct ActiveSubscription {
+    filter: SubscriptionFilter,
+    started: std::time::Instant,
 }
 
 #[cfg(feature = "stateless")]
@@ -134,6 +142,40 @@ impl StdioSubscriptions {
         }
     }
 
+    pub(crate) fn with_observer(mut self, observer: Option<Arc<dyn SubscriptionObserver>>) -> Self {
+        self.observer = observer;
+        self
+    }
+
+    fn observe_close(
+        &self,
+        subscription_id: RequestId,
+        started: std::time::Instant,
+        reason: SubscriptionCloseReason,
+    ) {
+        if let Some(observer) = &self.observer {
+            observer.on_close(SubscriptionClose {
+                subscription_id,
+                reason,
+                duration: started.elapsed(),
+            });
+        }
+    }
+
+    /// Report every remaining stream as disconnected.
+    ///
+    /// Called when the transport's read loop ends (EOF or client drop): the
+    /// streams die with the connection and no terminal frame can be written.
+    pub(crate) fn drain_disconnected(&mut self) {
+        for (id, subscription) in std::mem::take(&mut self.active) {
+            self.observe_close(
+                id,
+                subscription.started,
+                SubscriptionCloseReason::Disconnected,
+            );
+        }
+    }
+
     pub(crate) fn handle_input<S>(
         &mut self,
         service: &JsonRpcService<S>,
@@ -152,9 +194,14 @@ impl StdioSubscriptions {
                 return Ok(StdioSubscriptionInput::NotHandled);
             };
             if let Some(request_id) = params.request_id
-                && self.active.remove(&request_id).is_some()
+                && let Some(subscription) = self.active.remove(&request_id)
             {
                 tracing::debug!(?request_id, "Cancelled stdio subscription");
+                self.observe_close(
+                    request_id,
+                    subscription.started,
+                    SubscriptionCloseReason::Cancelled,
+                );
                 return Ok(StdioSubscriptionInput::Handled(Vec::new()));
             }
             return Ok(StdioSubscriptionInput::NotHandled);
@@ -245,7 +292,13 @@ impl StdioSubscriptions {
         let acknowledgment = subscription_acknowledgment(request_id.clone(), accepted.clone());
         let acknowledgment = serde_json::to_string(&acknowledgment)?;
         self.modern_mode = true;
-        self.active.insert(request_id, accepted);
+        self.active.insert(
+            request_id,
+            ActiveSubscription {
+                filter: accepted,
+                started: std::time::Instant::now(),
+            },
+        );
         Ok(vec![acknowledgment])
     }
 
@@ -271,16 +324,23 @@ impl StdioSubscriptions {
         Some(
             self.active
                 .iter()
-                .filter(|(_, filter)| subscription_matches(notification, filter))
+                .filter(|(_, subscription)| {
+                    subscription_matches(notification, &subscription.filter)
+                })
                 .filter_map(|(id, _)| tagged_subscription_notification(notification, id))
                 .collect(),
         )
     }
 
     fn close(&mut self, request_id: &RequestId) -> Result<Option<String>> {
-        if self.active.remove(request_id).is_none() {
+        let Some(subscription) = self.active.remove(request_id) else {
             return Ok(None);
-        }
+        };
+        self.observe_close(
+            request_id.clone(),
+            subscription.started,
+            SubscriptionCloseReason::Drained,
+        );
         Ok(Some(serde_json::to_string(
             &subscription_complete_response(request_id.clone(), self.server_info.clone()),
         )?))
@@ -572,6 +632,8 @@ impl StdioTransport {
     {
         let protocol_support = self.service.configured_protocol_support().clone();
         let annotations = self.router.tool_annotations_map();
+        #[cfg(feature = "stateless")]
+        let subscription_observer = self.router.subscription_observer();
         let wrapped = layer.layer(self.router);
         let service = InjectAnnotations::new(CatchError::new(wrapped), annotations);
         GenericStdioTransport {
@@ -579,6 +641,8 @@ impl StdioTransport {
             notification_rx: Some(self.notification_rx),
             control_tx: self.control_tx,
             control_rx: self.control_rx,
+            #[cfg(feature = "stateless")]
+            subscription_observer,
         }
     }
 
@@ -614,7 +678,8 @@ impl StdioTransport {
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
             ..StdioSubscriptions::default()
-        };
+        }
+        .with_observer(self.router.subscription_observer());
 
         tracing::info!("Stdio transport started, waiting for input");
 
@@ -728,6 +793,10 @@ impl StdioTransport {
             }
         }
 
+        // The read loop is over: any streams still registered die with
+        // the connection and cannot receive a terminal frame.
+        #[cfg(feature = "stateless")]
+        subscriptions.drain_disconnected();
         Ok(())
     }
 }
@@ -788,6 +857,11 @@ where
     notification_rx: Option<NotificationReceiver>,
     control_tx: mpsc::UnboundedSender<StdioControl>,
     control_rx: mpsc::UnboundedReceiver<StdioControl>,
+    /// Close observer threaded from the router by [`StdioTransport::layer`];
+    /// `None` for directly constructed generic transports, which have no
+    /// router to read it from.
+    #[cfg(feature = "stateless")]
+    subscription_observer: Option<Arc<dyn SubscriptionObserver>>,
 }
 
 impl<S> GenericStdioTransport<S>
@@ -813,6 +887,8 @@ where
             notification_rx: None,
             control_tx,
             control_rx,
+            #[cfg(feature = "stateless")]
+            subscription_observer: None,
         }
     }
 
@@ -830,6 +906,8 @@ where
             notification_rx: Some(notification_rx),
             control_tx,
             control_rx,
+            #[cfg(feature = "stateless")]
+            subscription_observer: None,
         }
     }
 
@@ -880,7 +958,8 @@ where
     {
         let mut lines = BufReader::new(reader).lines();
         #[cfg(feature = "stateless")]
-        let mut subscriptions = StdioSubscriptions::default();
+        let mut subscriptions =
+            StdioSubscriptions::default().with_observer(self.subscription_observer.clone());
 
         tracing::info!("Generic stdio transport started, waiting for input");
 
@@ -966,6 +1045,10 @@ where
             }
         }
 
+        // The read loop is over: any streams still registered die with
+        // the connection and cannot receive a terminal frame.
+        #[cfg(feature = "stateless")]
+        subscriptions.drain_disconnected();
         Ok(())
     }
 
@@ -1371,7 +1454,8 @@ impl BidirectionalStdioTransport {
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
             ..StdioSubscriptions::default()
-        };
+        }
+        .with_observer(self.router.subscription_observer());
 
         tracing::info!("Bidirectional stdio transport started, waiting for input");
 
@@ -1441,6 +1525,10 @@ impl BidirectionalStdioTransport {
             }
         }
 
+        // The read loop is over: any streams still registered die with
+        // the connection and cannot receive a terminal frame.
+        #[cfg(feature = "stateless")]
+        subscriptions.drain_disconnected();
         Ok(())
     }
 

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -1,5 +1,7 @@
 //! Shared transport helpers for final-protocol subscriptions.
 
+use std::time::Duration;
+
 use crate::context::ServerNotification;
 use crate::protocol::{
     Implementation, JsonRpcNotification, JsonRpcResponse, NotificationMeta, RequestId, ResultType,
@@ -85,6 +87,55 @@ pub(crate) fn subscription_acknowledgment(
         })
         .expect("subscription acknowledgment is serializable"),
     )
+}
+
+/// Why a `subscriptions/listen` stream ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SubscriptionCloseReason {
+    /// The client cancelled the subscription with `notifications/cancelled`.
+    Cancelled,
+    /// The client connection or response stream dropped.
+    Disconnected,
+    /// The server drained the stream gracefully (shutdown or an explicit
+    /// close), sending the terminal `SubscriptionsListenResult` first where
+    /// the transport still could.
+    Drained,
+}
+
+/// Terminal record of one `subscriptions/listen` stream.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct SubscriptionClose {
+    /// JSON-RPC id of the `subscriptions/listen` request that opened the
+    /// stream, the same id middleware observed at acceptance.
+    pub subscription_id: RequestId,
+    /// Why the stream ended.
+    pub reason: SubscriptionCloseReason,
+    /// Time from acceptance to close.
+    pub duration: Duration,
+}
+
+/// Observes the terminal half of `subscriptions/listen` streams.
+///
+/// The request half of the observation boundary is ordinary
+/// `Service<RouterRequest>` middleware: transports dispatch the listen
+/// request through the service before upgrading, so a layer sees acceptance
+/// and rejection like any other method. What that boundary cannot express is
+/// the stream's end, which happens long after the service call returns. This
+/// hook carries exactly that remainder and nothing else: implement it for
+/// ledger or audit records that need terminal reason and duration, and pair
+/// it with a layer for the request half.
+///
+/// Attach with [`McpRouter::with_subscription_observer`]; every transport
+/// that owns listen streams (stdio, generic stdio, bidirectional stdio,
+/// channel, HTTP) reports through it. Calls are made from transport
+/// internals, so implementations must be fast and non-blocking.
+///
+/// [`McpRouter::with_subscription_observer`]: crate::McpRouter::with_subscription_observer
+pub trait SubscriptionObserver: Send + Sync {
+    /// A `subscriptions/listen` stream reached its end.
+    fn on_close(&self, close: SubscriptionClose);
 }
 
 pub(crate) fn subscription_complete_response(

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -1365,3 +1365,174 @@ mod listen_observation {
         );
     }
 }
+
+// =============================================================================
+// Close observation (#1182, terminal half)
+// =============================================================================
+
+#[cfg(feature = "stateless")]
+mod close_observation {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use tower_mcp::{SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver};
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        closes: Mutex<Vec<SubscriptionClose>>,
+    }
+
+    impl SubscriptionObserver for RecordingObserver {
+        fn on_close(&self, close: SubscriptionClose) {
+            self.closes.lock().unwrap().push(close);
+        }
+    }
+
+    fn observed_router(observer: Arc<RecordingObserver>) -> McpRouter {
+        subscription_router().with_subscription_observer(observer)
+    }
+
+    fn listen_frame(id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "subscriptions/listen",
+            "params": {
+                "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28),
+                "notifications": {"toolsListChanged": true}
+            }
+        })
+    }
+
+    /// The client cancels its subscription; the observer records the reason
+    /// and a duration measured from acceptance.
+    #[tokio::test]
+    async fn cancellation_reaches_the_observer() {
+        let observer = Arc::new(RecordingObserver::default());
+        let mut transport = StdioTransport::new(observed_router(observer.clone()));
+        let control = transport.handle();
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(8192);
+        let (server_stdout, stdout_reader) = tokio::io::duplex(8192);
+        let task = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        stdin_writer
+            .write_all(format!("{}\n", listen_frame("cancel-me")).as_bytes())
+            .await
+            .unwrap();
+        let mut reader = BufReader::new(stdout_reader);
+        let _ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("acknowledgment");
+
+        let cancel = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "notifications/cancelled",
+            "params": {"requestId": "cancel-me"}
+        });
+        stdin_writer
+            .write_all(format!("{cancel}\n").as_bytes())
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+
+        // The cancellation produces no frame; give the loop a beat, then
+        // shut down and join before asserting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        control.shutdown().unwrap();
+        let _ = task.await;
+
+        let closes = observer.closes.lock().unwrap();
+        assert_eq!(closes.len(), 1, "exactly one close record");
+        assert_eq!(
+            closes[0].subscription_id,
+            tower_mcp::RequestId::String("cancel-me".to_string())
+        );
+        assert_eq!(closes[0].reason, SubscriptionCloseReason::Cancelled);
+    }
+
+    /// A server-driven graceful close reports Drained; the terminal frame
+    /// still reaches the wire.
+    #[tokio::test]
+    async fn graceful_close_reports_drained() {
+        let observer = Arc::new(RecordingObserver::default());
+        let mut transport = StdioTransport::new(observed_router(observer.clone()));
+        let control = transport.handle();
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(8192);
+        let (server_stdout, stdout_reader) = tokio::io::duplex(8192);
+        let task = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        stdin_writer
+            .write_all(format!("{}\n", listen_frame("drain-me")).as_bytes())
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+        let mut reader = BufReader::new(stdout_reader);
+        let _ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("acknowledgment");
+
+        control
+            .close_subscription(tower_mcp::RequestId::String("drain-me".to_string()))
+            .unwrap();
+        let complete = timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("graceful terminal result");
+        assert_eq!(complete["result"]["resultType"], "complete");
+
+        control.shutdown().unwrap();
+        let _ = task.await;
+
+        let closes = observer.closes.lock().unwrap();
+        assert_eq!(closes.len(), 1);
+        assert_eq!(closes[0].reason, SubscriptionCloseReason::Drained);
+    }
+
+    /// EOF with a live stream reports Disconnected: the connection died and
+    /// no terminal frame could be written.
+    #[tokio::test]
+    async fn eof_reports_disconnected() {
+        let observer = Arc::new(RecordingObserver::default());
+        let mut transport = StdioTransport::new(observed_router(observer.clone()));
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(8192);
+        let (server_stdout, stdout_reader) = tokio::io::duplex(8192);
+        let task = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        stdin_writer
+            .write_all(format!("{}\n", listen_frame("drop-me")).as_bytes())
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+        let mut reader = BufReader::new(stdout_reader);
+        let _ack = timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("acknowledgment");
+
+        // Closing the write half is EOF for the transport's read loop.
+        drop(stdin_writer);
+        timeout(Duration::from_secs(2), task)
+            .await
+            .expect("loop must end at EOF")
+            .expect("join")
+            .expect("run ok");
+
+        let closes = observer.closes.lock().unwrap();
+        assert_eq!(closes.len(), 1);
+        assert_eq!(
+            closes[0].subscription_id,
+            tower_mcp::RequestId::String("drop-me".to_string())
+        );
+        assert_eq!(closes[0].reason, SubscriptionCloseReason::Disconnected);
+    }
+}


### PR DESCRIPTION
Closes #1182 by completing the hybrid: the request half landed as #1185 (accepted and rejected listens pass through `Service<RouterRequest>` middleware), and this PR adds the close-only hook for what that boundary cannot express.

## API

```rust
pub trait SubscriptionObserver: Send + Sync {
    fn on_close(&self, close: SubscriptionClose);
}
```

`SubscriptionClose` carries the subscription id middleware observed at acceptance, a `SubscriptionCloseReason` (`Cancelled`, `Disconnected`, `Drained`), and the duration from acceptance. Attach once with `McpRouter::with_subscription_observer`; a ledger pairs this with a layer for the request half. The types are `non_exhaustive` and gated on `protocol-2026-07-28`, like the streams they describe.

## Wiring

| Transport | Close points |
|---|---|
| stdio / bidirectional | `notifications/cancelled` (Cancelled), control-driven graceful close (Drained), end-of-loop EOF drain (Disconnected) |
| generic stdio | same; the observer is threaded from the router by `StdioTransport::layer`, since the generic transport has no router of its own |
| channel | same registry, plus a drain when the client drops its sender |
| HTTP | guard drop and publish-time eviction (Disconnected), `close_all` (Drained) |

Each stream is reported exactly once: the record is emitted where the registry entry is removed, and removal happens exactly once (verified for the HTTP double-path case of `close_all` followed by the guard drop).

## Tests

- stdio: cancellation, graceful close, and EOF each produce one record with the right reason and id
- HTTP registry: guard drop reports Disconnected, `close_all` reports Drained, and the already-drained guard drop produces no second record
- Full workspace with all features, clippy, rustdoc clean; all pre-existing listen suites untouched

With this, #1182's acceptance criteria are covered end to end: middleware observes accepted and rejected listens with method, id, and filter (in #1185), and the observer supplies terminal reason and duration without buffering stream contents.