### PR TITLE
fix: re-export notification_channel from the crate root

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -579,7 +579,7 @@ pub use context::{
     ChannelClientRequester, ClientRequester, ClientRequesterHandle, Extensions,
     NotificationReceiver, NotificationSender, OutgoingRequest, OutgoingRequestReceiver,
     OutgoingRequestSender, RequestContext, RequestContextBuilder, ServerNotification,
-    outgoing_request_channel,
+    notification_channel, outgoing_request_channel,
 };
 pub use error::{BoxError, Error, Result, ResultExt, ToolError};
 pub use extension::{ExtensionDeclaration, NegotiatedExtension, NegotiatedExtensions};

--- a/crates/tower-mcp/tests/integration.rs
+++ b/crates/tower-mcp/tests/integration.rs
@@ -2464,3 +2464,27 @@ mod try_merge {
         }
     }
 }
+
+// =============================================================================
+// Crate-root re-exports (#1240)
+// =============================================================================
+
+mod reexports {
+    /// #1240: `NotificationSender`, `NotificationReceiver`, and
+    /// `ServerNotification` were all reachable from the crate root, but
+    /// `notification_channel`, the only public constructor for that pair,
+    /// was not. This is the exact import from the report.
+    #[tokio::test]
+    async fn notification_channel_is_reachable_from_the_crate_root() {
+        use tower_mcp::{NotificationSender, ServerNotification, notification_channel};
+
+        let (tx, mut rx): (NotificationSender, _) = notification_channel(4);
+        tx.send(ServerNotification::ToolsListChanged)
+            .await
+            .expect("send");
+        assert!(matches!(
+            rx.recv().await,
+            Some(ServerNotification::ToolsListChanged)
+        ));
+    }
+}


### PR DESCRIPTION
Closes #1240.

`NotificationSender`, `NotificationReceiver`, and `ServerNotification` are all reachable from the crate root, but `notification_channel`, the only public constructor for that pair, was not:

```rust
use tower_mcp::{NotificationSender, ServerNotification, notification_channel};
// error[E0432]: unresolved import `tower_mcp::notification_channel`
```

Callers had to reach through `tower_mcp::context::notification_channel`, which is inconsistent with the three types it produces. `context` has exactly two public free functions, and the other one, `outgoing_request_channel`, was already in the re-export list.

Additive: the `context::` path still works.

## Test

A test uses the exact import from the report and round-trips a notification through the channel. Confirmed it fails with `E0432` when the re-export is removed and passes with it, so it pins the path rather than just exercising the channel.

Full suite, clippy, `-Dmissing-docs`, and the 17-entry feature-combinations matrix are green locally.