### PR TITLE
feat(client): add a WebSocket client transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,10 +168,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1816,7 +1816,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_pcg",
  "ring",
  "rustc-hash",
@@ -1876,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -2097,7 +2097,7 @@ dependencies = [
  "http-body-util",
  "pastey",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2472,6 +2472,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2874,7 +2885,23 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.30.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2940,6 +2967,7 @@ dependencies = [
  "axum",
  "base64 0.23.0",
  "futures",
+ "futures-util",
  "getrandom 0.4.3",
  "http",
  "http-body-util",
@@ -2958,6 +2986,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-tungstenite 0.30.0",
  "tokio-util",
  "tower",
  "tower-mcp-macros",
@@ -3176,7 +3205,25 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.11.0",
  "thiserror",
 ]
 
@@ -3421,6 +3468,24 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ base64 = "0.23.0"
 # Elicitation form fields render in declaration order, so their schema map
 # must preserve insertion order (#1199).
 indexmap = { version = "2", features = ["serde"] }
+# Client-side WebSocket. The server side rides on axum, but a client needs its
+# own implementation.
+tokio-tungstenite = { version = "0.30", default-features = false, features = ["connect", "rustls-tls-webpki-roots"] }
 
 # Crypto
 sha2 = "0.11"

--- a/crates/tower-mcp/Cargo.toml
+++ b/crates/tower-mcp/Cargo.toml
@@ -57,7 +57,7 @@ default = []
 full = ["http", "websocket", "unix", "childproc", "oauth", "jwks", "testing", "dynamic-tools", "http-client", "oauth-client", "proxy", "macros", "resilience", "mcp-apps", "protocol-2026-07-28"]
 # Transport features
 http = ["dep:axum", "dep:hyper", "dep:http", "dep:http-body-util", "dep:tokio-stream", "dep:uuid"]
-websocket = ["dep:axum", "dep:uuid"]
+websocket = ["dep:axum", "dep:uuid", "dep:tokio-tungstenite", "dep:futures-util"]
 unix = ["http"]
 childproc = []
 # OAuth 2.1 resource server support
@@ -88,6 +88,14 @@ protocol-2026-07-28 = ["stateless"]
 # Compatibility alias for the former feature name. New consumers should enable
 # `protocol-2026-07-28`; existing `stateless` users retain the same behavior.
 stateless = ["dep:sha2"]
+
+[dependencies.tokio-tungstenite]
+workspace = true
+optional = true
+
+[dependencies.futures-util]
+version = "0.3"
+optional = true
 
 [dependencies.axum]
 workspace = true

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -46,6 +46,8 @@ mod oauth_flow;
 mod response_cache;
 mod stdio;
 mod transport;
+#[cfg(feature = "websocket")]
+mod websocket;
 
 pub use channel::ChannelTransport;
 pub use handler::{ClientHandler, NotificationHandler, ServerNotification};
@@ -80,6 +82,8 @@ pub use oauth_flow::{
 pub use response_cache::{ClientCacheConfig, DEFAULT_MAX_CACHE_TTL};
 pub use stdio::StdioClientTransport;
 pub use transport::ClientTransport;
+#[cfg(feature = "websocket")]
+pub use websocket::{WebSocketClientConfig, WebSocketClientTransport};
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/tower-mcp/src/client/websocket.rs
+++ b/crates/tower-mcp/src/client/websocket.rs
@@ -1,0 +1,213 @@
+//! WebSocket client transport.
+//!
+//! Connects an [`McpClient`](crate::client::McpClient) to a
+//! [`WebSocketTransport`](crate::transport::WebSocketTransport) server, or to
+//! any MCP server speaking the same binding.
+//!
+//! # How this differs from HTTP
+//!
+//! The streamable HTTP client carries a lot of machinery that exists to make
+//! a request/response protocol behave like a duplex one: an SSE stream for
+//! server-to-client traffic, session ids, `Last-Event-ID` resumption, and
+//! reconnect. A WebSocket is already duplex, so none of that applies. One
+//! connection carries requests, responses, notifications, and
+//! server-initiated requests, and the transport is correspondingly small.
+//!
+//! There is no session recovery: if the socket drops, the connection is over.
+//! [`supports_session_recovery`](ClientTransport::supports_session_recovery)
+//! reports `false`, so the client does not attempt a reconnect that cannot
+//! work.
+//!
+//! # Negotiation and auth
+//!
+//! Both ride on `Sec-WebSocket-Protocol`, matching the server:
+//!
+//! - `mcp.version.<version>` selects the protocol revision
+//! - `mcp.auth.<token>` carries a bearer token
+//!
+//! The subprotocol carries auth because a browser cannot set request headers
+//! on a WebSocket. A native client can, so [`WebSocketClientConfig::bearer`]
+//! sends both, and [`headers`](WebSocketClientConfig::headers) adds arbitrary
+//! ones for servers that want them.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use tower_mcp::client::{McpClient, WebSocketClientTransport};
+//!
+//! # async fn example() -> Result<(), tower_mcp::BoxError> {
+//! let transport = WebSocketClientTransport::connect("ws://127.0.0.1:3000/ws").await?;
+//! let client = McpClient::connect(transport).await?;
+//! client.initialize("my-client", "1.0.0").await?;
+//! # Ok(())
+//! # }
+//! ```
+
+use async_trait::async_trait;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::HeaderValue;
+use tokio_tungstenite::tungstenite::protocol::Message;
+
+use crate::error::{Error, Result};
+
+use super::transport::ClientTransport;
+
+/// Connection settings for [`WebSocketClientTransport`].
+#[derive(Debug, Clone, Default)]
+pub struct WebSocketClientConfig {
+    /// Protocol revision to request, sent as `mcp.version.<version>`.
+    ///
+    /// `None` sends no version subprotocol, leaving the server to apply its
+    /// own default.
+    pub protocol_version: Option<String>,
+    /// Bearer token. Sent both as an `Authorization` header and as an
+    /// `mcp.auth.<token>` subprotocol, since servers accept either.
+    pub bearer: Option<String>,
+    /// Additional headers for the opening handshake.
+    pub headers: Vec<(String, String)>,
+}
+
+/// A [`ClientTransport`] over a WebSocket connection.
+pub struct WebSocketClientTransport {
+    /// Outbound frames to the socket task.
+    outgoing_tx: mpsc::Sender<String>,
+    /// Inbound frames from the socket task.
+    incoming_rx: mpsc::Receiver<String>,
+    connected: bool,
+}
+
+impl WebSocketClientTransport {
+    /// Connect to `url` with default settings.
+    pub async fn connect(url: &str) -> Result<Self> {
+        Self::connect_with_config(url, WebSocketClientConfig::default()).await
+    }
+
+    /// Connect to `url`, negotiating a protocol version and authenticating.
+    pub async fn connect_with_config(url: &str, config: WebSocketClientConfig) -> Result<Self> {
+        let mut request = url
+            .into_client_request()
+            .map_err(|e| Error::Transport(format!("invalid WebSocket URL: {e}")))?;
+
+        // Subprotocols are how this binding negotiates, so build the header
+        // even when only one of the two parts is present.
+        let mut subprotocols = Vec::new();
+        if let Some(version) = &config.protocol_version {
+            subprotocols.push(format!("mcp.version.{version}"));
+        }
+        if let Some(token) = &config.bearer {
+            subprotocols.push(format!("mcp.auth.{token}"));
+        }
+        if !subprotocols.is_empty() {
+            let value = subprotocols.join(", ");
+            let header = HeaderValue::from_str(&value).map_err(|e| {
+                Error::Transport(format!("subprotocol is not a valid header value: {e}"))
+            })?;
+            request
+                .headers_mut()
+                .insert("sec-websocket-protocol", header);
+        }
+
+        if let Some(token) = &config.bearer {
+            let header = HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| Error::Transport(format!("bearer token is not a header: {e}")))?;
+            request.headers_mut().insert("authorization", header);
+        }
+
+        for (name, value) in &config.headers {
+            let name: tokio_tungstenite::tungstenite::http::HeaderName = name
+                .parse()
+                .map_err(|e| Error::Transport(format!("invalid header name '{name}': {e}")))?;
+            let value = HeaderValue::from_str(value)
+                .map_err(|e| Error::Transport(format!("invalid header value: {e}")))?;
+            request.headers_mut().insert(name, value);
+        }
+
+        let (stream, _response) = tokio_tungstenite::connect_async(request)
+            .await
+            .map_err(|e| Error::Transport(format!("WebSocket connect failed: {e}")))?;
+
+        let (mut sink, mut source) = stream.split();
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<String>(64);
+        let (incoming_tx, incoming_rx) = mpsc::channel::<String>(64);
+
+        // Writer: one task owns the sink, so `send` never contends.
+        tokio::spawn(async move {
+            while let Some(message) = outgoing_rx.recv().await {
+                if sink.send(Message::Text(message.into())).await.is_err() {
+                    break;
+                }
+            }
+            let _ = sink.close().await;
+        });
+
+        // Reader: text frames are MCP messages. Ping/pong is handled by the
+        // library; binary frames are not part of this binding and are
+        // ignored rather than treated as a protocol error, since a peer
+        // sending one has not necessarily broken the conversation.
+        tokio::spawn(async move {
+            while let Some(message) = source.next().await {
+                match message {
+                    Ok(Message::Text(text)) => {
+                        if incoming_tx.send(text.to_string()).await.is_err() {
+                            break;
+                        }
+                    }
+                    Ok(Message::Close(_)) => break,
+                    Ok(_) => continue,
+                    Err(error) => {
+                        tracing::debug!(%error, "WebSocket receive error");
+                        break;
+                    }
+                }
+            }
+            // Dropping `incoming_tx` closes the channel, which `recv` reports
+            // as end-of-stream so the client's message loop can shut down.
+        });
+
+        Ok(Self {
+            outgoing_tx,
+            incoming_rx,
+            connected: true,
+        })
+    }
+}
+
+#[async_trait]
+impl ClientTransport for WebSocketClientTransport {
+    async fn send(&mut self, message: &str) -> Result<()> {
+        self.outgoing_tx
+            .send(message.to_string())
+            .await
+            .map_err(|_| Error::Transport("WebSocket connection closed".to_string()))
+    }
+
+    async fn recv(&mut self) -> Result<Option<String>> {
+        match self.incoming_rx.recv().await {
+            Some(message) => Ok(Some(message)),
+            None => {
+                self.connected = false;
+                Ok(None)
+            }
+        }
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected && !self.outgoing_tx.is_closed()
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        self.connected = false;
+        // Dropping the sender ends the writer task, which closes the sink.
+        self.incoming_rx.close();
+        Ok(())
+    }
+
+    /// A dropped WebSocket cannot be resumed: there is no session id and no
+    /// replay, so a reconnect would start a new conversation rather than
+    /// continue this one.
+    fn supports_session_recovery(&self) -> bool {
+        false
+    }
+}

--- a/crates/tower-mcp/tests/websocket_client.rs
+++ b/crates/tower-mcp/tests/websocket_client.rs
@@ -1,0 +1,165 @@
+//! Round-trip coverage for `WebSocketClientTransport` against the crate's own
+//! `WebSocketTransport` server (#1032).
+
+#![cfg(feature = "websocket")]
+
+use std::time::Duration;
+
+use tower_mcp::client::{McpClient, WebSocketClientConfig, WebSocketClientTransport};
+use tower_mcp::{CallToolResult, McpRouter, PromptBuilder, ResourceBuilder, ToolBuilder};
+
+fn router() -> McpRouter {
+    let echo = ToolBuilder::new("echo")
+        .description("Echo a value")
+        .handler(|v: serde_json::Value| async move { Ok(CallToolResult::text(v.to_string())) })
+        .build();
+    // `ResourceBuilder` finishes at the content method; there is no `build`.
+    let resource = ResourceBuilder::new("mem://one").name("one").text("hello");
+    let prompt = PromptBuilder::new("greet")
+        .description("Greet")
+        .handler(
+            |_args: std::collections::HashMap<String, String>| async move {
+                Ok(tower_mcp::GetPromptResult {
+                    description: None,
+                    messages: vec![tower_mcp::protocol::PromptMessage {
+                        role: tower_mcp::protocol::PromptRole::User,
+                        content: tower_mcp::protocol::Content::Text {
+                            text: "hello there".to_string(),
+                            annotations: None,
+                            meta: None,
+                        },
+                        meta: None,
+                    }],
+                    meta: None,
+                })
+            },
+        )
+        .build();
+
+    McpRouter::new()
+        .server_info("ws-test-server", "1.0.0")
+        .tool(echo)
+        .resource(resource)
+        .prompt(prompt)
+}
+
+/// Start the server on an ephemeral port and return its ws:// URL.
+async fn serve(router: McpRouter) -> String {
+    let app = tower_mcp::WebSocketTransport::new(router).into_router();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    // Let the listener come up before the first dial.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    format!("ws://{addr}/")
+}
+
+/// The acceptance criterion: a client drives the full surface over a socket.
+#[tokio::test]
+async fn the_full_surface_round_trips_over_a_websocket() {
+    let url = serve(router()).await;
+    let transport = WebSocketClientTransport::connect(&url)
+        .await
+        .expect("connect");
+    let client = McpClient::connect(transport).await.expect("client");
+
+    let initialized = client.initialize("ws-client", "1.0.0").await.expect("init");
+    assert_eq!(initialized.server_info.name, "ws-test-server");
+
+    let tools = client.list_tools().await.expect("tools");
+    assert!(tools.tools.iter().any(|t| t.name == "echo"));
+
+    let result = client
+        .call_tool("echo", serde_json::json!({"v": 1}))
+        .await
+        .expect("call");
+    assert!(result.all_text().contains("\"v\""));
+
+    let resources = client.list_resources().await.expect("resources");
+    assert_eq!(resources.resources.len(), 1);
+
+    let read = client.read_resource("mem://one").await.expect("read");
+    assert!(!read.contents.is_empty());
+
+    let prompts = client.list_prompts().await.expect("prompts");
+    assert!(prompts.prompts.iter().any(|p| p.name == "greet"));
+
+    client.shutdown().await.expect("shutdown");
+}
+
+/// A version subprotocol is offered and honored, so a client can pin the
+/// revision it speaks rather than accepting the server's default.
+#[tokio::test]
+async fn a_requested_protocol_version_is_negotiated() {
+    let url = serve(router()).await;
+    let transport = WebSocketClientTransport::connect_with_config(
+        &url,
+        WebSocketClientConfig {
+            protocol_version: Some("2025-11-25".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("connect");
+
+    let client = McpClient::connect(transport).await.expect("client");
+    let initialized = client.initialize("ws-client", "1.0.0").await.expect("init");
+    assert_eq!(initialized.protocol_version, "2025-11-25");
+    client.shutdown().await.expect("shutdown");
+}
+
+/// Bearer and custom headers ride the opening handshake without breaking it.
+#[tokio::test]
+async fn bearer_and_custom_headers_are_accepted() {
+    let url = serve(router()).await;
+    let transport = WebSocketClientTransport::connect_with_config(
+        &url,
+        WebSocketClientConfig {
+            bearer: Some("test-token".to_string()),
+            headers: vec![("x-example".to_string(), "1".to_string())],
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("connect with auth");
+
+    let client = McpClient::connect(transport).await.expect("client");
+    client.initialize("ws-client", "1.0.0").await.expect("init");
+    client.shutdown().await.expect("shutdown");
+}
+
+/// A dropped socket ends the conversation rather than being retried: there is
+/// no session id and no replay, so a reconnect would start a new one.
+#[tokio::test]
+async fn a_closed_socket_reports_disconnected() {
+    let url = serve(router()).await;
+    let mut transport = WebSocketClientTransport::connect(&url)
+        .await
+        .expect("connect");
+
+    use tower_mcp::client::ClientTransport;
+    assert!(transport.is_connected());
+    assert!(
+        !transport.supports_session_recovery(),
+        "a WebSocket cannot resume, so the client must not try"
+    );
+
+    transport.close().await.expect("close");
+    assert!(!transport.is_connected());
+}
+
+/// An unreachable endpoint fails at connect rather than surfacing later as a
+/// confusing protocol error.
+#[tokio::test]
+async fn connecting_to_a_dead_endpoint_fails_immediately() {
+    let error = match WebSocketClientTransport::connect("ws://127.0.0.1:1/").await {
+        Ok(_) => panic!("connecting to a dead endpoint must fail"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("WebSocket connect failed"),
+        "the error should name the stage that failed: {error}"
+    );
+}


### PR DESCRIPTION
Closes #1032. The library half; the mcp-repl `--ws` half belongs in that repository.

## Why it is small

The streamable HTTP client is 2,479 lines, most of it making a request/response protocol behave like a duplex one: an SSE stream for server-to-client traffic, session ids, `Last-Event-ID` resumption, reconnect. A WebSocket is already duplex, so none of that applies. One connection carries requests, responses, notifications, and server-initiated requests, and `ClientTransport` is just `send`/`recv`/`is_connected`/`close`.

## Decisions worth review

- **`supports_session_recovery` returns `false`.** A dropped socket has no session id and no replay, so a reconnect starts a new conversation rather than continuing one. Reporting `true` would make the client retry into a silently different session, which is the failure mode #1219 was about.
- **Auth goes both ways.** The server accepts `mcp.auth.<token>` as a subprotocol, which exists because a browser cannot set headers on a WebSocket. A native client can, so a configured bearer is sent as both the subprotocol and an `Authorization` header, and the server takes whichever it prefers.
- **Binary frames are ignored, not fatal.** They are not part of this binding, but a peer sending one has not necessarily broken the conversation, so dropping the frame beats dropping the connection.
- **Two tasks own the split socket**, so `send` never contends with `recv` and the writer closes the sink on shutdown.

## Tests

Five, against the crate's own `WebSocketTransport`:

- the full surface round trips: initialize, tools list and call, resources list and read, prompts list
- a requested `mcp.version.*` is negotiated, so a client can pin its revision instead of taking the server's default
- bearer and custom headers ride the opening handshake
- a closed socket reports disconnected and declines session recovery
- an unreachable endpoint fails at connect, naming the stage, rather than surfacing later as a confusing protocol error

Checked across default, `websocket`, `http`, and `protocol-2026-07-28` feature sets plus the full workspace suite, since the last two PRs each tripped a feature-gating problem CI caught and local `--all-features` did not.