### PR TITLE
fix(stdio): keep inbound notification routing when layering or going silent

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -54,8 +54,9 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{Mutex, Semaphore, mpsc, oneshot};
 
 use crate::context::{
-    ChannelClientRequester, ClientRequesterHandle, NotificationReceiver, OutgoingRequest,
-    OutgoingRequestReceiver, ServerNotification, notification_channel, outgoing_request_channel,
+    ChannelClientRequester, ClientRequesterHandle, NotificationReceiver, NotificationSender,
+    OutgoingRequest, OutgoingRequestReceiver, ServerNotification, notification_channel,
+    outgoing_request_channel,
 };
 use tower_service::Service;
 
@@ -436,6 +437,18 @@ async fn acquire_request_permit(
     }
 }
 
+/// Routes a client-to-server notification to whatever owns request state.
+///
+/// [`GenericStdioTransport`] has no router of its own, so without this it
+/// drops every inbound notification, including `notifications/cancelled` for
+/// an ordinary in-flight request (#1250).
+pub(crate) type IncomingNotificationHandler = Arc<dyn Fn(McpNotification) + Send + Sync + 'static>;
+
+/// Build a handler that routes notifications back into a router.
+pub(crate) fn router_notification_handler(router: McpRouter) -> IncomingNotificationHandler {
+    Arc::new(move |notification| router.handle_notification(notification))
+}
+
 /// Whether a frame expects a response.
 ///
 /// A JSON-RPC notification carries no `id`, and a notification must never
@@ -682,6 +695,14 @@ pub struct StdioTransport {
     notification_rx: NotificationReceiver,
     control_tx: mpsc::UnboundedSender<StdioControl>,
     control_rx: mpsc::UnboundedReceiver<StdioControl>,
+    /// Held only by [`StdioTransport::without_server_notifications`], to keep
+    /// the unused outbound channel open rather than closed (#1250).
+    ///
+    /// Never read: the point is the sender's lifetime, not its value. A
+    /// dropped sender would make the receiver return `None` on every poll,
+    /// so the read loop would re-check a dead branch each iteration.
+    #[allow(dead_code)]
+    outbound_disabled: Option<NotificationSender>,
     /// Bound on requests in flight at once; `None` leaves it unbounded (#1231).
     max_concurrent_requests: Option<usize>,
 }
