### PR TITLE
fix(stdio): stop a saturated request limit from starving control traffic

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -436,6 +436,59 @@ async fn acquire_request_permit(
     }
 }
 
+/// Whether a frame expects a response.
+///
+/// A JSON-RPC notification carries no `id`, and a notification must never
+/// queue behind an ordinary request or wait for an execution permit:
+/// `notifications/cancelled` has to reach a running handler precisely when
+/// every slot is busy, which is the case that would otherwise deadlock
+/// (#1251). Batches count as requests, since one may contain them.
+fn expects_a_response(line: &str) -> bool {
+    #[derive(serde::Deserialize)]
+    struct IdPeek {
+        #[serde(default)]
+        id: Option<serde_json::Value>,
+    }
+
+    if line.trim_start().starts_with('[') {
+        return true;
+    }
+    match serde_json::from_str::<IdPeek>(line) {
+        Ok(IdPeek { id: Some(id) }) => !id.is_null(),
+        // Unparseable input still takes the request path, so the existing
+        // parse-error response is produced exactly as before.
+        Ok(IdPeek { id: None }) => false,
+        Err(_) => true,
+    }
+}
+
+/// One request's work, queued for the dispatcher.
+type QueuedRequest = std::pin::Pin<Box<dyn std::future::Future<Output = Option<String>> + Send>>;
+
+/// Run the queue that stands between reading and executing.
+///
+/// #1251: waiting for a permit in the read loop meant a saturated limit
+/// stopped the transport reading at all, so a `notifications/cancelled`
+/// queued behind an ordinary request could never arrive, and the request it
+/// would have cancelled never released its permit. Nothing progressed.
+///
+/// Moving the wait here keeps the reader free for control traffic while
+/// still bounding how many handlers run at once. Taking requests in order
+/// from a channel, rather than letting each spawned task race for a permit,
+/// is what keeps execution order predictable under a limit.
+fn spawn_request_dispatcher(
+    mut queue: mpsc::UnboundedReceiver<QueuedRequest>,
+    limit: Option<Arc<Semaphore>>,
+    out_tx: OutboundFrames,
+) {
+    tokio::spawn(async move {
+        while let Some(work) = queue.recv().await {
+            let permit = acquire_request_permit(&limit).await;
+            spawn_request(permit, &out_tx, work);
+        }
+    });
+}
+
 /// Run one request on its own task, sending any response frame back to the
 /// read loop.
 ///
@@ -666,8 +719,11 @@ impl StdioTransport {
     /// write. Set a cap when handlers are expensive enough that the number
     /// running at once matters.
     ///
-    /// Reaching the cap applies backpressure by pausing the read loop, so
-    /// requests queue on the input stream rather than piling up in memory.
+    /// The cap bounds how many handlers run at once, not how fast input is
+    /// read. Requests past the cap wait their turn in order. The transport
+    /// keeps reading either way, because control traffic such as
+    /// `notifications/cancelled` has to reach a running handler even when
+    /// every execution slot is busy (#1251).
     ///
     /// `1` restores the strictly serial handling this transport used before
     /// 0.21, which is the escape hatch for handlers that assume no two
@@ -806,6 +862,10 @@ impl StdioTransport {
         // (#1231).
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
         let limit = request_limiter(self.max_concurrent_requests);
+        // The reader hands work to the dispatcher and moves on, so a
+        // saturated limit never stops it reading control traffic (#1251).
+        let (work_tx, work_rx) = mpsc::unbounded_channel::<QueuedRequest>();
+        spawn_request_dispatcher(work_rx, limit, out_tx.clone());
 
         tracing::info!("Stdio transport started, waiting for input");
 
@@ -892,9 +952,12 @@ impl StdioTransport {
                         if let Some(frame) = work.await {
                             write_line_to_stdout(&mut writer, &frame).await?;
                         }
+                    } else if expects_a_response(trimmed) {
+                        let _ = work_tx.send(Box::pin(work));
                     } else {
-                        let permit = acquire_request_permit(&limit).await;
-                        spawn_request(permit, &out_tx, work);
+                        // No permit and no queue: a notification must be able
+                        // to overtake the requests it affects (#1251).
+                        spawn_request(None, &out_tx, work);
                     }
                 }
 
@@ -940,9 +1003,11 @@ impl StdioTransport {
             }
         }
 
