### PR TITLE
feat(router): add try_merge and conflicts for router composition

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -645,7 +645,10 @@ pub use resource::{
 };
 #[cfg(feature = "stateless")]
 pub use resource::{MrtrResourceHandler, MrtrResourceTemplateHandler};
-pub use router::{McpRouter, RouterRequest, RouterResponse, ToolAnnotationsMap};
+pub use router::{
+    McpRouter, MergeConflict, MergeConflictKind, MergeConflicts, RouterRequest, RouterResponse,
+    ToolAnnotationsMap,
+};
 pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -104,6 +104,100 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
     }
 }
 
+/// The kind of capability a [`MergeConflict`] refers to.
+///
+/// Ordered so that [`McpRouter::conflicts`] reports tools before resources
+/// before prompts, which reads more naturally than alphabetical order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MergeConflictKind {
+    /// A tool name defined by both routers.
+    Tool,
+    /// A resource URI defined by both routers.
+    Resource,
+    /// A resource template pattern defined by both routers.
+    ResourceTemplate,
+    /// A prompt name defined by both routers.
+    Prompt,
+}
+
+impl MergeConflictKind {
+    /// The name of this kind as it appears in a conflict message.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Tool => "tool",
+            Self::Resource => "resource",
+            Self::ResourceTemplate => "resource template",
+            Self::Prompt => "prompt",
+        }
+    }
+}
+
+impl std::fmt::Display for MergeConflictKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// One capability defined by both routers in a [`McpRouter::try_merge`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MergeConflict {
+    /// Which kind of capability collided.
+    pub kind: MergeConflictKind,
+    /// The tool or prompt name, or the resource URI or template pattern.
+    pub name: String,
+}
+
+impl MergeConflict {
+    fn new(kind: MergeConflictKind, name: impl Into<String>) -> Self {
+        Self {
+            kind,
+            name: name.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for MergeConflict {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} '{}'", self.kind, self.name)
+    }
+}
+
+/// The error returned by [`McpRouter::try_merge`].
+///
+/// Carries every conflicting name rather than the first, so a startup check
+/// reports all the work at once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MergeConflicts {
+    conflicts: Vec<MergeConflict>,
+}
+
+impl MergeConflicts {
+    /// The conflicting capabilities, ordered by kind and then name.
+    pub fn conflicts(&self) -> &[MergeConflict] {
+        &self.conflicts
+    }
+
+    /// Take ownership of the conflicting capabilities.
+    pub fn into_conflicts(self) -> Vec<MergeConflict> {
+        self.conflicts
+    }
+}
+
+impl std::fmt::Display for MergeConflicts {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "cannot merge routers: ")?;
+        for (index, conflict) in self.conflicts.iter().enumerate() {
+            if index > 0 {
+                f.write_str(", ")?;
+            }
+            write!(f, "{conflict}")?;
+        }
+        f.write_str(" defined by both")
+    }
+}
+
+impl std::error::Error for MergeConflicts {}
+
 /// Whether this request's client declared the final Tasks extension.
 ///
 /// Final requests carry client capabilities per request, so negotiation is
@@ -1677,6 +1771,140 @@ impl McpRouter {
         }
 
         self