@@ -697,6 +718,7 @@ impl StdioTransport {
             service,
             router,
             notification_rx,
+            outbound_disabled: None,
             control_tx,
             control_rx,
             max_concurrent_requests: None,
@@ -708,6 +730,44 @@ impl StdioTransport {
     pub fn handle(&self) -> StdioTransportHandle {
         StdioTransportHandle {
             control_tx: self.control_tx.clone(),
+        }
+    }
+
+    /// Create a transport that receives client notifications but sends none.
+    ///
+    /// [`new`](Self::new) installs an outbound notification sender on the
+    /// router, which is also what makes capability synthesis advertise MCP
+    /// logging and set `listChanged`. A server that logs to stderr or OTLP
+    /// and deliberately does not expose MCP logging had no way to keep
+    /// inbound `notifications/cancelled` without also advertising features it
+    /// does not offer (#1250).
+    ///
+    /// This routes inbound notifications exactly as [`new`](Self::new) does.
+    /// It only declines to send: no progress, logging, or `listChanged`
+    /// frames are emitted, and the router advertises neither.
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, StdioTransport};
+    ///
+    /// let router = McpRouter::new().server_info("my-server", "1.0.0");
+    /// let transport = StdioTransport::without_server_notifications(router);
+    /// ```
+    pub fn without_server_notifications(router: McpRouter) -> Self {
+        let (notification_tx, notification_rx) = notification_channel(256);
+        let (control_tx, control_rx) = stdio_control_channel();
+        // The router never learns about the sender, so it advertises no
+        // notification-derived capabilities. Holding the sender here keeps
+        // the receiver pending forever rather than immediately closed, which
+        // would make the read loop poll a dead branch every iteration.
+        let service = JsonRpcService::new(router.clone());
+        Self {
+            service,
+            router,
+            notification_rx,
+            outbound_disabled: Some(notification_tx),
+            control_tx,
+            control_rx,
+            max_concurrent_requests: None,
         }
     }
 
@@ -805,6 +865,10 @@ impl StdioTransport {
     {
         let protocol_support = self.service.configured_protocol_support().clone();
         let annotations = self.router.tool_annotations_map();
+        // Taken before the layer consumes the router. A clone shares the
+        // in-flight request registry, so cancellation routed through it
+        // reaches requests dispatched by the layered service (#1250).
+        let incoming_notifications = Some(router_notification_handler(self.router.clone()));
         #[cfg(feature = "stateless")]
         let subscription_observer = self.router.subscription_observer();
         let wrapped = layer.layer(self.router);
@@ -814,6 +878,7 @@ impl StdioTransport {
             notification_rx: Some(self.notification_rx),
             control_tx: self.control_tx,
             control_rx: self.control_rx,
+            incoming_notifications,
             // Carried across the conversion so `.layer()` does not silently
             // discard a concurrency bound set before it.
             max_concurrent_requests: self.max_concurrent_requests,
@@ -1077,6 +1142,10 @@ where
     notification_rx: Option<NotificationReceiver>,
     control_tx: mpsc::UnboundedSender<StdioControl>,
     control_rx: mpsc::UnboundedReceiver<StdioControl>,
+    /// Where inbound client notifications go. `None` drops them, which is
+    /// what a directly constructed generic transport did unconditionally
+    /// before (#1250).
+    incoming_notifications: Option<IncomingNotificationHandler>,
     /// Bound on requests in flight at once; `None` leaves it unbounded (#1231).
     max_concurrent_requests: Option<usize>,
     /// Close observer threaded from the router by [`StdioTransport::layer`];
@@ -1109,10 +1178,25 @@ where
             notification_rx: None,
             control_tx,
             control_rx,
+            incoming_notifications: None,
             max_concurrent_requests: None,
             #[cfg(feature = "stateless")]
             subscription_observer: None,
         }
+    }
+
+    /// Route inbound client notifications into `router`.
+    ///
+    /// A generic transport has no router of its own, so by default it drops
+    /// every client-to-server notification, including
+    /// `notifications/cancelled` for an in-flight request. Pass the router
+    /// backing this service to restore that (#1250).
+    ///
+    /// [`StdioTransport::layer`] does this automatically, so this is for
+    /// transports built directly from a service.
+    pub fn route_notifications_to(mut self, router: McpRouter) -> Self {
+        self.incoming_notifications = Some(router_notification_handler(router));
+        self
     }
 
     /// Cap how many requests this transport handles at once.
@@ -1138,6 +1222,7 @@ where
             notification_rx: Some(notification_rx),
             control_tx,
             control_rx,
+            incoming_notifications: None,
             max_concurrent_requests: None,
             #[cfg(feature = "stateless")]
             subscription_observer: None,
@@ -1224,6 +1309,7 @@ where
                             &line,
                             &out_tx,
                             &work_tx,
+                            self.incoming_notifications.as_ref(),
                             true,
                             #[cfg(feature = "stateless")]
                             &mut subscriptions,
@@ -1275,6 +1361,7 @@ where
                             &line,
                             &out_tx,
                             &work_tx,
+                            self.incoming_notifications.as_ref(),
                             false,
                             #[cfg(feature = "stateless")]
                             &mut subscriptions,
@@ -1325,6 +1412,7 @@ where
         line: &str,
         out_tx: &OutboundFrames,
         work_tx: &mpsc::UnboundedSender<QueuedRequest>,
+        incoming_notifications: Option<&IncomingNotificationHandler>,
         subscriptions_enabled: bool,
         #[cfg(feature = "stateless")] subscriptions: &mut StdioSubscriptions,
     ) -> Result<()> {
@@ -1377,11 +1465,26 @@ where
         }
 
         if !parsed.is_array() && parsed.get("id").is_none() {
-            // Notification - log and ignore since we don't have router access
-            tracing::debug!(
-                method = parsed.get("method").and_then(|m| m.as_str()),
-                "Received notification (ignored in generic transport)"
-            );
+            // Routed when the transport was given somewhere to route to,
+            // which is what keeps `notifications/cancelled` working after a
+            // layer is applied (#1250). Without a handler there is still
+            // nowhere for it to go.
+            match incoming_notifications {
+                Some(handler) => match serde_json::from_str::<JsonRpcNotification>(trimmed)
+                    .ok()
+                    .and_then(|n| McpNotification::from_jsonrpc(&n).ok())
+                {
+                    Some(notification) => handler(notification),
+                    None => tracing::debug!(
+                        method = parsed.get("method").and_then(|m| m.as_str()),
+                        "Unrecognized notification"
+                    ),
+                },
+                None => tracing::debug!(
+                    method = parsed.get("method").and_then(|m| m.as_str()),
+                    "Received notification but no handler is configured"
+                ),
+            }
             return Ok(());
         }
 

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -1780,3 +1780,142 @@ mod control_under_saturation {
         );
     }
 }
