### PR TITLE
ci: exercise the client against real public MCP servers on a schedule

### DIFF
--- a/.github/interop-snapshot.json
+++ b/.github/interop-snapshot.json
@@ -1,0 +1,78 @@
+[
+  {
+    "name": "deepwiki",
+    "connect": {
+      "outcome": "ok"
+    },
+    "protocol_version": "2025-11-25",
+    "tools": {
+      "outcome": "ok"
+    },
+    "resources": {
+      "outcome": "ok"
+    },
+    "resource_templates": {
+      "outcome": "ok"
+    },
+    "prompts": {
+      "outcome": "ok"
+    }
+  },
+  {
+    "name": "gitmcp",
+    "connect": {
+      "outcome": "ok"
+    },
+    "protocol_version": "2025-03-26",
+    "tools": {
+      "outcome": "ok"
+    },
+    "resources": {
+      "outcome": "not_declared"
+    },
+    "resource_templates": {
+      "outcome": "not_declared"
+    },
+    "prompts": {
+      "outcome": "not_declared"
+    }
+  },
+  {
+    "name": "context7",
+    "connect": {
+      "outcome": "ok"
+    },
+    "protocol_version": "2025-11-25",
+    "tools": {
+      "outcome": "ok"
+    },
+    "resources": {
+      "outcome": "ok"
+    },
+    "resource_templates": {
+      "outcome": "ok"
+    },
+    "prompts": {
+      "outcome": "ok"
+    }
+  },
+  {
+    "name": "huggingface",
+    "connect": {
+      "outcome": "ok"
+    },
+    "protocol_version": "2025-11-25",
+    "tools": {
+      "outcome": "ok"
+    },
+    "resources": {
+      "outcome": "ok"
+    },
+    "resource_templates": {
+      "outcome": "ok"
+    },
+    "prompts": {
+      "outcome": "not_declared"
+    }
+  }
+]

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -1,0 +1,118 @@
+name: Public server interop
+
+# Exercises tower-mcp's client against real public MCP servers.
+#
+# Deliberately never gates a pull request. A third party being down, slow, or
+# mid-deploy is not our regression, and a lane that reddens for that reason
+# teaches people to ignore CI. The signal is a *change* from the recorded
+# snapshot, reported as an issue.
+
+on:
+  schedule:
+    # Daily, offset from the top of the hour to avoid the scheduling crowd.
+    - cron: "23 7 * * *"
+  workflow_dispatch:
+  pull_request:
+    # Run on changes to the probe itself, so a broken probe is caught before
+    # it starts reporting nonsense on a schedule. Still non-gating below.
+    paths:
+      - "tools/interop-probe/**"
+      - ".github/workflows/interop.yml"
+      - ".github/interop-snapshot.json"
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  probe:
+    name: Probe public servers
+    runs-on: ubuntu-latest
+    # Never fail the workflow: the report is the product, not the exit code.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Probe
+        id: probe
+        run: |
+          set +e
+          cargo run -q -p interop-probe > interop-report.txt 2>&1
+          cargo run -q -p interop-probe -- --snapshot > interop-current.json 2>/dev/null
+          set -e
+          echo "--- report ---"
+          cat interop-report.txt
+
+      - name: Compare against the recorded snapshot
+        id: diff
+        run: |
+          if [ ! -s interop-current.json ]; then
+            echo "changed=error" >> "$GITHUB_OUTPUT"
+            echo "The probe produced no snapshot." > interop-diff.txt
+            exit 0
+          fi
+          if diff -u .github/interop-snapshot.json interop-current.json > interop-diff.txt; then
+            echo "changed=no" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=yes" >> "$GITHUB_OUTPUT"
+            echo "--- diff ---"
+            cat interop-diff.txt
+          fi
+
+      - name: Open or update the tracking issue
+        if: steps.diff.outputs.changed != 'no' && github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="Public server interop changed"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          # Built with a heredoc rather than printf: the diff and report are
+          # multi-line and contain backticks and quotes.
+          {
+            echo "The scheduled interop probe saw different behavior than the recorded snapshot."
+            echo
+            echo "This is not necessarily a regression in tower-mcp. A third-party server may have"
+            echo "changed, be mid-deploy, or be down. Read the diff before assuming."
+            echo
+            echo '```diff'
+            cat interop-diff.txt
+            echo '```'
+            echo
+            echo '<details><summary>Full report</summary>'
+            echo
+            echo '```'
+            cat interop-report.txt
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo "If the new behavior is correct, refresh the snapshot with"
+            # Backticks are literal here: this is a markdown code span, not
+            # command substitution.
+            # shellcheck disable=SC2016
+            echo '`cargo run -p interop-probe -- --snapshot > .github/interop-snapshot.json`.'
+            echo "If it is our bug, file it separately and link back here."
+            echo
+            echo "Run: $RUN_URL"
+          } > interop-issue.md
+
+          EXISTING=$(gh issue list --search "$TITLE in:title" --state open --json number --jq '.[0].number' || true)
+          if [ -n "$EXISTING" ]; then
+            gh issue comment "$EXISTING" --body-file interop-issue.md
+          else
+            gh issue create --title "$TITLE" --body-file interop-issue.md
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: interop-report
+          path: |
+            interop-report.txt
+            interop-current.json
+            interop-diff.txt
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "interop-probe"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-mcp",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "examples/conformance-client",
     "examples/codegen-mcp",
     "examples/mcp2md",
