### PR TITLE
fix(types): omit absent optional params instead of sending null

### DIFF
--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -3599,8 +3599,12 @@ pub struct UnsubscribeResourceParams {
 /// Parameters for listing resource templates
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ListResourceTemplatesParams {
-    /// Pagination cursor from previous response
-    #[serde(default)]
+    /// Opaque cursor returned by the preceding page, or `None` for page one.
+    ///
+    /// Omitted when absent rather than sent as `null`: the schema types this
+    /// `string | undefined`, so a server generating validators from it
+    /// rejects an explicit null (#1213).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
     /// Optional protocol-level metadata
     #[serde(
@@ -4378,10 +4382,10 @@ impl<'de> Deserialize<'de> for CreateTaskResult {
 #[serde(rename_all = "camelCase")]
 pub struct ListTasksParams {
     /// Filter by status (optional)
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<TaskStatus>,
     /// Pagination cursor
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
     /// Optional protocol-level metadata
     #[serde(
@@ -4443,7 +4447,7 @@ pub struct CancelTaskParams {
     /// Task ID to cancel
     pub task_id: String,
     /// Optional reason for cancellation
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
     /// Optional protocol-level metadata
     #[serde(
@@ -8039,5 +8043,97 @@ mod primitive_schema_dispatch_tests {
         let json = serde_json::json!({"type": "null", "title": "Nothing"});
         let parsed: PrimitiveSchemaDefinition = serde_json::from_value(json.clone()).unwrap();
         assert_eq!(serde_json::to_value(&parsed).unwrap(), json);
+    }
+}
+
+#[cfg(test)]
+mod absent_optional_param_tests {
+    use super::*;
+
+    fn keys(value: &serde_json::Value) -> Vec<&str> {
+        value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect()
+    }
+
+    /// #1213: `"cursor": null` is not the same as an absent cursor. The
+    /// schema types it `string | undefined`, so a server generating
+    /// validators from it (Zod, in the two cases that reported this) rejects
+    /// an explicit null and the whole listing fails.
+    #[test]
+    fn a_first_page_list_request_omits_the_cursor() {
+        for value in [
+            serde_json::to_value(ListToolsParams::default()).unwrap(),
+            serde_json::to_value(ListResourcesParams::default()).unwrap(),
+            serde_json::to_value(ListResourceTemplatesParams::default()).unwrap(),
+            serde_json::to_value(ListPromptsParams::default()).unwrap(),
+        ] {
+            assert!(
+                !keys(&value).contains(&"cursor"),
+                "an absent cursor must not be sent at all: {value}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_cursor_that_is_set_is_still_sent() {
+        let value = serde_json::to_value(ListResourceTemplatesParams {
+            cursor: Some("page-2".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(value["cursor"], "page-2");
+    }
+
+    #[test]
+    fn other_absent_optional_params_are_omitted() {
+        let tasks = serde_json::to_value(ListTasksParams::default()).unwrap();
+        assert!(!keys(&tasks).contains(&"status"), "{tasks}");
+        assert!(!keys(&tasks).contains(&"cursor"), "{tasks}");
+
+        let cancel = serde_json::to_value(CancelTaskParams {
+            task_id: "t".to_string(),
+            reason: None,
+            meta: None,
+        })
+        .unwrap();
+        assert!(!keys(&cancel).contains(&"reason"), "{cancel}");
+    }
+
+    /// Two nulls are deliberate and must stay. `requestId` is required on
+    /// `notifications/cancelled`, so sending null is the correct signal for a
+    /// malformed send rather than something to hide; and a legacy task's
+    /// `ttl` uses null to mean unlimited, which is distinct from absent.
+    #[test]
+    fn meaningful_nulls_are_preserved() {
+        let cancelled = serde_json::to_value(CancelledParams {
+            request_id: None,
+            reason: None,
+            meta: None,
+        })
+        .unwrap();
+        assert!(
+            cancelled["requestId"].is_null(),
+            "a malformed cancellation must remain visibly malformed: {cancelled}"
+        );
+
+        let status = serde_json::to_value(TaskStatusParams {
+            task_id: "t".to_string(),
+            status: TaskStatus::Working,
+            status_message: None,
+            created_at: "now".to_string(),
+            last_updated_at: "now".to_string(),
+            ttl: None,
+            poll_interval: None,
+            meta: None,
+        })
+        .unwrap();
+        assert!(
+            status["ttl"].is_null(),
+            "null ttl means unlimited, not absent: {status}"
+        );
     }
 }


### PR DESCRIPTION
Closes #1213.

## Bug

```json
{"method":"resources/templates/list","params":{"cursor":null,"_meta":{"progressToken":5}}}
```

`cursor` is optional in the MCP schema, and `null` is not the same as absent. A server generating validators from the schema types it `string | undefined`, so an explicit null is a type error:

```text
[{"expected":"string","code":"invalid_type","path":["params","cursor"],
  "message":"Invalid input: expected string, received null"}]
```

Context7 and the Hugging Face MCP server reject it independently, which is what makes this ours rather than theirs.

## Scope, which is narrower and wider than reported

Narrower: of the four list-params types, **only `ListResourceTemplatesParams`** lacked `skip_serializing_if`. `ListToolsParams`, `ListResourcesParams`, and `ListPromptsParams` already had it, which is exactly why the report names `resources/templates/list`.

Wider: the issue asked for "a check for other optional params serialized the same way". A scan of every `*Params` type found three more sending null for an absent value: `ListTasksParams::status`, `ListTasksParams::cursor`, and `CancelTaskParams::reason`. All four are fixed.

## Two nulls kept deliberately

The same scan flagged two that must stay, and both are documented in place:

- **`CancelledParams::request_id`** -- `requestId` is required on `notifications/cancelled`. The field is `Option` only so a malformed inbound notification still deserializes; sending null is the correct, visible signal for a malformed send.
- **`TaskStatusParams::ttl`** -- null means *unlimited*, which is semantically distinct from absent.

A test pins both, so a future sweep for this same pattern does not quietly strip them.

## Tests

- every list type omits `cursor` on a first-page request
- a cursor that is set is still sent
- the three sibling fields are omitted when absent
- the two meaningful nulls are preserved