+
+// ============================================================================
+// Inbound notification routing (#1250)
+// ============================================================================
+
+mod inbound_notifications {
+    use super::*;
+    use tower_mcp::extract::RawArgs;
+
+    fn router_with_a_waiting_tool() -> McpRouter {
+        let wait = ToolBuilder::new("wait")
+            .description("Waits until cancelled")
+            .extractor_handler((), |ctx: Context, RawArgs(_): RawArgs| async move {
+                ctx.cancelled().await;
+                Ok(CallToolResult::text("cancelled"))
+            })
+            .build();
+        McpRouter::new()
+            .server_info("inbound-test", "0.0.0")
+            .tool(wait)
+    }
+
+    const INIT: &str = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}"#;
+    const CALL_WAIT: &str =
+        r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"wait","arguments":{}}}"#;
+    const CANCEL: &str =
+        r#"{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":2}}"#;
+
+    /// Drive a transport through initialize, a slow call, and a cancellation.
+    /// Returns the frames written back.
+    async fn cancel_a_running_call<F, Fut>(run: F) -> Vec<serde_json::Value>
+    where
+        F: FnOnce(tokio::io::DuplexStream, tokio::io::DuplexStream) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        tokio::spawn(run(server_stdin, server_stdout));
+
+        for line in [INIT, CALL_WAIT] {
+            stdin_writer.write_all(line.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+        }
+        stdin_writer.flush().await.unwrap();
+        // Let the call register before cancelling it.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        stdin_writer.write_all(CANCEL.as_bytes()).await.unwrap();
+        stdin_writer.write_all(b"\n").await.unwrap();
+        stdin_writer.flush().await.unwrap();
+
+        timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 2),
+        )
+        .await
+        .expect("the cancelled call must be answered")
+    }
+
+    /// #1250: applying ordinary tower middleware converted the transport to
+    /// the generic one, which had no router and dropped every inbound
+    /// notification. Adding a no-op layer silently broke cancellation.
+    #[tokio::test]
+    async fn cancellation_survives_a_middleware_layer() {
+        let frames = cancel_a_running_call(|stdin, stdout| async move {
+            let mut transport = StdioTransport::new(router_with_a_waiting_tool())
+                .layer(tower::layer::util::Identity::new());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+
+        let answer = frames
+            .iter()
+            .find(|f| f["id"] == 2)
+            .unwrap_or_else(|| panic!("no answer for the cancelled call: {frames:?}"));
+        assert_eq!(answer["result"]["content"][0]["text"], "cancelled");
+    }
+
+    /// The same guarantee without any outbound notification channel, which
+    /// is the configuration that previously forced a server to advertise
+    /// MCP logging just to receive cancellation.
+    #[tokio::test]
+    async fn cancellation_works_without_server_notifications() {
+        let frames = cancel_a_running_call(|stdin, stdout| async move {
+            let mut transport =
+                StdioTransport::without_server_notifications(router_with_a_waiting_tool());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+
+        let answer = frames
+            .iter()
+            .find(|f| f["id"] == 2)
+            .unwrap_or_else(|| panic!("no answer for the cancelled call: {frames:?}"));
+        assert_eq!(answer["result"]["content"][0]["text"], "cancelled");
+    }
+
+    /// Capability advertisement must reflect what the server actually offers,
+    /// not the mere fact that it wants to receive control messages.
+    #[tokio::test]
+    async fn declining_outbound_notifications_drops_the_logging_capability() {
+        async fn initialize_with(transport: impl FnOnce() -> StdioTransport) -> serde_json::Value {
+            let mut transport = transport();
+            let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+            let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+            tokio::spawn(async move {
+                transport
+                    .run_with_streams(server_stdin, server_stdout)
+                    .await
+            });
+            stdin_writer.write_all(INIT.as_bytes()).await.unwrap();
+            stdin_writer.write_all(b"\n").await.unwrap();
+            stdin_writer.flush().await.unwrap();
+            drop(stdin_writer);
+            read_n_frames(BufReader::new(server_stdout_reader), 1)
+                .await
+                .remove(0)
+        }
+
+        let with = initialize_with(|| StdioTransport::new(router_with_a_waiting_tool())).await;
+        assert!(
+            with["result"]["capabilities"]["logging"].is_object(),
+            "the default still advertises logging: {with}"
+        );
+        assert_eq!(with["result"]["capabilities"]["tools"]["listChanged"], true);
+
+        let without = initialize_with(|| {
+            StdioTransport::without_server_notifications(router_with_a_waiting_tool())
+        })
+        .await;
+        assert!(
+            without["result"]["capabilities"]["logging"].is_null(),
+            "logging must not be advertised when nothing can be sent: {without}"
+        );
+        assert_ne!(
+            without["result"]["capabilities"]["tools"]["listChanged"], true,
+            "listChanged must not be claimed either: {without}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1250. Same family as #1251: control traffic not reaching the handler that needs it.

## Middleware silently disabled cancellation

`StdioTransport::layer(...)` converts to `GenericStdioTransport`, which has no router and so dropped every inbound client notification:

```rust
if !parsed.is_array() && parsed.get("id").is_none() {
    // Notification - log and ignore since we don't have router access
    return Ok(());
}
```

Applying a no-op layer was enough to stop `notifications/cancelled` reaching an in-flight request. Adding middleware is not supposed to change protocol semantics.

`GenericStdioTransport` now carries an optional inbound notification handler. `layer()` installs one backed by a clone of the router it is converting from; clones share the in-flight request registry through an `Arc`, so cancellation routed through the clone reaches requests dispatched by the layered service. `route_notifications_to(router)` covers transports built directly from a service.

## Receiving cancellation forced advertising logging

`StdioTransport::new` installs an outbound notification sender, and `notification_tx.is_some()` is exactly what makes capability synthesis advertise MCP logging, while `has_notifications` sets `listChanged` on every catalog. So a server that logs to stderr or OTLP and deliberately does not expose MCP logging had no way to keep inbound `notifications/cancelled` without also claiming features it does not offer.

`StdioTransport::without_server_notifications(router)` routes inbound notifications exactly as `new` does, sends none, and advertises neither. `new` is unchanged.

One implementation note: it holds the unused sender rather than dropping it. A dropped sender makes the receiver return `None` on every poll, so the read loop would re-check a dead select branch each iteration. The field is `#[allow(dead_code)]` because its purpose is the sender's lifetime, not its value.

## Tests

Against the acceptance criteria:

- a slow in-flight handler observes cancellation **after a tower layer is applied**
- the same with `without_server_notifications`, i.e. with no outbound channel at all
- `initialize` advertises `logging` and `listChanged` under `new`, and neither under `without_server_notifications`

Verified the middleware test fails without the source change: it times out waiting for the cancelled call, and passes after. The other two exercise the new constructor and so cannot compile against the old code.

Full suite, clippy, `-Dmissing-docs`, and the 17-entry feature matrix are green.