### PR TITLE
docs(context): explain why the final lifecycle has no client requester

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -342,6 +342,11 @@ pub struct RequestContext {
     extensions: Arc<Extensions>,
     /// Minimum log level set by the client (shared with router for dynamic updates)
     min_log_level: Option<Arc<RwLock<LogLevel>>>,
+    /// Whether this request arrived on the 2026-07-28 lifecycle, where the
+    /// server never initiates JSON-RPC requests. Distinguishes "the protocol
+    /// has no route for this" from "a transport did not wire one up", which
+    /// are the same absent requester but very different problems (#1201).
+    final_lifecycle: bool,
 }
 
 /// Type-erased extensions map for passing data to handlers.
@@ -427,6 +432,7 @@ impl RequestContext {
             cancellation: tokio_util::sync::CancellationToken::new(),
             notification_tx: None,
             client_requester: None,
+            final_lifecycle: false,
             extensions: Arc::new(Extensions::new()),
             min_log_level: None,
         }
@@ -454,6 +460,34 @@ impl RequestContext {
     }
 
     /// Set the client requester for server-to-client requests
+    /// Mark this context as serving a 2026-07-28 request.
+    ///
+    /// Only affects diagnostics: the final lifecycle has no server-initiated
+    /// requests, so the router does not attach a requester, and this lets the
+    /// resulting error say why rather than blaming configuration.
+    pub(crate) fn with_final_lifecycle(mut self, final_lifecycle: bool) -> Self {
+        self.final_lifecycle = final_lifecycle;
+        self
+    }
+
+    /// The error for a server-initiated request that has no route to the client.
+    fn no_requester(&self, what: &str, replacement: &str) -> Error {
+        if self.final_lifecycle {
+            Error::Internal(format!(
+                "{what} is not available on the 2026-07-28 lifecycle: servers do not \
+                 initiate JSON-RPC requests. Return {replacement} from the handler \
+                 instead, so the client fulfils the request and retries (SEP-2322 \
+                 Multi Round-Trip Requests)."
+            ))
+        } else {
+            Error::Internal(format!(
+                "{what} is not available: no client requester is configured. The \
+                 transport must provide one; stdio, HTTP, WebSocket, and the \
+                 in-process channel transport all do."
+            ))
+        }
+    }
+
     pub fn with_client_requester(mut self, requester: ClientRequesterHandle) -> Self {
         self.client_requester = Some(requester);
         self
@@ -802,9 +836,28 @@ impl RequestContext {
     ///     Ok(CallToolResult::text(format!("{:?}", result.content)))
     /// }
     /// ```
+    /// # Protocol lifecycle
+    ///
+    /// This is a 2025-11-25 mechanism. The 2026-07-28 lifecycle has no
+    /// server-initiated JSON-RPC requests: `ElicitRequest` and
+    /// `CreateMessageRequest` survive only as members of `InputRequest`,
+    /// carried inside an [`InputRequiredResult`](crate::protocol::InputRequiredResult)
+    /// that the client fulfils and retries. Calling this on a 2026-07-28
+    /// request therefore fails; return
+    /// [`RequestOutcome::input_required`](crate::protocol::RequestOutcome::input_required)
+    /// from the handler instead (SEP-2322 Multi Round-Trip Requests).
+    ///
+    /// [`can_sample`](Self::can_sample) and [`can_elicit`](Self::can_elicit)
+    /// both report `false` on that lifecycle, so a handler serving both eras
+    /// can branch on them rather than on the protocol version.
+    ///
     pub async fn sample(&self, params: CreateMessageParams) -> Result<CreateMessageResult> {
         let requester = self.client_requester.as_ref().ok_or_else(|| {
-            Error::Internal("Sampling not available: no client requester configured".to_string())
+            self.no_requester(
+                "Sampling",
+                "`RequestOutcome::input_required` carrying an \
+                 `InputRequest::CreateMessage`",
+            )
         })?;
 
         requester.sample(params).await
@@ -850,9 +903,27 @@ impl RequestContext {
     ///     }
     /// }
     /// ```
+    /// # Protocol lifecycle
+    ///
+    /// This is a 2025-11-25 mechanism. The 2026-07-28 lifecycle has no
+    /// server-initiated JSON-RPC requests: `ElicitRequest` and
+    /// `CreateMessageRequest` survive only as members of `InputRequest`,
+    /// carried inside an [`InputRequiredResult`](crate::protocol::InputRequiredResult)
+    /// that the client fulfils and retries. Calling this on a 2026-07-28
+    /// request therefore fails; return
+    /// [`RequestOutcome::input_required`](crate::protocol::RequestOutcome::input_required)
+    /// from the handler instead (SEP-2322 Multi Round-Trip Requests).
+    ///
+    /// [`can_sample`](Self::can_sample) and [`can_elicit`](Self::can_elicit)
+    /// both report `false` on that lifecycle, so a handler serving both eras
+    /// can branch on them rather than on the protocol version.
+    ///
     pub async fn elicit_form(&self, params: ElicitFormParams) -> Result<ElicitResult> {
         let requester = self.client_requester.as_ref().ok_or_else(|| {
-            Error::Internal("Elicitation not available: no client requester configured".to_string())
+            self.no_requester(
+                "Elicitation",
+                "`RequestOutcome::input_required` carrying an `InputRequest::Elicit`",
+            )
         })?;
 
         requester.elicit(ElicitRequestParams::Form(params)).await
@@ -894,9 +965,27 @@ impl RequestContext {
     ///     }
     /// }
     /// ```
+    /// # Protocol lifecycle
+    ///
+    /// This is a 2025-11-25 mechanism. The 2026-07-28 lifecycle has no
+    /// server-initiated JSON-RPC requests: `ElicitRequest` and
+    /// `CreateMessageRequest` survive only as members of `InputRequest`,
+    /// carried inside an [`InputRequiredResult`](crate::protocol::InputRequiredResult)
+    /// that the client fulfils and retries. Calling this on a 2026-07-28
+    /// request therefore fails; return
+    /// [`RequestOutcome::input_required`](crate::protocol::RequestOutcome::input_required)
+    /// from the handler instead (SEP-2322 Multi Round-Trip Requests).
+    ///
+    /// [`can_sample`](Self::can_sample) and [`can_elicit`](Self::can_elicit)
+    /// both report `false` on that lifecycle, so a handler serving both eras
+    /// can branch on them rather than on the protocol version.
+    ///
     pub async fn elicit_url(&self, params: ElicitUrlParams) -> Result<ElicitResult> {
         let requester = self.client_requester.as_ref().ok_or_else(|| {
-            Error::Internal("Elicitation not available: no client requester configured".to_string())
+            self.no_requester(
+                "Elicitation",
+                "`RequestOutcome::input_required` carrying an `InputRequest::Elicit`",
+            )
         })?;
 
         requester.elicit(ElicitRequestParams::Url(params)).await
@@ -1047,8 +1136,9 @@ impl RequestContext {
         params: serde_json::Value,
     ) -> Result<serde_json::Value> {
         let requester = self.client_requester.as_ref().ok_or_else(|| {
-            Error::Internal(
-                "Client request not available: no client requester configured".to_string(),
+            self.no_requester(
+                "A server-initiated client request",
+                "`RequestOutcome::input_required`",
             )
         })?;
         requester.request(method.to_string(), params).await
@@ -1250,7 +1340,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Sampling not available")
+                .contains("Sampling is not available: no client requester is configured")
         );
     }
 
@@ -1300,7 +1390,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Elicitation not available")
+                .contains("Elicitation is not available: no client requester is configured")
         );
     }
 
@@ -1323,7 +1413,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Elicitation not available")
+                .contains("Elicitation is not available: no client requester is configured")
         );
     }
 
@@ -1337,7 +1427,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Elicitation not available")
+                .contains("Elicitation is not available: no client requester is configured")
         );
     }
 
@@ -1581,7 +1671,7 @@ mod tests {
             result
                 .unwrap_err()
                 .to_string()
-                .contains("Client request not available")
+                .contains("no client requester is configured")
         );
     }
 
