### PR TITLE
docs: correct three claims that contradict the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,8 +365,8 @@ let v1 = McpRouter::new().tool(legacy_tool);
 let v2 = McpRouter::new().tool(new_tool);
 
 let versioned = McpRouter::new()
-    .nest("v1", v1)   // Tools become "v1_legacy_tool"
-    .nest("v2", v2);  // Tools become "v2_new_tool"
+    .nest("v1", v1)   // Tools become "v1.legacy_tool"
+    .nest("v2", v2);  // Tools become "v2.new_tool"
 ```
 
 ## Multi-Server Proxy
@@ -454,7 +454,7 @@ let router = McpRouter::new()
     .tool(my_tool);
 
 // Serve over stdin/stdout
-StdioTransport::new(router).serve().await?;
+StdioTransport::new(router).run().await?;
 ```
 
 ### HTTP with SSE

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -750,7 +750,7 @@ where
 /// in [`ToolCatchError`] to convert any errors (from handlers or middleware)
 /// into `CallToolResult::error()` responses.
 pub struct Tool {
-    /// Tool name (must be 1-128 chars, alphanumeric/underscore/hyphen/dot only)
+    /// Tool name (must be 1-64 chars, alphanumeric/underscore/hyphen/dot only)
     pub name: String,
     /// Human-readable title for the tool
     pub title: Option<String>,


### PR DESCRIPTION
Closes #1233. All three verified against the code before changing anything.

| Claim | Reality |
|---|---|
| `README.md:457` -- `StdioTransport::new(router).serve()` | The method is `run()` (`transport/stdio.rs:654`). `examples/getting_started.rs` already had it right. |
| `README.md:368` -- `nest("v1", ..)` gives `v1_legacy_tool` | `Tool::with_name_prefix` formats `"{prefix}.{name}"` (`tool.rs:1067`), so it is `v1.legacy_tool`. |
| `tool.rs:753` -- name "must be 1-128 chars" | `validate_tool_name` enforces 64 (`tool.rs:425`), and `tool.rs:416` and `:1195` already say 64. |

Each of these costs a reader real time. The first is the very first line anyone copies out of the README, so a new user's first attempt fails to compile. The third is worse than a wrong number: a name between 65 and 128 characters satisfies the documentation and then **panics** at `ToolBuilder::new`.

The `nest` separator matters beyond correctness, since clients differ in how they handle dots in tool names, and a reader planning around underscores would design the wrong naming scheme.