-        // Dropping this loop's sender leaves only the in-flight requests
-        // holding one, so the drain ends when the last of them finishes.
-        // Without it their responses would be lost on shutdown.
+        // Closing the queue lets the dispatcher finish what it has and drop
+        // its own sender; dropping this loop's leaves only the in-flight
+        // requests holding one, so the drain ends when the last finishes.
+        // Without this their responses would be lost on shutdown.
+        drop(work_tx);
         drop(out_tx);
         while let Some(frame) = out_rx.recv().await {
             write_line_to_stdout(&mut writer, &frame).await?;
@@ -1134,6 +1199,10 @@ where
         // (#1231).
         let (out_tx, mut out_rx) = mpsc::unbounded_channel::<String>();
         let limit = request_limiter(self.max_concurrent_requests);
+        // Same reasoning as the plain transport: reading must not stall on a
+        // saturated limit (#1251).
+        let (work_tx, work_rx) = mpsc::unbounded_channel::<QueuedRequest>();
+        spawn_request_dispatcher(work_rx, limit, out_tx.clone());
 
         tracing::info!("Generic stdio transport started, waiting for input");
 
@@ -1154,7 +1223,7 @@ where
                             &mut self.service,
                             &line,
                             &out_tx,
-                            &limit,
+                            &work_tx,
                             true,
                             #[cfg(feature = "stateless")]
                             &mut subscriptions,
@@ -1205,7 +1274,7 @@ where
                             &mut self.service,
                             &line,
                             &out_tx,
-                            &limit,
+                            &work_tx,
                             false,
                             #[cfg(feature = "stateless")]
                             &mut subscriptions,
@@ -1229,9 +1298,11 @@ where
             }
         }
 
-        // Dropping this loop's sender leaves only the in-flight requests
-        // holding one, so the drain ends when the last of them finishes.
-        // Without it their responses would be lost on shutdown.
+        // Closing the queue lets the dispatcher finish what it has and drop
+        // its own sender; dropping this loop's leaves only the in-flight
+        // requests holding one, so the drain ends when the last finishes.
+        // Without this their responses would be lost on shutdown.
+        drop(work_tx);
         drop(out_tx);
         while let Some(frame) = out_rx.recv().await {
             write_line_to_stdout(&mut writer, &frame).await?;
@@ -1253,7 +1324,7 @@ where
         service: &mut JsonRpcService<S>,
         line: &str,
         out_tx: &OutboundFrames,
-        limit: &Option<Arc<Semaphore>>,
+        work_tx: &mpsc::UnboundedSender<QueuedRequest>,
         subscriptions_enabled: bool,
         #[cfg(feature = "stateless")] subscriptions: &mut StdioSubscriptions,
     ) -> Result<()> {
@@ -1349,9 +1420,10 @@ where
             if let Some(frame) = work.await {
                 let _ = out_tx.send(frame);
             }
+        } else if expects_a_response(trimmed) {
+            let _ = work_tx.send(Box::pin(work));
         } else {
-            let permit = acquire_request_permit(limit).await;
-            spawn_request(permit, out_tx, work);
+            spawn_request(None, out_tx, work);
         }
         Ok(())
     }

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -1658,3 +1658,125 @@ mod concurrency {
         );
     }
 }