+    }
+
+    /// Report the names both this router and `other` define.
+    ///
+    /// [`merge`](Self::merge) resolves a collision by letting the incoming
+    /// router win, which is a reasonable default but leaves no trace that an
+    /// implementation was dropped. A host that composes a router it does not
+    /// own can call this first and fail at startup, which is the cheapest
+    /// moment to catch the clash (#1232).
+    ///
+    /// Results are ordered by kind and then name, so they are stable enough
+    /// to assert on and to print.
+    ///
+    /// Protocol extension declarations are deliberately excluded. Two routers
+    /// both declaring the same extension is ordinary composition rather than
+    /// a collision, since a declaration carries no implementation to lose.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+    /// use schemars::JsonSchema;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize, JsonSchema)]
+    /// struct Input { value: String }
+    ///
+    /// fn router_with(name: &str) -> McpRouter {
+    ///     McpRouter::new().tool(
+    ///         ToolBuilder::new(name)
+    ///             .description("example")
+    ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
+    ///             .build(),
+    ///     )
+    /// }
+    ///
+    /// let host = router_with("get_task");
+    /// let library = router_with("get_task");
+    /// let clashes = host.conflicts(&library);
+    /// assert_eq!(clashes.len(), 1);
+    /// assert_eq!(clashes[0].name, "get_task");
+    /// ```
+    pub fn conflicts(&self, other: &McpRouter) -> Vec<MergeConflict> {
+        let mut found = Vec::new();
+
+        for name in other.inner.tools.keys() {
+            if self.inner.tools.contains_key(name) {
+                found.push(MergeConflict::new(MergeConflictKind::Tool, name));
+            }
+        }
+        for uri in other.inner.resources.keys() {
+            if self.inner.resources.contains_key(uri) {
+                found.push(MergeConflict::new(MergeConflictKind::Resource, uri));
+            }
+        }
+        // Templates are stored as a list rather than a map because matching
+        // is pattern-based, so identity here is the template string itself.
+        for template in &other.inner.resource_templates {
+            if self
+                .inner
+                .resource_templates
+                .iter()
+                .any(|existing| existing.uri_template == template.uri_template)
+            {
+                found.push(MergeConflict::new(
+                    MergeConflictKind::ResourceTemplate,
+                    &template.uri_template,
+                ));
+            }
+        }
+        for name in other.inner.prompts.keys() {
+            if self.inner.prompts.contains_key(name) {
+                found.push(MergeConflict::new(MergeConflictKind::Prompt, name));
+            }
+        }
+
+        // `tools`, `resources`, and `prompts` are hash maps, so without this
+        // the order would vary between runs.
+        found.sort_by(|a, b| (a.kind, &a.name).cmp(&(b.kind, &b.name)));
+        found
+    }
+
+    /// Merge another router, failing if either defines a name the other does.
+    ///
+    /// This is [`merge`](Self::merge) with the collision reported instead of
+    /// resolved. Use it when a silently dropped tool would surface later as a
+    /// capability that behaves unexpectedly rather than as an error, which is
+    /// the usual case when a host merges in a router from a library that
+    /// cannot know what the host already registered.
+    ///
+    /// Callers who want the incoming router to win keep using
+    /// [`merge`](Self::merge). To inspect without consuming either router,
+    /// use [`conflicts`](Self::conflicts).
+    ///
+    /// # Errors
+    ///
+    /// Returns every conflicting name, not just the first, so a startup
+    /// failure names all the work to be done.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ToolBuilder, CallToolResult};
+    /// use schemars::JsonSchema;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize, JsonSchema)]
+    /// struct Input { value: String }
+    ///
+    /// fn router_with(name: &str) -> McpRouter {
+    ///     McpRouter::new().tool(
+    ///         ToolBuilder::new(name)
+    ///             .description("example")
+    ///             .handler(|i: Input| async move { Ok(CallToolResult::text(&i.value)) })
+    ///             .build(),
+    ///     )
+    /// }
+    ///
+    /// // Distinct names merge.
+    /// let combined = router_with("query").try_merge(router_with("fetch"));
+    /// assert!(combined.is_ok());
+    ///
+    /// // A shared name is reported rather than dropped.
+    /// let clash = router_with("get_task").try_merge(router_with("get_task"));
+    /// let error = clash.unwrap_err();
+    /// assert_eq!(error.conflicts().len(), 1);
+    /// ```
+    pub fn try_merge(self, other: McpRouter) -> std::result::Result<Self, MergeConflicts> {
+        let conflicts = self.conflicts(&other);
+        if conflicts.is_empty() {
+            Ok(self.merge(other))
+        } else {
+            Err(MergeConflicts { conflicts })
+        }
     }
 
     /// Nest another router's capabilities under a prefix.

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -2307,8 +2307,7 @@ mod try_merge {
     use tower_mcp::extract::{Context, RawArgs};
     use tower_mcp::{
         CallToolResult, GetPromptResult, McpRouter, MergeConflictKind, PromptBuilder,
-        ReadResourceResult, ResourceBuilder, ResourceContent, ResourceTemplateBuilder, TestClient,
-        ToolBuilder,
+        ReadResourceResult, ResourceBuilder, ResourceContent, ResourceTemplateBuilder, ToolBuilder,
     };
 
     fn body(uri: &str) -> ReadResourceResult {
@@ -2334,40 +2333,57 @@ mod try_merge {
             .build()
     }
 
-    fn tool_router(name: &str) -> McpRouter {
+    pub(super) fn tool_router(name: &str) -> McpRouter {
         McpRouter::new()
             .server_info("merge-test", "1.0.0")
             .tool(tool_named(name))
     }
 
-    /// Names of the tools the router actually serves.
-    async fn served_tool_names(router: McpRouter) -> Vec<String> {
-        let mut client = TestClient::from_router(router);
-        client.initialize().await;
-        let mut names: Vec<String> = client
-            .list_tools()
-            .await
-            .iter()
-            .map(|t| t["name"].as_str().expect("tool has a name").to_string())
-            .collect();
-        names.sort();
-        names
+    /// A router defining one of every kind, so a self-merge collides on all
+    /// four at once.
+    fn full_router() -> McpRouter {
+        McpRouter::new()
+            .tool(tool_named("dup_tool"))
+            .resource(
+                ResourceBuilder::new("file:///dup")
+                    .name("dup")
+                    .handler(|| async move { Ok(body("file:///dup")) })
+                    .build(),
+            )
+            .resource_template(
+                ResourceTemplateBuilder::new("file:///dup/{id}")
+                    .name("dup-template")
+                    .handler(|uri: String, _vars: HashMap<String, String>| async move {
+                        Ok(body(&uri))
+                    }),
+            )
+            .prompt(
+                PromptBuilder::new("dup_prompt")
+                    .description("example")
+                    .handler(|_args| async move {
+                        Ok(GetPromptResult {
+                            description: None,
+                            messages: Vec::new(),
+                            meta: None,
+                        })
+                    })
+                    .build(),
+            )
     }
 
-    /// Distinct names merge exactly as `merge` would.
-    #[tokio::test]
-    async fn disjoint_routers_merge() {
-        let merged = tool_router("query")
-            .try_merge(tool_router("fetch"))
-            .expect("no conflicts");
-        assert_eq!(served_tool_names(merged).await, vec!["fetch", "query"]);
+    /// Distinct names merge, and report nothing.
+    #[test]
+    fn disjoint_routers_merge() {
+        let host = tool_router("query");
+        assert!(host.conflicts(&tool_router("fetch")).is_empty());
+        assert!(host.try_merge(tool_router("fetch")).is_ok());
     }
 
     /// #1232: `merge` resolves a collision by dropping one implementation and
     /// says nothing. The point of `try_merge` is that the drop becomes an
     /// error a host can fail on at startup.
-    #[tokio::test]
-    async fn a_shared_tool_name_is_reported_not_dropped() {
+    #[test]
+    fn a_shared_tool_name_is_reported() {
         let error = tool_router("get_task")
             .try_merge(tool_router("get_task"))
             .expect_err("a shared name must not merge");
@@ -2378,46 +2394,12 @@ mod try_merge {
             error.to_string().contains("get_task"),
             "the message must name the clash: {error}"
         );
-
-        // `merge` still silently resolves it, so the default is unchanged.
-        let merged = tool_router("get_task").merge(tool_router("get_task"));
-        assert_eq!(served_tool_names(merged).await, vec!["get_task"]);
     }
 
     /// Every conflicting name is reported, not just the first, so one startup
     /// failure names all the work.
     #[test]
     fn every_conflicting_kind_is_reported() {
-        fn full_router() -> McpRouter {
-            McpRouter::new()
-                .tool(tool_named("dup_tool"))
-                .resource(
-                    ResourceBuilder::new("file:///dup")
-                        .name("dup")
-                        .handler(|| async move { Ok(body("file:///dup")) })
-                        .build(),
-                )
-                .resource_template(
-                    ResourceTemplateBuilder::new("file:///dup/{id}")
-                        .name("dup-template")
-                        .handler(|uri: String, _vars: HashMap<String, String>| async move {
-                            Ok(body(&uri))
-                        }),
-                )
-                .prompt(
-                    PromptBuilder::new("dup_prompt")
-                        .description("example")
-                        .handler(|_args| async move {
-                            Ok(GetPromptResult {
-                                description: None,
-                                messages: Vec::new(),
-                                meta: None,
-                            })
-                        })
-                        .build(),
-                )
-        }
-
         let error = full_router()
             .try_merge(full_router())
             .expect_err("everything collides");
@@ -2436,13 +2418,49 @@ mod try_merge {
 
     /// `conflicts` answers the question without consuming either router, so a
     /// host can assert at startup and still build.
-    #[tokio::test]
-    async fn conflicts_inspects_without_consuming() {
+    #[test]
+    fn conflicts_inspects_without_consuming() {
         let host = tool_router("get_task");
         let library = tool_router("get_task");
         assert_eq!(host.conflicts(&library).len(), 1);
         // Both are still usable afterwards.
-        let merged = host.merge(library);
-        assert_eq!(served_tool_names(merged).await, vec!["get_task"]);
+        let _merged = host.merge(library);
+    }
+
+    /// What the merged routers actually serve, which is the claim that
+    /// matters and the one an internal accessor could not make.
+    #[cfg(feature = "testing")]
+    mod served {
+        use super::tool_router;
+        use tower_mcp::{McpRouter, TestClient};
+
+        async fn tool_names(router: McpRouter) -> Vec<String> {
+            let mut client = TestClient::from_router(router);
+            client.initialize().await;
+            let mut names: Vec<String> = client
+                .list_tools()
+                .await
+                .iter()
+                .map(|t| t["name"].as_str().expect("tool has a name").to_string())
+                .collect();
+            names.sort();
+            names
+        }
+
+        #[tokio::test]
+        async fn a_successful_try_merge_serves_both_tools() {
+            let merged = tool_router("query")
+                .try_merge(tool_router("fetch"))
+                .expect("no conflicts");
+            assert_eq!(tool_names(merged).await, vec!["fetch", "query"]);
+        }
+
+        /// The behaviour `try_merge` exists to prevent: one implementation
+        /// silently gone, with nothing in `tools/list` to show it.
+        #[tokio::test]
+        async fn merge_still_drops_one_implementation() {
+            let merged = tool_router("get_task").merge(tool_router("get_task"));
+            assert_eq!(tool_names(merged).await, vec!["get_task"]);
+        }
     }
 }

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -2297,3 +2297,152 @@ async fn test_experimental_capabilities_round_trip() {
         _ => panic!("unexpected response variant"),
     }
 }
+
+// =============================================================================
+// Fallible merge (#1232)
+// =============================================================================
+
+mod try_merge {
+    use std::collections::HashMap;
+    use tower_mcp::extract::{Context, RawArgs};
+    use tower_mcp::{
+        CallToolResult, GetPromptResult, McpRouter, MergeConflictKind, PromptBuilder,
+        ReadResourceResult, ResourceBuilder, ResourceContent, ResourceTemplateBuilder, TestClient,
+        ToolBuilder,
+    };
+
+    fn body(uri: &str) -> ReadResourceResult {
+        ReadResourceResult {
+            contents: vec![ResourceContent {
+                uri: uri.to_string(),
+                mime_type: Some("text/plain".to_string()),
+                text: Some("body".to_string()),
+                blob: None,
+                meta: None,
+            }],
+            meta: None,
+            ..Default::default()
+        }
+    }
+
+    fn tool_named(name: &str) -> tower_mcp::Tool {
+        ToolBuilder::new(name)
+            .description("example")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                Ok(CallToolResult::text("ok"))
+            })
+            .build()
+    }
+
+    fn tool_router(name: &str) -> McpRouter {
+        McpRouter::new()
+            .server_info("merge-test", "1.0.0")
+            .tool(tool_named(name))
+    }
+
+    /// Names of the tools the router actually serves.
+    async fn served_tool_names(router: McpRouter) -> Vec<String> {
+        let mut client = TestClient::from_router(router);
+        client.initialize().await;
+        let mut names: Vec<String> = client
+            .list_tools()
+            .await
+            .iter()
+            .map(|t| t["name"].as_str().expect("tool has a name").to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Distinct names merge exactly as `merge` would.
+    #[tokio::test]
+    async fn disjoint_routers_merge() {
+        let merged = tool_router("query")
+            .try_merge(tool_router("fetch"))
+            .expect("no conflicts");
+        assert_eq!(served_tool_names(merged).await, vec!["fetch", "query"]);
+    }
+
+    /// #1232: `merge` resolves a collision by dropping one implementation and
+    /// says nothing. The point of `try_merge` is that the drop becomes an
+    /// error a host can fail on at startup.
+    #[tokio::test]
+    async fn a_shared_tool_name_is_reported_not_dropped() {
+        let error = tool_router("get_task")
+            .try_merge(tool_router("get_task"))
+            .expect_err("a shared name must not merge");
+        assert_eq!(error.conflicts().len(), 1);
+        assert_eq!(error.conflicts()[0].kind, MergeConflictKind::Tool);
+        assert_eq!(error.conflicts()[0].name, "get_task");
+        assert!(
+            error.to_string().contains("get_task"),
+            "the message must name the clash: {error}"
+        );
+
+        // `merge` still silently resolves it, so the default is unchanged.
+        let merged = tool_router("get_task").merge(tool_router("get_task"));
+        assert_eq!(served_tool_names(merged).await, vec!["get_task"]);
+    }
+
+    /// Every conflicting name is reported, not just the first, so one startup
+    /// failure names all the work.
+    #[test]
+    fn every_conflicting_kind_is_reported() {
+        fn full_router() -> McpRouter {
+            McpRouter::new()
+                .tool(tool_named("dup_tool"))
+                .resource(
+                    ResourceBuilder::new("file:///dup")
+                        .name("dup")
+                        .handler(|| async move { Ok(body("file:///dup")) })
+                        .build(),
+                )
+                .resource_template(
+                    ResourceTemplateBuilder::new("file:///dup/{id}")
+                        .name("dup-template")
+                        .handler(|uri: String, _vars: HashMap<String, String>| async move {
+                            Ok(body(&uri))
+                        }),
+                )
+                .prompt(
+                    PromptBuilder::new("dup_prompt")
+                        .description("example")
+                        .handler(|_args| async move {
+                            Ok(GetPromptResult {
+                                description: None,
+                                messages: Vec::new(),
+                                meta: None,
+                            })
+                        })
+                        .build(),
+                )
+        }
+
+        let error = full_router()
+            .try_merge(full_router())
+            .expect_err("everything collides");
+        let kinds: Vec<_> = error.conflicts().iter().map(|c| c.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                MergeConflictKind::Tool,
+                MergeConflictKind::Resource,
+                MergeConflictKind::ResourceTemplate,
+                MergeConflictKind::Prompt,
+            ],
+            "all four kinds, in a stable order: {error}"
+        );
+    }
+
+    /// `conflicts` answers the question without consuming either router, so a
+    /// host can assert at startup and still build.
+    #[tokio::test]
+    async fn conflicts_inspects_without_consuming() {
+        let host = tool_router("get_task");
+        let library = tool_router("get_task");
+        assert_eq!(host.conflicts(&library).len(), 1);
+        // Both are still usable afterwards.
+        let merged = host.merge(library);
+        assert_eq!(served_tool_names(merged).await, vec!["get_task"]);
+    }
+}


### PR DESCRIPTION
Closes #1232.

`merge` is last-wins on a name collision. That is a reasonable default, but it leaves no trace that an implementation was dropped: nothing in `tools/list` shows that anything went missing, and the failure surfaces later as a capability that behaves unexpectedly rather than as an error at startup.

This matters most for the case the reporter hit: a library crate hands back an `McpRouter` for hosts to merge into their own. The library cannot know what the host already registered, and `nest` is not an answer because it renames every tool.

## API

```rust
// Fails, naming every collision.
let router = host.try_merge(library)?;

// Or inspect without consuming either side.
let clashes = host.conflicts(&library);
assert!(clashes.is_empty(), "{clashes:?}");
```

`merge` is untouched, so callers who want last-wins keep it.

New public types: `MergeConflict { kind, name }`, `MergeConflictKind` (`Tool`, `Resource`, `ResourceTemplate`, `Prompt`), and `MergeConflicts`, the error, which implements `Display` and `Error` and carries every conflict rather than the first, so one startup failure names all the work.

## Details

Results are ordered by kind and then name. Tools, resources, and prompts live in hash maps, so without the sort the order would vary between runs and neither the error message nor a test assertion would be stable.

Resource templates are stored as a list rather than a map because matching is pattern-based, so identity there is the template string itself.

Protocol extension declarations are deliberately excluded. Two routers both declaring the same extension is ordinary composition, not a collision: a declaration carries no implementation to lose.

## Tests

- disjoint routers merge, and both tools are actually served
- a shared tool name is reported with its kind and name, and the message contains it
- `merge` still resolves the same collision, confirming the default is unchanged
- all four kinds are reported together in stable order
- `conflicts` leaves both routers usable afterwards

Assertions go through `TestClient` and `tools/list` rather than an internal accessor, so they check the served surface.