### PR TITLE
docs: worked examples for resources and prompts

### DIFF
--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -1,46 +1,73 @@
-//! Prompt definition and builder API
+//! Prompts: named message templates a user invokes
 //!
-//! Provides ergonomic ways to define MCP prompts:
+//! A prompt is a named generator of chat messages that the user picks
+//! deliberately, unlike a tool, which the model calls. `prompts/list`
+//! advertises the name, description, and arguments; `prompts/get` passes the
+//! supplied arguments to the handler and returns the messages it built.
 //!
-//! 1. **Builder pattern** - Fluent API for defining prompts
-//! 2. **Trait-based** - Implement `McpPrompt` for full control
-//! 3. **Per-prompt middleware** - Apply tower middleware layers to individual prompts
+//! Build one with [`PromptBuilder`], or write it as a type by implementing
+//! [`McpPrompt`], then register it with
+//! [`McpRouter::prompt`](crate::McpRouter::prompt).
 //!
-//! # Per-Prompt Middleware
+//! # Arguments are strings, and nothing checks them
 //!
-//! The `.layer()` method on `PromptBuilder` (after `.handler()`) allows applying
-//! tower middleware to a single prompt. This is useful for prompt-specific concerns
-//! like timeouts, rate limiting, or caching.
+//! Arguments arrive as a `HashMap<String, String>` because the protocol
+//! carries them that way, so a numeric argument is a string the handler
+//! parses. [`PromptBuilder::required_arg`] and [`PromptBuilder::optional_arg`]
+//! describe arguments to clients and nothing more: the router does not reject
+//! a `prompts/get` that omits a required argument, and a handler that assumes
+//! one is present is a handler that can be made to panic by a client. Read
+//! them with `get`, not by indexing.
+//!
+//! # Handler forms
+//!
+//! | builder call | what the handler receives |
+//! |---|---|
+//! | [`PromptBuilder::handler`] | the arguments |
+//! | [`PromptBuilder::handler_with_context`] | a [`RequestContext`] and the arguments |
+//! | [`PromptBuilder::static_prompt`], [`PromptBuilder::user_message`] | no handler at all |
+//!
+//! With the `stateless` feature, `mrtr_handler` accepts a handler that can
+//! suspend and ask the client for more input (SEP-2322).
+//!
+//! # Adding a layer changes what a handler error means
+//!
+//! Without middleware, an `Err` from the handler propagates and the router
+//! reports a JSON-RPC error. Add `.layer()` and the handler becomes a Tower
+//! service, whose errors have to be caught for the stack to compose, so the
+//! same `Err` (and any middleware error, such as a timeout) comes back as a
+//! successful `prompts/get` whose assistant message carries the error text:
 //!
 //! ```rust
 //! use std::collections::HashMap;
 //! use std::time::Duration;
 //! use tower::timeout::TimeoutLayer;
+//! use tower_mcp::error::Error;
 //! use tower_mcp::prompt::PromptBuilder;
-//! use tower_mcp::protocol::{GetPromptResult, PromptMessage, PromptRole, Content};
 //!
-//! let prompt = PromptBuilder::new("slow_prompt")
-//!     .description("A prompt that might take a while")
-//!     .handler(|args: HashMap<String, String>| async move {
-//!         // Slow prompt generation logic...
-//!         Ok(GetPromptResult {
-//!             description: Some("Generated prompt".to_string()),
-//!             messages: vec![PromptMessage {
-//!                 role: PromptRole::User,
-//!                 content: Content::Text {
-//!                     text: "Hello!".to_string(),
-//!                     annotations: None,
-//!                     meta: None,
-//!                 },
-//!                 meta: None,
-//!             }],
-//!             meta: None,
-//!         })
+//! # tokio_test::block_on(async {
+//! let plain = PromptBuilder::new("plain")
+//!     .handler(|_: HashMap<String, String>| async {
+//!         Err(Error::internal("template store is offline"))
+//!     })
+//!     .build();
+//! assert!(plain.get(HashMap::new()).await.is_err());
+//!
+//! let layered = PromptBuilder::new("layered")
+//!     .handler(|_: HashMap<String, String>| async {
+//!         Err(Error::internal("template store is offline"))
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(5)));
 //!
-//! assert_eq!(prompt.name, "slow_prompt");
+//! let result = layered.get(HashMap::new()).await.unwrap();
+//! let text = result.first_message_text().unwrap();
+//! assert!(text.contains("template store is offline"), "{text}");
+//! # });
 //! ```
+//!
+//! Per-prompt middleware is the place for a bound that only one prompt needs,
+//! such as a timeout on a prompt that reads from a network template store.
+//! Layering the whole router covers everything else.
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -71,10 +98,11 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 // Per-Prompt Middleware Types
 // =============================================================================
 
-/// Request type for prompt middleware.
+/// What a layer applied with `.layer()` sees for one `prompts/get`.
 ///