+
+// ============================================================================
+// Control traffic under a concurrency cap (#1251)
+// ============================================================================
+
+mod control_under_saturation {
+    use super::*;
+    use tower_mcp::extract::RawArgs;
+
+    /// A tool that only finishes when its request is cancelled.
+    fn router_with_a_waiting_tool() -> McpRouter {
+        let wait = ToolBuilder::new("wait")
+            .description("Waits until cancelled")
+            .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
+                ctx.cancelled().await;
+                Ok(CallToolResult::text("cancelled"))
+            })
+            .build();
+        McpRouter::new()
+            .server_info("stdio-control-test", "0.0.0")
+            .tool(wait)
+    }
+
+    const INIT: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"#;
+    const CALL_WAIT: &str =
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"wait","arguments":{}}}"#;
+    const PING: &str = r#"{"jsonrpc":"2.0","id":3,"method":"ping","params":{}}"#;
+    const CANCEL: &str =
+        r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2}}"#;
+
+    /// Control: with no cap at all, does stdio cancellation reach a running
+    /// handler? If this fails the problem is the harness, not the limit.
+    #[tokio::test]
+    async fn cancellation_reaches_a_running_handler_without_a_limit() {
+        let mut transport = StdioTransport::new(router_with_a_waiting_tool());
+
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        for line in [INIT, CALL_WAIT] {
+            stdin_writer.write_all(line.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+        }
+        stdin_writer.flush().await.unwrap();
+        // Let the call register as in-flight first. A real client cancels
+        // something it has observed; a cancellation that overtakes its own
+        // request names an id the server has not seen yet.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        for line in [PING, CANCEL] {
+            stdin_writer.write_all(line.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+        }
+        stdin_writer.flush().await.unwrap();
+
+        let frames = timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 3),
+        )
+        .await
+        .expect("unlimited transport must answer all three");
+        let ids: Vec<i64> = frames.iter().filter_map(|f| f["id"].as_i64()).collect();
+        assert!(ids.contains(&2), "cancelled call answered: {frames:?}");
+    }
+
+    /// #1251: the permit is acquired inside the read loop, so once every slot
+    /// is busy the loop stops reading. A `notifications/cancelled` queued
+    /// behind an ordinary request can then never be read, and the request it
+    /// would have cancelled never releases its permit. Nothing progresses.
+    ///
+    /// The transport's own documentation says cancellation has to overtake
+    /// the request it cancels, which is exactly what a cap prevents today.
+    #[tokio::test]
+    async fn a_saturated_limit_must_not_starve_cancellation() {
+        let mut transport =
+            StdioTransport::new(router_with_a_waiting_tool()).max_concurrent_requests(1);
+
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        for line in [INIT, CALL_WAIT] {
+            stdin_writer.write_all(line.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+        }
+        stdin_writer.flush().await.unwrap();
+        // Let the call register as in-flight first. A real client cancels
+        // something it has observed; a cancellation that overtakes its own
+        // request names an id the server has not seen yet.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        for line in [PING, CANCEL] {
+            stdin_writer.write_all(line.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+        }
+        stdin_writer.flush().await.unwrap();
+
+        let frames = timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 3),
+        )
+        .await
+        .expect("cancellation must be readable while the limit is saturated");
+
+        let ids: Vec<i64> = frames.iter().filter_map(|f| f["id"].as_i64()).collect();
+        assert!(
+            ids.contains(&2),
+            "the cancelled call must be answered: {frames:?}"
+        );
+        assert!(
+            ids.contains(&3),
+            "the queued request must run once the permit frees: {frames:?}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1251. This is a regression from #1238, shipped in 0.21.0, and only reachable when `max_concurrent_requests` is set, so the default unbounded path is unaffected.

## The deadlock

The permit was acquired inside the read loop:

```rust
} else {
    let permit = acquire_request_permit(&limit).await;
    spawn_request(permit, &out_tx, work);
}
```

Once every slot is busy the loop waits there, so the transport stops reading. A `notifications/cancelled` sitting behind an ordinary request can never be read, and the request it would have cancelled never releases its permit.

```
1. request 1 takes the only permit and awaits ctx.cancelled()
2. request 2 arrives, read loop blocks waiting for a permit
3. notifications/cancelled for request 1 is behind request 2 on stdin
4. request 1 cannot release the permit until that cancellation is dispatched
```

The transport's own doc comment, added in the same PR, says `notifications/cancelled` "has to overtake the request it cancels, which is the whole point of handling requests concurrently." A cap made that impossible.

## The fix

A dispatcher sits between reading and executing. The reader hands work to a queue and moves on; the dispatcher takes it in order, waits for a permit, and spawns it.

That keeps the reader free for control traffic while still bounding how many handlers run at once. Taking work from a queue in order, rather than letting each spawned task race for a permit, is what keeps execution order predictable under a limit, so `max_concurrent_requests(1)` still yields strictly serial execution.

Notifications skip the queue and the permit entirely. A notification carries no `id`, and cancellation has to reach a running handler precisely when every slot is busy.

## Semantics change

The cap now bounds concurrent execution rather than intake. The previous documentation promised backpressure by pausing the read loop; that promise was the bug. Bounded intake with a documented overload response, item 4 of the issue's proposed direction, is deliberately **not** included here, since it adds a new error path and config surface and is separable from the deadlock.

## Tests

Two, and the pair is what makes the result trustworthy:

- **control, no cap:** cancellation reaches a running handler. This passes both before and after, proving the harness is valid.
- **saturated cap:** the same sequence with `max_concurrent_requests(1)`. Fails by timeout before the fix, passes after.

Verified by stashing the source change: without it the control passes and the saturated case times out; with it, both pass.

One thing the first draft of these tests got wrong, worth noting for anyone writing similar ones: writing all frames in one burst lets the cancellation be dispatched before the call registers as in-flight, so it names an id the server has not seen and is dropped. That is a client-side ordering concern rather than anything to do with the cap, and it made the control test fail too. The tests now wait for the call to register, as a real client cancelling something it has observed would.

Full suite, clippy, `-Dmissing-docs`, and the 17-entry feature-combinations matrix are green.