### PR TITLE
fix(types)!: preserve elicitation form field order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,8 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2410,6 +2412,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2992,6 +2995,7 @@ name = "tower-mcp-types"
 version = "0.19.0"
 dependencies = [
  "base64 0.23.0",
+ "indexmap",
  "proptest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,11 @@ tower-mcp-macros = { version = "0.19", path = "crates/tower-mcp-macros" }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+# `preserve_order` keeps `Value` maps in document order. Every response is
+# serialized through `Value` in the JSON-RPC layer, and elicitation form
+# fields render in declaration order, so without this the ordered schema map
+# is re-sorted on the way out (#1199).
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 # Schema generation
 schemars = "1.2"
@@ -52,6 +56,9 @@ thiserror = "2"
 
 # Encoding
 base64 = "0.23.0"
+# Elicitation form fields render in declaration order, so their schema map
+# must preserve insertion order (#1199).
+indexmap = { version = "2", features = ["serde"] }
 
 # Crypto
 sha2 = "0.11"

--- a/crates/tower-mcp-types/Cargo.toml
+++ b/crates/tower-mcp-types/Cargo.toml
@@ -23,6 +23,7 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 base64.workspace = true
+indexmap.workspace = true
 
 [dev-dependencies]
 proptest = "1"

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -4662,8 +4662,14 @@ pub struct ElicitFormSchema {
     /// Must be "object"
     #[serde(rename = "type")]
     pub schema_type: String,
-    /// Map of property names to their schema definitions
-    pub properties: std::collections::HashMap<String, PrimitiveSchemaDefinition>,
+    /// Property names mapped to their schema definitions, in the order the
+    /// server declared them.
+    ///
+    /// Insertion order is preserved and is protocol-significant: a client
+    /// renders the form fields in this order. A hash map would have made the
+    /// rendered order arbitrary and, with `HashMap`'s per-process seed,
+    /// unstable between runs of the same server (#1199).
+    pub properties: indexmap::IndexMap<String, PrimitiveSchemaDefinition>,
     /// List of required property names
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub required: Vec<String>,
@@ -4674,7 +4680,7 @@ impl ElicitFormSchema {
     pub fn new() -> Self {
         Self {
             schema_type: "object".to_string(),
-            properties: std::collections::HashMap::new(),
+            properties: indexmap::IndexMap::new(),
             required: Vec::new(),
         }
     }
@@ -7832,6 +7838,102 @@ mod draft_2026_07_28_tests {
         let parsed: InputRequiredResult = serde_json::from_value(example).unwrap();
         assert_eq!(parsed.result_type, ResultType::InputRequired);
         assert!(parsed.input_requests.is_some_and(|r| r.contains_key("r1")));
+    }
+}
+
+#[cfg(test)]
+mod elicitation_field_order_tests {
+    use super::*;
+
+    /// Raw wire bytes, not a `json!` value: the macro builds a map that may
+    /// itself reorder keys, which would pre-sort the input and make these
+    /// tests pass for the wrong reason.
+    const DECLARED: &str = r#"{"type":"object","properties":{"firstName":{"type":"string"},"lastName":{"type":"string"},"email":{"type":"string"},"age":{"type":"integer"}},"required":["firstName"]}"#;
+
+    fn parse_declared() -> ElicitFormSchema {
+        serde_json::from_str(DECLARED).expect("declared schema parses")
+    }
+
+    /// #1199: elicitation schemas are the one place in MCP where a JSON
+    /// object's key order carries presentation meaning, since it is the order
+    /// a client renders the form in. A hash map made that order arbitrary and,
+    /// because `HashMap` seeds per process, unstable between runs of the same
+    /// server.
+    #[test]
+    fn declared_field_order_survives_a_round_trip() {
+        let parsed = parse_declared();
+
+        let order: Vec<&str> = parsed.properties.keys().map(String::as_str).collect();
+        assert_eq!(order, ["firstName", "lastName", "email", "age"]);
+
+        // Direct serialization, and the `Value` hop the JSON-RPC layer takes
+        // on every response. The latter needs serde_json's `preserve_order`;
+        // without it the ordered map is re-sorted on the way out.
+        let direct: ElicitFormSchema =
+            serde_json::from_str(&serde_json::to_string(&parsed).expect("serialize"))
+                .expect("reparse");
+        assert_eq!(
+            direct
+                .properties
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["firstName", "lastName", "email", "age"],
+        );
+
+        let round = serde_json::to_value(&parsed).unwrap();
+        let wire: Vec<&str> = round["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(
+            wire,
+            ["firstName", "lastName", "email", "age"],
+            "the order a server declared must reach the wire unchanged"
+        );
+    }
+
+    /// The order must also be stable across repeated decodes, which a
+    /// per-process-seeded hash map could not guarantee.
+    #[test]
+    fn field_order_is_deterministic_across_decodes() {
+        let first: Vec<String> = parse_declared().properties.keys().cloned().collect();
+        for _ in 0..16 {
+            let again: Vec<String> = parse_declared().properties.keys().cloned().collect();
+            assert_eq!(first, again);
+        }
+    }
+
+    /// The builder's declaration order is the order that ships.
+    #[test]
+    fn builder_insertion_order_is_preserved() {
+        let schema = ElicitFormSchema::new()
+            .string_field("zulu", None, true)
+            .string_field("alpha", None, false)
+            .string_field("mike", None, false);
+
+        let order: Vec<&str> = schema.properties.keys().map(String::as_str).collect();
+        assert_eq!(
+            order,
+            ["zulu", "alpha", "mike"],
+            "builder order must not be re-sorted"
+        );
+    }
+
+    /// Field types still dispatch correctly through the ordered map (#1189).
+    #[test]
+    fn ordering_does_not_disturb_variant_dispatch() {
+        let parsed = parse_declared();
+        assert!(matches!(
+            parsed.properties.get("age"),
+            Some(PrimitiveSchemaDefinition::Integer(_))
+        ));
+        assert!(matches!(
+            parsed.properties.get("firstName"),
+            Some(PrimitiveSchemaDefinition::String(_))
+        ));
     }
 }
 


### PR DESCRIPTION
Closes #1199. Same class as [rust-sdk#1109](https://github.com/modelcontextprotocol/rust-sdk/issues/1109), still open there.

## Problem

`ElicitFormSchema.properties` was a `HashMap`, so the order a server declared its form fields in was destroyed before any client could render them. `HashMap` seeds per process, so it was not merely wrong but **unstable**: two runs of the same binary on the same input gave

```text
declared:  firstName, lastName, email
run 1:     email, firstName, lastName
run 2:     lastName, firstName, email
```

Elicitation schemas are the one place in MCP where a JSON object's key order carries presentation meaning, and the type is shared by all three carrying paths: `elicitation/create`, MRTR `InputRequiredResult.inputRequests`, and the Tasks extension's `input_required` payloads.

## Fix, and why it takes two changes

`IndexMap` gives the typed field an order. That alone is not enough: **every response is serialized through `serde_json::Value`** in the JSON-RPC layer, and `Value::Object` is a `BTreeMap` without `preserve_order`, so the ordered map was re-sorted on the way out. Measured:

```text
typed order:   firstName, lastName, email, age   (IndexMap alone: correct)
to_string:     firstName, lastName, email, age   (correct)
through Value: age, email, firstName, lastName   (re-sorted -- the actual wire path)
```

Enabling `serde_json/preserve_order` closes it. Both changes are required; either alone leaves the wire order wrong.

This is the detail rmcp's issue calls out as *not* applying to them, because their `properties` never passes through `Value`. Ours does, so the conclusion inverts.

## Breaking

Marked `!`: a public field's type changes. The surface used in practice (`insert`, `get`, `keys`, `len`, iteration) carries over unchanged, and no call site in the workspace needed adjusting.

`preserve_order` also makes `Value` maps document-ordered workspace-wide. No test depended on alphabetical ordering; the full suite passes with all features.

## Dependency note, worth a veto if you disagree

This adds `indexmap` to `tower-mcp-types`. It already reaches `tower-mcp` via axum/hyper, but a **types-only** consumer gains it. The crate already carries serde, serde_json, thiserror, and base64, so this is not a change of kind, but it is a change. The alternative was `Vec<(String, PrimitiveSchemaDefinition)>`, which needs no dependency but loses map ergonomics on a public field and permits duplicate keys that JSON objects cannot express.

## Tests

Four, all deserializing from **raw wire bytes** rather than `json!`, because the macro builds a map that itself reorders keys and would have made these pass for the wrong reason:

- declared order survives the typed side, direct serialization, and the `Value` hop
- order is deterministic across repeated decodes, which the per-process-seeded hash map could not guarantee
- builder insertion order is preserved
- field-type dispatch (#1189) still works through the ordered map