@@ -1606,5 +1696,103 @@ mod tests {
 
         let err = ctx.get_task_info("x").await.unwrap_err();
         assert!(err.to_string().contains("does not support arbitrary"));
+    }
+}
+
+#[cfg(test)]
+mod final_lifecycle_diagnostics_tests {
+    use super::*;
+    use crate::protocol::{ElicitFormParams, ElicitFormSchema};
+
+    fn params() -> ElicitFormParams {
+        ElicitFormParams {
+            mode: None,
+            message: "confirm?".to_string(),
+            requested_schema: ElicitFormSchema::new(),
+            meta: None,
+        }
+    }
+
+    fn sampling_params() -> CreateMessageParams {
+        CreateMessageParams {
+            messages: Vec::new(),
+            max_tokens: 1,
+            system_prompt: None,
+            temperature: None,
+            stop_sequences: Vec::new(),
+            model_preferences: None,
+            include_context: None,
+            metadata: None,
+            tools: None,
+            tool_choice: None,
+            task: None,
+            meta: None,
+        }
+    }
+
+    /// #1201: the final lifecycle has no server-initiated requests, so the
+    /// absent requester is a protocol fact rather than missing configuration.
+    /// The message must say so and name the replacement, because the generic
+    /// text sent a reporter looking at transport wiring that was correct.
+    #[tokio::test]
+    async fn final_lifecycle_elicitation_error_names_the_replacement() {
+        let ctx = RequestContext::new(RequestId::Number(1)).with_final_lifecycle(true);
+
+        let error = ctx.elicit_form(params()).await.unwrap_err().to_string();
+        assert!(
+            error.contains("2026-07-28"),
+            "must name the lifecycle: {error}"
+        );
+        assert!(
+            error.contains("do not \ninitiate JSON-RPC requests")
+                || error.contains("do not initiate JSON-RPC requests"),
+            "must explain the cause: {error}"
+        );
+        assert!(
+            error.contains("RequestOutcome::input_required"),
+            "must name the replacement API: {error}"
+        );
+        assert!(
+            error.contains("SEP-2322"),
+            "must cite the mechanism: {error}"
+        );
+        assert!(
+            !error.contains("no client requester is configured"),
+            "must not blame configuration: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn final_lifecycle_sampling_error_names_the_replacement() {
+        let ctx = RequestContext::new(RequestId::Number(1)).with_final_lifecycle(true);
+        let error = ctx.sample(sampling_params()).await.unwrap_err().to_string();
+        assert!(error.contains("2026-07-28"), "{error}");
+        assert!(error.contains("RequestOutcome::input_required"), "{error}");
+    }
+
+    /// A legacy request with no requester is still a configuration problem,
+    /// and must not be mislabelled as a protocol restriction.
+    #[tokio::test]
+    async fn legacy_lifecycle_keeps_the_configuration_error() {
+        let ctx = RequestContext::new(RequestId::Number(1));
+
+        let error = ctx.elicit_form(params()).await.unwrap_err().to_string();
+        assert!(
+            error.contains("no client requester is configured"),
+            "a legacy transport without a requester is misconfigured: {error}"
+        );
+        assert!(
+            !error.contains("2026-07-28"),
+            "must not blame the protocol: {error}"
+        );
+    }
+
+    /// The capability probes report the restriction too, so a handler serving
+    /// both eras can branch without inspecting the protocol version.
+    #[tokio::test]
+    async fn capability_probes_report_false_on_the_final_lifecycle() {
+        let ctx = RequestContext::new(RequestId::Number(1)).with_final_lifecycle(true);
+        assert!(!ctx.can_elicit());
+        assert!(!ctx.can_sample());
     }
 }

--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -459,7 +459,6 @@ impl RequestContext {
         self
     }
 
-    /// Set the client requester for server-to-client requests
     /// Mark this context as serving a 2026-07-28 request.
     ///
     /// Only affects diagnostics: the final lifecycle has no server-initiated
@@ -488,6 +487,11 @@ impl RequestContext {
         }
     }
 