+    "tools/interop-probe",
     "tools/rmcp-compat",
     "tools/sdk-interop",
 ]

--- a/tools/interop-probe/Cargo.toml
+++ b/tools/interop-probe/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "interop-probe"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[[bin]]
+name = "interop-probe"
+path = "src/main.rs"
+
+[dependencies]
+tower-mcp = { workspace = true, features = ["http-client"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true

--- a/tools/interop-probe/src/main.rs
+++ b/tools/interop-probe/src/main.rs
@@ -1,0 +1,304 @@
+//! Connects tower-mcp's client to real public MCP servers and reports what
+//! happened, so interop breakage is noticed here rather than downstream.
+//!
+//! Every other test in this workspace runs against a server built from these
+//! same types, which agrees with our assumptions by construction. A client's
+//! actual job is coping with servers that were not. Both bugs this tool was
+//! written after (#1212, #1213) were live while the client conformance suite
+//! was green, because that suite drives our client against a *conformant*
+//! peer and neither bug appears against one.
+//!
+//! ```bash
+//! cargo run -p interop-probe                 # human-readable
+//! cargo run -p interop-probe -- --snapshot   # diffable outcome record
+//! ```
+//!
+//! # Read-only
+//!
+//! These are other people's services. The probe performs the handshake and
+//! the list operations a server declares, and nothing else: no tool calls, no
+//! resource reads, no prompt renders, no subscriptions. One pass per run.
+
+use std::time::Duration;
+
+use serde::Serialize;
+use tower_mcp::client::{HttpClientTransport, McpClient};
+
+/// A server reachable without credentials.
+struct Target {
+    name: &'static str,
+    url: &'static str,
+    /// What it is, for the human-readable output. Not diffed.
+    note: &'static str,
+}
+
+const TARGETS: &[Target] = &[
+    Target {
+        name: "deepwiki",
+        url: "https://mcp.deepwiki.com/mcp",
+        note: "FastMCP; emits a `_fastmcp` _meta key (#1212)",
+    },
+    Target {
+        name: "gitmcp",
+        url: "https://gitmcp.io/docs",
+        note: "declares tools only",
+    },
+    Target {
+        name: "context7",
+        url: "https://mcp.context7.com/mcp",
+        note: "Zod-validated params; rejected a null cursor (#1213)",
+    },
+    Target {
+        name: "huggingface",
+        url: "https://huggingface.co/mcp",
+        note: "@huggingface/mcp-services",
+    },
+];
+
+/// Outcome of one operation. This is what gets diffed between runs, so it
+/// deliberately excludes anything that changes for uninteresting reasons: no
+/// counts, no timings, no timestamps. A server adding a tool must not look
+/// like a regression, or the signal becomes noise and the lane stops being
+/// trusted.
+#[derive(Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "outcome")]
+enum Outcome {
+    /// The operation succeeded.
+    Ok,
+    /// The server does not declare this capability, so it was not attempted.
+    NotDeclared,
+    /// The operation failed. `error` is normalized: volatile substrings such
+    /// as ports and request ids are stripped so the same failure compares
+    /// equal across runs.
+    Failed { error: String },
+}
+
+#[derive(Serialize)]
+struct ServerReport {
+    name: &'static str,
+    connect: Outcome,
+    protocol_version: Option<String>,
+    tools: Outcome,
+    resources: Outcome,
+    resource_templates: Outcome,
+    prompts: Outcome,
+}
+
+/// Detail for humans reading the run log, never part of the diffed snapshot.
+struct Detail {
+    server_name: Option<String>,
+    counts: Vec<(&'static str, usize)>,
+}
+
+/// Strip the parts of an error that differ between runs of the same failure.
+fn normalize(error: &tower_mcp::Error) -> String {
+    let text = error.to_string();
+    let mut out = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    while let Some(c) = chars.next() {
+        // Collapse digit runs, which carry ports, ids, and durations.
+        if c.is_ascii_digit() {
+            while chars.peek().is_some_and(char::is_ascii_digit) {
+                chars.next();
+            }
+            out.push('N');
+            continue;
+        }
+        out.push(c);
+    }
+    // Keep it short enough to read in an issue body.
+    out.chars().take(200).collect()
+}
+
+async fn probe(target: &Target) -> (ServerReport, Detail) {
+    let mut report = ServerReport {
+        name: target.name,
+        connect: Outcome::Ok,
+        protocol_version: None,
+        tools: Outcome::NotDeclared,
+        resources: Outcome::NotDeclared,
+        resource_templates: Outcome::NotDeclared,
+        prompts: Outcome::NotDeclared,
+    };
+    let mut detail = Detail {
+        server_name: None,
+        counts: Vec::new(),
+    };
+
+    let transport = HttpClientTransport::new(target.url);
+    let client = match McpClient::connect(transport).await {
+        Ok(client) => client,
+        Err(error) => {
+            report.connect = Outcome::Failed {
+                error: normalize(&error),
+            };
+            return (report, detail);
+        }
+    };
+
+    let initialized = match client
+        .initialize("interop-probe", env!("CARGO_PKG_VERSION"))
+        .await
+    {
+        Ok(result) => result,
+        Err(error) => {
+            report.connect = Outcome::Failed {
+                error: normalize(&error),
+            };
+            return (report, detail);
+        }
+    };
+    report.protocol_version = Some(initialized.protocol_version.clone());
+    detail.server_name = Some(initialized.server_info.name.clone());
+
+    // Only ask for what the server declares. Asking for an undeclared
+    // capability earns a correct "method not found", which is the server
+    // behaving properly rather than a finding.
+    let caps = &initialized.capabilities;
+
+    if caps.tools.is_some() {
+        report.tools = match client.list_tools().await {
+            Ok(result) => {
+                detail.counts.push(("tools", result.tools.len()));
+                Outcome::Ok
+            }
+            Err(error) => Outcome::Failed {
+                error: normalize(&error),
+            },
+        };
+    }
+    if caps.resources.is_some() {
+        report.resources = match client.list_resources().await {
+            Ok(result) => {
+                detail.counts.push(("resources", result.resources.len()));
+                Outcome::Ok
+            }
+            Err(error) => Outcome::Failed {
+                error: normalize(&error),
+            },
+        };
+        report.resource_templates = match client.list_resource_templates().await {
+            Ok(result) => {
+                detail
+                    .counts
+                    .push(("resource_templates", result.resource_templates.len()));
+                Outcome::Ok
+            }
+            Err(error) => Outcome::Failed {
+                error: normalize(&error),
+            },
+        };
+    }
+    if caps.prompts.is_some() {
+        report.prompts = match client.list_prompts().await {
+            Ok(result) => {
+                detail.counts.push(("prompts", result.prompts.len()));
+                Outcome::Ok
+            }
+            Err(error) => Outcome::Failed {
+                error: normalize(&error),
+            },
+        };
+    }
+
+    let _ = client.shutdown().await;
+    (report, detail)
+}
+
+fn describe(outcome: &Outcome) -> String {
+    match outcome {
+        Outcome::Ok => "ok".to_string(),
+        Outcome::NotDeclared => "not declared".to_string(),
+        Outcome::Failed { error } => format!("FAILED: {error}"),
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let snapshot_mode = std::env::args().any(|a| a == "--snapshot");
+    let mut reports = Vec::new();
+
+    for target in TARGETS {
+        // A third party being slow is not a finding, but it must not hang the
+        // lane either.
+        let probed = tokio::time::timeout(Duration::from_secs(45), probe(target)).await;
+        let (report, detail) = match probed {
+            Ok(pair) => pair,
+            Err(_) => (
+                ServerReport {
+                    name: target.name,
+                    connect: Outcome::Failed {
+                        error: "timed out".to_string(),
+                    },
+                    protocol_version: None,
+                    tools: Outcome::NotDeclared,
+                    resources: Outcome::NotDeclared,
+                    resource_templates: Outcome::NotDeclared,
+                    prompts: Outcome::NotDeclared,
+                },
+                Detail {
+                    server_name: None,
+                    counts: Vec::new(),
+                },
+            ),
+        };
+
+        if !snapshot_mode {
+            println!("## {} -- {}", target.name, target.note);
+            println!("   url:      {}", target.url);
+            if let Some(name) = &detail.server_name {
+                println!("   server:   {name}");
+            }
+            if let Some(version) = &report.protocol_version {
+                println!("   protocol: {version}");
+            }
+            println!("   connect:  {}", describe(&report.connect));
+            for (label, outcome) in [
+                ("tools", &report.tools),
+                ("resources", &report.resources),
+                ("templates", &report.resource_templates),
+                ("prompts", &report.prompts),
+            ] {
+                println!("   {label:<9} {}", describe(outcome));
+            }
+            if !detail.counts.is_empty() {
+                let counts: Vec<String> = detail
+                    .counts
+                    .iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect();
+                println!("   counts:   {}", counts.join(" "));
+            }
+            println!();
+        }
+
+        reports.push(report);
+    }
+
+    if snapshot_mode {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&reports).expect("reports serialize")
+        );
+    } else {
+        let failures = reports
+            .iter()
+            .filter(|r| {
+                [
+                    &r.connect,
+                    &r.tools,
+                    &r.resources,
+                    &r.resource_templates,
+                    &r.prompts,
+                ]
+                .iter()
+                .any(|o| matches!(o, Outcome::Failed { .. }))
+            })
+            .count();
+        println!(
+            "{} of {} servers reported a failure",
+            failures,
+            reports.len()
+        );
+    }
+}


### PR DESCRIPTION
Closes #1215.

## Why

Every test in this workspace runs against a server built from these same types, so it agrees with our assumptions by construction. Both interop bugs fixed today were live **while the client conformance suite was green**, because that suite drives our client against a conformant peer and neither bug appears against one:

- #1212: a `_meta` key named `_fastmcp` discarded the whole `tools/list`, so any FastMCP server listed zero tools
- #1213: `"cursor": null` sent instead of omitted, rejected by two unrelated Zod-validated servers

## What it does

`tools/interop-probe` connects to four credential-free servers and performs the handshake plus the list operations each one **declares**, and nothing else. No tool calls, no resource reads, no prompt renders: these are other people's services, and one pass per run.

Capability-gating matters -- asking for something a server never declared earns a correct "method not found", which is the server behaving properly rather than a finding.

## The design decision that makes it usable

**The diffed record is per-operation outcome, not counts.** A server adding a tool must not look like a regression, or the signal becomes noise and people stop trusting the lane. Error text is normalized (digit runs collapsed) so the same failure compares equal across runs.

Verified reproducible: two consecutive runs produce byte-identical snapshots.

The workflow is scheduled and dispatchable, `continue-on-error`, never gates a PR, and reports a change by opening or updating an issue rather than reddening a badge. A third party being down is not our regression. It does run on PRs that touch the probe itself, so a broken probe is caught before it starts reporting nonsense on a schedule.

## Current result

```text
deepwiki      2025-11-25  connect ok  tools ok  resources ok  templates ok  prompts ok
gitmcp        2025-03-26  connect ok  tools ok  (nothing else declared)
context7      2025-11-25  connect ok  tools ok  resources ok  templates ok  prompts ok
huggingface   2025-11-25  connect ok  tools ok  resources ok  templates ok
0 of 4 servers reported a failure
```

Zero failures, which independently confirms today's fixes against the exact servers that broke.

Note `gitmcp` negotiates **2025-03-26**, our oldest supported revision, so this lane also exercises backward compatibility against a real peer rather than a fixture.