### PR TITLE
fix(tasks): only resume a task when an update actually answered something

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3971,7 +3971,16 @@ impl McpRouter {
                     // The client answered everything outstanding, so re-invoke
                     // the handler with the accumulated responses (#1208). A
                     // partial answer leaves the task parked for the rest.
-                    if applied.is_complete() {
+                    //
+                    // `is_complete` is also true when nothing was outstanding
+                    // in the first place, so on its own it would resume a task
+                    // that never parked. Requiring this update to have answered
+                    // something is what distinguishes a real
+                    // `input_required -> working` transition from a stray,
+                    // duplicate, or already-satisfied update, either of which
+                    // would otherwise start a second handler alongside the one
+                    // still running (#1246).
+                    if !applied.accepted.is_empty() && applied.is_complete() {
                         self.resume_task(&params.task_id).await;
                     }
                     return Ok(McpResponse::FinalTaskAck(
@@ -6508,6 +6517,99 @@ mod tests {
         assert!(
             error.unwrap().message.contains("resume_context"),
             "the failure must name what to implement"
+        );
+    }
+    /// #1246 point 1: `tasks/update` resumes whenever nothing is
+    /// outstanding, without checking that an `input_required -> working`
+    /// transition actually happened. A stray update while the first handler
+    /// is still running therefore starts a second one.
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn a_stray_update_while_working_must_not_reinvoke_the_handler() {
+        use crate::async_task::{MemoryTaskStore, TaskStore};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let invocations = std::sync::Arc::new(AtomicUsize::new(0));
+        let counter = invocations.clone();
+
+        let slow = ToolBuilder::new("slow")
+            .description("Runs for a while")
+            .task_support(TaskSupportMode::Optional)
+            .mrtr_handler::<serde_json::Value, _, _>(move |_ctx, _input| {
+                let counter = counter.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                    Ok(crate::protocol::RequestOutcome::Complete(
+                        CallToolResult::text("done"),
+                    ))
+                }
+            })
+            .build();
+
+        let store = std::sync::Arc::new(MemoryTaskStore::new());
+        let mut router = McpRouter::new()
+            .task_store(store.clone())
+            .tool(slow)
+            .with_tasks();
+        init_router(&mut router).await;
+
+        let resp = router
+            .ready()
+            .await
+            .unwrap()
+            .call(RouterRequest {
+                id: RequestId::Number(1),
+                inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
+                    name: "slow".to_string(),
+                    arguments: serde_json::json!({}),
+                    meta: None,
+                    task: None,
+                }),
+                extensions: tasks_client_extensions(),
+            })
+            .await
+            .unwrap();
+        let task_id = match resp.inner {
+            Ok(McpResponse::FinalCreateTask(result)) => result.task.metadata.task_id,
+            other => panic!("expected a created task, got {other:?}"),
+        };
+
+        // The handler is running and nothing is outstanding.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            1,
+            "handler started once"
+        );
+        let task = store.get_task(&task_id).await.unwrap().unwrap();
+        assert_eq!(task.status, TaskStatus::Working);
+
+        // A stray update answering nothing.
+        let update = router
+            .ready()
+            .await
+            .unwrap()
+            .call(RouterRequest {
+                id: RequestId::Number(2),
+                inner: McpRequest::UpdateTask(UpdateTaskParams {
+                    task_id: task_id.clone(),
+                    input_responses: Default::default(),
+                    meta: None,
+                }),
+                extensions: tasks_client_extensions(),
+            })
+            .await
+            .unwrap();
+        assert!(update.inner.is_ok());
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            invocations.load(Ordering::SeqCst),
+            1,
+            "a stray update must not start a second handler"
         );
     }
 


### PR DESCRIPTION
The first correctness point from #1242's sibling, #1246. Filed separately because it is a live bug independent of the larger execution-mode proposal in that issue.

## The bug

`tasks/update` resumes the handler when `applied.is_complete()`, which reports that nothing is outstanding. Nothing is *also* outstanding when nothing was ever outstanding, so an update against a `working` task satisfies it:

```rust
if applied.is_complete() {
    self.resume_task(&params.task_id).await;
}
```

`resume_task` re-invokes the tool from the top. Neither it nor the caller checks that the task was in `input_required`, so a stray update starts a second handler alongside the one still running.

Any client can trigger this by sending `tasks/update` with an empty `inputResponses` against a running task. For a tool that spawns a process, calls a provider, or bills for work, that is a duplicated execution rather than a harmless no-op.

## Failing test first

```
assertion `left == right` failed: a stray update must not start a second handler
  left: 2
 right: 1
```

The test starts a task whose handler sleeps, confirms it is `working` with one invocation recorded, sends an empty `tasks/update`, and counts invocations again.

## The fix

Require the update to have accepted at least one response:

```rust
if !applied.accepted.is_empty() && applied.is_complete() {
```

`accepted` is only populated for keys that matched an outstanding request, and a task only has outstanding requests while it is `input_required`, so a non-empty `accepted` is what distinguishes a real `input_required -> working` transition from an update that changed nothing.

Behaviour that is deliberately unchanged: a partial answer still leaves the task parked for the rest, and an unknown, stale, or already-answered key is still ignored rather than rejected, so a client replaying a stale update does not fail the task.

## Scope

This does not address the rest of #1246. The larger proposal there, a non-replay execution mode for live long-running operations, is a design discussion; this is the one item in its list that is a confirmed defect in current behaviour.

All 58 existing task tests pass unchanged, along with the full suite, clippy, `-Dmissing-docs`, and the 17-entry feature-combinations matrix.