### PR TITLE
feat(router): add opt-in panic containment for tool handlers

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -90,6 +90,20 @@ fn is_final_protocol_request(_extensions: &crate::context::Extensions) -> bool {
     false
 }
 
+/// Recover a readable message from a panic payload.
+///
+/// `panic!` with a literal yields `&str` and with a format yields `String`;
+/// anything else is opaque and reported as such rather than guessed at.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(text) = payload.downcast_ref::<&'static str>() {
+        (*text).to_string()
+    } else if let Some(text) = payload.downcast_ref::<String>() {
+        text.clone()
+    } else {
+        "panicked with a non-string payload".to_string()
+    }
+}
+
 /// Whether this request's client declared the final Tasks extension.
 ///
 /// Final requests carry client capabilities per request, so negotiation is
@@ -424,6 +438,9 @@ struct McpRouterInner {
     /// URL of the server's website
     server_website_url: Option<String>,
     instructions: Option<String>,
+    /// Whether to convert a panicking tool handler into an error result
+    /// rather than letting it unwind out of the service (#1230).
+    catch_panics: bool,
     auto_instructions: Option<AutoInstructionsConfig>,
     tools: HashMap<String, Arc<Tool>>,
     resources: HashMap<String, Arc<Resource>>,
@@ -599,6 +616,7 @@ impl McpRouter {
                 server_icons: None,
                 server_website_url: None,
                 instructions: None,
+                catch_panics: false,
                 auto_instructions: None,
                 tools: HashMap::new(),
                 resources: HashMap::new(),
@@ -1210,6 +1228,31 @@ impl McpRouter {
     /// Set instructions for LLMs describing how to use this server
     pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
         Arc::make_mut(&mut self.inner).instructions = Some(instructions.into());
+        self
+    }
+
+    /// Convert a panicking tool handler into an error result instead of
+    /// letting it unwind out of the service.
+    ///
+    /// Without this, a panic in one handler ends the whole server over stdio
+    /// and kills the connection task over HTTP. A bug in one tool should fail
+    /// that call, not disconnect every client on the process, which is what
+    /// makes this worth having on a long-running shared server.
+    ///
+    /// Off by default, deliberately. A panic is an invariant violation, and
+    /// converting one into a tidy error result hides a bug that the author
+    /// probably wants to see. Opting in is a statement that availability
+    /// matters more than failing fast, which is true for a shared server and
+    /// often false for a local one.
+    ///
+    /// The caught panic becomes a `CallToolResult` with `is_error: true`
+    /// carrying the panic message, and is logged at error level with the tool
+    /// name so it is not silently swallowed.
+    ///
+    /// A panic that unwinds is caught; one that aborts the process (a
+    /// double panic, or `panic = "abort"`) cannot be, by construction.
+    pub fn catch_panics(mut self) -> Self {
+        Arc::make_mut(&mut self.inner).catch_panics = true;
         self
     }
 
@@ -2522,7 +2565,9 @@ impl McpRouter {
         let notifier = self.clone();
         let task_store = self.inner.task_store.clone();
         tokio::spawn(async move {
-            let outcome = tool.call_outcome_with_context(ctx, resume.arguments).await;
+            let outcome = notifier
+                .invoke_tool(&tool, ctx, resume.arguments, &resume.tool_name)
+                .await;
             let result = match outcome {
                 Ok(crate::protocol::RequestOutcome::Complete(result)) => result,
                 // A handler may ask again; each round parks and resumes the
@@ -2539,6 +2584,50 @@ impl McpRouter {
             }
             notifier.notify_task_state(&task_id).await;
         });
+    }
+
+    /// Invoke a tool, optionally converting a panic into an error result.
+    ///
+    /// Enabled by [`McpRouter::catch_panics`]. Without it this is a direct
+    /// call and a panic unwinds as before, which is the default because a
+    /// panic is an invariant violation and hiding one is not always a favour.
+    async fn invoke_tool(
+        &self,
+        tool: &crate::tool::Tool,
+        ctx: RequestContext,
+        arguments: serde_json::Value,
+        tool_name: &str,
+    ) -> Result<crate::protocol::RequestOutcome<CallToolResult>> {
+        if !self.inner.catch_panics {
+            return tool.call_outcome_with_context(ctx, arguments).await;
+        }
+
+        use futures::FutureExt;
+        // AssertUnwindSafe: the future may hold &mut across the await, which
+        // Rust cannot prove safe to observe post-unwind. Any state a panicking
+        // handler leaves behind belongs to that handler; the router's own
+        // state is not mutated by this call.
+        let called = std::panic::AssertUnwindSafe(tool.call_outcome_with_context(ctx, arguments))
+            .catch_unwind()
+            .await;
+
+        match called {
+            Ok(outcome) => outcome,
+            Err(payload) => {
+                let message = panic_message(&*payload);
+                // Logged at error, not swallowed: an operator who opted into
+                // availability still needs to learn about the bug.
+                tracing::error!(
+                    target: "mcp::tools",
+                    tool = %tool_name,
+                    panic = %message,
+                    "tool handler panicked; returning an error result"
+                );
+                Ok(crate::protocol::RequestOutcome::Complete(
+                    CallToolResult::error(format!("tool '{tool_name}' panicked: {message}")),
+                ))
+            }
+        }
     }
 
     /// Push the current state of a task to subscribed listen streams.
@@ -3009,7 +3098,9 @@ impl McpRouter {
                         // answers with `tasks/update` and the router resumes
                         // it (#1208).
                         let start = std::time::Instant::now();
-                        let outcome = tool.call_outcome_with_context(ctx, arguments).await;
+                        let outcome = notifier
+                            .invoke_tool(&tool, ctx, arguments, &tool_name)
+                            .await;
                         let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
                         let result = match outcome {
@@ -3105,8 +3196,8 @@ impl McpRouter {
                     };
 
                     let start = std::time::Instant::now();
-                    let outcome = tool
-                        .call_outcome_with_context(ctx, params.arguments)
+                    let outcome = self
+                        .invoke_tool(&tool, ctx, params.arguments, &params.name)
                         .await?;
                     let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
@@ -5979,6 +6070,22 @@ mod tests {
     // =========================================================================
     // Task Lifecycle Tests
     // =========================================================================
+
+    /// #1230: a panic payload is `&'static str` for a literal and `String`
+    /// for a formatted message, and both have to survive the trip through
+    /// `Box<dyn Any>` or the error result says nothing useful.
+    #[test]
+    fn panic_message_recovers_both_payload_shapes() {
+        let literal = std::panic::catch_unwind(|| panic!("boom literal")).unwrap_err();
+        assert_eq!(panic_message(&*literal), "boom literal");
+
+        let n = 7;
+        let formatted = std::panic::catch_unwind(|| panic!("boom {n}")).unwrap_err();
+        assert_eq!(panic_message(&*formatted), "boom 7");
+
+        let odd = std::panic::catch_unwind(|| std::panic::panic_any(42u8)).unwrap_err();
+        assert_eq!(panic_message(&*odd), "panicked with a non-string payload");
+    }
 
     /// #1208: the full task input round trip. The handler asks, the task
     /// parks in `input_required` carrying the requests, the client answers

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -854,3 +854,119 @@ mod cancellation {
         keeper.abort();
     }
 }
+
+// =============================================================================
+// Panic containment (#1230)
+// =============================================================================
+
+mod panics {
+    use super::*;
+    use tower_mcp::extract::Context;
+
+    fn panicking_router(catch: bool) -> McpRouter {
+        let boom = ToolBuilder::new("boom")
+            .description("Panics")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                panic!("overflow when adding duration to `SystemTime`");
+                #[allow(unreachable_code)]
+                Ok(CallToolResult::text("unreachable"))
+            })
+            .build();
+        let fine = ToolBuilder::new("fine")
+            .description("Works")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                Ok(CallToolResult::text("ok"))
+            })
+            .build();
+
+        let router = McpRouter::new()
+            .server_info("panic-test", "1.0.0")
+            .tool(boom)
+            .tool(fine);
+        if catch { router.catch_panics() } else { router }
+    }
+
+    /// #1230: a panicking handler took down the whole server. The blast
+    /// radius is the point: a bug in one tool should fail that call, not
+    /// disconnect every client on the process.
+    #[tokio::test]
+    async fn a_panicking_tool_does_not_take_down_the_server() {
+        let client = McpClient::connect(ChannelTransport::new(panicking_router(true)))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        let result = client
+            .call_tool("boom", serde_json::json!({}))
+            .await
+            .expect("the call must return, not kill the connection");
+        assert!(result.is_error, "a caught panic is an error result");
+        assert!(
+            result.all_text().contains("panicked"),
+            "the message must say what happened: {}",
+            result.all_text()
+        );
+        assert!(
+            result.all_text().contains("SystemTime"),
+            "and carry the panic's own message: {}",
+            result.all_text()
+        );
+
+        // The decisive assertion: the connection survives and other tools
+        // still work.
+        let after = client
+            .call_tool("fine", serde_json::json!({}))
+            .await
+            .expect("the server must still be serving");
+        assert_eq!(after.all_text(), "ok");
+    }
+
+    /// Off by default: opting in is a statement that availability matters
+    /// more than failing fast, and that is the caller's call to make.
+    #[tokio::test]
+    async fn panics_are_not_caught_by_default() {
+        let client = McpClient::connect(ChannelTransport::new(panicking_router(false)))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        // The panic unwinds out of the spawned dispatch task rather than
+        // becoming a tidy error result, so the caller does not receive one.
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            client.call_tool("boom", serde_json::json!({})),
+        )
+        .await;
+        let caught_as_error =
+            matches!(&result, Ok(Ok(r)) if r.is_error && r.all_text().contains("panicked"));
+        assert!(
+            !caught_as_error,
+            "without catch_panics the panic must not be converted: {result:?}"
+        );
+    }
+
+    /// A tool that returns an error normally is unaffected by the wrapper.
+    #[tokio::test]
+    async fn catching_panics_does_not_disturb_ordinary_results() {
+        let client = McpClient::connect(ChannelTransport::new(panicking_router(true)))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        let result = client
+            .call_tool("fine", serde_json::json!({}))
+            .await
+            .expect("call");
+        assert!(!result.is_error);
+        assert_eq!(result.all_text(), "ok");
+    }
+}


### PR DESCRIPTION
Closes #1230.

A panicking tool handler unwound out of the router and took the connection down with it. On stdio that ends the process; on HTTP and WebSocket it drops every client sharing it. A bug in one tool should fail that call, not the server.

`McpRouter::catch_panics()` wraps tool invocation in `catch_unwind` and converts a panic into an error result naming the tool and the panic message, logged at error level.

## Off by default

A panic is an invariant violation, and turning one into a tidy error result hides a bug the author probably wants to see. Opting in is a statement that availability matters more than failing fast, which is the caller decision, not ours. It also keeps the default path free of `AssertUnwindSafe`.

```rust
let router = McpRouter::new()
    .server_info("my-server", "1.0.0")
    .tool(my_tool)
    .catch_panics();
```

`panic = "abort"` builds cannot be caught, and the rustdoc says so.

## Coverage

All three tool invocation paths route through one helper: the synchronous call, the task spawn, and the input resume.

## Tests

- a panicking tool returns `is_error` carrying the panic message, and the connection still serves other tools afterward
- without `catch_panics()` the panic is not converted
- ordinary results are unaffected by the wrapper
- `panic_message` recovers both payload shapes (`&'static str` from a literal, `String` from a formatted message) and degrades gracefully on anything else