### PR TITLE
feat(client): cancel an in-flight request when its caller drops

### DIFF
--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -160,10 +160,38 @@ impl_cacheable_response!(
     ReadResourceResult,
 );
 
+/// Cancels an in-flight request if its caller's future is dropped.
+///
+/// Disarmed as soon as the response arrives, so only an abandoned request is
+/// cancelled. Uses `try_send` because `Drop` cannot await: if the command
+/// channel is full or closed the cancellation is skipped rather than blocking
+/// a drop, which is the same trade-off `SubscriptionHandle` already makes.
+struct CancelOnDrop {
+    id: RequestId,
+    command_tx: mpsc::Sender<LoopCommand>,
+    armed: bool,
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            let _ = self.command_tx.try_send(LoopCommand::CancelRequest {
+                request_id: self.id.clone(),
+                done_tx: None,
+            });
+        }
+    }
+}
+
 /// Internal command sent from McpClient methods to the background loop.
 enum LoopCommand {
     /// Send a JSON-RPC request and await a response.
+    ///
+    /// The id is allocated by the caller rather than the loop, so a caller
+    /// can cancel the request it sent (#1202). The loop previously owned the
+    /// counter, which left callers with no way to name their own request.
     Request {
+        id: RequestId,
         method: String,
         params: serde_json::Value,
         response_tx: oneshot::Sender<Result<serde_json::Value>>,
@@ -175,7 +203,7 @@ enum LoopCommand {
         acknowledgment_tx: oneshot::Sender<SubscriptionFilter>,
         response_tx: oneshot::Sender<Result<serde_json::Value>>,
     },
-    /// Cancel one active subscription request.
+    /// Cancel one in-flight request, of any method.
     CancelRequest {
         request_id: RequestId,
         done_tx: Option<oneshot::Sender<Result<()>>>,
@@ -358,6 +386,9 @@ pub struct McpClient {
     /// Allocator for per-request progress tokens; `None` when the client did
     /// not opt into progress.
     progress_tokens: Option<Arc<AtomicI64>>,
+    /// Allocator for JSON-RPC request ids, shared with the message loop so
+    /// caller-issued and loop-issued ids never collide.
+    next_request_id: Arc<AtomicI64>,
 }
 
 /// Settings a builder hands to the connect path, grouped so the private
@@ -606,6 +637,8 @@ impl McpClient {
         let loop_connected = connected.clone();
         let loop_roots = roots.clone();
         let loop_response_cache = response_cache.clone();
+        let next_request_id = Arc::new(AtomicI64::new(1));
+        let loop_next_id = next_request_id.clone();
 
         let task = tokio::spawn(async move {
             message_loop(
@@ -615,6 +648,7 @@ impl McpClient {
                 loop_connected,
                 loop_roots,
                 loop_response_cache,
+                loop_next_id,
             )
             .await;
         });
@@ -637,6 +671,7 @@ impl McpClient {
             max_mrtr_rounds,
             response_cache,
             progress_tokens: request_progress.then(|| Arc::new(AtomicI64::new(1))),
+            next_request_id,
         })
     }
 
@@ -1993,9 +2028,11 @@ impl McpClient {
         let params_value = self.with_final_request_meta(params_value).await?;
         let params_value = self.with_progress_token(params_value);
 
+        let id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
         let (response_tx, response_rx) = oneshot::channel();
         self.command_tx
             .send(LoopCommand::Request {
+                id: id.clone(),
                 method: method.to_string(),
                 params: params_value,
                 response_tx,
@@ -2003,9 +2040,22 @@ impl McpClient {
             .await
             .map_err(|_| Error::Transport("Connection closed".to_string()))?;
 
+        // Dropping the returned future is what a Rust caller does to abandon
+        // a call: a `select!` losing a race, a timeout, a Ctrl-C handler. The
+        // server was never told, so it kept working on an answer nobody was
+        // waiting for. This guard tells it (#1202), and disarms once the
+        // response arrives so a completed request is never cancelled.
+        let mut guard = CancelOnDrop {
+            id,
+            command_tx: self.command_tx.clone(),
+            armed: true,
+        };
+
         let result = response_rx
             .await
-            .map_err(|_| Error::Transport("Connection closed".to_string()))??;
+            .map_err(|_| Error::Transport("Connection closed".to_string()));
+        guard.armed = false;
+        let result = result??;
 
         serde_json::from_value(result)
             .map_err(|e| Error::Transport(format!("Failed to deserialize response: {}", e)))
@@ -2287,18 +2337,17 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
     connected: Arc<AtomicBool>,
     roots: Arc<RwLock<Vec<Root>>>,
     response_cache: Arc<ClientResponseCache>,
+    next_id: Arc<AtomicI64>,
 ) {
     let handler = Arc::new(handler);
     let mut pending_requests: HashMap<RequestId, PendingRequest> = HashMap::new();
-    let next_id = AtomicI64::new(1);
 
     loop {
         tokio::select! {
             // Commands from McpClient methods
             command = command_rx.recv() => {
                 match command {
-                    Some(LoopCommand::Request { method, params, response_tx }) => {
-                        let id = RequestId::Number(next_id.fetch_add(1, Ordering::Relaxed));
+                    Some(LoopCommand::Request { id, method, params, response_tx }) => {
 
                         let request = JsonRpcRequest::new(id.clone(), &method)
                             .with_params(params);
@@ -2365,21 +2414,32 @@ async fn message_loop<T: ClientTransport, H: ClientHandler>(
                         request_id,
                         done_tx,
                     }) => {
-                        let result = if pending_requests
-                            .get(&request_id)
-                            .is_some_and(|pending| pending.method == "subscriptions/listen")
-                        {
-                            let result = transport.cancel_request(&request_id).await;
-                            if result.is_ok()
-                                && let Some(pending) = pending_requests.remove(&request_id)
-                            {
-                                let _ = pending.response_tx.send(Err(Error::Transport(
-                                    "subscription cancelled".to_string(),
-                                )));
+                        // Any in-flight request may be cancelled, not only a
+                        // subscription (#1202). An id with nothing pending is
+                        // a no-op: the response already arrived, or the caller
+                        // cancelled twice.
+                        let result = match pending_requests.remove(&request_id) {
+                            Some(pending) => {
+                                let subscription = pending.method == "subscriptions/listen";
+                                let result = transport.cancel_request(&request_id).await;
+                                if result.is_ok() {
+                                    let reason = if subscription {
+                                        "subscription cancelled"
+                                    } else {
+                                        "request cancelled"
+                                    };
+                                    let _ = pending
+                                        .response_tx
+                                        .send(Err(Error::Transport(reason.to_string())));
+                                } else {
+                                    // The notification did not go out, so the
+                                    // request is still live on the server;
+                                    // put it back rather than orphan it.
+                                    pending_requests.insert(request_id.clone(), pending);
+                                }
+                                result
                             }
-                            result
-                        } else {
-                            Ok(())
+                            None => Ok(()),
                         };
                         if let Some(done_tx) = done_tx {
                             let _ = done_tx.send(result);

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -676,3 +676,181 @@ mod progress {
         assert_eq!(tokens.len(), 2, "one distinct token per call: {tokens:?}");
     }
 }
+
+// =============================================================================
+// Client-side request cancellation (#1202)
+// =============================================================================
+
+mod cancellation {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration as StdDuration;
+
+    use tower_mcp::extract::Context;
+
+    /// Records every frame the client sends, so a `notifications/cancelled`
+    /// can be observed with the id it carried.
+    #[derive(Clone, Default)]
+    struct FrameLog(Arc<Mutex<Vec<serde_json::Value>>>);
+
+    impl FrameLog {
+        fn cancelled_ids(&self) -> Vec<serde_json::Value> {
+            self.0
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|f| f["method"] == "notifications/cancelled")
+                .map(|f| f["params"]["requestId"].clone())
+                .collect()
+        }
+    }
+
+    /// Wraps ChannelTransport to observe outbound frames.
+    struct LoggingTransport {
+        inner: ChannelTransport,
+        log: FrameLog,
+    }
+
+    #[async_trait::async_trait]
+    impl tower_mcp::client::ClientTransport for LoggingTransport {
+        async fn send(&mut self, message: &str) -> tower_mcp::Result<()> {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(message) {
+                self.log.0.lock().unwrap().push(v);
+            }
+            self.inner.send(message).await
+        }
+        async fn recv(&mut self) -> tower_mcp::Result<Option<String>> {
+            self.inner.recv().await
+        }
+        fn is_connected(&self) -> bool {
+            self.inner.is_connected()
+        }
+        async fn close(&mut self) -> tower_mcp::Result<()> {
+            self.inner.close().await
+        }
+    }
+
+    fn slow_router() -> McpRouter {
+        let slow = ToolBuilder::new("slow")
+            .description("Runs long enough to be abandoned")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                tokio::time::sleep(StdDuration::from_secs(30)).await;
+                Ok(CallToolResult::text("finished"))
+            })
+            .build();
+        McpRouter::new()
+            .server_info("cancel-test", "1.0.0")
+            .tool(slow)
+    }
+
+    async fn connected(log: FrameLog) -> McpClient {
+        let transport = LoggingTransport {
+            inner: ChannelTransport::new(slow_router()),
+            log,
+        };
+        let client = McpClient::connect(transport).await.expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+        client
+    }
+
+    /// #1202: abandoning a call left the server working on an answer nobody
+    /// was waiting for. Dropping the future is what a Rust caller does on
+    /// Ctrl-C or a timeout, so that is the trigger.
+    #[tokio::test]
+    async fn dropping_a_call_cancels_it_on_the_server() {
+        let log = FrameLog::default();
+        let client = connected(log.clone()).await;
+
+        // Abandon the call the way a timeout or a select! loser would.
+        let abandoned = tokio::time::timeout(
+            StdDuration::from_millis(100),
+            client.call_tool("slow", serde_json::json!({})),
+        )
+        .await;
+        assert!(abandoned.is_err(), "the call must still be running");
+
+        // The guard runs on drop; give the loop a moment to send.
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+
+        let cancelled = log.cancelled_ids();
+        assert_eq!(
+            cancelled.len(),
+            1,
+            "exactly one cancellation must be sent: {cancelled:?}"
+        );
+        assert!(
+            cancelled[0].is_number(),
+            "the id must keep its original JSON type, not become a string: {:?}",
+            cancelled[0]
+        );
+    }
+
+    /// A completed call must never be cancelled: the guard disarms on the
+    /// response, so a normal call emits nothing.
+    #[tokio::test]
+    async fn a_completed_call_is_not_cancelled() {
+        let quick = ToolBuilder::new("quick")
+            .description("Returns immediately")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                Ok(CallToolResult::text("done"))
+            })
+            .build();
+        let log = FrameLog::default();
+        let transport = LoggingTransport {
+            inner: ChannelTransport::new(
+                McpRouter::new()
+                    .server_info("cancel-test", "1.0.0")
+                    .tool(quick),
+            ),
+            log: log.clone(),
+        };
+        let client = McpClient::connect(transport).await.unwrap();
+        client.initialize("test", "1.0.0").await.unwrap();
+
+        client
+            .call_tool("quick", serde_json::json!({}))
+            .await
+            .expect("call completes");
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+
+        assert!(
+            log.cancelled_ids().is_empty(),
+            "a completed call must not be cancelled: {:?}",
+            log.cancelled_ids()
+        );
+    }
+
+    /// Cancelling one call must not disturb another in flight, which is the
+    /// risk that made matching ids out of a wire trace unworkable downstream.
+    #[tokio::test]
+    async fn cancelling_one_call_leaves_another_running() {
+        let log = FrameLog::default();
+        let client = Arc::new(connected(log.clone()).await);
+
+        // A long call we intend to keep.
+        let keeper = {
+            let client = client.clone();
+            tokio::spawn(async move { client.call_tool("slow", serde_json::json!({})).await })
+        };
+        tokio::time::sleep(StdDuration::from_millis(50)).await;
+
+        // A second call we abandon.
+        let _ = tokio::time::timeout(
+            StdDuration::from_millis(100),
+            client.call_tool("slow", serde_json::json!({})),
+        )
+        .await;
+        tokio::time::sleep(StdDuration::from_millis(100)).await;
+
+        let cancelled = log.cancelled_ids();
+        assert_eq!(cancelled.len(), 1, "only the abandoned call: {cancelled:?}");
+        assert!(
+            !keeper.is_finished(),
+            "the call that was not abandoned must still be pending"
+        );
+        keeper.abort();
+    }
+}


### PR DESCRIPTION
Closes #1202.

## What changes

Two things blocked cancellation, and both are gone:

- `LoopCommand::CancelRequest` acted only on `subscriptions/listen` and returned `Ok(())` for everything else. It now cancels any in-flight request.
- Request ids were allocated **inside** the message loop, so a caller could never learn the id of its own call and could not send `notifications/cancelled` by hand either. Allocation moves to the caller, sharing one `AtomicI64` with the loop so caller-issued and loop-issued ids cannot collide.

The trigger is dropping the returned future, which the issue identified as the shape a Rust caller already expects: a timeout, a `select!` loser, a Ctrl-C handler. So existing call sites gain cancellation without changing, which is what mcp-repl needs.

## Details worth review

- **The guard disarms on the response**, so a completed call is never cancelled. Pinned by a test rather than left to inspection.
- **`Drop` cannot await**, so the guard uses `try_send`. A full or closed command channel skips the cancellation rather than blocking a drop, the same trade-off `SubscriptionHandle` already makes.
- **A failed cancellation puts the pending entry back.** If the notification does not reach the transport, the request is still live on the server, and dropping the entry would orphan it.
- Subscription cancellation keeps its distinct "subscription cancelled" wording; ordinary requests report "request cancelled".

## Tests

All three acceptance criteria, over `ChannelTransport` with a frame-logging wrapper so the wire is observed directly:

- an abandoned call emits exactly one `notifications/cancelled`, and the id **stays a JSON number** rather than becoming a string
- a completed call emits none
- cancelling one call leaves another in flight untouched, which is the failure mode that made the downstream id-matching workaround unworkable