-/// Contains the request context and prompt arguments, allowing middleware
-/// to access and modify the request before it reaches the prompt handler.
+/// Middleware runs on this rather than on the handler's arguments, so a layer
+/// can read or rewrite the arguments, and reach the request context, without
+/// knowing anything about the handler behind it.
 #[derive(Debug, Clone)]
 pub struct PromptRequest {
     /// The request context with progress reporting, cancellation, etc.
@@ -89,7 +117,11 @@ impl PromptRequest {
         Self { context, arguments }
     }
 
-    /// Create a prompt request with a default context (for testing or simple use cases).
+    /// Create a request carrying a placeholder context.
+    ///
+    /// The context reports request id `0`, has no notification channel, and is
+    /// never cancelled, which is what a test or an isolated layer needs and
+    /// not what a real request carries.
     pub fn with_arguments(arguments: HashMap<String, String>) -> Self {
         Self {
             context: RequestContext::new(RequestId::Number(0)),
@@ -370,7 +402,12 @@ where
     }
 }
 
-/// Prompt handler trait - the core abstraction for prompt generation
+/// The shape a prompt handler is adapted to internally.
+///
+/// [`PromptBuilder`] wraps closures, and layered services, in an
+/// implementation of this trait, and the router drives every prompt through
+/// it. No public constructor accepts an implementation, so a prompt written as
+/// a type rather than a closure implements [`McpPrompt`] instead.
 pub trait PromptHandler: Send + Sync {
     /// Get the prompt with the given arguments
     fn get(&self, arguments: HashMap<String, String>) -> BoxFuture<'_, Result<GetPromptResult>>;
@@ -405,7 +442,12 @@ pub trait MrtrPromptHandler: Send + Sync {
     ) -> BoxFuture<'_, Result<RequestOutcome<GetPromptResult>>>;
 }
 
-/// A complete prompt definition with handler
+/// A prompt that is ready to register.
+///
+/// Produced by [`PromptBuilder`] or [`McpPrompt::into_prompt`] and consumed by
+/// [`McpRouter::prompt`](crate::McpRouter::prompt). The public fields are
+/// exactly what `prompts/list` advertises; the handler behind them is private,
+/// so a prompt is cheap to clone and to share between routers.
 pub struct Prompt {
     /// The prompt name (must be unique within the router).
     pub name: String,
@@ -455,7 +497,7 @@ impl Prompt {
         PromptBuilder::new(name)
     }
 
-    /// Get the prompt definition for prompts/list
+    /// The entry this prompt contributes to `prompts/list`.
     pub fn definition(&self) -> PromptDefinition {
         PromptDefinition {
             name: self.name.clone(),
@@ -467,7 +509,16 @@ impl Prompt {
         }
     }
 
-    /// Get the prompt with arguments
+    /// Generate the messages for these arguments.
+    ///
+    /// A handler registered through [`PromptBuilder::handler_with_context`]
+    /// still runs, but against a placeholder context, so progress reporting
+    /// and cancellation are inert. The router calls
+    /// [`get_with_context`](Self::get_with_context) instead.
+    ///
+    /// Whether a handler error arrives as `Err` or as an assistant message
+    /// depends on whether the prompt carries middleware; see the [module
+    /// documentation](crate::prompt).
     pub fn get(
         &self,
         arguments: HashMap<String, String>,
@@ -482,9 +533,15 @@ impl Prompt {
         }
     }
 
-    /// Get the prompt with request context
+    /// Generate the messages with the context the transport built.
     ///
-    /// Use this when you have a RequestContext available for progress/cancellation.
+    /// This is the path the router takes. The context carries the request id,
+    /// progress reporting, the cancellation token, and the client requester
+    /// used for sampling and elicitation.
+    ///
+    /// A prompt registered with `mrtr_handler` has no plain handler to call
+    /// and reports that as an error here; use
+    /// [`get_outcome_with_context`](Self::get_outcome_with_context).
     pub fn get_with_context(
         &self,
         ctx: RequestContext,
@@ -500,7 +557,12 @@ impl Prompt {
         }
     }
 
-    /// Get the prompt while preserving an SEP-2322 input-required outcome.
+    /// Generate the messages while preserving an SEP-2322 continuation.
+    ///
+    /// The router calls this so a handler that needs more input from the
+    /// client can say so, rather than having the request fail or return
+    /// half-built messages. A prompt without an MRTR handler answers here
+    /// too, always with a completed result.
     pub fn get_outcome_with_context(
         &self,
         ctx: RequestContext,
@@ -525,7 +587,11 @@ impl Prompt {
         }
     }
 
-    /// Returns true if this prompt uses context
+    /// Whether the handler was registered in a context-aware form.
+    ///
+    /// An MRTR prompt reports `true` as well, since a continuation is only
+    /// reachable through the context. The router does not branch on this; it
+    /// is here for code that drives prompts directly.
     pub fn uses_context(&self) -> bool {
         self.handler
             .as_ref()
@@ -537,36 +603,41 @@ impl Prompt {
 // Builder API
 // =============================================================================
 
-/// Builder for creating prompts with a fluent API
+/// Builder for a prompt.
+///
+/// The name is the identity clients call by and must be unique in the router.
+/// Declare the arguments so a client knows what to collect, attach a handler,
+/// and finish with `.build()`. For a prompt with no logic behind it, end the
+/// chain at [`user_message`](Self::user_message) or
+/// [`static_prompt`](Self::static_prompt) instead.
 ///
 /// # Example
 ///
 /// ```rust
+/// use std::collections::HashMap;
 /// use tower_mcp::prompt::PromptBuilder;
-/// use tower_mcp::protocol::{GetPromptResult, PromptMessage, PromptRole, Content};
+/// use tower_mcp::protocol::GetPromptResult;
 ///
+/// # tokio_test::block_on(async {
 /// let prompt = PromptBuilder::new("greet")
 ///     .description("Generate a greeting")
 ///     .required_arg("name", "The name to greet")
-///     .handler(|args| async move {
-///         let name = args.get("name").map(|s| s.as_str()).unwrap_or("World");
-///         Ok(GetPromptResult {
-///             description: Some("A greeting prompt".to_string()),
-///             messages: vec![PromptMessage {
-///                 role: PromptRole::User,
-///                 content: Content::Text {
-///                     text: format!("Please greet {}", name),
-///                     annotations: None,
-///                     meta: None,
-///                 },
-///                 meta: None,
-///             }],
-///             meta: None,
-///         })
+///     .handler(|args: HashMap<String, String>| async move {
+///         // Required arguments are advertised, not enforced, so read
+///         // defensively rather than indexing.
+///         let name = args.get("name").map(String::as_str).unwrap_or("World");
+///         Ok(GetPromptResult::user_message_with_description(
+///             format!("Please greet {name}"),
+///             "A greeting prompt",
+///         ))
 ///     })
 ///     .build();
 ///
 /// assert_eq!(prompt.name, "greet");
+///
+/// let result = prompt.get(HashMap::new()).await.unwrap();
+/// assert_eq!(result.first_message_text(), Some("Please greet World"));
+/// # });
 /// ```
 pub struct PromptBuilder {
     name: String,
@@ -627,7 +698,11 @@ impl PromptBuilder {
         self
     }
 
-    /// Add a required argument
+    /// Declare an argument clients are expected to supply.
+    ///
+    /// This is advertisement, not validation. The argument appears in
+    /// `prompts/list` so a client can collect it, and a `prompts/get` that
+    /// omits it still reaches the handler, so the handler needs a fallback.
     pub fn required_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
         self.arguments.push(PromptArgument {
             name: name.into(),
@@ -637,7 +712,10 @@ impl PromptBuilder {
         self
     }
 
-    /// Add an optional argument
+    /// Declare an argument clients may supply.
+    ///
+    /// The only difference from [`required_arg`](Self::required_arg) is the
+    /// flag clients see, since neither is enforced server-side.
     pub fn optional_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
         self.arguments.push(PromptArgument {
             name: name.into(),
@@ -647,16 +725,21 @@ impl PromptBuilder {
         self
     }
 
-    /// Add an argument with full control
+    /// Add an argument that was built elsewhere.
+    ///
+    /// For argument metadata that comes from a schema, a manifest, or another
+    /// prompt, rather than from a literal in the builder chain.
     pub fn argument(mut self, arg: PromptArgument) -> Self {
         self.arguments.push(arg);
         self
     }
 
-    /// Set the handler function for getting the prompt.
+    /// Set the handler that builds the messages.
     ///
-    /// Returns a `PromptBuilderWithHandler` which can be finalized with `.build()`
-    /// or have middleware applied with `.layer()`.
+    /// The handler is called with whatever arguments the client sent, as
+    /// strings, with no entry at all for the ones it left out. Finish with
+    /// `.build()`, or apply middleware with `.layer()` first, remembering that
+    /// a layer turns handler errors into prompt content.
     ///
     /// # Sharing State
     ///
@@ -715,10 +798,46 @@ impl PromptBuilder {
         }
     }
 
-    /// Set a context-aware handler function for getting the prompt
+    /// Set a handler that receives the [`RequestContext`] with the arguments.
     ///
-    /// The handler receives a `RequestContext` for progress reporting and
-    /// cancellation checking, along with the prompt arguments.
+    /// Worth the extra parameter when assembling the messages is expensive
+    /// enough to report progress against or to abandon on cancellation, or
+    /// when the prompt needs something from the client. Otherwise use
+    /// [`handler`](Self::handler).
+    ///
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::context::RequestContext;
+    /// use tower_mcp::error::Error;
+    /// use tower_mcp::prompt::PromptBuilder;
+    /// use tower_mcp::protocol::GetPromptResult;
+    ///
+    /// let prompt = PromptBuilder::new("summarize_changes")
+    ///     .description("Summarize the changed files")
+    ///     .handler_with_context(
+    ///         |ctx: RequestContext, _args: HashMap<String, String>| async move {
+    ///             let files = ["src/lib.rs", "src/router.rs"];
+    ///             let mut body = String::new();
+    ///             for (index, file) in files.iter().enumerate() {
+    ///                 if ctx.is_cancelled() {
+    ///                     return Err(Error::internal("cancelled while reading files"));
+    ///                 }
+    ///                 ctx.report_progress(index as f64, Some(files.len() as f64), Some(file))
+    ///                     .await;
+    ///                 body.push_str(file);
+    ///                 body.push('\n');
+    ///             }
+    ///             Ok(GetPromptResult::user_message(format!("Summarize:\n{body}")))
+    ///         },
+    ///     )
+    ///     .build();
+    ///
+    /// # tokio_test::block_on(async {
+    /// let result = prompt.get(HashMap::new()).await.unwrap();
+    /// let text = result.first_message_text().unwrap();
+    /// assert!(text.contains("src/router.rs"), "{text}");
+    /// # });
+    /// ```
     pub fn handler_with_context<F, Fut>(self, handler: F) -> PromptBuilderWithContextHandler<F>
     where
         F: Fn(RequestContext, HashMap<String, String>) -> Fut + Send + Sync + Clone + 'static,
@@ -751,7 +870,41 @@ impl PromptBuilder {
         }
     }
 
-    /// Create a static prompt (no arguments needed)
+    /// Finish the builder with a fixed list of messages.
+    ///
+    /// Arguments are ignored, so this is for a prompt that is the same every
+    /// time: a checklist, a house style, a standing instruction. The
+    /// description set on the builder is carried into every result.
+    ///
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::prompt::PromptBuilder;
+    /// use tower_mcp::protocol::{Content, PromptMessage, PromptRole};
+    ///
+    /// # tokio_test::block_on(async {
+    /// let prompt = PromptBuilder::new("review_checklist")
+    ///     .description("The standing review checklist")
+    ///     .static_prompt(vec![
+    ///         PromptMessage {
+    ///             role: PromptRole::Assistant,
+    ///             content: Content::text("I check correctness before style."),
+    ///             meta: None,
+    ///         },
+    ///         PromptMessage {
+    ///             role: PromptRole::User,
+    ///             content: Content::text("Review the diff."),
+    ///             meta: None,
+    ///         },
+    ///     ]);
+    ///
+    /// let result = prompt.get(HashMap::new()).await.unwrap();
+    /// assert_eq!(result.messages.len(), 2);
+    /// assert_eq!(
+    ///     result.description.as_deref(),
+    ///     Some("The standing review checklist")
+    /// );
+    /// # });
+    /// ```
     pub fn static_prompt(self, messages: Vec<PromptMessage>) -> Prompt {
         let description = self.description.clone();
         self.handler(move |_| {
@@ -768,7 +921,24 @@ impl PromptBuilder {
         .build()
     }
 
-    /// Create a simple text prompt with a user message
+    /// Finish the builder with one user message.
+    ///
+    /// The shortest complete prompt there is, and the shape most prompts that
+    /// only seed a conversation want.
+    ///
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::prompt::PromptBuilder;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let prompt = PromptBuilder::new("help")
+    ///     .description("Ask the user what they need")
+    ///     .user_message("How can I help you today?");
+    ///
+    /// let result = prompt.get(HashMap::new()).await.unwrap();
+    /// assert_eq!(result.first_message_text(), Some("How can I help you today?"));
+    /// # });
+    /// ```
     pub fn user_message(self, text: impl Into<String>) -> Prompt {
         let text = text.into();
         self.static_prompt(vec![PromptMessage {
@@ -782,10 +952,13 @@ impl PromptBuilder {
         }])
     }
 
-    /// Finalize the builder into a Prompt
+    /// Attach a handler and finish, in one call.
     ///
-    /// This is an alias for `handler(...).build()` for when you want to
-    /// explicitly mark the build step.
+    /// `PromptBuilder::build(handler)` and `handler(handler).build()` produce
+    /// the same prompt. Note that the argument-less `.build()` seen in most
+    /// examples belongs to the builder [`handler`](Self::handler) returns, not
+    /// to this type, so only this form takes the handler as a parameter, and
+    /// only the other form can be preceded by `.layer()`.
     pub fn build<F, Fut>(self, handler: F) -> Prompt
     where
         F: Fn(HashMap<String, String>) -> Fut + Send + Sync + Clone + 'static,

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -648,7 +648,12 @@ pub struct PromptBuilder {
 }
 
 impl PromptBuilder {
-    /// Create a new prompt builder with the given name.
+    /// Start a prompt with this name.
+    ///
+    /// The name is the key the router registers under, so registering a second
+    /// prompt with the same name replaces the first rather than failing.
+    /// [`McpRouter::try_merge`](crate::McpRouter::try_merge) reports that
+    /// collision when composing routers.
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
@@ -659,7 +664,10 @@ impl PromptBuilder {
         }
     }
 
-    /// Set a human-readable title for the prompt
+    /// Set the display title, which a client prefers over the name.
+    ///
+    /// Worth setting when the name has to stay stable for other reasons and
+    /// is not what a person should read.
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -1360,10 +1368,13 @@ impl PromptHandler for ServiceContextHandler {
 // Trait-based prompt definition
 // =============================================================================
 
-/// Trait for defining prompts with full control
+/// Define a prompt as a type rather than a closure.
 ///
-/// Implement this trait when you need more control than the builder provides,
-/// or when you want to define prompts as standalone types.
+/// The name and description are associated constants and the arguments come
+/// from a method, so a prompt with state holds it in `self` rather than in an
+/// `Arc` captured by a closure. Finish with
+/// [`into_prompt`](Self::into_prompt), which produces the same [`Prompt`] the
+/// builder does.
 ///
 /// # Example
 ///

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -15,9 +15,9 @@
 //! carries them that way, so a numeric argument is a string the handler
 //! parses. [`PromptBuilder::required_arg`] and [`PromptBuilder::optional_arg`]
 //! describe arguments to clients and nothing more: the router does not reject
-//! a `prompts/get` that omits a required argument, and a handler that assumes
-//! one is present is a handler that can be made to panic by a client. Read
-//! them with `get`, not by indexing.
+//! a `prompts/get` that omits a required argument, so a handler that indexes
+//! the map can be panicked by a client. Read arguments with `get` and supply
+//! a default.
 //!
 //! # Handler forms
 //!

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -1892,8 +1892,8 @@ impl ResourceTemplate {
 
     /// The entry this template contributes to `resources/templates/list`.
     ///
-    /// Clients discover the pattern itself and expand it themselves, so the
-    /// declared variables are not repeated as `arguments`.
+    /// It advertises the pattern, not the variables: `arguments` is left
+    /// empty, and a client expands the pattern itself.
     pub fn definition(&self) -> ResourceTemplateDefinition {
         ResourceTemplateDefinition {
             uri_template: self.uri_template.clone(),

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -827,7 +827,12 @@ pub struct ResourceBuilder {
 }
 
 impl ResourceBuilder {
-    /// Create a new resource builder with the given URI.
+    /// Start a resource at this URI.
+    ///
+    /// The URI is the key the router registers under, so registering a second
+    /// resource with the same URI replaces the first rather than failing.
+    /// [`McpRouter::try_merge`](crate::McpRouter::try_merge) is the way to
+    /// find that out instead of discovering it in production.
     pub fn new(uri: impl Into<String>) -> Self {
         Self {
             uri: uri.into(),
@@ -841,13 +846,19 @@ impl ResourceBuilder {
         }
     }
 
-    /// Set the resource name (human-readable)
+    /// Set the name clients list this resource under.
+    ///
+    /// Defaults to the URI when unset, which is legal and unhelpful in a
+    /// picker.
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
-    /// Set a human-readable title for the resource
+    /// Set the display title, which a client prefers over the name.
+    ///
+    /// Worth setting when the name has to stay stable for other reasons and
+    /// is not what a person should read.
     pub fn title(mut self, title: impl Into<String>) -> Self {
         self.title = Some(title.into());
         self
@@ -859,7 +870,13 @@ impl ResourceBuilder {
         self
     }
 
-    /// Set the MIME type of the resource
+    /// Declare the MIME type in `resources/list`.
+    ///
+    /// A handler sets the type on each content item it returns, and nothing
+    /// reconciles the two, so a resource that declares one type and returns
+    /// another is simply lying to clients. [`text`](Self::text) and
+    /// [`json`](Self::json) cannot drift this way because they build the
+    /// content themselves.
     pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
         self.mime_type = Some(mime_type.into());
         self
@@ -892,7 +909,9 @@ impl ResourceBuilder {
         self
     }
 
-    /// Set the size of the resource in bytes
+    /// Advertise a size in bytes, so a client can decide before reading.
+    ///
+    /// A hint only: nothing compares it with what the handler returns.
     pub fn size(mut self, size: u64) -> Self {
         self.size = Some(size);
         self
@@ -1642,10 +1661,14 @@ where
 // Trait-based resource definition
 // =============================================================================
 
-/// Trait for defining resources with full control
+/// Define a resource as a type rather than a closure.
 ///
-/// Implement this trait when you need more control than the builder provides,
-/// or when you want to define resources as standalone types.
+/// The URI, name, description, and MIME type are associated constants, so they
+/// are decided at compile time and the type owns whatever state the read needs.
+/// A resource whose identity is only known at runtime belongs in
+/// [`ResourceBuilder`] instead. Finish with
+/// [`into_resource`](Self::into_resource), which produces the same [`Resource`]
+/// the builder does.
 ///
 /// # Example
 ///

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -31,9 +31,10 @@
 //! | [`ResourceTemplateBuilder::handler`] | the request URI and the extracted variables |
 //!
 //! Each returns a [`ReadResourceResult`]. For content already in memory,
-//! [`ResourceBuilder::text`] and [`ResourceBuilder::json`] skip the handler
-//! entirely. With the `stateless` feature, `mrtr_handler` accepts a handler
-//! that can suspend and ask the client for more input (SEP-2322).
+//! [`ResourceBuilder::text`] and [`ResourceBuilder::json`] finish the builder
+//! without a handler at all. With the `stateless` feature, `mrtr_handler`
+//! accepts a handler that can suspend and ask the client for more input
+//! (SEP-2322).
 //!
 //! # A failing resource handler is not a failed request
 //!

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -1,71 +1,100 @@
-//! Resource definition and builder API
+//! Resources: one fixed URI, or a URI template that routes
 //!
-//! Provides ergonomic ways to define MCP resources:
+//! A resource is content a client reads by URI. Which of the two kinds you
+//! build depends on whether the URI is known before the request arrives:
 //!
-//! 1. **Builder pattern** - Fluent API for defining resources
-//! 2. **Trait-based** - Implement `McpResource` for full control
-//! 3. **Resource templates** - Parameterized resources using URI templates (RFC 6570)
+//! - [`Resource`], built with [`ResourceBuilder`], answers for exactly one
+//!   URI and appears in `resources/list`.
+//! - [`ResourceTemplate`], built with [`ResourceTemplateBuilder`], answers for
+//!   a family of URIs described by an RFC 6570 template, appears in
+//!   `resources/templates/list`, and hands its handler the variables it
+//!   extracted from the request URI.
 //!
-//! ## Per-Resource Middleware
+//! A resource can also be written as a type rather than a closure by
+//! implementing [`McpResource`].
 //!
-//! Resources are implemented as Tower services internally, enabling middleware
-//! composition via the `.layer()` method:
+//! # How a read finds its handler
+//!
+//! [`McpRouter`](crate::McpRouter) answers `resources/read` by trying an exact
+//! URI match against the registered resources first, then each registered
+//! template in registration order, stopping at the first template that
+//! matches. Registration order is the only tie-break, so register the narrower
+//! pattern first: `db://users/{id}` before `db://{+rest}`, or the second one
+//! swallows every read and the first never runs.
+//!
+//! # Handler forms
+//!
+//! | builder call | what the handler receives |
+//! |---|---|
+//! | [`ResourceBuilder::handler`] | nothing |
+//! | [`ResourceBuilder::handler_with_context`] | a [`RequestContext`] for progress, cancellation, and client requests |
+//! | [`ResourceTemplateBuilder::handler`] | the request URI and the extracted variables |
+//!
+//! Each returns a [`ReadResourceResult`]. For content already in memory,
+//! [`ResourceBuilder::text`] and [`ResourceBuilder::json`] skip the handler
+//! entirely. With the `stateless` feature, `mrtr_handler` accepts a handler
+//! that can suspend and ask the client for more input (SEP-2322).
+//!
+//! # A failing resource handler is not a failed request
+//!
+//! Every [`Resource`] handler is wrapped in an error-catching service, because
+//! a Tower stack composes only when the inner service cannot fail. An `Err`
+//! from the handler, or from middleware such as a timeout, therefore reaches
+//! the client as a successful read whose text is the error message, not as a
+//! JSON-RPC error. [`ResourceTemplate`] handlers are not wrapped: their errors
+//! propagate and the router reports them as JSON-RPC errors. See
+//! [`Resource::read`] for a worked example of the difference.
+//!
+//! # Per-resource middleware
+//!
+//! Resources are Tower services internally, so any layer composes onto a
+//! single resource through `.layer()`. This is the per-resource counterpart to
+//! layering the whole router, and the place to put a bound that only one
+//! expensive resource needs:
 //!
 //! ```rust
 //! use std::time::Duration;
 //! use tower::timeout::TimeoutLayer;
 //! use tower_mcp::resource::ResourceBuilder;
-//! use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+//! use tower_mcp::protocol::ReadResourceResult;
 //!
 //! let resource = ResourceBuilder::new("file:///large-file.txt")
 //!     .name("Large File")
-//!     .description("A large file that may take time to read")
+//!     .description("A file large enough that a read can hang")
 //!     .handler(|| async {
-//!         // Simulate slow read
-//!         Ok(ReadResourceResult {
-//!             contents: vec![ResourceContent {
-//!                 uri: "file:///large-file.txt".to_string(),
-//!                 mime_type: Some("text/plain".to_string()),
-//!                 text: Some("content".to_string()),
-//!                 blob: None,
-//!                 meta: None,
-//!             }],
-//!             meta: None,
-//!             ..Default::default()
-//!         })
+//!         Ok(ReadResourceResult::text("file:///large-file.txt", "content"))
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(30)))
 //!     .build();
 //! ```
 //!
-//! # Resource Templates
+//! # URI templates
 //!
-//! Resource templates allow servers to expose parameterized resources using URI templates.
-//! When a client requests `resources/read` with a URI matching a template, the server
-//! extracts the variables and passes them to the handler.
+//! A template is compiled once, at build time, into a matcher:
+//!
+//! - `{var}` matches any run of non-slash characters
+//! - `{+var}` matches any characters at all, including `/`
+//! - `{?a,b}` and `{&a,b}` declare optional query parameters (#1253)
+//!
+//! [`ResourceTemplate::match_uri`] documents the matching rules and shows each
+//! of them running against real URIs.
 //!
 //! ```rust
 //! use tower_mcp::resource::ResourceTemplateBuilder;
-//! use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
+//! use tower_mcp::protocol::ReadResourceResult;
 //! use std::collections::HashMap;
 //!
-//! let template = ResourceTemplateBuilder::new("file:///{path}")
+//! let template = ResourceTemplateBuilder::new("file:///{+path}")
 //!     .name("Project Files")
-//!     .description("Access files in the project directory")
+//!     .description("Any file under the project directory")
 //!     .handler(|uri: String, vars: HashMap<String, String>| async move {
-//!         let path = vars.get("path").unwrap_or(&String::new()).clone();
-//!         Ok(ReadResourceResult {
-//!             contents: vec![ResourceContent {
-//!                 uri,
-//!                 mime_type: Some("text/plain".to_string()),
-//!                 text: Some(format!("Contents of {}", path)),
-//!                 blob: None,
-//!                 meta: None,
-//!             }],
-//!             meta: None,
-//!             ..Default::default()
-//!         })
+//!         let path = vars["path"].clone();
+//!         Ok(ReadResourceResult::text(uri, format!("contents of {path}")))
 //!     });
+//!
+//! // `{+path}` spans slashes, so nested paths reach the same handler.
+//! let vars = template.match_uri("file:///src/lib.rs").unwrap();
+//! assert_eq!(vars["path"], "src/lib.rs");
 //! ```
 
 use std::collections::HashMap;
@@ -98,10 +127,11 @@ use crate::protocol::{
 // Service Types for Per-Resource Middleware
 // =============================================================================
 
-/// Request type for resource services.
+/// What a layer applied with `.layer()` sees for one read.
 ///
-/// Contains the request context (for progress reporting, cancellation, etc.)
-/// and the resource URI being read.
+/// Middleware runs on this rather than on the handler's arguments, so a layer
+/// can read the URI and the request context without knowing anything about the
+/// handler behind it.
 #[derive(Debug, Clone)]
 pub struct ResourceRequest {
     /// Request context for progress reporting, cancellation, and client requests
@@ -290,7 +320,12 @@ where
 /// A boxed future for resource handlers
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-/// Resource handler trait - the core abstraction for resource reading
+/// The shape a resource handler is adapted to internally.
+///
+/// [`ResourceBuilder`] wraps closures in an implementation of this trait, and
+/// the router reads every resource through it. No public constructor accepts
+/// an implementation, so a resource written as a type rather than a closure
+/// implements [`McpResource`] instead.
 pub trait ResourceHandler: Send + Sync {
     /// Read the resource contents
     fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>>;
@@ -439,12 +474,16 @@ where
     }
 }
 
-/// A complete resource definition with service-based execution.
+/// A resource that is ready to register.
 ///
-/// Resources are implemented as Tower services internally, enabling middleware
-/// composition via the builder's `.layer()` method. The service is wrapped
-/// in [`ResourceCatchError`] to convert any errors (from handlers or middleware)
-/// into error result responses.
+/// Produced by [`ResourceBuilder`] or [`McpResource::into_resource`] and
+/// consumed by [`McpRouter::resource`](crate::McpRouter::resource). The public
+/// fields are what `resources/list` advertises; behind them is a Tower service,
+/// which is what lets `.layer()` compose middleware onto a single resource.
+///
+/// That service is wrapped so it cannot fail, so handler and middleware errors
+/// come back as content rather than as errors. [`read`](Self::read) shows what
+/// that looks like.
 pub struct Resource {
     /// Resource URI
     pub uri: String,
@@ -516,7 +555,7 @@ impl Resource {
         ResourceBuilder::new(uri)
     }
 
-    /// Get the resource definition for resources/list
+    /// The entry this resource contributes to `resources/list`.
     pub fn definition(&self) -> ResourceDefinition {
         ResourceDefinition {
             uri: self.uri.clone(),
@@ -531,7 +570,29 @@ impl Resource {
         }
     }
 
-    /// Attach validated protocol metadata to this resource definition.
+    /// Attach `_meta` to what `resources/list` publishes for this resource.
+    ///
+    /// The value is checked here rather than at serialization time, so a key
+    /// that does not fit the spec's name grammar is rejected while there is
+    /// still a caller to tell.
+    ///
+    /// ```rust
+    /// use serde_json::json;
+    /// use tower_mcp::resource::ResourceBuilder;
+    ///
+    /// let resource = ResourceBuilder::new("docs://usage")
+    ///     .name("Usage")
+    ///     .text("...")
+    ///     .with_meta(json!({ "example.com/generated-at": "2026-08-10" }))
+    ///     .expect("valid _meta key");
+    ///
+    /// assert!(
+    ///     resource
+    ///         .clone()
+    ///         .with_meta(json!({ "/leading-slash": true }))
+    ///         .is_err()
+    /// );
+    /// ```
     pub fn with_meta(
         mut self,
         meta: Value,
@@ -541,25 +602,54 @@ impl Resource {
         Ok(self)
     }
 
-    /// Read the resource without context
+    /// Read the resource with a placeholder request context.
     ///
-    /// Creates a dummy request context. For full context support, use
-    /// [`read_with_context`](Self::read_with_context).
+    /// Progress reporting, cancellation, and client requests are inert on the
+    /// placeholder context, so this is for tests and for handlers built with
+    /// [`ResourceBuilder::handler`], which never see the context anyway. The
+    /// transports call [`read_with_context`](Self::read_with_context).
+    ///
+    /// There is no `Result` here because a handler error has already been
+    /// turned into the value returned. That is the cost of letting middleware
+    /// compose onto a resource, and it means a failed read still looks like a
+    /// read: the error text arrives as content.
+    ///
+    /// ```rust
+    /// use tower_mcp::error::Error;
+    /// use tower_mcp::resource::ResourceBuilder;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let resource = ResourceBuilder::new("db://users")
+    ///     .name("Users")
+    ///     .handler(|| async { Err(Error::internal("database is offline")) })
+    ///     .build();
+    ///
+    /// let result = resource.read().await;
+    /// let text = result.contents[0].text.as_deref().unwrap();
+    /// assert!(text.contains("database is offline"), "{text}");
+    /// # });
+    /// ```
+    ///
+    /// A [`ResourceTemplate`] handler behaves the other way round: its errors
+    /// stay errors, and [`ResourceTemplate::read`] returns a `Result`.
     pub fn read(&self) -> BoxFuture<'static, ReadResourceResult> {
         let ctx = RequestContext::new(crate::protocol::RequestId::Number(0));
         self.read_with_context(ctx)
     }
 
-    /// Read the resource with request context
+    /// Read the resource with the request context the transport built.
     ///
-    /// The context provides progress reporting, cancellation support, and
-    /// access to client requests (for sampling, etc.).
+    /// This is the path the router takes. The context carries the request id,
+    /// progress reporting, the cancellation token, and the client requester
+    /// used for sampling and elicitation. Handlers registered through
+    /// [`ResourceBuilder::handler`] ignore it; those registered through
+    /// [`ResourceBuilder::handler_with_context`] receive it.
     ///
-    /// # Note
-    ///
-    /// This method returns `ReadResourceResult` directly (not `Result<ReadResourceResult>`).
-    /// Any errors from the handler or middleware are converted to error responses
-    /// in the result contents.
+    /// Errors become content rather than a `Result`, as described on
+    /// [`read`](Self::read). A handler that suspends for client input is
+    /// reported the same way, since this signature has nowhere to put a
+    /// continuation; use [`read_outcome_with_context`](Self::read_outcome_with_context)
+    /// for that.
     pub fn read_with_context(&self, ctx: RequestContext) -> BoxFuture<'static, ReadResourceResult> {
         let resource = self.clone();
         let uri = self.uri.clone();
@@ -594,6 +684,10 @@ impl Resource {
     }
 
     /// Read the resource while preserving an SEP-2322 continuation.
+    ///
+    /// The router calls this so that a handler which needs more input from the
+    /// client can say so, instead of having that outcome flattened into
+    /// content by [`read_with_context`](Self::read_with_context).
     pub fn read_outcome_with_context(
         &self,
         ctx: RequestContext,
@@ -683,34 +777,43 @@ impl Resource {
 // Builder API
 // =============================================================================
 
-/// Builder for creating resources with a fluent API
+/// Builder for a resource served at one fixed URI.
+///
+/// The URI is the identity clients read by; the name is what a user sees in a
+/// picker, and defaults to the URI when it is not set. Finish the chain with a
+/// handler and [`build`](ResourceBuilderWithHandler::build), or with
+/// [`text`](Self::text) or [`json`](Self::json) for content already in memory,
+/// then register the result with
+/// [`McpRouter::resource`](crate::McpRouter::resource).
 ///
 /// # Example
 ///
 /// ```rust
+/// use tower_mcp::protocol::ReadResourceResult;
 /// use tower_mcp::resource::ResourceBuilder;
-/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 ///
+/// # tokio_test::block_on(async {
 /// let resource = ResourceBuilder::new("file:///config.json")
 ///     .name("Configuration")
 ///     .description("Application configuration file")
 ///     .mime_type("application/json")
 ///     .handler(|| async {
-///         Ok(ReadResourceResult {
-///             contents: vec![ResourceContent {
-///                 uri: "file:///config.json".to_string(),
-///                 mime_type: Some("application/json".to_string()),
-///                 text: Some(r#"{"setting": "value"}"#.to_string()),
-///                 blob: None,
-///                 meta: None,
-///             }],
-///             meta: None,
-///             ..Default::default()
-///         })
+///         Ok(ReadResourceResult::text_with_mime(
+///             "file:///config.json",
+///             r#"{"setting": "value"}"#,
+///             "application/json",
+///         ))
 ///     })
 ///     .build();
 ///
 /// assert_eq!(resource.uri, "file:///config.json");
+///
+/// let result = resource.read().await;
+/// assert_eq!(
+///     result.contents[0].text.as_deref(),
+///     Some(r#"{"setting": "value"}"#)
+/// );
+/// # });
 /// ```
 pub struct ResourceBuilder {
     uri: String,
@@ -861,13 +964,46 @@ impl ResourceBuilder {
         }
     }
 
-    /// Set a context-aware handler for reading the resource.
+    /// Set a handler that receives the [`RequestContext`].
     ///
-    /// The handler receives a `RequestContext` for progress reporting and
-    /// cancellation checking.
+    /// Take this form when the read runs long enough to report progress
+    /// against, has to notice cancellation, or wants to ask the client
+    /// something. Everything else can use [`handler`](Self::handler), which
+    /// skips the context entirely.
     ///
-    /// Returns a [`ResourceBuilderWithContextHandler`] that can be used to apply
-    /// middleware layers via `.layer()` or build the resource directly via `.build()`.
+    /// Reporting progress is unconditional in the handler and free when
+    /// unwanted: a client that sent no progress token receives nothing.
+    ///
+    /// ```rust
+    /// use tower_mcp::context::RequestContext;
+    /// use tower_mcp::error::Error;
+    /// use tower_mcp::protocol::ReadResourceResult;
+    /// use tower_mcp::resource::ResourceBuilder;
+    ///
+    /// let resource = ResourceBuilder::new("logs://today")
+    ///     .name("Today's logs")
+    ///     .handler_with_context(|ctx: RequestContext| async move {
+    ///         let mut pages = Vec::new();
+    ///         for page in 0..4 {
+    ///             if ctx.is_cancelled() {
+    ///                 return Err(Error::internal("read cancelled"));
+    ///             }
+    ///             ctx.report_progress(f64::from(page), Some(4.0), Some("reading"))
+    ///                 .await;
+    ///             pages.push(format!("page {page}"));
+    ///         }
+    ///         Ok(ReadResourceResult::text("logs://today", pages.join("\n")))
+    ///     })
+    ///     .build();
+    ///
+    /// # tokio_test::block_on(async {
+    /// let result = resource.read().await;
+    /// let text = result.contents[0].text.as_deref().unwrap();
+    /// assert!(text.contains("page 3"), "{text}");
+    /// # });
+    /// ```
+    ///
+    /// Returns a builder that still accepts `.layer()` before `.build()`.
     pub fn handler_with_context<F, Fut>(self, handler: F) -> ResourceBuilderWithContextHandler<F>
     where
         F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
@@ -906,7 +1042,28 @@ impl ResourceBuilder {
         }
     }
 
-    /// Create a static text resource (convenience method)
+    /// Finish the builder by serving a fixed string.
+    ///
+    /// The content is captured once, so this is for text that does not change
+    /// while the server runs: instructions, a licence, a schema. Anything read
+    /// from disk or a database on demand needs [`handler`](Self::handler).
+    ///
+    /// ```rust
+    /// use tower_mcp::resource::ResourceBuilder;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let resource = ResourceBuilder::new("docs://usage")
+    ///     .name("Usage")
+    ///     .mime_type("text/markdown")
+    ///     .text("# Usage\n\nStart the server, then call `tools/list`.");
+    ///
+    /// let result = resource.read().await;
+    /// assert_eq!(
+    ///     result.contents[0].mime_type.as_deref(),
+    ///     Some("text/markdown")
+    /// );
+    /// # });
+    /// ```
     pub fn text(self, content: impl Into<String>) -> Resource {
         let uri = self.uri.clone();
         let content = content.into();
@@ -933,7 +1090,28 @@ impl ResourceBuilder {
         .build()
     }
 
-    /// Create a static JSON resource (convenience method)
+    /// Finish the builder by serving a fixed JSON value.
+    ///
+    /// The value is serialized once, at build time, and the MIME type is set
+    /// to `application/json` whatever [`mime_type`](Self::mime_type) said
+    /// earlier, so the declared type cannot drift from the body.
+    ///
+    /// ```rust
+    /// use serde_json::json;
+    /// use tower_mcp::resource::ResourceBuilder;
+    ///
+    /// # tokio_test::block_on(async {
+    /// let resource = ResourceBuilder::new("config://limits")
+    ///     .name("Limits")
+    ///     .json(json!({ "max_connections": 100 }));
+    ///
+    /// let result = resource.read().await;
+    /// assert_eq!(
+    ///     result.contents[0].mime_type.as_deref(),
+    ///     Some("application/json")
+    /// );
+    /// # });
+    /// ```
     pub fn json(mut self, value: serde_json::Value) -> Resource {
         let uri = self.uri.clone();
         self.mime_type = Some("application/json".to_string());
@@ -1553,10 +1731,13 @@ impl<T: McpResource> ResourceHandler for McpResourceHandler<T> {
 // Resource Templates
 // =============================================================================
 
-/// Handler trait for resource templates
+/// The shape a resource-template handler is adapted to internally.
 ///
-/// Unlike [`ResourceHandler`], template handlers receive the extracted
-/// URI variables as a parameter.
+/// Unlike [`ResourceHandler`], a template handler is told which URI matched
+/// and what was extracted from it, because one handler serves many URIs.
+/// Templates are built from closures through
+/// [`ResourceTemplateBuilder::handler`]; no public constructor accepts an
+/// implementation of this trait.
 pub trait ResourceTemplateHandler: Send + Sync {
     /// Read a resource with the given URI variables extracted from the template
     fn read(
@@ -1578,35 +1759,44 @@ pub trait MrtrResourceTemplateHandler: Send + Sync {
     ) -> BoxFuture<'_, Result<RequestOutcome<ReadResourceResult>>>;
 }
 
-/// A parameterized resource template
+/// A resource whose URI is a pattern rather than a constant.
 ///
-/// Resource templates use URI template syntax (RFC 6570) to match multiple URIs
-/// and extract variable values. This allows servers to expose dynamic resources
-/// like file systems or database records.
+/// The pattern is compiled once, when the handler is attached, and every
+/// `resources/read` that does not name a registered [`Resource`] is offered to
+/// each template in registration order. The first match wins, and the
+/// variables it extracted are passed to the handler together with the URI that
+/// produced them, so one handler serves a whole family of URIs: a filesystem
+/// subtree, a table of records, a paged listing.
+///
+/// [`match_uri`](Self::match_uri) documents the matching rules and shows them
+/// running.
 ///
 /// # Example
 ///
 /// ```rust
-/// use tower_mcp::resource::ResourceTemplateBuilder;
-/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
 /// use std::collections::HashMap;
+/// use serde_json::json;
+/// use tower_mcp::protocol::ReadResourceResult;
+/// use tower_mcp::resource::ResourceTemplateBuilder;
 ///
-/// let template = ResourceTemplateBuilder::new("file:///{path}")
-///     .name("Project Files")
+/// let template = ResourceTemplateBuilder::new("db://users/{id}")
+///     .name("User Records")
+///     .description("One user record per id")
 ///     .handler(|uri: String, vars: HashMap<String, String>| async move {
-///         let path = vars.get("path").unwrap_or(&String::new()).clone();
-///         Ok(ReadResourceResult {
-///             contents: vec![ResourceContent {
-///                 uri,
-///                 mime_type: Some("text/plain".to_string()),
-///                 text: Some(format!("Contents of {}", path)),
-///                 blob: None,
-///                 meta: None,
-///             }],
-///             meta: None,
-///             ..Default::default()
-///         })
+///         let id = vars["id"].clone();
+///         Ok(ReadResourceResult::json(uri, &json!({ "id": id })))
 ///     });
+///
+/// # tokio_test::block_on(async {
+/// let vars = template.match_uri("db://users/42").expect("42 is one segment");
+/// assert_eq!(vars["id"], "42");
+///
+/// let result = template.read("db://users/42", vars).await.unwrap();
+/// assert!(result.contents[0].text.as_deref().unwrap().contains("42"));
+/// # });
+///
+/// // `{id}` stops at a slash, so a deeper URI is left for another template.
+/// assert!(template.match_uri("db://users/42/posts").is_none());
 /// ```
 pub struct ResourceTemplate {
     /// The URI template pattern (e.g., `file:///{path}`)
@@ -1676,7 +1866,10 @@ impl ResourceTemplate {
         ResourceTemplateBuilder::new(uri_template)
     }
 
-    /// Get the template definition for resources/templates/list
+    /// The entry this template contributes to `resources/templates/list`.
+    ///
+    /// Clients discover the pattern itself and expand it themselves, so the
+    /// declared variables are not repeated as `arguments`.
     pub fn definition(&self) -> ResourceTemplateDefinition {
         ResourceTemplateDefinition {
             uri_template: self.uri_template.clone(),
@@ -1691,10 +1884,116 @@ impl ResourceTemplate {
         }
     }
 
-    /// Check if a URI matches this template and extract variables
+    /// Match a URI against this template and extract its variables.
     ///
-    /// Returns `Some(HashMap)` with extracted variables if the URI matches,
-    /// `None` if it doesn't match.
+    /// `None` means this template does not serve that URI, which is the
+    /// router's signal to try the next one. The whole URI must match, not a
+    /// prefix of it.
+    ///
+    /// # Path expansion
+    ///
+    /// `{var}` matches a run of non-slash characters and `{+var}` matches
+    /// anything at all. That single difference decides whether a template
+    /// routes one path segment or an entire subtree:
+    ///
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::protocol::ReadResourceResult;
+    /// use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
+    ///
+    /// fn template(pattern: &str) -> ResourceTemplate {
+    ///     ResourceTemplateBuilder::new(pattern).name("example").handler(
+    ///         |uri: String, _vars: HashMap<String, String>| async move {
+    ///             Ok(ReadResourceResult::text(uri, "body"))
+    ///         },
+    ///     )
+    /// }
+    ///
+    /// let segment = template("db://users/{id}");
+    /// assert_eq!(segment.match_uri("db://users/42").unwrap()["id"], "42");
+    /// assert!(segment.match_uri("db://users/42/posts").is_none());
+    ///
+    /// let subtree = template("file:///{+path}");
+    /// assert_eq!(
+    ///     subtree.match_uri("file:///src/lib.rs").unwrap()["path"],
+    ///     "src/lib.rs"
+    /// );
+    ///
+    /// // Both forms require something to capture: neither matches empty.
+    /// assert!(segment.match_uri("db://users/").is_none());
+    /// ```
+    ///
+    /// # Query expansion
+    ///
+    /// `{?a,b}`, and the `{&a,b}` continuation form, declare query parameters
+    /// (#1253). They are matched against the URI's query string rather than
+    /// compiled into the pattern, because a regex cannot reasonably express
+    /// "any subset of these, in any order".
+    ///
+    /// RFC 6570 defines expansion rather than matching, so the routing policy
+    /// is this crate's:
+    ///
+    /// - every declared variable is optional, and the bare URI still matches
+    /// - order is not significant
+    /// - present with no value is an empty string, and distinct from absent
+    /// - undeclared keys are ignored rather than rejected, so a caller
+    ///   appending a tracking parameter cannot break routing
+    /// - the first occurrence of a repeated key wins
+    /// - values are percent-decoded and `+` reads as a space; a malformed
+    ///   escape is left as written rather than dropped, so a bad value still
+    ///   reaches the handler instead of vanishing
+    ///
+    /// Path captures are handed over exactly as matched. That asymmetry is
+    /// deliberate: query strings are form-encoded by convention, and path
+    /// captures were never decoded, so decoding them now would silently change
+    /// what existing handlers receive.
+    ///
+    /// ```rust
+    /// # use std::collections::HashMap;
+    /// # use tower_mcp::protocol::ReadResourceResult;
+    /// # use tower_mcp::resource::{ResourceTemplate, ResourceTemplateBuilder};
+    /// # fn template(pattern: &str) -> ResourceTemplate {
+    /// #     ResourceTemplateBuilder::new(pattern).name("example").handler(
+    /// #         |uri: String, _vars: HashMap<String, String>| async move {
+    /// #             Ok(ReadResourceResult::text(uri, "body"))
+    /// #         },
+    /// #     )
+    /// # }
+    /// let threads = template("agent://threads{?cursor,limit}");
+    ///
+    /// // Nothing supplied still routes here, with no variables.
+    /// assert!(threads.match_uri("agent://threads").unwrap().is_empty());
+    ///
+    /// // A subset in any order, each variable under its own name.
+    /// let vars = threads.match_uri("agent://threads?limit=20").unwrap();
+    /// assert_eq!(vars["limit"], "20");
+    /// assert!(!vars.contains_key("cursor"));
+    ///
+    /// // Present-but-empty is a different fact from absent.
+    /// let vars = threads.match_uri("agent://threads?cursor=").unwrap();
+    /// assert_eq!(vars["cursor"], "");
+    ///
+    /// // An undeclared key is ignored; a repeated key keeps the first.
+    /// let vars = threads
+    ///     .match_uri("agent://threads?utm=ad&cursor=one&cursor=two")
+    ///     .unwrap();
+    /// assert_eq!(vars["cursor"], "one");
+    /// assert!(!vars.contains_key("utm"));
+    ///
+    /// // Query values are decoded; the path capture beside them is not.
+    /// let files = template("file:///{name}{?rev}");
+    /// let vars = files.match_uri("file:///a%20b?rev=a+b").unwrap();
+    /// assert_eq!(vars["name"], "a%20b");
+    /// assert_eq!(vars["rev"], "a b");
+    ///
+    /// // A template that declares no query expression never splits on `?`,
+    /// // so a literal `?` in the pattern keeps matching literally.
+    /// let literal = template("http://example.com/api?query={q}");
+    /// assert_eq!(
+    ///     literal.match_uri("http://example.com/api?query=hello").unwrap()["q"],
+    ///     "hello"
+    /// );
+    /// ```
     pub fn match_uri(&self, uri: &str) -> Option<HashMap<String, String>> {
         // Only a template that declares a query expression splits the URI.
         // Without one the pattern matches the whole string, including any
@@ -1725,12 +2024,20 @@ impl ResourceTemplate {
         Some(matched)
     }
 
-    /// Read a resource at the given URI using this template's handler
+    /// Read one URI through this template's handler.
     ///
-    /// # Arguments
+    /// `variables` is what [`match_uri`](Self::match_uri) returned for `uri`.
+    /// Nothing re-derives or checks it here, so a map taken from a different
+    /// URI is passed to the handler as given.
     ///
-    /// * `uri` - The actual URI being read
-    /// * `variables` - Variables extracted from matching the URI against the template
+    /// Unlike [`Resource::read`], this returns a `Result`. Template handlers
+    /// are not wrapped in an error-catching service, so an `Err` stays an
+    /// error and the router turns it into a JSON-RPC error rather than into
+    /// resource content.
+    ///
+    /// A template built with `mrtr_handler` has no plain handler to call and
+    /// reports that as an error here; use
+    /// [`read_outcome_with_context`](Self::read_outcome_with_context).
     pub fn read(
         &self,
         uri: &str,
@@ -1778,32 +2085,47 @@ impl ResourceTemplate {
     }
 }
 
-/// Builder for creating resource templates
+/// Builder for a [`ResourceTemplate`].
+///
+/// The chain ends at [`handler`](Self::handler), which compiles the pattern
+/// and returns the template itself; there is no separate `build` step. The
+/// name defaults to the pattern when it is not set.
 ///
 /// # Example
 ///
-/// ```rust
-/// use tower_mcp::resource::ResourceTemplateBuilder;
-/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
-/// use std::collections::HashMap;
+/// A paged listing, where the page cursor is a declared query variable and the
+/// handler has to cope with its absence because every query variable is
+/// optional:
 ///
-/// let template = ResourceTemplateBuilder::new("db://users/{id}")
-///     .name("User Records")
-///     .description("Access user records by ID")
+/// ```rust
+/// use std::collections::HashMap;
+/// use tower_mcp::protocol::ReadResourceResult;
+/// use tower_mcp::resource::ResourceTemplateBuilder;
+///
+/// let template = ResourceTemplateBuilder::new("agent://threads{?cursor,limit}")
+///     .name("Threads")
+///     .description("Conversation threads, newest first")
+///     .mime_type("application/json")
 ///     .handler(|uri: String, vars: HashMap<String, String>| async move {
-///         let id = vars.get("id").unwrap();
-///         Ok(ReadResourceResult {
-///             contents: vec![ResourceContent {
-///                 uri,
-///                 mime_type: Some("application/json".to_string()),
-///                 text: Some(format!(r#"{{"id": "{}"}}"#, id)),
-///                 blob: None,
-///                 meta: None,
-///             }],
-///             meta: None,
-///             ..Default::default()
-///         })
+///         let cursor = vars.get("cursor").map(String::as_str).unwrap_or("start");
+///         let limit: usize = vars
+///             .get("limit")
+///             .and_then(|value| value.parse().ok())
+///             .unwrap_or(50);
+///         Ok(ReadResourceResult::text(
+///             uri,
+///             format!("{limit} threads from {cursor}"),
+///         ))
 ///     });
+///
+/// # tokio_test::block_on(async {
+/// let vars = template.match_uri("agent://threads").unwrap();
+/// let result = template.read("agent://threads", vars).await.unwrap();
+/// assert_eq!(
+///     result.contents[0].text.as_deref(),
+///     Some("50 threads from start")
+/// );
+/// # });
 /// ```
 pub struct ResourceTemplateBuilder {
     uri_template: String,
@@ -1816,36 +2138,32 @@ pub struct ResourceTemplateBuilder {
 }
 
 impl ResourceTemplateBuilder {
-    /// Create a new builder with the given URI template
+    /// Start a template from an RFC 6570 URI pattern.
     ///
-    /// # URI Template Syntax
+    /// The pattern is not compiled until a handler is attached, so a mistake
+    /// in it surfaces at [`handler`](Self::handler) (a panic) or
+    /// [`try_handler`](Self::try_handler) (an error), not here.
     ///
-    /// - `{varname}` - simple expansion, matches any non-slash characters
-    /// - `{+varname}` - reserved expansion, matches any characters
-    /// - `{?a,b}` or `{&a,b}` - form-style query expansion (#1253)
+    /// # Supported expansions
     ///
-    /// # Examples
+    /// | form | matches | example |
+    /// |---|---|---|
+    /// | `{var}` | any run of non-slash characters | `db://users/{id}` matches `db://users/123` |
+    /// | `{+var}` | any characters, slashes included | `file:///{+path}` matches `file:///src/lib.rs` |
+    /// | `{?a,b}`, `{&a,b}` | optional query parameters (#1253) | `agent://threads{?cursor,limit}` matches `agent://threads` and `agent://threads?limit=20` |
     ///
-    /// - `file:///{path}` - Matches `file:///README.md`
-    /// - `db://users/{id}` - Matches `db://users/123`
-    /// - `api://v1/{resource}/{id}` - Matches `api://v1/posts/456`
-    /// - `agent://threads{?cursor,limit}` - Matches `agent://threads` and
-    ///   `agent://threads?limit=20`
+    /// Everything else in the pattern is literal, including a `?` in a
+    /// template that declares no query expression.
+    /// [`ResourceTemplate::match_uri`] documents the matching rules in full,
+    /// with the query routing policy this crate settled on where RFC 6570
+    /// defines expansion but not matching.
     ///
-    /// # Query expansion
+    /// # Rejected at build time
     ///
-    /// A query expression describes the query string, so it must end the
-    /// template. Every variable it lists is optional: the template matches
-    /// with none of them present, in any order, and each arrives under its
-    /// own name rather than as one undifferentiated suffix.
-    ///
-    /// RFC 6570 defines expansion, not matching, so the routing policy is
-    /// this crate's: a declared variable present with no value maps to an
-    /// empty string and is distinct from being absent, undeclared keys are
-    /// ignored rather than rejected so an added tracking parameter cannot
-    /// break routing, and the first occurrence of a repeated key wins.
-    /// Values are percent-decoded and `+` is read as a space; path captures
-    /// are still handed over exactly as matched.
+    /// A query expression describes the query string, so nothing can follow
+    /// it: trailing text, a second query expression, and an empty variable
+    /// name are all reported rather than left to mismatch silently at
+    /// request time.
     pub fn new(uri_template: impl Into<String>) -> Self {
         Self {
             uri_template: uri_template.into(),
@@ -1915,17 +2233,42 @@ impl ResourceTemplateBuilder {
         self
     }
 
-    /// Set the handler function for reading template resources.
+    /// Attach the handler, compile the pattern, and return the template.
     ///
-    /// The handler receives:
-    /// - `uri`: The full URI being read
-    /// - `variables`: A map of variable names to their values extracted from the URI
+    /// The handler is called with the URI that was requested and the variables
+    /// [`ResourceTemplate::match_uri`] pulled out of it. Only variables that
+    /// actually matched are present: path variables always are, query
+    /// variables only when the request supplied them.
+    ///
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::protocol::ReadResourceResult;
+    /// use tower_mcp::resource::ResourceTemplateBuilder;
+    ///
+    /// let template = ResourceTemplateBuilder::new("api://v1/{collection}/{id}")
+    ///     .name("API records")
+    ///     .handler(|uri: String, vars: HashMap<String, String>| async move {
+    ///         let body = format!("{} #{}", vars["collection"], vars["id"]);
+    ///         Ok(ReadResourceResult::text(uri, body))
+    ///     });
+    ///
+    /// # tokio_test::block_on(async {
+    /// let uri = "api://v1/posts/456";
+    /// let vars = template.match_uri(uri).unwrap();
+    /// let result = template.read(uri, vars).await.unwrap();
+    /// assert_eq!(result.contents[0].text.as_deref(), Some("posts #456"));
+    /// # });
+    /// ```
+    ///
+    /// Indexing the map, as above, is safe for a path variable the pattern
+    /// declares and a panic for anything else. Use `get` for query variables.
     ///
     /// # Panics
     ///
-    /// Panics if the URI template produces an invalid regex pattern. For a
-    /// non-panicking alternative (useful with dynamic/user-supplied templates),
-    /// use [`try_handler`](Self::try_handler).
+    /// Panics if the URI template is not a valid pattern. That is the right
+    /// trade for a template written as a literal, since it fails on the first
+    /// run rather than on the first request. For a pattern that comes from
+    /// configuration or user input, use [`try_handler`](Self::try_handler).
     pub fn handler<F, Fut>(self, handler: F) -> ResourceTemplate
     where
         F: Fn(String, HashMap<String, String>) -> Fut + Send + Sync + 'static,
@@ -1936,16 +2279,35 @@ impl ResourceTemplateBuilder {
         })
     }
 
-    /// Set the handler function for reading template resources, returning an
-    /// error if the URI template is invalid.
+    /// The fallible form of [`handler`](Self::handler).
     ///
-    /// This is the fallible version of [`handler`](Self::handler), suitable for
-    /// use with dynamically created templates where the URI pattern may come
-    /// from user input.
+    /// Reach for this when the pattern is not a literal in the source: a
+    /// plugin manifest, a config file, an argument. A bad pattern then
+    /// disables one template with a reportable error instead of taking down
+    /// the server that loaded it.
     ///
-    /// The handler receives:
-    /// - `uri`: The full URI being read
-    /// - `variables`: A map of variable names to their values extracted from the URI
+    /// ```rust
+    /// use std::collections::HashMap;
+    /// use tower_mcp::protocol::ReadResourceResult;
+    /// use tower_mcp::resource::ResourceTemplateBuilder;
+    ///
+    /// fn load(pattern: &str) -> Result<(), String> {
+    ///     ResourceTemplateBuilder::new(pattern)
+    ///         .name("configured")
+    ///         .try_handler(|uri: String, _vars: HashMap<String, String>| async move {
+    ///             Ok(ReadResourceResult::text(uri, "body"))
+    ///         })
+    ///         .map(|_template| ())
+    ///         .map_err(|error| error.to_string())
+    /// }
+    ///
+    /// assert!(load("agent://threads{?cursor}").is_ok());
+    ///
+    /// // A query expression describes the end of the URI, so nothing may
+    /// // follow it.
+    /// let error = load("agent://threads{?cursor}/latest").unwrap_err();
+    /// assert!(error.contains("after its query expression"), "{error}");
+    /// ```
     pub fn try_handler<F, Fut>(self, handler: F) -> std::result::Result<ResourceTemplate, Error>
     where
         F: Fn(String, HashMap<String, String>) -> Fut + Send + Sync + 'static,


### PR DESCRIPTION
Rustdoc pass over `crates/tower-mcp/src/resource.rs` and
`crates/tower-mcp/src/prompt.rs`. Every public item in both already had a doc
comment, since CI enforces `-Dmissing-docs`; what was missing was the shape of
each subsystem and anything showing it run. Before this change resource.rs had
6 examples across 71 public items and prompt.rs had 4 across 45, none of which
asserted a result.

Docs only. No behaviour changes.

## Module overviews

Each module now opens with the shape of the subsystem: the two kinds of
resource and which one a URI maps to, the order the router resolves a
`resources/read` in (exact URI, then templates in registration order, first
match wins), the handler forms in a table, and where a handler error ends up.

Two behaviours that surprise people are now stated and demonstrated:

- A `Resource` handler error becomes resource content, because the handler is
  wrapped in a service that cannot fail so middleware can compose onto it. A
  `ResourceTemplate` handler error stays an error and the router reports a
  JSON-RPC error.
- A prompt handler error propagates as an error, until `.layer()` is applied.
  The layered path has to catch errors for the stack to compose, so the same
  `Err` comes back as a successful `prompts/get` carrying an assistant message.

Both claims are asserted in doctests rather than only written down.

## URI templates

None of the matching rules are visible from the types, so
`ResourceTemplate::match_uri` now documents them and runs them:

- `{var}` matches non-slash characters, `{+var}` matches across slashes, and
  neither matches empty
- the `{?a,b}` and `{&a,b}` query routing policy (#1253) that RFC 6570 leaves
  open: every declared variable optional, order not significant,
  present-with-no-value distinct from absent, undeclared keys ignored rather
  than rejected, first occurrence of a repeated key winning, values
  percent-decoded with `+` as a space, path captures not decoded
- a template with no query expression still treats `?` literally, which is what
  kept #1259 from being a breaking change

`ResourceTemplateBuilder::new` keeps the build-time rules (a query expression
must end the template) and links to `match_uri` for matching, rather than
carrying a second copy of the policy that can drift.

## Examples added

resource.rs: module overview (2), `ResourceBuilder`, `ResourceBuilder::text`,
`ResourceBuilder::json`, `ResourceBuilder::handler_with_context`,
`Resource::read`, `Resource::with_meta`, `ResourceTemplate`,
`ResourceTemplate::match_uri` (2), `ResourceTemplateBuilder`,
`ResourceTemplateBuilder::handler`, `ResourceTemplateBuilder::try_handler`.

prompt.rs: module overview, `PromptBuilder`,
`PromptBuilder::handler_with_context`, `PromptBuilder::static_prompt`,
`PromptBuilder::user_message`.

Every one executes and asserts; none needs `no_run`. Trivial getters, the
`#[doc(hidden)]` builder-state types, and the MRTR handlers were deliberately
left without examples.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features`
- `cargo test --workspace --all-features`
- `cargo test -p tower-mcp --all-features --doc`
- `RUSTDOCFLAGS="-Dwarnings -Dmissing-docs" cargo doc -p tower-mcp --all-features --no-deps`