### PR TITLE
fix(tasks): enforce input request key uniqueness over a task's lifetime

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -353,11 +353,17 @@ impl CancellationToken {
 
 /// Errors returned by [`TaskStore`] implementations.
 ///
-/// Mirrors the three-variant shape of
-/// [`SessionStoreError`](crate::session_store::SessionStoreError): encode and
-/// decode errors from (de)serializing task state, and catch-all backend errors
-/// from the storage layer. [`MemoryTaskStore`] never returns errors; the
-/// variants exist for external implementations.
+/// Encode and decode errors come from (de)serializing task state, and
+/// [`Backend`](Self::Backend) is the catch-all for the storage layer. Those
+/// three mirror
+/// [`SessionStoreError`](crate::session_store::SessionStoreError) and exist
+/// for external implementations; [`MemoryTaskStore`] never returns them.
+///
+/// [`InvalidTransition`](Self::InvalidTransition) is different in kind. It
+/// reports that the requested change is not legal for the task's current
+/// state, which is deterministic and says nothing about storage health, so a
+/// caller must not treat it as retryable. [`MemoryTaskStore`] does return it
+/// (#1246).
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum TaskStoreError {
@@ -370,6 +376,30 @@ pub enum TaskStoreError {
     /// Backend error (e.g. connection failure, transient storage error).
     #[error("backend error: {0}")]
     Backend(String),
+    /// The requested change is not valid for the task's current state.
+    ///
+    /// Deterministic: the same call fails the same way, so retrying cannot
+    /// help and callers should not confuse it with an infrastructure
+    /// failure. Reusing an input request key is the current instance (#1246).
+    #[error("invalid task transition: {0}")]
+    InvalidTransition(String),
+}
+
+/// Whether two input requests are the same question.
+///
+/// [`InputRequest`](crate::protocol::InputRequest) is `#[non_exhaustive]` and
+/// carries params that do not implement `Eq`, so this compares their
+/// serialized forms. A request that cannot be serialized is treated as
+/// changed, which errs toward reporting reuse rather than silently accepting
+/// a second question under a spent key.
+fn same_input_request(
+    a: &crate::protocol::InputRequest,
+    b: &crate::protocol::InputRequest,
+) -> bool {
+    match (serde_json::to_value(a), serde_json::to_value(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
 }
 
 /// Result alias for task store operations.
@@ -461,22 +491,41 @@ pub trait TaskStore: Send + Sync + 'static {
 
     /// Mark a task as requiring input, recording the requests to be answered.
     ///
-    /// `requests` replaces the outstanding set. Any key that was outstanding
-    /// and is not re-issued becomes superseded; a re-issued key is a fresh
-    /// question and becomes outstanding again even if previously answered.
+    /// `requests` replaces the outstanding set. A key that was outstanding
+    /// and does not appear in the new snapshot becomes superseded.
     ///
     /// Returns `Ok(false)` if the task is unknown, expired, or already
     /// terminal.
+    ///
     /// # Key uniqueness
     ///
     /// SEP-2663 requires every request key to be unique over a single task's
-    /// lifetime: a key is spent once it has been issued, whether it was
-    /// answered or superseded, and must never name a second request. An
-    /// implementation is expected to return an error rather than reissue one,
-    /// which is what lets a client deduplicate across polls (#1246).
+    /// lifetime. A key is spent once its request has been answered or
+    /// superseded, and must never name a second request; that guarantee is
+    /// what lets a client deduplicate across polls and lets a server ignore
+    /// responses for already-satisfied requests (#1246).
+    ///
+    /// Reissuing a spent key is a
+    /// [`TaskStoreError::InvalidTransition`], not a backend failure: it is
+    /// deterministic, and retrying cannot help.
+    ///
+    /// Carrying an unanswered request forward is not reuse. Because
+    /// `requests` replaces the whole snapshot, a still-outstanding key has to
+    /// be reissued to stay outstanding, and doing so names the same question
+    /// rather than a second one. Repointing a live key at a *different*
+    /// request is reuse and must be rejected.
     ///
     /// The uniqueness scope is the task. Keys from a preceding MRTR phase are
     /// a separate namespace and do not constrain a task's keys.
+    ///
+    /// # Implementing this
+    ///
+    /// An external store must enforce the same rule, and the check and the
+    /// snapshot replacement must be atomic: two concurrent parks that each
+    /// see a key as unspent would otherwise both admit it. Stores written
+    /// before this rule existed keep compiling and keep their old permissive
+    /// behaviour, so this is a behavioural migration rather than a
+    /// compile-visible one.
     async fn require_input(
         &self,
         task_id: &str,
@@ -743,17 +792,28 @@ impl TaskStore for MemoryTaskStore {
         // That guarantee is what lets a client deduplicate across polls and
         // lets a server ignore responses for already-satisfied requests, so
         // reissuing a key is rejected rather than quietly accepted (#1246).
+        //
+        // A key still outstanding is a different case. `requests` replaces
+        // the whole snapshot, so carrying an unanswered request forward
+        // reissues its key without naming a second request. That is only
+        // reuse if the request behind the key changed.
         let reused: Vec<String> = requests
-            .keys()
-            .filter(|key| {
-                task.answered_input_keys.contains(*key)
+            .iter()
+            .filter(|(key, request)| {
+                if task.answered_input_keys.contains(*key)
                     || task.superseded_input_keys.contains(*key)
-                    || task.input_requests.contains_key(*key)
+                {
+                    return true;
+                }
+                match task.input_requests.get(*key) {
+                    Some(current) => !same_input_request(current, request),
+                    None => false,
+                }
             })
-            .cloned()
+            .map(|(key, _)| key.clone())
             .collect();
         if !reused.is_empty() {
-            return Err(TaskStoreError::Backend(format!(
+            return Err(TaskStoreError::InvalidTransition(format!(
                 "input request keys must be unique over a task's lifetime, but {} \
                  already {} used by this task; use a new key to ask again",
                 reused.join(", "),
@@ -761,11 +821,13 @@ impl TaskStore for MemoryTaskStore {
             )));
         }
 
-        // Outstanding requests the server did not reissue are superseded.
-        // They stay recorded, since a superseded key is still spent for the
-        // rest of the task's lifetime.
+        // Outstanding requests the server dropped from the snapshot are
+        // superseded, and stay recorded because a superseded key is spent for
+        // the rest of the task's lifetime. A key carried forward is not.
         for key in std::mem::take(&mut task.input_requests).into_keys() {
-            task.superseded_input_keys.insert(key);
+            if !requests.contains_key(&key) {
+                task.superseded_input_keys.insert(key);
+            }
         }
 
         task.input_requests = requests;
@@ -1534,6 +1596,80 @@ mod tests {
             error.to_string().contains("approval"),
             "the message must name the offending key: {error}"
         );
+    }
+
+    /// `requests` replaces the whole snapshot, so an unanswered request has
+    /// to be reissued to stay outstanding. Carrying it forward alongside a
+    /// new one is not reuse: the key still names the same question.
+    #[tokio::test]
+    async fn an_outstanding_request_can_be_carried_forward() {
+        let store = MemoryTaskStore::new();
+        let id = working_task(&store, None).await;
+        store
+            .require_input(&id, requests(&["approval"]), None)
+            .await
+            .unwrap();
+
+        // {approval} -> {approval, region}: approval is retained, not reused.
+        assert!(
+            store
+                .require_input(&id, requests(&["approval", "region"]), None)
+                .await
+                .unwrap()
+        );
+
+        let outstanding = store
+            .outstanding_input_requests(&id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(outstanding.contains_key("approval"));
+        assert!(outstanding.contains_key("region"));
+
+        // Both still answer normally.
+        let applied = store
+            .apply_input_responses(
+                &id,
+                [accept("approval"), accept("region")].into_iter().collect(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            applied.accepted,
+            ["approval".to_string(), "region".to_string()].into()
+        );
+        assert!(applied.is_complete());
+    }
+
+    /// Carrying a key forward is only legitimate while it names the same
+    /// question. Pointing a live key at a different request is the reuse the
+    /// SEP forbids.
+    #[tokio::test]
+    async fn an_outstanding_key_cannot_change_what_it_asks() {
+        use crate::protocol::{ElicitFormParams, ElicitFormSchema, ElicitRequestParams};
+
+        let store = MemoryTaskStore::new();
+        let id = working_task(&store, None).await;
+        store
+            .require_input(&id, requests(&["approval"]), None)
+            .await
+            .unwrap();
+
+        let mut changed: InputRequests = Default::default();
+        changed.insert(
+            "approval".to_string(),
+            InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                mode: None,
+                message: "a different question".to_string(),
+                requested_schema: ElicitFormSchema::new(),
+                meta: None,
+            })),
+        );
+        store
+            .require_input(&id, changed, None)
+            .await
+            .expect_err("a live key must not be repointed at another request");
     }
 
     /// A key issued and then superseded without an answer is spent too: the

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -467,6 +467,16 @@ pub trait TaskStore: Send + Sync + 'static {
     ///
     /// Returns `Ok(false)` if the task is unknown, expired, or already
     /// terminal.
+    /// # Key uniqueness
+    ///
+    /// SEP-2663 requires every request key to be unique over a single task's
+    /// lifetime: a key is spent once it has been issued, whether it was
+    /// answered or superseded, and must never name a second request. An
+    /// implementation is expected to return an error rather than reissue one,
+    /// which is what lets a client deduplicate across polls (#1246).
+    ///
+    /// The uniqueness scope is the task. Keys from a preceding MRTR phase are
+    /// a separate namespace and do not constrain a task's keys.
     async fn require_input(
         &self,
         task_id: &str,
@@ -724,16 +734,38 @@ impl TaskStore for MemoryTaskStore {
             return Ok(false);
         }
 
-        // Outstanding requests the server did not re-issue are superseded.
-        for key in std::mem::take(&mut task.input_requests).into_keys() {
-            if !requests.contains_key(&key) {
-                task.superseded_input_keys.insert(key);
-            }
+        // SEP-2663: "Each request key in `inputRequests` MUST be unique over
+        // the lifetime of a single task. A server MUST NOT reuse a key for a
+        // subsequent server-to-client request after a response for that key
+        // has been delivered, and MUST NOT use the same key to refer to two
+        // distinct requests over a task's lifetime."
+        //
+        // That guarantee is what lets a client deduplicate across polls and
+        // lets a server ignore responses for already-satisfied requests, so
+        // reissuing a key is rejected rather than quietly accepted (#1246).
+        let reused: Vec<String> = requests
+            .keys()
+            .filter(|key| {
+                task.answered_input_keys.contains(*key)
+                    || task.superseded_input_keys.contains(*key)
+                    || task.input_requests.contains_key(*key)
+            })
+            .cloned()
+            .collect();
+        if !reused.is_empty() {
+            return Err(TaskStoreError::Backend(format!(
+                "input request keys must be unique over a task's lifetime, but {} \
+                 already {} used by this task; use a new key to ask again",
+                reused.join(", "),
+                if reused.len() == 1 { "was" } else { "were" },
+            )));
         }
-        // A re-issued key is a fresh question, whatever its prior fate.
-        for key in requests.keys() {
-            task.answered_input_keys.remove(key);
-            task.superseded_input_keys.remove(key);
+
+        // Outstanding requests the server did not reissue are superseded.
+        // They stay recorded, since a superseded key is still spent for the
+        // rest of the task's lifetime.
+        for key in std::mem::take(&mut task.input_requests).into_keys() {
+            task.superseded_input_keys.insert(key);
         }
 
         task.input_requests = requests;
@@ -1476,8 +1508,12 @@ mod tests {
         );
     }
 
+    /// SEP-2663: a key is spent for the rest of the task once it has been
+    /// answered. Treating a reissue as a fresh question, which this store
+    /// used to do, breaks the guarantee clients rely on to deduplicate
+    /// across polls (#1246).
     #[tokio::test]
-    async fn reissued_key_becomes_a_fresh_question() {
+    async fn an_answered_key_cannot_be_reissued() {
         let store = MemoryTaskStore::new();
         let id = working_task(&store, None).await;
         store
@@ -1490,18 +1526,67 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        // The server asks the same key again: the earlier answer must not
-        // satisfy it.
+        let error = store
+            .require_input(&id, requests(&["approval"]), None)
+            .await
+            .expect_err("an answered key must not be reissued");
+        assert!(
+            error.to_string().contains("approval"),
+            "the message must name the offending key: {error}"
+        );
+    }
+
+    /// A key issued and then superseded without an answer is spent too: the
+    /// SEP forbids one key naming two distinct requests, regardless of
+    /// whether the first was answered.
+    #[tokio::test]
+    async fn a_superseded_key_cannot_be_reissued() {
+        let store = MemoryTaskStore::new();
+        let id = working_task(&store, None).await;
         store
             .require_input(&id, requests(&["approval"]), None)
             .await
             .unwrap();
-        let applied = store
+        // Asking something else supersedes the unanswered `approval`.
+        store
+            .require_input(&id, requests(&["region"]), None)
+            .await
+            .unwrap();
+
+        store
+            .require_input(&id, requests(&["approval"]), None)
+            .await
+            .expect_err("a superseded key must not be reissued");
+    }
+
+    /// Distinct keys are the normal case and stay unaffected, including
+    /// asking again after an answer under a new name.
+    #[tokio::test]
+    async fn distinct_keys_across_rounds_are_fine() {
+        let store = MemoryTaskStore::new();
+        let id = working_task(&store, None).await;
+        store
+            .require_input(&id, requests(&["approval"]), None)
+            .await
+            .unwrap();
+        store
             .apply_input_responses(&id, [accept("approval")].into_iter().collect())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(applied.accepted, ["approval".to_string()].into());
+
+        assert!(
+            store
+                .require_input(&id, requests(&["approval_2"]), None)
+                .await
+                .unwrap()
+        );
+        let applied = store
+            .apply_input_responses(&id, [accept("approval_2")].into_iter().collect())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(applied.accepted, ["approval_2".to_string()].into());
         assert!(applied.is_complete());
     }
 

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2730,10 +2730,33 @@ impl McpRouter {
                 );
             }
             Err(e) => {
-                tracing::warn!(task_id = %task_id, error = %e, "failed to park task for input");
-                let error = JsonRpcError::internal_error(format!(
-                    "handler could not park the task for input: {e}"
-                ));
+                // Either way the park is lost and the task can never be
+                // answered, so both end it. They are not the same fault
+                // though: an invalid transition is the handler asking for
+                // something the protocol forbids, which no retry fixes,
+                // while a backend failure is infrastructure (#1246).
+                let error = match &e {
+                    crate::async_task::TaskStoreError::InvalidTransition(message) => {
+                        tracing::error!(
+                            task_id = %task_id,
+                            error = %message,
+                            "handler asked for input the protocol does not allow"
+                        );
+                        JsonRpcError::internal_error(format!(
+                            "handler asked for input the protocol does not allow: {message}"
+                        ))
+                    }
+                    other => {
+                        tracing::warn!(
+                            task_id = %task_id,
+                            error = %other,
+                            "task store could not park the task for input"
+                        );
+                        JsonRpcError::internal_error(format!(
+                            "could not park the task for input: {other}"
+                        ))
+                    }
+                };
                 if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
                     tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
                 }
@@ -6538,10 +6561,6 @@ mod tests {
             "the failure must name what to implement"
         );
     }
-    /// #1246 point 1: `tasks/update` resumes whenever nothing is
-    /// outstanding, without checking that an `input_required -> working`
-    /// transition actually happened. A stray update while the first handler
-    /// is still running therefore starts a second one.
     /// #1246 point 5: a handler that reuses a spent key is asking for
     /// something SEP-2663 forbids the server to send. The park is refused,
     /// and the task must say so rather than sit in `working` with nothing
@@ -6661,6 +6680,10 @@ mod tests {
         );
     }
 
+    /// #1246 point 1: `tasks/update` resumes whenever nothing is
+    /// outstanding, without checking that an `input_required -> working`
+    /// transition actually happened. A stray update while the first handler
+    /// is still running therefore starts a second one.
     #[cfg(feature = "stateless")]
     #[tokio::test]
     async fn a_stray_update_while_working_must_not_reinvoke_the_handler() {

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2712,13 +2712,32 @@ impl McpRouter {
             return;
         }
 
-        if let Err(e) = self
+        // A park that does not take leaves the task working with nothing
+        // outstanding, which no `tasks/update` can ever move. Failing it says
+        // why instead of stranding it, matching the empty-request case above
+        // (#1246).
+        match self
             .inner
             .task_store
             .require_input(task_id, requests, input_required.request_state.as_deref())
             .await
         {
-            tracing::warn!(task_id = %task_id, error = %e, "failed to park task for input");
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "task was already terminal or gone when parking for input"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(task_id = %task_id, error = %e, "failed to park task for input");
+                let error = JsonRpcError::internal_error(format!(
+                    "handler could not park the task for input: {e}"
+                ));
+                if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
+                    tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
+                }
+            }
         }
         self.notify_task_state(task_id).await;
     }
@@ -6523,6 +6542,125 @@ mod tests {
     /// outstanding, without checking that an `input_required -> working`
     /// transition actually happened. A stray update while the first handler
     /// is still running therefore starts a second one.
+    /// #1246 point 5: a handler that reuses a spent key is asking for
+    /// something SEP-2663 forbids the server to send. The park is refused,
+    /// and the task must say so rather than sit in `working` with nothing
+    /// outstanding, which no `tasks/update` could ever move.
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn reusing_a_spent_input_key_fails_the_task_instead_of_stranding_it() {
+        use crate::async_task::{MemoryTaskStore, TaskStore};
+        use crate::protocol::{
+            ElicitFormParams, ElicitFormSchema, ElicitRequestParams, InputRequest, InputRequests,
+            InputRequiredResult, RequestOutcome,
+        };
+
+        fn ask(key: &str) -> InputRequests {
+            let mut requests: InputRequests = Default::default();
+            requests.insert(
+                key.to_string(),
+                InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                    mode: None,
+                    message: "approve?".to_string(),
+                    requested_schema: ElicitFormSchema::new(),
+                    meta: None,
+                })),
+            );
+            requests
+        }
+
+        // Always asks for "decision", even after it has been answered.
+        let repeats = ToolBuilder::new("repeats")
+            .description("Reuses a spent key")
+            .task_support(TaskSupportMode::Optional)
+            .mrtr_handler::<serde_json::Value, _, _>(|_ctx, _input| async move {
+                Ok(RequestOutcome::input_required(
+                    InputRequiredResult::with_requests(ask("decision")),
+                ))
+            })
+            .build();
+
+        let store = std::sync::Arc::new(MemoryTaskStore::new());
+        let mut router = McpRouter::new()
+            .task_store(store.clone())
+            .tool(repeats)
+            .with_tasks();
+        init_router(&mut router).await;
+
+        let resp = router
+            .ready()
+            .await
+            .unwrap()
+            .call(RouterRequest {
+                id: RequestId::Number(1),
+                inner: McpRequest::CallTool(CallToolParams {
+                    input_responses: None,
+                    request_state: None,
+                    name: "repeats".to_string(),
+                    arguments: serde_json::json!({}),
+                    meta: None,
+                    task: None,
+                }),
+                extensions: tasks_client_extensions(),
+            })
+            .await
+            .unwrap();
+        let task_id = match resp.inner {
+            Ok(McpResponse::FinalCreateTask(result)) => result.task.metadata.task_id,
+            other => panic!("expected a created task, got {other:?}"),
+        };
+
+        // First park is legitimate.
+        let mut parked = false;
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            if store.get_task(&task_id).await.unwrap().unwrap().status == TaskStatus::InputRequired
+            {
+                parked = true;
+                break;
+            }
+        }
+        assert!(parked, "the task must reach input_required");
+
+        // Answering resumes the handler, which asks for the same key again.
+        router
+            .ready()
+            .await
+            .unwrap()
+            .call(RouterRequest {
+                id: RequestId::Number(2),
+                inner: McpRequest::UpdateTask(UpdateTaskParams {
+                    task_id: task_id.clone(),
+                    input_responses: [(
+                        "decision".to_string(),
+                        serde_json::json!({"action": "accept"}),
+                    )]
+                    .into_iter()
+                    .collect(),
+                    meta: None,
+                }),
+                extensions: tasks_client_extensions(),
+            })
+            .await
+            .unwrap();
+
+        let mut failed = None;
+        for _ in 0..50 {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            let (task, _, error) = store.get_task_result(&task_id).await.unwrap().unwrap();
+            if task.status == TaskStatus::Failed {
+                failed = error;
+                break;
+            }
+        }
+        let error = failed.expect("the task must fail rather than strand");
+        assert!(
+            error.message.contains("decision"),
+            "the failure must name the offending key: {}",
+            error.message
+        );
+    }
+
     #[cfg(feature = "stateless")]
     #[tokio::test]
     async fn a_stray_update_while_working_must_not_reinvoke_the_handler() {


### PR DESCRIPTION
Point 5 from #1246, filed separately as a focused correctness change.

## The rule

SEP-2663 is explicit:

> Each request key in `inputRequests` **MUST** be unique over the lifetime of a single task. A server **MUST NOT** reuse a key for a subsequent server-to-client request after a response for that key has been delivered, and **MUST NOT** use the same key to refer to two distinct requests over a task's lifetime. This guarantees that `inputResponses` keyed by the same identifier always refer to the request the client expects, eliminates ambiguity for clients deduplicating across polls, and lets servers ignore `inputResponses` for unknown or already-satisfied requests.

## What we did instead

`MemoryTaskStore::require_input` cleared a key's history on reissue:

```rust
// A re-issued key is a fresh question, whatever its prior fate.
for key in requests.keys() {
    task.answered_input_keys.remove(key);
    task.superseded_input_keys.remove(key);
}
```

This was deliberate, and a test named `reissued_key_becomes_a_fresh_question` asserted it. It is still a conformance bug: our own `apply_input_responses` relies on the spec guarantee to ignore already-satisfied keys, so permitting reuse makes the two halves disagree about what a key means.

## The change

A key is spent once issued, whether it was answered or superseded. Reissuing one returns an error naming it, rather than silently starting a second question under an identifier the client may already have answered.

A refused park previously only logged a warning, which left the task `working` with nothing outstanding, a state no `tasks/update` can move. It now fails the task with the reason, matching how an empty request set is already handled.

Uniqueness is scoped to the task. Per the SEP, keys from a preceding MRTR phase are a separate namespace and do not constrain a task's keys, so nothing here reaches across that boundary.

## Tests

`reissued_key_becomes_a_fresh_question` encoded the old behaviour and is replaced by three:

- an answered key cannot be reissued, and the message names it
- a superseded key cannot be reissued either, since the SEP forbids one key naming two distinct requests regardless of whether the first was answered
- distinct keys across rounds still work, including asking again under a new name after an answer

Plus an end-to-end router test: a handler that always asks for the same key parks once, gets answered, asks again on resume, and the task ends `failed` with the key named rather than stranded in `working`.

Full suite, clippy, `-Dmissing-docs`, and the 17-entry feature-combinations matrix are green.