### PR TITLE
feat(http,ws): bridge server-supplied request extensions into RequestContext

### DIFF
--- a/crates/tower-mcp/src/transport/extension_bridge.rs
+++ b/crates/tower-mcp/src/transport/extension_bridge.rs
@@ -1,0 +1,114 @@
+//! Bridging server-supplied request extensions into MCP requests.
+//!
+//! A tower layer in front of an HTTP or WebSocket transport can attach
+//! anything it likes to the request: a resolved identity, a tenant, a
+//! tracing id, the peer address. None of it reached the handler, because
+//! the transports built the per-request [`Extensions`] from scratch and
+//! lifted exactly one type out of the HTTP request (OAuth `TokenClaims`).
+//!
+//! Registering a type with `bridge_extension` copies it across, where
+//! [`RequestContext::extension`](crate::RequestContext::extension) can find
+//! it (#1242).
+//!
+//! Bridging is opt-in per type rather than wholesale. The alternative,
+//! carrying the whole HTTP extension map over, would put an
+//! `axum::http::Extensions` in front of handlers that are otherwise
+//! transport-agnostic, and would move data across the boundary that the
+//! server never decided to expose.
+
+use std::sync::Arc;
+
+use crate::context::Extensions;
+
+/// Copies one registered type from an HTTP request's extensions into the
+/// per-request MCP extensions.
+///
+/// Type-erased so a transport can hold a list of them without naming the
+/// types it was asked to bridge.
+pub(crate) type ExtensionBridge =
+    Arc<dyn Fn(&axum::http::Extensions, &mut Extensions) + Send + Sync>;
+
+/// Build a bridge for `T`.
+///
+/// A request that carries no `T` is left alone rather than treated as an
+/// error: a layer that only attaches an identity to some routes is a normal
+/// configuration, and the handler already has to treat the extension as
+/// optional.
+pub(crate) fn extension_bridge<T>() -> ExtensionBridge
+where
+    T: Clone + Send + Sync + 'static,
+{
+    Arc::new(|from, to| {
+        if let Some(value) = from.get::<T>() {
+            to.insert(value.clone());
+        }
+    })
+}
+
+/// Run every registered bridge for one request.
+pub(crate) fn apply_extension_bridges(
+    bridges: &[ExtensionBridge],
+    from: &axum::http::Extensions,
+    to: &mut Extensions,
+) {
+    for bridge in bridges {
+        bridge(from, to);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct Identity(&'static str);
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct TraceId(u32);
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct NeverRegistered;
+
+    #[test]
+    fn a_registered_type_crosses_and_an_unregistered_one_does_not() {
+        let mut from = axum::http::Extensions::new();
+        from.insert(Identity("agent-7"));
+        from.insert(NeverRegistered);
+
+        let mut to = Extensions::new();
+        apply_extension_bridges(&[extension_bridge::<Identity>()], &from, &mut to);
+
+        assert_eq!(to.get::<Identity>(), Some(&Identity("agent-7")));
+        assert!(
+            to.get::<NeverRegistered>().is_none(),
+            "only registered types cross the boundary"
+        );
+    }
+
+    /// A request missing the type is not an error; the handler already has
+    /// to treat the extension as optional.
+    #[test]
+    fn a_missing_type_is_skipped() {
+        let from = axum::http::Extensions::new();
+        let mut to = Extensions::new();
+        apply_extension_bridges(&[extension_bridge::<Identity>()], &from, &mut to);
+        assert!(to.get::<Identity>().is_none());
+    }
+
+    #[test]
+    fn every_registered_type_is_applied() {
+        let mut from = axum::http::Extensions::new();
+        from.insert(Identity("agent-7"));
+        from.insert(TraceId(42));
+
+        let mut to = Extensions::new();
+        apply_extension_bridges(
+            &[extension_bridge::<Identity>(), extension_bridge::<TraceId>()],
+            &from,
+            &mut to,
+        );
+
+        assert_eq!(to.get::<Identity>(), Some(&Identity("agent-7")));
+        assert_eq!(to.get::<TraceId>(), Some(&TraceId(42)));
+    }
+}

--- a/crates/tower-mcp/src/transport/extension_bridge.rs
+++ b/crates/tower-mcp/src/transport/extension_bridge.rs
@@ -103,7 +103,10 @@ mod tests {
 
         let mut to = Extensions::new();
         apply_extension_bridges(
-            &[extension_bridge::<Identity>(), extension_bridge::<TraceId>()],
+            &[
+                extension_bridge::<Identity>(),
+                extension_bridge::<TraceId>(),
+            ],
             &from,
             &mut to,
         );

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1317,6 +1317,9 @@ enum ServiceSource {
 struct AppState {
     /// Source for creating new session services
     service_source: ServiceSource,
+    /// Types copied from each HTTP request's extensions into the per-request
+    /// MCP extensions (#1242). Empty by default.
+    extension_bridges: Vec<crate::transport::extension_bridge::ExtensionBridge>,
     /// Exact protocol versions accepted and advertised by this transport.
     protocol_support: ProtocolSupport,
     /// Session store
@@ -1557,6 +1560,9 @@ pub(crate) struct OAuthConfig {
 ///   `.layer()` is not supported in this mode.
 pub struct HttpTransport {
     service_source: ServiceSource,
+    /// Types copied from each HTTP request's extensions into the per-request
+    /// MCP extensions (#1242). Empty by default.
+    extension_bridges: Vec<crate::transport::extension_bridge::ExtensionBridge>,
     protocol_support: ProtocolSupport,
     validate_origin: bool,
     allowed_origins: Vec<String>,
@@ -1621,8 +1627,49 @@ impl HttpTransport {
             #[cfg(feature = "oauth")]
             oauth_config: None,
             sse_responses: false,
+            extension_bridges: Vec::new(),
             max_body_size: DEFAULT_MAX_BODY_SIZE,
         }
+    }
+
+    /// Copy `T` out of each HTTP request's extensions into the per-request
+    /// MCP extensions.
+    ///
+    /// A tower layer in front of this transport can attach anything it likes
+    /// to the request: a resolved identity, a tenant, a tracing id, the peer
+    /// address. Registering the type here is what makes it visible to
+    /// handlers through
+    /// [`RequestContext::extension`](crate::RequestContext::extension)
+    /// (#1242).
+    ///
+    /// Requests that do not carry a `T` are left alone, so a layer that only
+    /// attaches its value on some routes is fine.
+    ///
+    /// Bridging is per type rather than wholesale, so nothing crosses into
+    /// handler code that the server did not choose to expose.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{McpRouter, HttpTransport};
+    ///
+    /// #[derive(Clone)]
+    /// struct AgentIdentity(String);
+    ///
+    /// let router = McpRouter::new().server_info("my-server", "1.0.0");
+    /// let app = HttpTransport::new(router)
+    ///     .bridge_extension::<AgentIdentity>()
+    ///     .into_router_at("/mcp");
+    /// // A layer inserts AgentIdentity; a handler reads it with
+    /// // ctx.extension::<AgentIdentity>().
+    /// ```
+    pub fn bridge_extension<T>(mut self) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.extension_bridges
+            .push(crate::transport::extension_bridge::extension_bridge::<T>());
+        self
     }
 
     /// Create an HTTP transport from a pre-built service.
@@ -1681,6 +1728,7 @@ impl HttpTransport {
             #[cfg(feature = "oauth")]
             oauth_config: None,
             sse_responses: false,
+            extension_bridges: Vec::new(),
             max_body_size: DEFAULT_MAX_BODY_SIZE,
         }
     }
@@ -2370,6 +2418,7 @@ impl HttpTransport {
             #[cfg(feature = "stateless")]
             modern_subscriptions,
             sse_responses: self.sse_responses,
+            extension_bridges: self.extension_bridges.clone(),
             max_body_size: self.max_body_size,
         })
     }
@@ -2877,11 +2926,11 @@ async fn handle_post(
         }
     };
 
-    // Bridge TokenClaims from HTTP extensions to MCP extensions (if present)
-    #[cfg(feature = "oauth")]
+    // Per-request data bridged from HTTP into MCP extensions: OAuth claims
+    // when that feature is compiled in, plus whatever types the server
+    // registered with `bridge_extension`, which is independent of OAuth
+    // (#1242). Always bound, since the bridges run in every build.
     let http_extensions = parts.extensions;
-    #[cfg(not(feature = "oauth"))]
-    let _ = parts.extensions;
 
     // Parse the request body
     let parsed: serde_json::Value = match serde_json::from_str(&body) {
@@ -3138,6 +3187,11 @@ async fn handle_post(
                 ext.insert(claims.clone());
             }
             stash_per_request_meta(&request, &mut ext);
+            crate::transport::extension_bridge::apply_extension_bridges(
+                &state.extension_bridges,
+                &http_extensions,
+                &mut ext,
+            );
 
             // rmcp #967 analog: give the request a cancellation token that
             // fires if the client disconnects before the response is
@@ -3341,6 +3395,11 @@ async fn handle_post(
             }
             #[cfg(feature = "stateless")]
             stash_per_request_meta(&request, &mut ext);
+            crate::transport::extension_bridge::apply_extension_bridges(
+                &state.extension_bridges,
+                &http_extensions,
+                &mut ext,
+            );
             if !ext.is_empty() {
                 service = service.with_extensions(ext);
             }
@@ -3373,7 +3432,7 @@ async fn handle_post(
     // must be established before consulting any legacy session state.
     #[cfg(feature = "stateless")]
     if modern_request && request_method == "subscriptions/listen" {
-        return handle_modern_subscriptions_listen_sse(state, &parsed).await;
+        return handle_modern_subscriptions_listen_sse(state, &parsed, &http_extensions).await;
     }
 
     // Runtime allowlist enforcement precedes semantic profile validation.
@@ -3545,6 +3604,11 @@ async fn handle_post(
         if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
             extensions.insert(claims.clone());
         }
+        crate::transport::extension_bridge::apply_extension_bridges(
+            &state.extension_bridges,
+            &http_extensions,
+            &mut extensions,
+        );
 
         let mut service = JsonRpcService::new(session.make_service())
             .with_extensions(extensions)
@@ -3760,6 +3824,11 @@ async fn handle_post(
     if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
         ext.insert(claims.clone());
     }
+    crate::transport::extension_bridge::apply_extension_bridges(
+        &state.extension_bridges,
+        &http_extensions,
+        &mut ext,
+    );
     #[cfg(feature = "stateless")]
     stash_per_request_meta(&request, &mut ext);
 
@@ -4290,6 +4359,7 @@ fn stateless_sse_with_notifications(
 async fn handle_modern_subscriptions_listen_sse(
     state: Arc<AppState>,
     parsed: &serde_json::Value,
+    http_extensions: &axum::http::Extensions,
 ) -> Response {
     let id = extract_request_id(parsed);
     let Some(subscription_id) = id.clone() else {
@@ -4328,6 +4398,11 @@ async fn handle_modern_subscriptions_listen_sse(
     let mut ext = crate::router::Extensions::new();
     ext.insert(state.protocol_support.clone());
     stash_per_request_meta(&request, &mut ext);
+    crate::transport::extension_bridge::apply_extension_bridges(
+        &state.extension_bridges,
+        http_extensions,
+        &mut ext,
+    );
     if ext
         .get::<crate::stateless::StatelessRequestMeta>()
         .is_none()

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -26,6 +26,9 @@ pub mod unix;
 #[cfg(feature = "childproc")]
 pub mod childproc;
 
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub(crate) mod extension_bridge;
+
 pub mod service;
 
 pub use service::{CatchError, InjectAnnotations};

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -206,6 +206,9 @@ struct PendingRequest {
 /// Shared state for WebSocket transport
 struct AppState {
     router_template: McpRouter,
+    /// Types copied from each upgrade request's extensions into the
+    /// per-connection MCP extensions (#1242). Empty by default.
+    extension_bridges: Vec<crate::transport::extension_bridge::ExtensionBridge>,
     service_factory: ServiceFactory,
     sessions: SessionStore,
     protocol_support: ProtocolSupport,
@@ -231,6 +234,9 @@ struct AppState {
 /// `subscriptions/listen` multiplexing is not implemented on this binding.
 pub struct WebSocketTransport {
     router: McpRouter,
+    /// Types copied from each upgrade request's extensions into the
+    /// per-connection MCP extensions (#1242). Empty by default.
+    extension_bridges: Vec<crate::transport::extension_bridge::ExtensionBridge>,
     sampling_enabled: bool,
     service_factory: ServiceFactory,
     protocol_support: ProtocolSupport,
@@ -239,10 +245,26 @@ pub struct WebSocketTransport {
 }
 
 impl WebSocketTransport {
+    /// Copy `T` out of each upgrade request's extensions into the
+    /// per-connection MCP extensions.
+    ///
+    /// See [`HttpTransport::bridge_extension`](crate::HttpTransport::bridge_extension).
+    /// The value is read once, from the HTTP request that opens the socket,
+    /// and is then visible to every request on that connection.
+    pub fn bridge_extension<T>(mut self) -> Self
+    where
+        T: Clone + Send + Sync + 'static,
+    {
+        self.extension_bridges
+            .push(crate::transport::extension_bridge::extension_bridge::<T>());
+        self
+    }
+
     /// Create a new WebSocket transport
     pub fn new(router: McpRouter) -> Self {
         Self {
             router,
+            extension_bridges: Vec::new(),
             sampling_enabled: false,
             service_factory: identity_factory(),
             protocol_support: ProtocolSupport::default(),
@@ -406,6 +428,7 @@ impl WebSocketTransport {
 
         let state = Arc::new(AppState {
             router_template: self.router,
+            extension_bridges: self.extension_bridges,
             service_factory: self.service_factory,
             sessions: SessionStore::new(),
             protocol_support: self.protocol_support,
@@ -429,6 +452,7 @@ impl WebSocketTransport {
 
         let state = Arc::new(AppState {
             router_template: self.router,
+            extension_bridges: self.extension_bridges,
             service_factory: self.service_factory,
             sessions: SessionStore::new(),
             protocol_support: self.protocol_support,
@@ -570,6 +594,11 @@ async fn handle_websocket(
             mcp_extensions.insert(claims.clone());
         }
     }
+    crate::transport::extension_bridge::apply_extension_bridges(
+        &state.extension_bridges,
+        &parts.extensions,
+        &mut mcp_extensions,
+    );
 
     // Store subprotocol auth token in extensions for downstream use
     if let Some(ref token) = subprotocols.auth_token {

--- a/crates/tower-mcp/tests/extension_bridge.rs
+++ b/crates/tower-mcp/tests/extension_bridge.rs
@@ -1,0 +1,392 @@
+//! #1242: bridging server-supplied request extensions into `RequestContext`.
+//!
+//! A tower layer in front of the transport can attach anything it likes to
+//! the request. Before this, only OAuth `TokenClaims` was lifted across, so
+//! `ctx.extension::<T>()` never found what a layer had inserted.
+//!
+//! These tests drive the reporter's actual shape: a per-request secret in a
+//! header, mapped to an identity by a layer, read by a tool handler.
+
+#![cfg(any(feature = "http", feature = "websocket"))]
+
+use std::sync::{Arc, Mutex};
+
+use axum::body::Body;
+use axum::http::Request;
+use axum::response::Response;
+#[cfg(feature = "http")]
+use tower::ServiceExt;
+#[cfg(feature = "http")]
+use tower_mcp::HttpTransport;
+use tower_mcp::extract::{Context, RawArgs, State};
+use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+
+/// What a layer resolves a caller's secret into. The reporter's case: the
+/// server cannot otherwise tell one loopback caller from another.
+#[derive(Debug, Clone, PartialEq)]
+struct AgentIdentity(String);
+
+/// A second type, registered nowhere, to prove bridging is per type.
+#[derive(Debug, Clone, PartialEq)]
+struct NeverRegistered(u32);
+
+#[derive(Default, Clone)]
+struct Seen(Arc<Mutex<Option<String>>>);
+
+fn router(seen: Seen) -> McpRouter {
+    let tool = ToolBuilder::new("whoami")
+        .description("Reports the identity a layer attached, if any.")
+        .read_only()
+        .extractor_handler(
+            seen,
+            |State(seen): State<Seen>, ctx: Context, RawArgs(_): RawArgs| async move {
+                let identity = ctx.extension::<AgentIdentity>().map(|i| i.0.clone());
+                let leaked = ctx.extension::<NeverRegistered>().is_some();
+                *seen.0.lock().unwrap() = identity.clone();
+                Ok(CallToolResult::text(format!(
+                    "{}|leaked={leaked}",
+                    identity.unwrap_or_else(|| "anonymous".into())
+                )))
+            },
+        )
+        .build();
+    McpRouter::new()
+        .server_info("bridge-test", "1.0.0")
+        .tool(tool)
+}
+
+/// Stands in for the reporter's layer: maps a per-agent secret in a header
+/// to an identity. Also inserts a type nobody registered.
+async fn attach_identity(mut request: Request<Body>, next: axum::middleware::Next) -> Response {
+    if let Some(secret) = request
+        .headers()
+        .get("x-agent-secret")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
+    {
+        request.extensions_mut().insert(AgentIdentity(secret));
+    }
+    request.extensions_mut().insert(NeverRegistered(1));
+    next.run(request).await
+}
+
+#[cfg(feature = "http")]
+/// Call `whoami` over HTTP, optionally registering the bridge and optionally
+/// sending the secret header. Returns the handler's text answer.
+async fn call(register_bridge: bool, secret: Option<&str>) -> (String, Seen) {
+    let seen = Seen::default();
+    let transport = HttpTransport::new(router(seen.clone())).disable_origin_validation();
+    let transport = if register_bridge {
+        transport.bridge_extension::<AgentIdentity>()
+    } else {
+        transport
+    };
+    let app = transport
+        .into_router()
+        .layer(axum::middleware::from_fn(attach_identity));
+
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json");
+    if let Some(secret) = secret {
+        request = request.header("x-agent-secret", secret);
+    }
+    let body = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+        "params": {"name": "whoami", "arguments": {}}
+    });
+    let response = app
+        .oneshot(request.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap();
+    assert!(
+        response.status().is_success(),
+        "expected 2xx, got {}",
+        response.status()
+    );
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let text = json["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no tool text in {json}"))
+        .to_string();
+    (text, seen)
+}
+
+/// The core claim: a registered type attached by a layer reaches the handler.
+#[cfg(feature = "http")]
+#[tokio::test]
+async fn a_registered_extension_reaches_the_handler() {
+    let (text, seen) = call(true, Some("agent-7")).await;
+    assert_eq!(text, "agent-7|leaked=false");
+    assert_eq!(*seen.0.lock().unwrap(), Some("agent-7".to_string()));
+}
+
+/// Bridging is per type: the same layer inserts `NeverRegistered` on every
+/// request and it must not cross, or the opt-in would be meaningless.
+#[cfg(feature = "http")]
+#[tokio::test]
+async fn an_unregistered_extension_does_not_cross() {
+    let (text, _) = call(true, Some("agent-7")).await;
+    assert!(
+        text.ends_with("|leaked=false"),
+        "an unregistered type must not be bridged: {text}"
+    );
+}
+
+/// Default behaviour is unchanged: with nothing registered, a layer's value
+/// stays invisible exactly as before.
+#[cfg(feature = "http")]
+#[tokio::test]
+async fn without_registration_nothing_is_bridged() {
+    let (text, seen) = call(false, Some("agent-7")).await;
+    assert_eq!(text, "anonymous|leaked=false");
+    assert_eq!(*seen.0.lock().unwrap(), None);
+}
+
+/// A request the layer did not tag is not an error. A layer that only
+/// attaches its value on some routes is a normal configuration.
+#[cfg(feature = "http")]
+#[tokio::test]
+async fn a_request_without_the_extension_is_not_an_error() {
+    let (text, seen) = call(true, None).await;
+    assert_eq!(text, "anonymous|leaked=false");
+    assert_eq!(*seen.0.lock().unwrap(), None);
+}
+
+// ============================================================================
+// The other dispatch paths
+// ============================================================================
+//
+// `Extensions` is built at five places in the HTTP transport. The tests above
+// cover the plain POST; these cover the session handshake and the 2026-07-28
+// header path, so a site left unwired shows up as a failure rather than as a
+// gap nobody notices.
+
+#[cfg(feature = "http")]
+/// Build the app once so a session survives across requests.
+fn app_with_bridge(seen: Seen) -> axum::Router {
+    HttpTransport::new(router(seen))
+        .disable_origin_validation()
+        .bridge_extension::<AgentIdentity>()
+        .into_router()
+        .layer(axum::middleware::from_fn(attach_identity))
+}
+
+#[cfg(feature = "http")]
+async fn post(
+    app: &axum::Router,
+    body: serde_json::Value,
+    headers: &[(&str, &str)],
+) -> (axum::http::HeaderMap, serde_json::Value) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream");
+    for (name, value) in headers {
+        request = request.header(*name, *value);
+    }
+    let response = app
+        .clone()
+        .oneshot(request.body(Body::from(body.to_string())).unwrap())
+        .await
+        .unwrap();
+    let response_headers = response.headers().clone();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8_lossy(&bytes).to_string();
+    // A session response may arrive as SSE; take the data line either way.
+    let json = serde_json::from_str(&text).unwrap_or_else(|_| {
+        // A notification is answered with an empty body; a session request
+        // may be answered as SSE.
+        match text.lines().find_map(|l| l.strip_prefix("data: ")) {
+            Some(data) => serde_json::from_str(data).expect("SSE data is JSON"),
+            None => serde_json::Value::Null,
+        }
+    });
+    (response_headers, json)
+}
+
+/// The session path builds its extensions at a different site than the plain
+/// POST, and it is the common production path.
+#[cfg(feature = "http")]
+#[tokio::test]
+async fn a_registered_extension_reaches_the_handler_on_a_session() {
+    let seen = Seen::default();
+    let app = app_with_bridge(seen.clone());
+
+    let (headers, init) = post(
+        &app,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "bridge-test", "version": "1.0.0"}
+            }
+        }),
+        &[("x-agent-secret", "agent-9")],
+    )
+    .await;
+    assert!(init["result"].is_object(), "initialize failed: {init}");
+    let session = headers
+        .get("mcp-session-id")
+        .expect("session id")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    post(
+        &app,
+        serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        &[("x-agent-secret", "agent-9"), ("mcp-session-id", &session)],
+    )
+    .await;
+
+    let (_, response) = post(
+        &app,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 2, "method": "tools/call",
+            "params": {"name": "whoami", "arguments": {}}
+        }),
+        &[("x-agent-secret", "agent-9"), ("mcp-session-id", &session)],
+    )
+    .await;
+    assert_eq!(
+        response["result"]["content"][0]["text"], "agent-9|leaked=false",
+        "session path did not bridge: {response}"
+    );
+    assert_eq!(*seen.0.lock().unwrap(), Some("agent-9".to_string()));
+}
+
+/// The 2026-07-28 path dispatches on the version header and skips the
+/// handshake entirely, so it builds its extensions at yet another site.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn a_registered_extension_reaches_the_handler_on_the_final_protocol() {
+    let seen = Seen::default();
+    let app = app_with_bridge(seen.clone());
+    let version = tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28;
+
+    let (_, response) = post(
+        &app,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": {
+                "name": "whoami",
+                "arguments": {},
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": version,
+                    "io.modelcontextprotocol/clientCapabilities": {},
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "bridge-test", "version": "1.0.0"
+                    }
+                }
+            }
+        }),
+        &[
+            ("x-agent-secret", "agent-final"),
+            ("Mcp-Protocol-Version", version),
+            ("Mcp-Method", "tools/call"),
+            ("Mcp-Name", "whoami"),
+        ],
+    )
+    .await;
+    assert_eq!(
+        response["result"]["content"][0]["text"], "agent-final|leaked=false",
+        "final protocol path did not bridge: {response}"
+    );
+    assert_eq!(*seen.0.lock().unwrap(), Some("agent-final".to_string()));
+}
+
+// ============================================================================
+// WebSocket (#1242)
+// ============================================================================
+//
+// The WebSocket transport had the identical TokenClaims-only lift. The value
+// is read once from the HTTP request that opens the socket, so it applies to
+// every request on that connection.
+
+#[cfg(feature = "websocket")]
+mod websocket {
+    use super::{AgentIdentity, NeverRegistered, Seen, attach_identity, router};
+    use std::time::Duration;
+    use tower_mcp::client::{McpClient, WebSocketClientConfig, WebSocketClientTransport};
+
+    async fn serve(seen: Seen, register_bridge: bool) -> String {
+        let transport = tower_mcp::WebSocketTransport::new(router(seen));
+        let transport = if register_bridge {
+            transport.bridge_extension::<AgentIdentity>()
+        } else {
+            transport
+        };
+        let app = transport
+            .into_router()
+            .layer(axum::middleware::from_fn(attach_identity));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        format!("ws://{addr}/")
+    }
+
+    async fn whoami(url: &str, secret: Option<&str>) -> String {
+        let mut config = WebSocketClientConfig::default();
+        if let Some(secret) = secret {
+            config.headers = vec![("x-agent-secret".to_string(), secret.to_string())];
+        }
+        let transport = WebSocketClientTransport::connect_with_config(url, config)
+            .await
+            .expect("connect");
+        let client = McpClient::connect(transport).await.expect("client");
+        client.initialize("ws-client", "1.0.0").await.expect("init");
+        client
+            .call_tool("whoami", serde_json::json!({}))
+            .await
+            .expect("call")
+            .all_text()
+    }
+
+    #[tokio::test]
+    async fn a_registered_extension_reaches_the_handler() {
+        let seen = Seen::default();
+        let url = serve(seen.clone(), true).await;
+        assert_eq!(
+            whoami(&url, Some("agent-ws")).await,
+            "agent-ws|leaked=false"
+        );
+        assert_eq!(*seen.0.lock().unwrap(), Some("agent-ws".to_string()));
+    }
+
+    #[tokio::test]
+    async fn without_registration_nothing_is_bridged() {
+        let seen = Seen::default();
+        let url = serve(seen.clone(), false).await;
+        assert_eq!(
+            whoami(&url, Some("agent-ws")).await,
+            "anonymous|leaked=false"
+        );
+        assert_eq!(*seen.0.lock().unwrap(), None);
+    }
+
+    /// Keeps the unregistered marker referenced on this path too.
+    #[tokio::test]
+    async fn an_unregistered_extension_does_not_cross() {
+        let seen = Seen::default();
+        let url = serve(seen, true).await;
+        let text = whoami(&url, Some("agent-ws")).await;
+        assert!(
+            text.ends_with("|leaked=false"),
+            "an unregistered type must not be bridged: {text}"
+        );
+        let _ = NeverRegistered(0);
+    }
+}


### PR DESCRIPTION
Closes #1242.

A tower layer in front of `HttpTransport` can attach anything it likes to the request, but none of it reached the handler. Both transports build the per-request `Extensions` from scratch and lift exactly one type out of the HTTP request (OAuth `TokenClaims`, and only under the `oauth` feature), so `RequestContext::extension::<MyThing>()` never found what a layer had inserted.

The reporter runs a server whose agents call back into it over loopback HTTP. Every agent hits the same URL, so parentage is self-reported: an agent passes its own `spawned_by` and nothing stops it passing someone else's, while that field drives a cost rollup and a recursion depth cap. The fix they wanted is a per-agent secret in the MCP config headers, mapped to an identity by a small layer. That identity had nowhere to go.

## API

```rust
HttpTransport::new(router)
    .bridge_extension::<AgentIdentity>()
    .into_router_at("/mcp")
```

Then `ctx.extension::<AgentIdentity>()` in the handler. `WebSocketTransport` has the same method.

Default behaviour is unchanged: with nothing registered, no bridges run. A request that does not carry the type is left alone, so a layer that only attaches its value on some routes is fine.

## Why per type, not a blanket copy

The issue also floated `bridge_http_extensions()` for the whole map. Not doing that. `axum::http::Extensions` exposes no iteration API, so a true blanket copy is impossible; the only version that compiles inserts the whole map as one value, which forces handlers to write `ctx.extension::<axum::http::Extensions>()?.get::<T>()` and puts an HTTP type in front of code that is otherwise transport-agnostic. Typed registration covers every case the issue lists (identity, tenant, tracing id, `ConnectInfo` for client IP) at one line each, and stays explicit about what crosses the boundary.

## Scope

`Extensions` is built at five places in the HTTP transport. All five are wired, including `subscriptions/listen`, whose handler took only `(state, parsed)` and so had nothing to bridge from. It now receives the request extensions, so a long-lived listen stream is not the one path where a registered type is silently absent.

WebSocket had the identical `TokenClaims`-only lift and gets the same treatment. There the value is read once from the HTTP request that opens the socket, and then applies to every request on that connection.

One non-obvious change: `http_extensions` was itself gated on the `oauth` feature, because OAuth claims were the only thing being lifted; without `oauth` the request extensions were discarded outright. It is now bound unconditionally, since bridging has nothing to do with OAuth.

## Tests

Driven through a real `axum::middleware::from_fn` layer that maps an `x-agent-secret` header to an identity, which is the reporter's actual shape. The layer also inserts a second type that is never registered.

- a registered type reaches the handler, on the plain POST, the session handshake, and the 2026-07-28 header path, so a site left unwired fails rather than going unnoticed
- the unregistered type does not cross, or the opt-in would be meaningless
- with no registration, a layer's value stays invisible exactly as before
- a request the layer did not tag is not an error
- the same positive and negative cases over a real WebSocket

The positive and negative tests are mutually validating: a bridge that did nothing fails the first, and one that copied everything fails the second.

Full suite, clippy, `-Dmissing-docs`, and the 17-entry feature-combinations matrix are green locally, plus `http`/`websocket`/`http,websocket`/`http,oauth`/`websocket,oauth`/`http,stateless` checked individually at zero warnings.