+    /// Set the client requester for server-to-client requests.
+    ///
+    /// Only the 2025-11-25 lifecycle uses this: the router does not attach a
+    /// requester to a 2026-07-28 request, because that protocol has no
+    /// server-initiated JSON-RPC requests.
     pub fn with_client_requester(mut self, requester: ClientRequesterHandle) -> Self {
         self.client_requester = Some(requester);
         self

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -1089,7 +1089,9 @@ impl McpRouter {
         // requests. Legacy transports may provide a requester scoped to the
         // originating request; prefer it over a transport-wide fallback so
         // restricted requests stay on their associated response channel.
-        let ctx = if !is_final_protocol_request(per_request)
+        let final_lifecycle = is_final_protocol_request(per_request);
+        let ctx = ctx.with_final_lifecycle(final_lifecycle);
+        let ctx = if !final_lifecycle
             && let Some(requester) = merged
                 .get::<ClientRequesterHandle>()
                 .cloned()

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -66,6 +66,11 @@ name = "tasks"
 path = "tasks.rs"
 required-features = ["protocol-2026-07-28"]
 
+[[example]]
+name = "mrtr_elicitation"
+path = "mrtr_elicitation.rs"
+required-features = ["protocol-2026-07-28"]
+
 # --- Transports ---
 [[example]]
 name = "http_server"

--- a/examples/mrtr_elicitation.rs
+++ b/examples/mrtr_elicitation.rs
@@ -1,0 +1,153 @@
+//! Asking the client for input on both protocol lifecycles.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo run --example mrtr_elicitation --features protocol-2026-07-28
+//! ```
+//!
+//! A server frequently needs something from the user mid-call: a confirmation,
+//! a missing field, a choice. How it asks depends on the lifecycle, and the
+//! two mechanisms are not interchangeable.
+//!
+//! On **2025-11-25** the server initiates a JSON-RPC request:
+//! [`RequestContext::elicit_form`] sends `elicitation/create` and awaits the
+//! answer inline. The handler blocks; one call, one result.
+//!
+//! On **2026-07-28** there are no server-initiated requests at all. The schema
+//! keeps `ElicitRequest` only as a member of `InputRequest`, carried inside an
+//! `InputRequiredResult`. So the handler *returns* the request instead of
+//! sending it, the client fulfils it, and the client calls the tool again with
+//! the answers attached. That is SEP-2322, Multi Round-Trip Requests.
+//!
+//! Calling `elicit_form` on a 2026-07-28 request therefore fails, and the
+//! error says so and points here. The two shapes are below, and
+//! `confirm_deploy` serves both eras from one handler.
+
+use std::collections::BTreeMap;
+
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower_mcp::context::RequestContext;
+use tower_mcp::protocol::{
+    ElicitFormParams, ElicitFormSchema, ElicitRequestParams, InputRequest, InputRequests,
+    InputRequiredResult, RequestOutcome,
+};
+use tower_mcp::{CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DeployInput {
+    /// Which environment to deploy to.
+    environment: String,
+}
+
+/// The key the server issues its request under, and reads the answer back
+/// from. It is the server's own identifier: the client echoes it verbatim.
+const CONFIRMATION: &str = "confirmation";
+
+fn confirmation_form() -> ElicitFormParams {
+    ElicitFormParams {
+        mode: None,
+        message: "Confirm the deploy?".to_string(),
+        // Field order is preserved and is presentation-significant: the client
+        // renders the form in the order declared here.
+        requested_schema: ElicitFormSchema::new().string_field(
+            "decision",
+            Some("Type 'yes' to proceed"),
+            true,
+        ),
+        meta: None,
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let confirm = ToolBuilder::new("confirm_deploy")
+        .description("Deploy after confirming with the user")
+        .mrtr_handler(|ctx: RequestContext, input: DeployInput| async move {
+            // Retry leg: the client fulfilled the request and called again
+            // with the answers. Read them by the key we issued.
+            if let Some(responses) = ctx.input_responses()
+                && let Some(answer) = responses.get(CONFIRMATION)
+            {
+                let accepted = matches!(
+                    answer,
+                    tower_mcp::protocol::InputResponse::Elicit(result)
+                        if result.action == tower_mcp::protocol::ElicitAction::Accept
+                );
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    if accepted {
+                        format!("deployed to {}", input.environment)
+                    } else {
+                        "deploy declined".to_string()
+                    },
+                )));
+            }
+
+            // First leg. A 2025-11-25 client can be asked inline, because that
+            // lifecycle permits server-initiated requests. `can_elicit()`
+            // reports whether this request has that route, so the handler does
+            // not need to inspect the protocol version itself.
+            if ctx.can_elicit() {
+                let result = ctx.elicit_form(confirmation_form()).await?;
+                let accepted = result.action == tower_mcp::protocol::ElicitAction::Accept;
+                return Ok(RequestOutcome::Complete(CallToolResult::text(
+                    if accepted {
+                        format!("deployed to {}", input.environment)
+                    } else {
+                        "deploy declined".to_string()
+                    },
+                )));
+            }
+
+            // 2026-07-28: return the request rather than sending it. The
+            // client fulfils every entry in `inputRequests` and retries the
+            // original call with the answers in `inputResponses`.
+            //
+            // `requestState` is an opaque blob echoed back on the retry. It is
+            // the handler's own resumption state, and the client must not
+            // interpret it. Sign or encrypt anything sensitive: it is a round
+            // trip through an untrusted peer.
+            let mut requests: InputRequests = BTreeMap::new();
+            requests.insert(
+                CONFIRMATION.to_string(),
+                InputRequest::Elicit(ElicitRequestParams::Form(confirmation_form())),
+            );
+
+            Ok(RequestOutcome::input_required(
+                InputRequiredResult::with_requests(requests)
+                    .with_request_state(format!("env={}", input.environment)),
+            ))
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("mrtr-elicitation-example", env!("CARGO_PKG_VERSION"))
+        .tool(confirm);
+
+    StdioTransport::new(router).run().await?;
+    Ok(())
+}
+
+// # Choosing between the two
+//
+// A handler that only ever serves 2025-11-25 can keep calling `elicit_form`
+// and ignore all of this. A handler that serves 2026-07-28 at all must have
+// the input-required path, because the inline call cannot work there.
+//
+// Branch on `ctx.can_elicit()` (or `can_sample()`), not on the protocol
+// version: those report whether *this* request has a route back to the client,
+// which is the question the code actually cares about, and they stay correct
+// if a transport declines to provide a requester for its own reasons.
+//
+// # Why the round trip is not just a slower inline call
+//
+// The client re-invokes the tool from the top. The handler gets a fresh
+// context and must reconstruct whatever it had before asking, either by
+// recomputing from the arguments (which the client resends unchanged) or by
+// carrying it in `requestState`. Anything held only in a local variable across
+// the `await` in the inline version is gone in the MRTR version.
+//
+// This is also why a single handler can issue several requests at once: fill
+// `inputRequests` with every key it needs, and the client answers all of them
+// before the retry, rather than one round trip per question.


### PR DESCRIPTION
Closes #1201. Reported as a transport bug; it is correct protocol behavior with a misleading error, which is arguably worse since it sent a consumer to debug wiring that was fine.

## The reported behavior is right

The router deliberately withholds the client requester on 2026-07-28 requests. Verified against the published `schema/2026-07-28/schema.ts` rather than our own code comment: there is no `ServerRequest` union, and `ElicitRequest`/`CreateMessageRequest` are reachable only through

```typescript
export type InputRequest = CreateMessageRequest | ListRootsRequest | ElicitRequest;
```

which `InputRequiredResult.inputRequests` carries. They are requests the server *returns* and the client fulfils before retrying, not requests the server sends. Wiring a requester through would put a frame on the wire the spec has no place for.

## What actually needed fixing

1. **The error blamed configuration.** "no client requester configured" describes missing setup, so the reporter concluded `ChannelTransport` had lost its wiring, and the issue's own guess was that a rebuild dropped it. The final lifecycle now gets its own message naming the cause and the replacement; legacy keeps the configuration wording, because there an absent requester *is* a fault.

   The context carries an explicit flag for this. An absent requester alone cannot distinguish "the protocol has no route" from "the transport did not wire one", and those need different messages.

2. **The restriction was undocumented.** Now on `sample`, `elicit_form`, and `elicit_url`, with the reason and the replacement, plus a note that `can_sample`/`can_elicit` report `false` there so a handler serving both eras branches on capability rather than on protocol version.

3. **The migration existed only in tests.** `mrtr_handler` and `RequestOutcome::input_required` were reachable but undemonstrated, so an author hitting the error had no path from message to working code. `examples/mrtr_elicitation.rs` now shows one handler serving both eras: the inline call when `can_elicit()`, the input-required return otherwise, the retry leg reading `input_responses`, and the `requestState` round trip.

   The example also covers the part that bites: the client re-invokes the tool from the top, so anything held in a local across the `await` in the inline version is gone, and state must be recomputed or carried in `requestState`.

## Tests

- The final-lifecycle error names the lifecycle, the cause, `RequestOutcome::input_required`, and SEP-2322, and does **not** blame configuration
- The legacy error still blames configuration and does not mention 2026-07-28
- `can_sample`/`can_elicit` report `false` on the final lifecycle

Five existing tests asserted the old message text and were updated; they cover the legacy path and still assert the cause, now against the new wording.

## Downstream

mcp-repl's `--demo sign_in` needs porting to the MRTR shape to work under `--protocol 2026-07-28`. That is real work in that repository, not a workaround, and the new example is the reference for it.