### PR TITLE
test: keep examples on the public API surface

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -581,7 +581,14 @@ pub use context::{
     OutgoingRequestSender, RequestContext, RequestContextBuilder, ServerNotification,
     notification_channel, outgoing_request_channel,
 };
-pub use error::{BoxError, Error, Result, ResultExt, ToolError};
+// `JsonRpcError` is the type of `JsonRpcErrorResponse::error`, and every
+// other JSON-RPC message type is re-exported here, so leaving it out meant a
+// caller could build the response from the crate root but not name its one
+// field. `ErrorCode` and `McpErrorCode` are its constructor arguments and
+// come along for the same reason (#1258, same class as #1240).
+pub use error::{
+    BoxError, Error, ErrorCode, JsonRpcError, McpErrorCode, Result, ResultExt, ToolError,
+};
 pub use extension::{ExtensionDeclaration, NegotiatedExtension, NegotiatedExtensions};
 pub use filter::{
     CapabilityFilter, DenialBehavior, Filterable, PromptFilter, ResourceFilter, ToolFilter,

--- a/crates/tower-mcp/tests/example_imports.rs
+++ b/crates/tower-mcp/tests/example_imports.rs
@@ -1,0 +1,269 @@
+//! The examples must import from the crate root, so they double as a smoke
+//! test of the public API surface.
+//!
+//! #1240 was a missing `pub use` for `notification_channel`: every example
+//! reached it as `tower_mcp::context::notification_channel`, the internal
+//! path, so nothing ever exercised `tower_mcp::notification_channel` and the
+//! gap survived until a user hit it. An example that only names crate-root
+//! items fails to compile the day a re-export goes missing.
+//!
+//! Where an internal path is genuinely required, that is a signal the item
+//! wants re-exporting from `lib.rs` (#1258).
+
+use std::path::{Path, PathBuf};
+
+/// Modules an example may import from directly.
+///
+/// These are namespace modules: the crate's own README and `lib.rs` doc
+/// examples spell them as `tower_mcp::<module>::Item`, and their contents are
+/// deliberately not flattened into the crate root.
+///
+/// Adding an entry here is a decision that the module is part of the public
+/// namespace. The other option, and usually the right one, is to re-export
+/// the item from `lib.rs` and import it as `tower_mcp::Item`. The list covers
+/// what the examples currently need; a module missing from it is not
+/// necessarily private, it just has not had to be decided yet.
+const NAMESPACE_MODULES: &[&str] = &[
+    // Protocol and JSON-RPC types. Several hundred of them, and the crate
+    // root already re-exports the commonly used subset.
+    "protocol",
+    // Handler extractors: `Json`, `State`, `Context`, `Extension`, `RawArgs`.
+    "extract",
+    // Client API: `McpClient`, the client transports, the OAuth client flow.
+    "client",
+    // In-process test utilities, behind the `testing` feature.
+    "testing",
+    // API key and bearer authentication middleware, behind no feature.
+    "auth",
+    // OAuth 2.1 validators and metadata, behind the `oauth` feature.
+    "oauth",
+    // MCP proxy, behind the `proxy` feature.
+    "proxy",
+    // Pluggable storage for HTTP and WebSocket sessions and for SSE replay.
+    // Each defines its own `Error` and `Result<T>` pair, and a crate-root
+    // `Result` already means `Result<T, tower_mcp::Error>`, so these cannot be
+    // flattened without a collision.
+    "event_store",
+    "session_store",
+    // Long-form prose documentation. Contains no runtime items, so it can
+    // only ever be named in a doc link.
+    "guides",
+];
+
+#[test]
+fn examples_import_from_the_crate_root() {
+    let Some(examples) = examples_dir() else {
+        // The `examples/` tree lives outside this package, so it is absent
+        // from the published archive. Nothing to check there.
+        return;
+    };
+
+    let mut offenders = Vec::new();
+    for file in rust_sources(&examples) {
+        let source = std::fs::read_to_string(&file).expect("read example source");
+        let relative = file.strip_prefix(&examples).unwrap_or(&file).to_path_buf();
+        for (line, module) in module_segments(&source) {
+            if !NAMESPACE_MODULES.contains(&module.as_str()) {
+                offenders.push(format!(
+                    "  examples/{}:{line}: tower_mcp::{module}::",
+                    relative.display()
+                ));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "examples reached into internal module paths:\n{}\n\n\
+         An example should name `tower_mcp::Item`, not \
+         `tower_mcp::<module>::Item`. If the item is already re-exported from \
+         crates/tower-mcp/src/lib.rs, switch the example to the crate-root \
+         path. If it is not, the item probably wants re-exporting: add the \
+         `pub use` to lib.rs. Only if the module is a deliberate public \
+         namespace should it join NAMESPACE_MODULES at the top of this file, \
+         with a comment saying why.",
+        offenders.join("\n")
+    );
+}
+
+/// Repository `examples/` directory, if this checkout has one.
+fn examples_dir() -> Option<PathBuf> {
+    let dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../examples");
+    dir.is_dir().then(|| dir.canonicalize().unwrap_or(dir))
+}
+
+/// Every `.rs` file under `root`, including the example crates that are
+/// workspace members. Build output is skipped.
+fn rust_sources(root: &Path) -> Vec<PathBuf> {
+    let mut found = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        for entry in std::fs::read_dir(&dir)
+            .expect("read examples dir")
+            .flatten()
+        {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "target") {
+                    continue;
+                }
+                pending.push(path);
+            } else if path.extension().is_some_and(|ext| ext == "rs") {
+                found.push(path);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// Every `tower_mcp::<module>::` segment in `source`, with its line number.
+///
+/// Both spellings count: the plain `tower_mcp::context::RequestContext` and
+/// the braced `use tower_mcp::{context::notification_channel, McpRouter}`.
+/// Without the second, the exact import that hid #1240 could come back in a
+/// form the check does not see.
+fn module_segments(source: &str) -> Vec<(usize, String)> {
+    const PREFIX: &str = "tower_mcp::";
+
+    let mut segments = Vec::new();
+    let mut cursor = 0;
+    while let Some(offset) = source[cursor..].find(PREFIX) {
+        let start = cursor + offset;
+        cursor = start + PREFIX.len();
+
+        // `some_tower_mcp::x::y` would name a different crate.
+        if source[..start].chars().next_back().is_some_and(is_ident) {
+            continue;
+        }
+
+        let rest = &source[cursor..];
+        if let Some(group) = brace_group(rest) {
+            for (offset, module) in leading_modules(group) {
+                // +1 for the brace itself.
+                segments.push((line_of(source, cursor + 1 + offset), module));
+            }
+        } else if let Some(module) = leading_module(rest) {
+            segments.push((line_of(source, cursor), module));
+        }
+    }
+    segments
+}
+
+/// Contents of the balanced `{...}` starting at `s`, if `s` starts with one.
+fn brace_group(s: &str) -> Option<&str> {
+    if !s.starts_with('{') {
+        return None;
+    }
+    let mut depth = 0usize;
+    for (index, ch) in s.char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&s[1..index]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The module name at the head of `s`, when it is followed by `::`.
+///
+/// `tower_mcp::Content::text(..)` and `tower_mcp::Error::JsonRpc(..)` are
+/// crate-root items with an associated item hanging off them, not module
+/// paths, so a segment that does not start lowercase is not a module. That is
+/// Rust naming convention rather than a guarantee, and it is the only thing
+/// that separates the two forms without parsing the crate.
+fn leading_module(s: &str) -> Option<String> {
+    let end = s.find(|c: char| !is_ident(c))?;
+    let head = &s[..end];
+    let starts_lowercase = head.starts_with(|c: char| c.is_lowercase());
+    (starts_lowercase && s[end..].starts_with("::")).then(|| head.to_string())
+}
+
+/// Every `name::` at the head of a `use` group item, with its byte offset.
+///
+/// A group item starts at the group's beginning or just after a comma, which
+/// is what separates `{context::notification_channel}` (a module segment)
+/// from `{extract::{Json, State}}` (where `Json` heads an item but is not
+/// followed by `::`).
+fn leading_modules(group: &str) -> Vec<(usize, String)> {
+    let mut modules = Vec::new();
+    let mut at_item_start = true;
+    for (index, ch) in group.char_indices() {
+        match ch {
+            _ if ch.is_whitespace() => {}
+            ',' | '{' => at_item_start = true,
+            _ if at_item_start => {
+                at_item_start = false;
+                if let Some(module) = leading_module(&group[index..]) {
+                    modules.push((index, module));
+                }
+            }
+            _ => {}
+        }
+    }
+    modules
+}
+
+fn is_ident(c: char) -> bool {
+    c.is_alphanumeric() || c == '_'
+}
+
+/// One-based line number of `offset` in `source`.
+fn line_of(source: &str, offset: usize) -> usize {
+    source[..offset].lines().count().max(1)
+}
+
+mod parsing {
+    use super::*;
+
+    #[test]
+    fn a_plain_path_is_a_module_segment() {
+        let found = module_segments("use tower_mcp::context::RequestContext;");
+        assert_eq!(found, vec![(1, "context".to_string())]);
+    }
+
+    #[test]
+    fn a_crate_root_item_is_not() {
+        assert!(module_segments("use tower_mcp::McpRouter;").is_empty());
+        assert!(module_segments("use tower_mcp::{McpRouter, ToolBuilder};").is_empty());
+    }
+
+    /// The braced form is how the check could be sidestepped by accident.
+    #[test]
+    fn a_braced_path_is_a_module_segment() {
+        let found = module_segments("use tower_mcp::{McpRouter, context::notification_channel};");
+        assert_eq!(found, vec![(1, "context".to_string())]);
+    }
+
+    #[test]
+    fn a_nested_group_reports_only_the_module() {
+        let found = module_segments("use tower_mcp::{extract::{Json, State}, McpRouter};");
+        assert_eq!(found, vec![(1, "extract".to_string())]);
+    }
+
+    #[test]
+    fn another_crate_with_a_matching_suffix_is_ignored() {
+        assert!(module_segments("use my_tower_mcp::context::Thing;").is_empty());
+    }
+
+    #[test]
+    fn the_line_number_points_at_the_import() {
+        let found = module_segments("use std::io;\n\nuse tower_mcp::router::McpRouter;\n");
+        assert_eq!(found, vec![(3, "router".to_string())]);
+    }
+
+    /// A multi-line `use` should blame the line the module is on, not the
+    /// line `tower_mcp::` is on.
+    #[test]
+    fn a_multiline_group_blames_the_right_line() {
+        let found =
+            module_segments("use tower_mcp::{\n    McpRouter,\n    context::Extensions,\n};");
+        assert_eq!(found, vec![(3, "context".to_string())]);
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -118,6 +118,11 @@ name = "middleware"
 path = "middleware.rs"
 
 [[example]]
+name = "middleware_extension"
+path = "middleware_extension.rs"
+required-features = ["http"]
+
+[[example]]
 name = "rate_limiting"
 path = "rate_limiting.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,7 @@ cargo run -p tower-mcp-examples --example tool_macro --features macros
 | Example | What it shows |
 |---------|---------------|
 | [middleware](middleware.rs) | All four levels: transport, per-tool, per-resource, per-prompt, and guards |
+| [middleware_extension](middleware_extension.rs) | A layer resolves a per-request identity and a handler reads it, via `bridge_extension` |
 | [rate_limiting](rate_limiting.rs) | Per-tool rate limiting with tower-resilience |
 | [capability_filtering](capability_filtering.rs) | Session-based tool/resource/prompt visibility |
 | [tool_selection](tool_selection.rs) | Tool groups, safety tiers, allow/deny lists |

--- a/examples/conformance-client/src/core_scenarios.rs
+++ b/examples/conformance-client/src/core_scenarios.rs
@@ -492,7 +492,7 @@ mod handshake_retry_tests {
             attempts.fetch_add(1, Ordering::Relaxed);
             async move {
                 Err::<(), _>(tower_mcp::Error::JsonRpc(
-                    tower_mcp::error::JsonRpcError::invalid_request("bad handshake"),
+                    tower_mcp::JsonRpcError::invalid_request("bad handshake"),
                 ))
             }
         })

--- a/examples/conformance-client/src/handlers.rs
+++ b/examples/conformance-client/src/handlers.rs
@@ -1,9 +1,9 @@
 //! Client handlers for server-initiated requests (sampling, elicitation, roots).
 
 use std::collections::HashMap;
+use tower_mcp::JsonRpcError;
 use tower_mcp::client::ClientHandler;
 use tower_mcp::client::ServerNotification;
-use tower_mcp::error::JsonRpcError;
 use tower_mcp::protocol::*;
 
 /// Basic handler that does nothing special. Used for `initialize` and `sse-retry`.

--- a/examples/conformance-server/src/main.rs
+++ b/examples/conformance-server/src/main.rs
@@ -30,9 +30,10 @@ mod resources;
 mod tools;
 
 use clap::Parser;
-use tower_mcp::context::notification_channel;
 use tower_mcp::protocol::DeprecationInfo;
-use tower_mcp::{HttpTransport, McpRouter, RequestStateCodec, StdioTransport};
+use tower_mcp::{
+    HttpTransport, McpRouter, RequestStateCodec, StdioTransport, notification_channel,
+};
 
 #[derive(Parser)]
 #[command(name = "conformance-server")]

--- a/examples/dynamic_capabilities.rs
+++ b/examples/dynamic_capabilities.rs
@@ -20,11 +20,10 @@
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::context::notification_channel;
 use tower_mcp::extract::{Json, State};
 use tower_mcp::{
     CallToolResult, DynamicToolRegistry, JsonRpcRequest, JsonRpcService, McpRouter, PromptBuilder,
-    ResourceBuilder, ToolBuilder,
+    ResourceBuilder, ToolBuilder, notification_channel,
 };
 
 /// Input for the `create_tool` meta-tool.

--- a/examples/external_notifications.rs
+++ b/examples/external_notifications.rs
@@ -21,10 +21,7 @@
 
 use std::time::Duration;
 
-use tower_mcp::{
-    BoxError, HttpTransport, McpRouter,
-    context::{ServerNotification, notification_channel},
-};
+use tower_mcp::{BoxError, HttpTransport, McpRouter, ServerNotification, notification_channel};
 
 #[tokio::main]
 async fn main() -> Result<(), BoxError> {

--- a/examples/middleware_extension.rs
+++ b/examples/middleware_extension.rs
@@ -1,0 +1,173 @@
+//! Passing data from a tower layer to a tool handler.
+//!
+//! `middleware.rs` shows middleware *composing*: timeouts, concurrency limits,
+//! guards. This shows middleware *communicating*. A layer in front of the
+//! transport resolves something per request, and a handler reads it.
+//!
+//! The mechanism is [`HttpTransport::bridge_extension`]. Each transport builds
+//! a request's MCP extensions from scratch, so by default nothing a layer
+//! attached to the HTTP request is visible to a handler (#1242). Registering a
+//! type is what carries it across. Registration is per type rather than
+//! wholesale, so nothing reaches handler code that the server did not choose
+//! to expose.
+//!
+//! Three pieces, and all three are required:
+//!
+//! 1. A layer that inserts `T` into the HTTP request's extensions.
+//! 2. `.bridge_extension::<T>()` on the transport.
+//! 3. A handler that reads `T` back out.
+//!
+//! Run with: `cargo run --example middleware_extension --features http`
+//!
+//! ```bash
+//! # No API key: the layer attaches nothing, and `whoami` says so.
+//! curl -sX POST http://127.0.0.1:3000/ \
+//!   -H "Content-Type: application/json" -H "Accept: application/json" \
+//!   -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"whoami","arguments":{}}}'
+//!
+//! # With a key, the same call reports the caller the layer resolved.
+//! curl -sX POST http://127.0.0.1:3000/ \
+//!   -H "Content-Type: application/json" -H "Accept: application/json" \
+//!   -H "x-api-key: key-alice" \
+//!   -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"whoami","arguments":{}}}'
+//!
+//! # `admin_ping` requires an identity, so without a key it is rejected.
+//! curl -sX POST http://127.0.0.1:3000/ \
+//!   -H "Content-Type: application/json" -H "Accept: application/json" \
+//!   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"admin_ping","arguments":{}}}'
+//! ```
+//!
+//! `WebSocketTransport::bridge_extension` is the same call. There the value is
+//! read once from the HTTP request that opens the socket, so it applies to
+//! every request on that connection.
+
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use tower_mcp::extract::{Context, Extension};
+use tower_mcp::{BoxError, CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+/// What the layer resolves an API key into.
+///
+/// Any `Clone + Send + Sync + 'static` type works. Prefer a type you own:
+/// bridging is keyed on the type, so a newtype or a small struct is what makes
+/// the registration unambiguous. Registering `String` would be a request to
+/// bridge every `String` any layer happened to insert.
+#[derive(Debug, Clone)]
+struct Caller {
+    name: String,
+    admin: bool,
+}
+
+/// Stand-in for whatever a real server does here: a database lookup, a JWT
+/// signature check, a cache hit.
+fn lookup(api_key: &str) -> Option<Caller> {
+    match api_key {
+        "key-alice" => Some(Caller {
+            name: "alice".to_string(),
+            admin: true,
+        }),
+        "key-bob" => Some(Caller {
+            name: "bob".to_string(),
+            admin: false,
+        }),
+        _ => None,
+    }
+}
+
+/// Piece 1: the layer.
+///
+/// Anything an axum or tower middleware can do belongs here. This one maps a
+/// header to a caller and inserts it. That single `insert` is the whole layer
+/// side of the pattern.
+///
+/// A request with no usable key is passed through untagged rather than
+/// rejected. Rejecting is equally valid, and is what an auth layer would do:
+/// return a response instead of calling `next`. Passing it through is what
+/// makes the extension genuinely optional on the handler side, which is the
+/// more interesting case to demonstrate.
+async fn identify(mut request: Request, next: Next) -> Response {
+    let caller = request
+        .headers()
+        .get("x-api-key")
+        .and_then(|value| value.to_str().ok())
+        .and_then(lookup);
+
+    if let Some(caller) = caller {
+        request.extensions_mut().insert(caller);
+    }
+
+    next.run(request).await
+}
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    tracing_subscriber::fmt()
+        .with_env_filter("tower_mcp=info")
+        .init();
+
+    // Piece 3a: read the bridged value straight off the request context.
+    //
+    // `ctx.extension::<T>()` returns `Option`, so the handler decides what a
+    // missing value means. Use this when the tool has something sensible to do
+    // for an unidentified caller.
+    let whoami = ToolBuilder::new("whoami")
+        .description("Report the caller the layer identified, if any")
+        .read_only()
+        .extractor_handler((), |ctx: Context| async move {
+            Ok(CallToolResult::text(match ctx.extension::<Caller>() {
+                Some(caller) => format!("you are {} (admin: {})", caller.name, caller.admin),
+                None => "you are anonymous".to_string(),
+            }))
+        })
+        .build();
+
+    // Piece 3b: the same value through the `Extension<T>` extractor.
+    //
+    // This is the shorthand, and it is not merely shorter: a missing value is
+    // a rejection before the handler body runs, so a tool that cannot work
+    // without an identity never has to write the `None` arm.
+    let admin_ping = ToolBuilder::new("admin_ping")
+        .description("Requires an identified caller, and an admin one at that")
+        .read_only()
+        .extractor_handler((), |Extension(caller): Extension<Caller>| async move {
+            // The identity is a whole value, not just a name, so authorization
+            // reads off the same thing the layer resolved.
+            Ok(if caller.admin {
+                CallToolResult::text(format!("pong, {}", caller.name))
+            } else {
+                CallToolResult::error(format!("{} is not an admin", caller.name))
+            })
+        })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("middleware-extension-example", "1.0.0")
+        .auto_instructions()
+        .tool(whoami)
+        .tool(admin_ping);
+
+    // Piece 2: register the type.
+    //
+    // Without this line the server still runs, the layer still inserts a
+    // `Caller`, and every call reports "anonymous". That silent version is
+    // #1242 exactly, so it is worth trying: comment the line out and re-run
+    // the second curl above.
+    let transport = HttpTransport::new(router)
+        .bridge_extension::<Caller>()
+        // Local development only. In production name the origins you accept.
+        .disable_origin_validation();
+
+    // `into_router()` hands back a plain `axum::Router`, which is where the
+    // layer goes. It wraps the whole HTTP surface, so it sees every request
+    // before the transport decodes any MCP out of it.
+    let app = transport
+        .into_router()
+        .layer(axum::middleware::from_fn(identify));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:3000").await?;
+    tracing::info!("Listening on http://127.0.0.1:3000 -- try the curls in this file's header");
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/examples/mrtr_elicitation.rs
+++ b/examples/mrtr_elicitation.rs
@@ -28,12 +28,11 @@ use std::collections::BTreeMap;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::context::RequestContext;
 use tower_mcp::protocol::{
     ElicitFormParams, ElicitFormSchema, ElicitRequestParams, InputRequest, InputRequests,
     InputRequiredResult, RequestOutcome,
 };
-use tower_mcp::{CallToolResult, McpRouter, StdioTransport, ToolBuilder};
+use tower_mcp::{CallToolResult, McpRouter, RequestContext, StdioTransport, ToolBuilder};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct DeployInput {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -18,10 +18,9 @@
 use std::time::Duration;
 
 use tower::timeout::TimeoutLayer;
-use tower_mcp::GenericStdioTransport;
 use tower_mcp::client::StdioClientTransport;
-use tower_mcp::context::notification_channel;
 use tower_mcp::proxy::McpProxy;
+use tower_mcp::{GenericStdioTransport, notification_channel};
 
 #[tokio::main]
 async fn main() -> Result<(), tower_mcp::BoxError> {

--- a/examples/resource_templates.rs
+++ b/examples/resource_templates.rs
@@ -18,8 +18,7 @@
 use std::collections::HashMap;
 
 use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
-use tower_mcp::resource::ResourceTemplateBuilder;
-use tower_mcp::{BoxError, McpRouter, StdioTransport};
+use tower_mcp::{BoxError, McpRouter, ResourceTemplateBuilder, StdioTransport};
 
 #[tokio::main]
 async fn main() -> Result<(), BoxError> {

--- a/examples/sampling_server.rs
+++ b/examples/sampling_server.rs
@@ -16,13 +16,12 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, McpRouter, ToolBuilder,
+    BidirectionalStdioTransport, CallToolResult, McpRouter, ToolBuilder,
     extract::{Context, Json},
     protocol::{
         ContentRole, CreateMessageParams, ElicitAction, ElicitFormParams, ElicitFormSchema,
         SamplingContent, SamplingContentOrArray, SamplingMessage,
     },
-    transport::stdio::BidirectionalStdioTransport,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/examples/websocket_server.rs
+++ b/examples/websocket_server.rs
@@ -23,8 +23,7 @@ use std::time::Duration;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::timeout::TimeoutLayer;
-use tower_mcp::transport::WebSocketTransport;
-use tower_mcp::{CallToolResult, McpRouter, ResourceBuilder, ToolBuilder};
+use tower_mcp::{CallToolResult, McpRouter, ResourceBuilder, ToolBuilder, WebSocketTransport};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct EchoInput {


### PR DESCRIPTION
Axes 2 and 3 of #1258.

## Why

Two of the blind spots in the #1258 retrospective share a root: the examples are the only thing in this repository that exercises the public API the way a user writes it, and they were not doing that job.

- **Axis 2**: every example reached past the crate root. `use tower_mcp::context::notification_channel` compiles whether or not `lib.rs` re-exports it, so `tower_mcp::notification_channel` was broken for the entire life of #1240 with nothing to notice.
- **Axis 3**: no example showed a tower layer handing data to a handler, which is the shape #1242 was about.

## Public API gaps found

`JsonRpcError` was not re-exported from the crate root. Every other JSON-RPC message type is (`JsonRpcErrorResponse`, `JsonRpcRequest`, `JsonRpcResponse`, and the rest), and `JsonRpcError` is the type of `JsonRpcErrorResponse::error`, so a caller could build the response from the crate root but could not name its one field. `ErrorCode` and `McpErrorCode` are its constructor arguments and were missing for the same reason. All three are now re-exported. This is the same class of gap as #1240 and it survived the same way: the conformance client used `tower_mcp::error::JsonRpcError`, the internal path, so nothing ever tried the crate-root spelling.

## Internal paths found and fixed

| Example | Was | Now |
|---|---|---|
| `dynamic_capabilities.rs` | `context::notification_channel` | crate root |
| `proxy.rs` | `context::notification_channel` | crate root |
| `conformance-server/src/main.rs` | `context::notification_channel` | crate root |
| `external_notifications.rs` | `context::{ServerNotification, notification_channel}` | crate root |
| `mrtr_elicitation.rs` | `context::RequestContext` | crate root |
| `resource_templates.rs` | `resource::ResourceTemplateBuilder` | crate root |
| `websocket_server.rs` | `transport::WebSocketTransport` | crate root |
| `sampling_server.rs` | `transport::stdio::BidirectionalStdioTransport` | crate root |
| `conformance-client/src/handlers.rs` | `error::JsonRpcError` | crate root, after the re-export above |
| `conformance-client/src/core_scenarios.rs` | `error::JsonRpcError` | crate root, after the re-export above |

Four of those were written as `use tower_mcp::{McpRouter, context::notification_channel}`. A line-oriented grep for `tower_mcp::context::` does not see that form, which is part of why they lasted. `external_notifications.rs` is the file #1258 cites as evidence for #1240, and it was hiding in exactly this way.

## The check

`crates/tower-mcp/tests/example_imports.rs` walks every `.rs` file under `examples/`, including the workspace-member example crates, and fails on any `tower_mcp::<module>::` path whose module is not on an explicit list. It reads the braced form as well as the plain one, skips `Type::assoc_item` paths by the lowercase-module convention, and its failure message states the three ways to resolve a hit, in order of how often each is right.

Modules on the allowed list, each with a comment saying why:

- `protocol`, `extract`, `client`, `testing` -- established namespaces the README and `lib.rs` doc examples already spell this way.
- `auth`, `oauth`, `proxy`, `guides` -- feature-gated or docs-only namespaces with nothing re-exported at the crate root, so the module path is the only spelling.
- `event_store`, `session_store` -- each defines its own `Error` and `Result<T>` pair, and a crate-root `Result` already means `Result<T, tower_mcp::Error>`. They cannot be flattened without a collision.

The last three rows are a judgment call rather than a gap, and the comment in the file says so. Note the asymmetry it exposes: `async_task::{TaskStore, MemoryTaskStore}` is re-exported at the crate root while `event_store::EventStore` and `session_store::SessionStore` are not. Worth settling separately; this PR does not change it.

## The example

`examples/middleware_extension.rs`, registered with `required-features = ["http"]`. It walks the three pieces of the pattern and labels them:

1. An axum layer that maps an `x-api-key` header to a `Caller`.
2. `HttpTransport::bridge_extension::<Caller>()`.
3. Two handlers: `whoami` reads it with `ctx.extension::<Caller>()` and handles `None`; `admin_ping` takes `Extension<Caller>` so a missing identity is a rejection before the body runs.

The comment on piece 2 says what the server does when that line is absent -- it runs, the layer still inserts, and every call reports anonymous -- because that silent version is #1242. The four curls in the file header were run against the built example and produce the documented output.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features` (zero warnings), `cargo test --workspace --all-features`, `cargo build -p tower-mcp-examples --examples --all-features`, plus the conformance-server and codegen-mcp manifests.

The check was verified to fail on a reintroduced internal path, in both the plain and braced spellings, before being reverted.