### PR TITLE
docs: worked examples for tasks, auth, and the client

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -13,18 +13,129 @@
 //! be plugged in so `tasks/get` works on any instance behind a load balancer
 //! in the sessionless 2026-07-28 flows (SEP-2663).
 //!
-//! # Example
+//! Nothing here is advertised until a server asks for it:
+//! [`McpRouter::with_tasks`](crate::McpRouter::with_tasks) is the runtime
+//! opt-in, and a client that did not declare the extension keeps receiving
+//! ordinary synchronous results. See `examples/tasks.rs` for a runnable
+//! server.
 //!
-//! ```rust,no_run
-//! use std::sync::Arc;
+//! # Lifecycle
+//!
+//! A task exists independently of the request that created it. The
+//! `tools/call` response carries the task in place of the tool's result, and
+//! every later operation names the task by its ID rather than by connection or
+//! session. That is what lets a task outlive its transport, and what makes an
+//! external store the requirement for more than one server instance.
+//!
+//! | Status | Reached by | Terminal |
+//! |----------------|--------------------------------------------------------|-----|
+//! | `working`      | creation, and again once every input request is answered | no  |
+//! | `input_required` | [`TaskStore::require_input`]                          | no  |
+//! | `completed`    | [`TaskStore::complete_task`]                            | yes |
+//! | `failed`       | [`TaskStore::fail_task`]                                | yes |
+//! | `cancelled`    | [`TaskStore::cancel_task`]                              | yes |
+//!
+//! Terminal states are immutable. A transition method answers `Ok(false)`
+//! rather than an error when the task is already terminal, unknown, or
+//! expired, so a handler finishing just after a cancellation is dropped
+//! instead of overwriting the recorded outcome.
+//!
+//! Which terminal state a finished tool call reaches is the distinction to get
+//! right:
+//!
+//! - A [`CallToolResult`] with `is_error: true` **completes** the task. The
+//!   tool ran and reported a domain error, which is an answer the caller asked
+//!   for, and `tasks/get` returns it in the result field exactly as the
+//!   synchronous call would have. SEP-2663 keeps that separate from failure.
+//! - `failed` carries a [`JsonRpcError`] and no result, meaning the call never
+//!   produced one. The router uses it when the task machinery itself gives
+//!   out: a park that cannot take, a store that cannot resume, a tool
+//!   deregistered while its task waited.
+//!
+//! A tool handler returning `Err` lands in the first category, not the second:
+//! the router converts it to an `is_error` result, so the task completes. A
+//! server that wants a `failed` task drives [`TaskStore::fail_task`] itself.
+//!
+//! `ttlMs` runs from creation rather than from the terminal transition, so a
+//! task can expire while still working. Past that point every read returns
+//! `None` and every transition returns `Ok(false)`, whether or not the entry
+//! has been reclaimed: an expired task is indistinguishable from one that
+//! never existed.
+//!
+//! ```rust
+//! use tower_mcp::CallToolResult;
 //! use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
-//! use tower_mcp::McpRouter;
+//! use tower_mcp::protocol::TaskStatus;
 //!
-//! let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
-//! let router = McpRouter::new().task_store(store);
+//! # #[tokio::main]
+//! # async fn main() {
+//! let store = MemoryTaskStore::new();
+//! let (id, _cancel) = store
+//!     .create_task("build_report", serde_json::json!({"rows": 10}), None, None)
+//!     .await
+//!     .unwrap();
+//!
+//! assert_eq!(
+//!     store.get_task(&id).await.unwrap().unwrap().status,
+//!     TaskStatus::Working
+//! );
+//!
+//! assert!(
+//!     store
+//!         .complete_task(&id, CallToolResult::text("report ready"))
+//!         .await
+//!         .unwrap()
+//! );
+//!
+//! let (task, result, error) = store.get_task_result(&id).await.unwrap().unwrap();
+//! assert_eq!(task.status, TaskStatus::Completed);
+//! assert_eq!(result.unwrap().all_text(), "report ready");
+//! assert!(error.is_none());
+//!
+//! // Terminal is final: a late transition is reported as not applied rather
+//! // than rewriting the outcome a client may already have read.
+//! assert!(
+//!     !store
+//!         .complete_task(&id, CallToolResult::text("stale"))
+//!         .await
+//!         .unwrap()
+//! );
+//! # }
 //! ```
 //!
-//! See `examples/tasks.rs` for a runnable server.
+//! # Waiting on the client
+//!
+//! A tool handler that needs something from the client returns an
+//! input-required outcome instead of a result. The router parks the task by
+//! calling [`TaskStore::require_input`] with the keyed requests, and the task
+//! sits in `input_required` until the client answers with `tasks/update`.
+//!
+//! The client answers the *task*, not the original call, so there is no
+//! `tools/call` for it to retry and the server performs the retry itself. Once
+//! [`TaskStore::apply_input_responses`] reports nothing outstanding, the router
+//! reads [`TaskStore::resume_context`] and invokes the handler again from the
+//! top, with the accumulated answers reaching it through the request context
+//! exactly as a client retry would have delivered them. A handler is free to
+//! ask again; each round parks and resumes the same way.
+//!
+//! [`TaskStore::resume_context`] has a default returning `None` so that stores
+//! written before resumption existed keep compiling. The router treats that as
+//! "this store cannot resume" and fails the task with a message saying so,
+//! rather than leaving it working forever (#1208).
+//!
+//! Two rules make the exchange safe to replay:
+//!
+//! - **A request key is unique over a task's lifetime.** Once answered or
+//!   superseded it is spent, and reissuing it is a
+//!   [`TaskStoreError::InvalidTransition`]. Reissuing a key that is still
+//!   outstanding, still naming the same question, is not reuse: `requests`
+//!   replaces the whole outstanding set, so carrying a key forward is how it
+//!   stays outstanding (#1246).
+//! - **Response keys that are not outstanding are ignored.** Unknown,
+//!   already-answered, and superseded keys land in
+//!   [`AppliedInputResponses::ignored`] instead of failing the update, so a
+//!   client replaying a stale `tasks/update` neither breaks the task nor
+//!   resumes it early.
 //!
 //! # Authorization
 //!
@@ -120,6 +231,12 @@ const DEFAULT_TTL_MS: u64 = 300_000;
 const DEFAULT_POLL_INTERVAL_MS: u64 = 2_000;
 
 /// Internal task representation with full state
+///
+/// The record [`MemoryTaskStore`] keeps, exposed because its fields describe
+/// what a store has to track. There is no public constructor: tasks come from
+/// [`TaskStore::create_task`], and an external store is free to persist an
+/// entirely different shape as long as it answers the trait's methods the same
+/// way.
 #[derive(Debug)]
 pub struct Task {
     /// Unique task identifier
@@ -216,6 +333,11 @@ impl Task {
     }
 
     /// Convert to TaskObject for API responses
+    ///
+    /// The `result` and `error` fields are deliberately left empty. A task
+    /// object travels in status responses, where the payload is not wanted;
+    /// [`TaskStore::get_task_result`] is what pairs the object with whichever
+    /// of the two the task actually holds.
     pub fn to_task_object(&self) -> TaskObject {
         TaskObject {
             task_id: self.id.clone(),
@@ -290,6 +412,23 @@ pub type TaskOwner = Option<String>;
 /// open". An unowned task can only exist if it was created with no
 /// authenticated context, so a request that now carries a principal is a
 /// different security context and is refused.
+///
+/// ```rust
+/// use tower_mcp::async_task::owner_matches;
+///
+/// assert!(owner_matches(&None, None), "no authentication configured");
+/// assert!(owner_matches(&Some("alice".into()), Some("alice")));
+///
+/// assert!(!owner_matches(&Some("alice".into()), Some("bob")));
+/// assert!(
+///     !owner_matches(&Some("alice".into()), None),
+///     "dropping the token does not grant access"
+/// );
+/// assert!(
+///     !owner_matches(&None, Some("alice")),
+///     "a task created anonymously is unreachable once a token is presented"
+/// );
+/// ```
 pub fn owner_matches(owner: &TaskOwner, principal: Option<&str>) -> bool {
     owner.as_deref() == principal
 }
@@ -299,6 +438,9 @@ pub fn owner_matches(owner: &TaskOwner, principal: Option<&str>) -> bool {
 /// SEP-2663 requires partial responses to be honored: keys that match an
 /// outstanding request are consumed, everything else is ignored rather than
 /// rejected, and any request left unanswered stays outstanding.
+///
+/// Returned by [`TaskStore::apply_input_responses`], which carries the worked
+/// example.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AppliedInputResponses {
     /// Keys matched to an outstanding request and consumed.
@@ -315,6 +457,10 @@ pub struct AppliedInputResponses {
 /// The client answers a task through `tasks/update`, not by retrying
 /// `tools/call`, so the server re-invokes the handler itself and must supply
 /// what the client would otherwise have resent.
+///
+/// The handler runs from the top rather than continuing where it stopped, so
+/// the arguments are the original ones, unmodified, and `input_responses`
+/// accumulates across every round rather than holding only the latest answer.
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct TaskResumeContext {
@@ -334,6 +480,11 @@ impl AppliedInputResponses {
 }
 
 /// A shareable cancellation token for task management
+///
+/// Handed back by [`TaskStore::create_task`] and raised by
+/// [`TaskStore::cancel_task`]. It is cooperative: setting it does not
+/// interrupt anything, so long-running work has to check it between steps to
+/// notice. Every clone observes the same flag, and it is never lowered again.
 #[derive(Debug, Clone)]
 pub struct CancellationToken {
     cancelled: Arc<AtomicBool>,
@@ -433,6 +584,137 @@ pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<JsonRpcError
 ///   reaches a terminal state; how an implementation waits (notification,
 ///   polling, pub/sub) is an implementation detail and must not leak into the
 ///   trait.
+///
+/// # Implementing this trait
+///
+/// Three methods carry defaults so that stores written before the features
+/// existed keep compiling: [`set_task_meta`](Self::set_task_meta),
+/// [`discard_task`](Self::discard_task), and
+/// [`resume_context`](Self::resume_context). Each default reports "not
+/// supported" rather than quietly succeeding, and the router turns that into a
+/// visible failure. A store that supports input requests must therefore
+/// override `resume_context`, or its first `tasks/update` fails the task.
+///
+/// That also makes wrapping another store a trap worth naming. A decorator
+/// that implements only the required methods inherits the defaults, which
+/// silently disables resumption for the store it wraps even though the wrapped
+/// store supports it. Forward every method, including the defaulted ones:
+///
+/// ```rust
+/// use std::sync::Arc;
+/// use std::sync::atomic::{AtomicUsize, Ordering};
+///
+/// use async_trait::async_trait;
+/// use tower_mcp::CallToolResult;
+/// use tower_mcp::async_task::{
+///     AppliedInputResponses, CancellationToken, MemoryTaskStore, Result, TaskOwner,
+///     TaskResumeContext, TaskSnapshot, TaskStore,
+/// };
+/// use tower_mcp::error::JsonRpcError;
+/// use tower_mcp::protocol::{InputRequests, InputResponses, TaskObject, TaskStatus};
+///
+/// /// Counts the completions it actually applied, and delegates the rest.
+/// struct CountingStore {
+///     inner: MemoryTaskStore,
+///     completed: Arc<AtomicUsize>,
+/// }
+///
+/// #[async_trait]
+/// impl TaskStore for CountingStore {
+///     async fn complete_task(&self, id: &str, result: CallToolResult) -> Result<bool> {
+///         let applied = self.inner.complete_task(id, result).await?;
+///         // `false` means the task was already terminal, expired, or gone,
+///         // so counting it would inflate the number of finished tasks.
+///         if applied {
+///             self.completed.fetch_add(1, Ordering::Relaxed);
+///         }
+///         Ok(applied)
+///     }
+///
+///     // Required methods, forwarded unchanged.
+///     async fn create_task(
+///         &self,
+///         tool_name: &str,
+///         arguments: serde_json::Value,
+///         ttl: Option<u64>,
+///         owner: TaskOwner,
+///     ) -> Result<(String, CancellationToken)> {
+///         self.inner.create_task(tool_name, arguments, ttl, owner).await
+///     }
+///     async fn task_owner(&self, id: &str) -> Result<Option<TaskOwner>> {
+///         self.inner.task_owner(id).await
+///     }
+///     async fn get_task(&self, id: &str) -> Result<Option<TaskObject>> {
+///         self.inner.get_task(id).await
+///     }
+///     async fn get_task_result(&self, id: &str) -> Result<Option<TaskSnapshot>> {
+///         self.inner.get_task_result(id).await
+///     }
+///     async fn wait_for_completion(&self, id: &str) -> Result<Option<TaskSnapshot>> {
+///         self.inner.wait_for_completion(id).await
+///     }
+///     async fn list_tasks(&self, status: Option<TaskStatus>) -> Result<Vec<TaskObject>> {
+///         self.inner.list_tasks(status).await
+///     }
+///     async fn require_input(
+///         &self,
+///         id: &str,
+///         requests: InputRequests,
+///         message: Option<&str>,
+///     ) -> Result<bool> {
+///         self.inner.require_input(id, requests, message).await
+///     }
+///     async fn outstanding_input_requests(&self, id: &str) -> Result<Option<InputRequests>> {
+///         self.inner.outstanding_input_requests(id).await
+///     }
+///     async fn apply_input_responses(
+///         &self,
+///         id: &str,
+///         responses: InputResponses,
+///     ) -> Result<Option<AppliedInputResponses>> {
+///         self.inner.apply_input_responses(id, responses).await
+///     }
+///     async fn set_ttl(&self, id: &str, ttl_ms: u64) -> Result<bool> {
+///         self.inner.set_ttl(id, ttl_ms).await
+///     }
+///     async fn fail_task(&self, id: &str, error: JsonRpcError) -> Result<bool> {
+///         self.inner.fail_task(id, error).await
+///     }
+///     async fn cancel_task(&self, id: &str, reason: Option<&str>) -> Result<Option<TaskObject>> {
+///         self.inner.cancel_task(id, reason).await
+///     }
+///
+///     // Defaulted methods. Omitting these would leave the wrapper reporting
+///     // "not supported" for a store that supports them.
+///     async fn resume_context(&self, id: &str) -> Result<Option<TaskResumeContext>> {
+///         self.inner.resume_context(id).await
+///     }
+///     async fn set_task_meta(&self, id: &str, meta: serde_json::Value) -> Result<bool> {
+///         self.inner.set_task_meta(id, meta).await
+///     }
+///     async fn discard_task(&self, id: &str) -> Result<bool> {
+///         self.inner.discard_task(id).await
+///     }
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let completed = Arc::new(AtomicUsize::new(0));
+/// let store: Arc<dyn TaskStore> = Arc::new(CountingStore {
+///     inner: MemoryTaskStore::new(),
+///     completed: completed.clone(),
+/// });
+/// // Ready to hand to `McpRouter::task_store`.
+///
+/// let (id, _cancel) = store
+///     .create_task("build_report", serde_json::json!({}), None, None)
+///     .await
+///     .unwrap();
+/// assert!(store.complete_task(&id, CallToolResult::text("done")).await.unwrap());
+/// assert!(!store.complete_task(&id, CallToolResult::text("again")).await.unwrap());
+/// assert_eq!(completed.load(Ordering::Relaxed), 1);
+/// # }
+/// ```
 #[async_trait]
 pub trait TaskStore: Send + Sync + 'static {
     /// Create and store a new task owned by `owner`.
@@ -526,6 +808,64 @@ pub trait TaskStore: Send + Sync + 'static {
     /// before this rule existed keep compiling and keep their old permissive
     /// behaviour, so this is a behavioural migration rather than a
     /// compile-visible one.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore, TaskStoreError};
+    /// use tower_mcp::protocol::{InputRequest, InputRequests, ListRootsParams, TaskStatus};
+    ///
+    /// fn ask(keys: &[&str]) -> InputRequests {
+    ///     keys.iter()
+    ///         .map(|key| {
+    ///             (
+    ///                 key.to_string(),
+    ///                 InputRequest::ListRoots(ListRootsParams { meta: None }),
+    ///             )
+    ///         })
+    ///         .collect()
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({}), None, None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// assert!(
+    ///     store
+    ///         .require_input(&id, ask(&["approval"]), Some("needs a decision"))
+    ///         .await
+    ///         .unwrap()
+    /// );
+    /// let task = store.get_task(&id).await.unwrap().unwrap();
+    /// assert_eq!(task.status, TaskStatus::InputRequired);
+    /// assert_eq!(task.status_message.as_deref(), Some("needs a decision"));
+    ///
+    /// // Asking a second thing means reissuing the first: the snapshot is
+    /// // replaced wholesale, so a key left out becomes superseded.
+    /// assert!(
+    ///     store
+    ///         .require_input(&id, ask(&["approval", "region"]), None)
+    ///         .await
+    ///         .unwrap()
+    /// );
+    ///
+    /// // A spent key cannot come back. This one was superseded rather than
+    /// // answered; both count as spent.
+    /// store
+    ///     .require_input(&id, ask(&["region"]), None)
+    ///     .await
+    ///     .unwrap();
+    /// let error = store
+    ///     .require_input(&id, ask(&["approval"]), None)
+    ///     .await
+    ///     .expect_err("a spent key must not name a second question");
+    /// assert!(matches!(error, TaskStoreError::InvalidTransition(_)));
+    /// # }
+    /// ```
     async fn require_input(
         &self,
         task_id: &str,
@@ -546,6 +886,100 @@ pub trait TaskStore: Send + Sync + 'static {
     /// [`TaskStatus::Working`].
     ///
     /// Returns `None` if the task is unknown, expired, or already terminal.
+    ///
+    /// Ignoring is deliberate rather than lenient parsing. A key that was
+    /// never issued, one already answered, and one superseded by a later
+    /// request are indistinguishable to a client that is retrying, and
+    /// rejecting the whole update would fail a task over a duplicate delivery.
+    /// They are reported in [`AppliedInputResponses::ignored`] so a server can
+    /// still notice.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::protocol::{
+    ///     ElicitAction, ElicitResult, InputRequest, InputRequests, InputResponse,
+    ///     ListRootsParams, TaskStatus,
+    /// };
+    ///
+    /// fn ask(keys: &[&str]) -> InputRequests {
+    ///     keys.iter()
+    ///         .map(|key| {
+    ///             (
+    ///                 key.to_string(),
+    ///                 InputRequest::ListRoots(ListRootsParams { meta: None }),
+    ///             )
+    ///         })
+    ///         .collect()
+    /// }
+    ///
+    /// fn accept(key: &str) -> (String, InputResponse) {
+    ///     (
+    ///         key.to_string(),
+    ///         InputResponse::Elicit(ElicitResult {
+    ///             action: ElicitAction::Accept,
+    ///             content: None,
+    ///             meta: None,
+    ///         }),
+    ///     )
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({}), None, None)
+    ///     .await
+    ///     .unwrap();
+    /// store
+    ///     .require_input(&id, ask(&["approval", "region"]), None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// // A partial answer is valid, and leaves the task parked.
+    /// let applied = store
+    ///     .apply_input_responses(&id, [accept("approval")].into_iter().collect())
+    ///     .await
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert_eq!(applied.accepted, ["approval".to_string()].into());
+    /// assert_eq!(applied.still_outstanding, ["region".to_string()].into());
+    /// assert!(!applied.is_complete());
+    /// assert_eq!(
+    ///     store.get_task(&id).await.unwrap().unwrap().status,
+    ///     TaskStatus::InputRequired
+    /// );
+    ///
+    /// // A replayed answer, plus a key nobody asked for: both ignored, so the
+    /// // task is neither failed nor resumed early.
+    /// let applied = store
+    ///     .apply_input_responses(
+    ///         &id,
+    ///         [accept("approval"), accept("never-issued")].into_iter().collect(),
+    ///     )
+    ///     .await
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert!(applied.accepted.is_empty());
+    /// assert_eq!(
+    ///     applied.ignored,
+    ///     ["approval".to_string(), "never-issued".to_string()].into()
+    /// );
+    ///
+    /// // Answering the last outstanding request is what resumes the task.
+    /// let applied = store
+    ///     .apply_input_responses(&id, [accept("region")].into_iter().collect())
+    ///     .await
+    ///     .unwrap()
+    ///     .unwrap();
+    /// assert!(applied.is_complete());
+    /// assert_eq!(
+    ///     store.get_task(&id).await.unwrap().unwrap().status,
+    ///     TaskStatus::Working
+    /// );
+    /// # }
+    /// ```
     async fn apply_input_responses(
         &self,
         task_id: &str,
@@ -560,6 +994,69 @@ pub trait TaskStore: Send + Sync + 'static {
     /// forever. The default returns `None` so an external store written
     /// before resumption existed keeps compiling and fails loudly instead of
     /// hanging; implement it to support the flow (#1208).
+    ///
+    /// # Example
+    ///
+    /// The answers accumulate across rounds, because the handler is re-run
+    /// from the top and has to see everything it was told so far, not only the
+    /// most recent answer:
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::protocol::{
+    ///     ElicitAction, ElicitResult, InputRequest, InputRequests, InputResponse,
+    ///     ListRootsParams,
+    /// };
+    ///
+    /// # fn ask(keys: &[&str]) -> InputRequests {
+    /// #     keys.iter()
+    /// #         .map(|key| {
+    /// #             (
+    /// #                 key.to_string(),
+    /// #                 InputRequest::ListRoots(ListRootsParams { meta: None }),
+    /// #             )
+    /// #         })
+    /// #         .collect()
+    /// # }
+    /// # fn accept(key: &str) -> (String, InputResponse) {
+    /// #     (
+    /// #         key.to_string(),
+    /// #         InputResponse::Elicit(ElicitResult {
+    /// #             action: ElicitAction::Accept,
+    /// #             content: None,
+    /// #             meta: None,
+    /// #         }),
+    /// #     )
+    /// # }
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({"service": "api"}), None, None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// store.require_input(&id, ask(&["approval"]), None).await.unwrap();
+    /// store
+    ///     .apply_input_responses(&id, [accept("approval")].into_iter().collect())
+    ///     .await
+    ///     .unwrap();
+    /// store.require_input(&id, ask(&["region"]), None).await.unwrap();
+    /// store
+    ///     .apply_input_responses(&id, [accept("region")].into_iter().collect())
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let resume = store.resume_context(&id).await.unwrap().unwrap();
+    /// assert_eq!(resume.tool_name, "deploy");
+    /// assert_eq!(resume.arguments, serde_json::json!({"service": "api"}));
+    /// assert_eq!(
+    ///     resume.input_responses.keys().collect::<Vec<_>>(),
+    ///     vec!["approval", "region"],
+    ///     "an earlier round's answer is still there on the second resume"
+    /// );
+    /// # }
+    /// ```
     async fn resume_context(&self, task_id: &str) -> Result<Option<TaskResumeContext>> {
         let _ = task_id;
         Ok(None)
@@ -579,12 +1076,78 @@ pub trait TaskStore: Send + Sync + 'static {
     ///
     /// Returns `Ok(false)` if the task is unknown, expired, or already
     /// terminal.
+    ///
+    /// # Example
+    ///
+    /// A tool that ran and reported a problem is a completed task, and the
+    /// error result is what `tasks/get` hands back:
+    ///
+    /// ```rust
+    /// use tower_mcp::CallToolResult;
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::protocol::TaskStatus;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({}), None, None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let mut result = CallToolResult::text("region eu-west-3 is not enabled");
+    /// result.is_error = true;
+    /// assert!(store.complete_task(&id, result).await.unwrap());
+    ///
+    /// let (task, result, error) = store.get_task_result(&id).await.unwrap().unwrap();
+    /// assert_eq!(task.status, TaskStatus::Completed);
+    /// assert!(result.unwrap().is_error);
+    /// assert!(error.is_none(), "isError is a result, not a JSON-RPC error");
+    /// # }
+    /// ```
     async fn complete_task(&self, task_id: &str, result: CallToolResult) -> Result<bool>;
 
     /// Mark a task as failed with a structured execution error.
     ///
     /// Returns `Ok(false)` if the task is unknown, expired, or already
     /// terminal.
+    ///
+    /// Reserved for a call that never produced a result at all. A tool that
+    /// ran and reported a problem completes instead, carrying an `isError`
+    /// result; see [`complete_task`](Self::complete_task).
+    ///
+    /// # Example
+    ///
+    /// The error is stored whole, not flattened to a message, because
+    /// SEP-2663 requires `tasks/get` on a failed task to return a JSON-RPC
+    /// error object:
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::error::JsonRpcError;
+    /// use tower_mcp::protocol::TaskStatus;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({}), None, None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// let mut error = JsonRpcError::invalid_params("unknown region");
+    /// error.data = Some(serde_json::json!({"field": "region"}));
+    /// assert!(store.fail_task(&id, error).await.unwrap());
+    ///
+    /// let (task, result, error) = store.get_task_result(&id).await.unwrap().unwrap();
+    /// assert_eq!(task.status, TaskStatus::Failed);
+    /// assert!(result.is_none());
+    ///
+    /// let error = error.unwrap();
+    /// assert_eq!(error.code, -32602);
+    /// assert_eq!(error.data.unwrap()["field"], "region");
+    /// # }
+    /// ```
     async fn fail_task(&self, task_id: &str, error: JsonRpcError) -> Result<bool>;
 
     /// Cancel a task.
@@ -592,6 +1155,44 @@ pub trait TaskStore: Send + Sync + 'static {
     /// Signals the task's [`CancellationToken`] and, if the task is not
     /// already terminal, marks it cancelled. Returns the updated task object,
     /// or `None` if the task is unknown.
+    ///
+    /// The token is raised even for a task that already finished, so work
+    /// still winding down behind a completed task is told to stop. That is
+    /// also why the returned object may read `completed` rather than
+    /// `cancelled`: the recorded outcome does not change, only the token.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::CallToolResult;
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::protocol::TaskStatus;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// let (id, token) = store
+    ///     .create_task("deploy", serde_json::json!({}), None, None)
+    ///     .await
+    ///     .unwrap();
+    ///
+    /// // A handler polls the token between steps; cancellation is
+    /// // cooperative and interrupts nothing on its own.
+    /// assert!(!token.is_cancelled());
+    ///
+    /// let task = store.cancel_task(&id, Some("user closed the tab")).await.unwrap();
+    /// assert_eq!(task.unwrap().status, TaskStatus::Cancelled);
+    /// assert!(token.is_cancelled());
+    ///
+    /// // Cancelling again is harmless, and a late result is refused.
+    /// assert!(
+    ///     !store
+    ///         .complete_task(&id, CallToolResult::text("finished anyway"))
+    ///         .await
+    ///         .unwrap()
+    /// );
+    /// # }
+    /// ```
     async fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Result<Option<TaskObject>>;
 }
 
@@ -628,6 +1229,32 @@ impl MemoryTaskStore {
     ///
     /// Calling this is an optimization, not a correctness requirement: reads
     /// already treat an expired task as absent.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let store = MemoryTaskStore::new();
+    /// // A one millisecond retention window, and no terminal state: the
+    /// // clock runs from creation, so the task retires while still working.
+    /// let (id, _cancel) = store
+    ///     .create_task("deploy", serde_json::json!({}), Some(1), None)
+    ///     .await
+    ///     .unwrap();
+    /// tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    ///
+    /// // Already invisible, before anything has been reclaimed.
+    /// assert!(store.get_task(&id).await.unwrap().is_none());
+    /// assert!(store.list_tasks(None).await.unwrap().is_empty());
+    ///
+    /// // Cleanup only frees the memory the entry was still holding.
+    /// assert_eq!(store.cleanup_expired(), 1);
+    /// assert_eq!(store.cleanup_expired(), 0);
+    /// # }
+    /// ```
     pub fn cleanup_expired(&self) -> usize {
         if let Ok(mut tasks) = self.tasks.write() {
             let before = tasks.len();
@@ -1003,6 +1630,18 @@ impl crate::McpRouter {
     /// `io.modelcontextprotocol/tasks`, elect to return tasks from ordinary
     /// `tools/call` requests, or serve the final task methods. Legacy
     /// 2025-11-25 task behavior is unaffected either way.
+    ///
+    /// Adding this cannot change what an existing client sees. Both peers must
+    /// declare the extension for it to be negotiated, so a client that did not
+    /// keeps receiving the synchronous result.
+    ///
+    /// ```rust
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .with_tasks();
+    /// ```
     pub fn with_tasks(self) -> Self {
         self.with_protocol_extension(tasks_extension())
     }

--- a/crates/tower-mcp/src/auth.rs
+++ b/crates/tower-mcp/src/auth.rs
@@ -1,38 +1,59 @@
-//! Authentication middleware helpers for MCP servers
+//! Header-credential authentication for HTTP MCP servers.
 //!
-//! This module provides helper types and layers for common authentication patterns.
-//! Since tower-mcp is built on Tower, standard tower middleware can be used directly.
+//! These helpers cover the case where the credential is a shared secret the
+//! server can check against something it already holds: an API key, or a
+//! bearer token drawn from a fixed set. Write the check as a [`Validate`]
+//! implementation and install it with [`AuthLayer`].
 //!
-//! # Patterns
+//! For OAuth 2.1 resource-server behavior, reach for [`crate::oauth`] instead.
+//! It validates JWT signatures and audiences, enforces scopes, serves
+//! Protected Resource Metadata, and answers with the `WWW-Authenticate`
+//! challenge an OAuth client needs in order to recover. It also bridges the
+//! token's `sub` claim into the request extensions, which is what binds an
+//! async task to the principal that created it. Nothing in this module
+//! populates that claim, so on a server authenticated with an [`AuthLayer`]
+//! every task is unowned (see [`crate::async_task`]).
 //!
-//! ## API Key Authentication
+//! # Where the layer belongs
 //!
-//! ```rust,ignore
-//! // Requires the `http` feature
-//! use tower_mcp::auth::{AuthConfig, ApiKeyValidator};
-//! use tower_mcp::{McpRouter, HttpTransport};
-//! use std::sync::Arc;
+//! [`AuthLayer`] operates on the HTTP request, not on a decoded MCP request,
+//! so it wraps the transport rather than being installed inside it with
+//! [`HttpTransport::layer`]. A request with no acceptable credential is
+//! refused before its JSON-RPC body is parsed, so no handler ever runs for it,
+//! and the rejection costs nothing but the header read.
 //!
-//! // Simple in-memory API key validator
-//! let valid_keys = vec!["sk-test-key-123".to_string()];
-//! let validator = ApiKeyValidator::new(valid_keys);
+//! ```rust
+//! # #[tokio::main]
+//! # async fn main() {
+//! # #[cfg(feature = "http")]
+//! # {
+//! use tower_mcp::auth::{ApiKeyValidator, AuthLayer};
+//! use tower_mcp::transport::HttpTransport;
+//! use tower_mcp::McpRouter;
 //!
+//! let validator = ApiKeyValidator::new(["sk-live-1".to_string()]);
 //! let router = McpRouter::new().server_info("my-server", "1.0.0");
-//! let transport = HttpTransport::new(router);
 //!
-//! // The auth layer extracts the key from the Authorization header
-//! // and validates it using the provided validator
+//! // `into_router` hands back a plain axum router, so the auth layer goes on
+//! // the outside like any other HTTP middleware.
+//! let app = HttpTransport::new(router)
+//!     .into_router()
+//!     .layer(AuthLayer::new(validator));
+//! # let _ = app;
+//! # }
+//! # }
 //! ```
 //!
-//! ## Bearer Token Authentication
+//! # What a rejection looks like
 //!
-//! For OAuth2/JWT tokens, use the `BearerTokenValidator` trait to implement
-//! custom validation logic (e.g., JWT verification, token introspection).
+//! A missing credential and a rejected one both produce HTTP 401 carrying a
+//! JSON-RPC error body; only the message differs. The body's code is
+//! [`McpErrorCode::Forbidden`] (-32007) rather than the -32001 earlier
+//! versions used, because SEP-2243 reclaimed -32001 for `HeaderMismatch` and
+//! clients route on the code.
 //!
-//! ## Custom Authentication
-//!
-//! You can implement custom auth by creating a Tower layer. See the examples
-//! directory for a complete example.
+//! [`HttpTransport::layer`]: crate::transport::HttpTransport::layer
+//! [`McpErrorCode::Forbidden`]: crate::error::McpErrorCode::Forbidden
 
 use std::collections::HashSet;
 use std::future::Future;
@@ -43,16 +64,28 @@ use tower::Layer;
 use tower::ServiceExt;
 
 /// Result of an authentication attempt
+///
+/// Returned by [`Validate::validate`] and consumed by [`AuthService`].
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum AuthResult {
-    /// Authentication succeeded with optional user/client info
+    /// Authentication succeeded with optional user/client info.
+    ///
+    /// The [`AuthInfo`], when present, is inserted into the request's
+    /// extensions for downstream services to read. `None` admits the request
+    /// without recording who sent it, which is worth avoiding on anything
+    /// that later wants to attribute an action.
     Authenticated(Option<AuthInfo>),
     /// Authentication failed with a reason
     Failed(AuthError),
 }
 
 /// Information about an authenticated client
+///
+/// [`AuthService`] inserts this into the HTTP request extensions, so an inner
+/// service reads it with `req.extensions().get::<AuthInfo>()`. It does not
+/// reach an MCP handler's [`RequestContext`](crate::context::RequestContext):
+/// only the OAuth path bridges a principal that far.
 #[derive(Debug, Clone)]
 pub struct AuthInfo {
     /// Client/user identifier
@@ -62,6 +95,11 @@ pub struct AuthInfo {
 }
 
 /// Authentication error
+///
+/// The `code` is for the server's own logs and metrics; it is not the
+/// JSON-RPC error code the client sees, which is always -32007. `message` is
+/// copied into the 401 body verbatim, so it should say what the caller can act
+/// on and nothing about why the check failed internally.
 #[derive(Debug, Clone)]
 pub struct AuthError {
     /// Error code (e.g., "invalid_token", "expired_token")
@@ -88,33 +126,67 @@ impl std::error::Error for AuthError {}
 /// with [`AuthLayer`] and [`AuthService`].
 ///
 /// The credential string passed to [`validate`](Validate::validate) is the
-/// value extracted from the configured request header after parsing
-/// (e.g., the token portion of `"Bearer sk-123"`).
+/// value extracted from the configured request header after parsing by
+/// [`extract_api_key`], so an implementation sees `sk-123` whether the header
+/// read `Bearer sk-123`, `ApiKey sk-123`, or `sk-123`.
+///
+/// The bound is `Clone + Send + Sync + 'static` because [`AuthService`] clones
+/// the validator for every request. Keep any shared state behind an [`Arc`],
+/// as [`ApiKeyValidator`] does, so cloning stays cheap.
 ///
 /// # Example
 ///
+/// A validator that looks the credential up in a store, and reports who the
+/// caller is so the inner service can attribute the request:
+///
 /// ```rust
-/// use tower_mcp::auth::{Validate, AuthResult, AuthInfo, AuthError};
+/// use std::collections::HashMap;
+/// use std::sync::Arc;
+///
+/// use tower_mcp::auth::{AuthError, AuthInfo, AuthResult, Validate};
 ///
 /// #[derive(Clone)]
-/// struct MyValidator;
+/// struct TenantKeys {
+///     // Cheap to clone: the map is shared, not copied, per request.
+///     keys: Arc<HashMap<String, String>>,
+/// }
 ///
-/// impl Validate for MyValidator {
+/// impl Validate for TenantKeys {
 ///     async fn validate(&self, credential: &str) -> AuthResult {
-///         if credential.starts_with("sk-") {
-///             AuthResult::Authenticated(Some(AuthInfo {
-///                 client_id: credential.to_string(),
+///         match self.keys.get(credential) {
+///             Some(tenant) => AuthResult::Authenticated(Some(AuthInfo {
+///                 client_id: tenant.clone(),
 ///                 claims: None,
-///             }))
-///         } else {
-///             AuthResult::Failed(AuthError {
-///                 code: "invalid_credential".to_string(),
-///                 message: "Credential must start with sk-".to_string(),
-///             })
+///             })),
+///             // The message is copied into the 401 body, so it says what to
+///             // do rather than which lookup missed.
+///             None => AuthResult::Failed(AuthError {
+///                 code: "invalid_api_key".to_string(),
+///                 message: "Unknown API key".to_string(),
+///             }),
 ///         }
 ///     }
 /// }
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let validator = TenantKeys {
+///     keys: Arc::new(HashMap::from([("sk-live-1".to_string(), "acme".to_string())])),
+/// };
+///
+/// let AuthResult::Authenticated(Some(info)) = validator.validate("sk-live-1").await else {
+///     panic!("a known key authenticates");
+/// };
+/// assert_eq!(info.client_id, "acme");
+///
+/// assert!(matches!(
+///     validator.validate("sk-unknown").await,
+///     AuthResult::Failed(_)
+/// ));
+/// # }
 /// ```
+///
+/// [`Arc`]: std::sync::Arc
 pub trait Validate: Clone + Send + Sync + 'static {
     /// Validate a credential and return the authentication result.
     fn validate(&self, credential: &str) -> impl Future<Output = AuthResult> + Send;
@@ -126,10 +198,17 @@ pub trait Validate: Clone + Send + Sync + 'static {
 
 /// Simple in-memory API key validator
 ///
+/// The key set is fixed at construction and shared by every clone, which is
+/// what makes it cheap enough for [`AuthService`] to clone per request.
+///
 /// For production use, consider:
 /// - Database-backed validation
 /// - Caching with TTL
 /// - Rate limiting per key
+///
+/// The [`AuthInfo`] it reports names the caller as `api_key:` followed by the
+/// first eight characters of the key, so a log line identifies which key was
+/// used without recording the secret.
 #[derive(Debug, Clone)]
 pub struct ApiKeyValidator {
     valid_keys: Arc<HashSet<String>>,
@@ -144,6 +223,26 @@ impl ApiKeyValidator {
     }
 
     /// Add a key to the valid set
+    ///
+    /// The set is copy-on-write, so this affects only the validator it is
+    /// called on. A validator already handed to [`AuthLayer::new`] was cloned
+    /// into the layer, and the running service keeps serving the set it was
+    /// built with. Rotating keys on a live server therefore needs a validator
+    /// that reads shared mutable state, not this method.
+    ///
+    /// ```rust
+    /// use tower_mcp::auth::ApiKeyValidator;
+    ///
+    /// let installed = ApiKeyValidator::new(["sk-live-1".to_string()]);
+    /// let mut local = installed.clone();
+    /// local.add_key("sk-live-2".to_string());
+    ///
+    /// assert!(local.is_valid("sk-live-2"));
+    /// assert!(
+    ///     !installed.is_valid("sk-live-2"),
+    ///     "the clone diverged; the already-installed validator did not change"
+    /// );
+    /// ```
     pub fn add_key(&mut self, key: String) {
         Arc::make_mut(&mut self.valid_keys).insert(key);
     }
@@ -176,10 +275,18 @@ impl Validate for ApiKeyValidator {
 
 /// Simple bearer token validator that checks against a static set of tokens.
 ///
+/// An exact match against an in-memory set: it does not decode the token, so
+/// it cannot notice an expiry, an audience, or a scope. That makes it suitable
+/// for development, tests, and machine-to-machine links where the token is a
+/// shared secret you rotate by restarting.
+///
 /// For production, implement [`Validate`] with:
 /// - JWT verification using a signing key
 /// - OAuth2 token introspection
 /// - OIDC ID token validation
+///
+/// [`crate::oauth`] already does the first of those, including audience checks
+/// and the `WWW-Authenticate` challenge an OAuth client needs to recover.
 #[derive(Debug, Clone)]
 pub struct StaticBearerValidator {
     valid_tokens: Arc<HashSet<String>>,
@@ -220,6 +327,27 @@ impl Validate for StaticBearerValidator {
 /// - `Bearer <key>` (standard)
 /// - `ApiKey <key>`
 /// - `<key>` (raw key)
+///
+/// This is what [`AuthService`] applies to whichever header
+/// [`AuthLayer::header_name`] names, so a custom header accepts all three
+/// forms too.
+///
+/// Two consequences are easy to miss. Any value with no spaces is taken as a
+/// raw key, so a header carrying something that is not a credential at all is
+/// still handed to the validator to reject. And the scheme match is
+/// case-sensitive, so `bearer <key>` is not recognized: it has a space but no
+/// known prefix, which reads as no credential.
+///
+/// ```rust
+/// use tower_mcp::auth::extract_api_key;
+///
+/// assert_eq!(extract_api_key("Bearer sk-123"), Some("sk-123"));
+/// assert_eq!(extract_api_key("ApiKey sk-123"), Some("sk-123"));
+/// assert_eq!(extract_api_key("sk-123"), Some("sk-123"));
+///
+/// assert_eq!(extract_api_key("Basic dXNlcjpwYXNz"), None);
+/// assert_eq!(extract_api_key("bearer sk-123"), None);
+/// ```
 pub fn extract_api_key(auth_header: &str) -> Option<&str> {
     let auth_header = auth_header.trim();
 
@@ -236,6 +364,18 @@ pub fn extract_api_key(auth_header: &str) -> Option<&str> {
 }
 
 /// Extract a bearer token from an Authorization header
+///
+/// Stricter than [`extract_api_key`]: only the `Bearer ` form is accepted, and
+/// the scheme is matched case-sensitively. A bare value with no scheme is
+/// rejected rather than treated as a raw token.
+///
+/// ```rust
+/// use tower_mcp::auth::extract_bearer_token;
+///
+/// assert_eq!(extract_bearer_token("Bearer abc123"), Some("abc123"));
+/// assert_eq!(extract_bearer_token("abc123"), None);
+/// assert_eq!(extract_bearer_token("bearer abc123"), None);
+/// ```
 pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
     auth_header.trim().strip_prefix("Bearer ").map(|t| t.trim())
 }
@@ -246,8 +386,69 @@ pub fn extract_bearer_token(auth_header: &str) -> Option<&str> {
 
 /// A Tower layer that performs authentication using a provided validator
 ///
-/// This is a generic auth layer that can be used with any validator that
-/// implements the appropriate validation trait.
+/// Wraps an HTTP service with any [`Validate`] implementation: the credential
+/// is read from one header, checked, and either the request continues with an
+/// [`AuthInfo`] in its extensions or it is answered with 401 without reaching
+/// the inner service.
+///
+/// The layer itself imposes no bounds, so it can be constructed in any build.
+/// The [`Service`](tower_service::Service) implementation it produces exists
+/// only with the `http` feature, since that is what supplies the request and
+/// response types.
+///
+/// # Example
+///
+/// ```rust
+/// # #[tokio::main]
+/// # async fn main() {
+/// # #[cfg(feature = "http")]
+/// # {
+/// use axum::body::Body;
+/// use axum::http::{Request, StatusCode};
+/// use axum::response::Response;
+/// use tower::{Layer, ServiceExt};
+/// use tower_mcp::auth::{ApiKeyValidator, AuthInfo, AuthLayer};
+///
+/// // Stands in for the transport. It answers 200 only when the layer named
+/// // the caller, so the assertions below also prove the extension is set.
+/// let inner = tower::service_fn(|req: Request<Body>| async move {
+///     let status = match req.extensions().get::<AuthInfo>() {
+///         Some(_) => StatusCode::OK,
+///         None => StatusCode::INTERNAL_SERVER_ERROR,
+///     };
+///     Ok::<_, std::convert::Infallible>(
+///         Response::builder().status(status).body(Body::empty()).unwrap(),
+///     )
+/// });
+///
+/// let service = AuthLayer::new(ApiKeyValidator::new(["sk-live-1".to_string()])).layer(inner);
+///
+/// let no_credential = Request::builder().uri("/mcp").body(Body::empty()).unwrap();
+/// let response = service.clone().oneshot(no_credential).await.unwrap();
+/// assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+///
+/// let wrong_key = Request::builder()
+///     .uri("/mcp")
+///     .header("Authorization", "Bearer sk-not-issued")
+///     .body(Body::empty())
+///     .unwrap();
+/// let response = service.clone().oneshot(wrong_key).await.unwrap();
+/// assert_eq!(
+///     response.status(),
+///     StatusCode::UNAUTHORIZED,
+///     "a rejected credential is answered exactly like a missing one"
+/// );
+///
+/// let good_key = Request::builder()
+///     .uri("/mcp")
+///     .header("Authorization", "Bearer sk-live-1")
+///     .body(Body::empty())
+///     .unwrap();
+/// let response = service.oneshot(good_key).await.unwrap();
+/// assert_eq!(response.status(), StatusCode::OK);
+/// # }
+/// # }
+/// ```
 #[derive(Clone)]
 pub struct AuthLayer<V> {
     validator: V,
@@ -266,6 +467,15 @@ impl<V> AuthLayer<V> {
     }
 
     /// Use a custom header name for the auth token
+    ///
+    /// Only where the credential is read from changes. The value is still
+    /// parsed by [`extract_api_key`], so `X-API-Key: sk-1` and
+    /// `X-API-Key: Bearer sk-1` are both accepted and both reach the validator
+    /// as `sk-1`.
+    ///
+    /// The named header becomes the only one consulted: an `Authorization`
+    /// header alongside it is ignored, and a request carrying only
+    /// `Authorization` is refused as though it carried no credential at all.
     pub fn header_name(mut self, name: impl Into<String>) -> Self {
         self.header_name = name.into();
         self
@@ -286,24 +496,23 @@ impl<S, V: Clone> Layer<S> for AuthLayer<V> {
 
 /// Tower service that performs authentication on incoming requests.
 ///
-/// Created by [`AuthLayer`]. Extracts credentials from the configured HTTP
-/// header, validates them using the provided [`Validate`] implementation,
-/// and either forwards the request (injecting [`AuthInfo`] into request
-/// extensions) or returns an HTTP 401 response.
+/// Created by [`AuthLayer`], which carries the worked example. Extracts the
+/// credential from the configured HTTP header with [`extract_api_key`],
+/// validates it with the provided [`Validate`] implementation, and either
+/// forwards the request or answers 401 without calling the inner service.
 ///
-/// # Example
+/// Three details are worth knowing before relying on it:
 ///
-/// ```rust,ignore
-/// // Requires the `http` feature
-/// use tower::ServiceBuilder;
-/// use tower_mcp::auth::{AuthLayer, ApiKeyValidator};
-///
-/// let validator = ApiKeyValidator::new(vec!["sk-test-key-123".to_string()]);
-///
-/// let service = ServiceBuilder::new()
-///     .layer(AuthLayer::new(validator))
-///     .service(inner_service);
-/// ```
+/// - A missing credential is refused without consulting the validator, so a
+///   [`Validate`] implementation never sees an empty string and cannot choose
+///   to admit anonymous callers. Use [`AuthLayer`] only on routes that must be
+///   authenticated, and leave public routes outside it.
+/// - [`AuthResult::Authenticated(None)`](AuthResult::Authenticated) forwards
+///   the request with no [`AuthInfo`] in its extensions, so the inner service
+///   cannot tell it apart from an unauthenticated one it never sees.
+/// - `poll_ready` delegates to the inner service, so backpressure is the inner
+///   service's, unchanged. Validation itself runs in the returned future, not
+///   in `poll_ready`.
 #[derive(Clone)]
 #[cfg_attr(not(feature = "http"), allow(dead_code))]
 pub struct AuthService<S, V> {
@@ -395,7 +604,38 @@ fn unauthorized_response(message: &str) -> axum::response::Response {
 // Helper for building auth middleware
 // =============================================================================
 
-/// Builder for creating auth middleware configurations
+/// Auth policy an application applies itself.
+///
+/// A container for the three settings an HTTP server usually needs to decide
+/// before it authenticates anything. Nothing in this crate reads it:
+/// [`AuthLayer`] takes its header name directly and authenticates every
+/// request it wraps, so routing public paths around it, or honoring
+/// `allow_anonymous`, is the application's own dispatch.
+///
+/// [`OAuthLayer::public_path`] is the enforced equivalent for servers on the
+/// OAuth path.
+///
+/// # Example
+///
+/// ```rust
+/// use tower_mcp::auth::AuthConfig;
+///
+/// let config = AuthConfig::new()
+///     .public_path("/health")
+///     .header_name("X-API-Key");
+///
+/// assert!(config.is_public("/health"));
+/// // Matching is by prefix, so everything under a public path is public too.
+/// assert!(config.is_public("/health/ready"));
+/// assert!(!config.is_public("/mcp"));
+///
+/// // Prefix matching does not stop at a path segment: a neighboring route
+/// // that merely starts with the same text is public as well. Name paths
+/// // that would be unsafe to expose so that no prefix of them is listed.
+/// assert!(config.is_public("/healthz-internal"));
+/// ```
+///
+/// [`OAuthLayer::public_path`]: crate::oauth::OAuthLayer::public_path
 #[derive(Clone)]
 pub struct AuthConfig {
     /// Whether to allow unauthenticated requests to pass through
@@ -429,18 +669,26 @@ impl AuthConfig {
     }
 
     /// Add paths that don't require authentication
+    ///
+    /// Read back with [`is_public`](Self::is_public), which matches by prefix.
     pub fn public_path(mut self, path: impl Into<String>) -> Self {
         self.public_paths.push(path.into());
         self
     }
 
     /// Set the header name for auth tokens
+    ///
+    /// Recording the choice here does not apply it. The layer reads whichever
+    /// header [`AuthLayer::header_name`] names.
     pub fn header_name(mut self, name: impl Into<String>) -> Self {
         self.header_name = name.into();
         self
     }
 
     /// Check if a path is public (doesn't require auth)
+    ///
+    /// True when the path starts with any registered prefix. See the type
+    /// documentation for what that includes and does not.
     pub fn is_public(&self, path: &str) -> bool {
         self.public_paths.iter().any(|p| path.starts_with(p))
     }

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -8,6 +8,23 @@
 //! See [`crate::guides::client`] for transport selection, lifecycle setup,
 //! callbacks, common requests, caching, retry policy, and shutdown guidance.
 //!
+//! # Opening a connection
+//!
+//! Connecting and starting a session are separate steps, because which session
+//! to start is a choice:
+//!
+//! 1. [`McpClient::connect`] (or [`McpClientBuilder::connect`]) takes the
+//!    transport and spawns the message loop. No MCP traffic has happened yet.
+//! 2. [`McpClient::initialize`] performs the 2025-11-25 handshake, or
+//!    [`McpClient::discover`] starts the sessionless 2026-07-28 lifecycle.
+//!    Every other request is refused until one of them has run.
+//!
+//! Which requests exist depends on that choice, and the difference is not
+//! cosmetic: 2026-07-28 removed `ping`, replaced `resources/subscribe` with
+//! [`McpClient::listen_subscriptions`], and made task creation the server's
+//! decision. The methods that changed say so, and
+//! [`crate::guides::protocol_versions`] covers the split.
+//!
 //! # Example
 //!
 //! ```rust,no_run
@@ -232,11 +249,20 @@ enum LoopCommand {
 
 /// An active `subscriptions/listen` request.
 ///
+/// Returned by [`McpClient::listen_subscriptions`], which is refused unless
+/// the 2026-07-28 lifecycle is active: this is what replaced
+/// `resources/subscribe` there.
+///
 /// The handle exposes the JSON-RPC request ID used as the subscription ID,
 /// the server's acknowledged filter, graceful server completion, and explicit
 /// cancellation. Dropping an active handle requests cancellation on a
 /// best-effort basis; callers that need confirmation should call
 /// [`cancel()`](Self::cancel).
+///
+/// The notifications themselves do not arrive through this handle. They reach
+/// the client's [`NotificationHandler`], tagged with the subscription ID, so a
+/// client that opens a stream without registering one receives nothing it can
+/// observe.
 #[must_use = "dropping the handle cancels the active subscription"]
 pub struct SubscriptionHandle {
     request_id: RequestId,
@@ -332,25 +358,58 @@ impl Drop for SubscriptionHandle {
 /// into a background Tokio task that handles message multiplexing.
 ///
 /// All public methods take `&self`, enabling concurrent use from multiple
-/// tasks.
+/// tasks. Responses are correlated by JSON-RPC id, so two tasks sharing one
+/// client do not queue behind each other and a slow tool call does not hold up
+/// a `tools/list` issued after it.
 ///
-/// # Construction
+/// # Ending the connection
 ///
-/// ```rust,no_run
-/// use tower_mcp::client::{McpClient, StdioClientTransport};
+/// [`shutdown()`](Self::shutdown) asks the loop to stop and waits for it.
+/// Dropping the client instead aborts the loop where it stands, so anything
+/// still in flight is abandoned and the transport closes without a parting
+/// message. Prefer `shutdown` wherever the server cares about a clean close.
 ///
-/// # async fn example() -> Result<(), tower_mcp::BoxError> {
-/// // Simple: no handler for server-initiated requests
-/// let transport = StdioClientTransport::spawn("server", &[]).await?;
-/// let client = McpClient::connect(transport).await?;
+/// # Example
 ///
-/// // With configuration
-/// use tower_mcp::protocol::Root;
-/// let transport = StdioClientTransport::spawn("server", &[]).await?;
-/// let client = McpClient::builder()
-///     .with_roots(vec![Root::new("file:///project")])
-///     .connect_simple(transport)
-///     .await?;
+/// [`ChannelTransport`] connects to a router in the same process, which is
+/// what makes this runnable here. Swap it for [`StdioClientTransport`] or
+/// `HttpClientTransport` and nothing else changes:
+///
+/// ```rust
+/// use tower_mcp::client::{ChannelTransport, McpClient};
+/// use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+/// use schemars::JsonSchema;
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize, JsonSchema)]
+/// struct AddInput {
+///     a: i64,
+///     b: i64,
+/// }
+///
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), tower_mcp::BoxError> {
+/// let add = ToolBuilder::new("add")
+///     .description("Add two numbers")
+///     .handler(|input: AddInput| async move {
+///         Ok(CallToolResult::text((input.a + input.b).to_string()))
+///     })
+///     .build();
+/// let server = McpRouter::new().server_info("calculator", "1.0.0").tool(add);
+///
+/// let client = McpClient::connect(ChannelTransport::new(server)).await?;
+///
+/// // Nothing else is permitted until the session is open.
+/// let server_info = client.initialize("my-client", "1.0.0").await?;
+/// assert_eq!(server_info.server_info.name, "calculator");
+///
+/// let tools = client.list_tools().await?;
+/// assert_eq!(tools.tools[0].name, "add");
+///
+/// let result = client.call_tool("add", serde_json::json!({"a": 2, "b": 3})).await?;
+/// assert_eq!(result.all_text(), "5");
+///
+/// client.shutdown().await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -408,20 +467,39 @@ struct ClientSettings {
 
 /// Builder for configuring and connecting an [`McpClient`].
 ///
+/// Everything here is settled before the connection opens, because it is what
+/// the client declares about itself during the handshake. Declaring a
+/// capability is a promise to answer the matching server request, so pair
+/// [`with_sampling`](Self::with_sampling) and
+/// [`with_elicitation`](Self::with_elicitation) with a [`ClientHandler`] that
+/// implements them; a client that declares one and connects with
+/// [`connect_simple`](Self::connect_simple) advertises something it will
+/// refuse.
+///
 /// # Example
 ///
-/// ```rust,no_run
-/// use tower_mcp::client::{McpClient, StdioClientTransport};
+/// ```rust
+/// use tower_mcp::client::{ChannelTransport, McpClient};
 /// use tower_mcp::protocol::Root;
+/// use tower_mcp::McpRouter;
 ///
-/// # async fn example() -> Result<(), tower_mcp::BoxError> {
-/// let transport = StdioClientTransport::spawn("server", &[]).await?;
-/// let handler = (); // Use a real ClientHandler for bidirectional support
+/// # #[tokio::main]
+/// # async fn main() -> Result<(), tower_mcp::BoxError> {
+/// # let transport = ChannelTransport::new(McpRouter::new().server_info("server", "1.0.0"));
+/// // A handler-free client: it declares roots, which it answers itself, but
+/// // nothing that needs a ClientHandler.
 /// let client = McpClient::builder()
 ///     .with_roots(vec![Root::new("file:///project")])
-///     .with_sampling()
-///     .connect(transport, handler)
+///     .connect_simple(transport)
 ///     .await?;
+///
+/// client.initialize("my-client", "1.0.0").await?;
+/// assert_eq!(client.roots().await.len(), 1);
+///
+/// // Roots stay editable, and the server is told when they change.
+/// client.add_root(Root::new("file:///scratch")).await?;
+/// assert_eq!(client.roots().await.len(), 2);
+/// # client.shutdown().await?;
 /// # Ok(())
 /// # }
 /// ```
@@ -562,6 +640,9 @@ impl McpClientBuilder {
     ///
     /// Spawns a background task to handle message I/O. The transport is
     /// consumed and owned by the background task.
+    ///
+    /// No MCP request has been sent when this returns. Call
+    /// [`McpClient::initialize`] or [`McpClient::discover`] next.
     pub async fn connect<T, H>(self, transport: T, handler: H) -> Result<McpClient>
     where
         T: ClientTransport,
@@ -585,6 +666,9 @@ impl McpClientBuilder {
     /// Connect to a server without a handler.
     ///
     /// All server-initiated requests will be rejected with `method_not_found`.
+    /// Two are answered by the loop itself and so still work: `ping`, and
+    /// `roots/list` whenever [`with_roots`](Self::with_roots) configured a
+    /// non-empty list.
     pub async fn connect_simple<T: ClientTransport>(self, transport: T) -> Result<McpClient> {
         self.connect(transport, ()).await
     }
@@ -739,8 +823,25 @@ impl McpClient {
 
     /// Initialize the MCP connection.
     ///
-    /// Sends the `initialize` request and `notifications/initialized` notification.
-    /// Must be called before any other operations.
+    /// Sends the `initialize` request and `notifications/initialized`
+    /// notification. Must be called before any other operations: everything
+    /// else refuses to run until this has succeeded.
+    ///
+    /// This is the 2025-11-25 handshake. It always offers
+    /// [`LATEST_PROTOCOL_VERSION`](crate::protocol::LATEST_PROTOCOL_VERSION)
+    /// and lets the server choose; the sessionless 2026-07-28 lifecycle is
+    /// [`discover`](Self::discover) instead, and the two are alternatives
+    /// rather than steps.
+    ///
+    /// A failure to deliver `notifications/initialized` fails the whole call,
+    /// even though the `initialize` request itself succeeded. The server
+    /// rejects every later request until that notification lands, so reporting
+    /// success here would leave a client that looks connected and works for
+    /// nothing.
+    ///
+    /// The name and version are recorded, so a transport that supports session
+    /// recovery can re-initialize with the same identity without the caller
+    /// repeating it.
     pub async fn initialize(
         &self,
         client_name: &str,
@@ -885,17 +986,87 @@ impl McpClient {
     }
 
     /// List available tools.
+    ///
+    /// One page. A server that paginates returns a `next_cursor`, and
+    /// ignoring it silently hides the rest of the catalogue, so prefer
+    /// [`list_all_tools`](Self::list_all_tools) unless the caller is driving
+    /// pagination itself with
+    /// [`list_tools_with_cursor`](Self::list_tools_with_cursor).
     pub async fn list_tools(&self) -> Result<ListToolsResult> {
         self.list_tools_with_cursor(None).await
     }
 
     /// Call a tool.
     ///
+    /// Returns the tool's result whatever route the server took to produce it.
+    /// If the server asks for input, the registered [`ClientHandler`] answers
+    /// and the call is retried, up to
+    /// [`max_mrtr_rounds`](McpClientBuilder::max_mrtr_rounds). If the server
+    /// elects to run the call as a task, the task is polled to completion and
+    /// its result returned here. Use
+    /// [`call_tool_once`](Self::call_tool_once) or
+    /// [`call_tool_once_task_aware`](Self::call_tool_once_task_aware) to drive
+    /// either of those yourself.
+    ///
+    /// A result carrying `is_error: true` is returned as `Ok`, not `Err`: the
+    /// tool ran and reported a domain error, which is an answer. `Err` is for
+    /// a call that produced no result at all.
+    ///
     /// On the final lifecycle, a header mismatch, method-not-found, or
     /// invalid-params response can indicate that the cached tool schema is
     /// stale. The client invalidates `tools/list`, refreshes it, and retries
     /// the rejected round once. These errors are raised before tool execution,
     /// so the bounded retry does not replay a completed side effect.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::client::{ChannelTransport, McpClient};
+    /// use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+    /// use schemars::JsonSchema;
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Debug, Deserialize, JsonSchema)]
+    /// struct DivideInput {
+    ///     numerator: i64,
+    ///     denominator: i64,
+    /// }
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), tower_mcp::BoxError> {
+    /// let divide = ToolBuilder::new("divide")
+    ///     .description("Divide two integers")
+    ///     .handler(|input: DivideInput| async move {
+    ///         if input.denominator == 0 {
+    ///             return Ok(CallToolResult::error("cannot divide by zero"));
+    ///         }
+    ///         Ok(CallToolResult::text(
+    ///             (input.numerator / input.denominator).to_string(),
+    ///         ))
+    ///     })
+    ///     .build();
+    ///
+    /// let server = McpRouter::new().server_info("math", "1.0.0").tool(divide);
+    /// let client = McpClient::connect(ChannelTransport::new(server)).await?;
+    /// client.initialize("my-client", "1.0.0").await?;
+    ///
+    /// let result = client
+    ///     .call_tool("divide", serde_json::json!({"numerator": 9, "denominator": 3}))
+    ///     .await?;
+    /// assert!(!result.is_error);
+    /// assert_eq!(result.all_text(), "3");
+    ///
+    /// // The tool's own error is a successful call with an error result, so
+    /// // `?` does not short-circuit here.
+    /// let refused = client
+    ///     .call_tool("divide", serde_json::json!({"numerator": 9, "denominator": 0}))
+    ///     .await?;
+    /// assert!(refused.is_error);
+    /// assert_eq!(refused.all_text(), "cannot divide by zero");
+    /// # client.shutdown().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn call_tool(
         &self,
         name: &str,
@@ -1070,6 +1241,11 @@ impl McpClient {
     /// [`CallToolResult`] in its `result` field; for `failed` tasks the
     /// JSON-RPC error is in `error`. Unknown or expired task ids surface as
     /// an invalid-params error from the server.
+    ///
+    /// A denied task reads exactly like an unknown one, so an
+    /// invalid-params answer here does not distinguish "never existed",
+    /// "expired", and "belongs to someone else". [`crate::async_task`]
+    /// explains why the server refuses to tell them apart.
     pub async fn task_get(&self, task_id: &str) -> Result<TaskObject> {
         self.ensure_initialized()?;
         if self.uses_final_protocol().await {
@@ -1177,6 +1353,13 @@ impl McpClient {
     /// task purged after its TTL surfaces as the server's task-not-found
     /// error. Wrap in
     /// [`tokio::time::timeout`] to bound the overall wait.
+    ///
+    /// This loops on its own: there is no upper bound beyond the task's TTL,
+    /// and a task that keeps asking for input keeps the loop running. The
+    /// push alternative is a
+    /// [`listen_subscriptions`](Self::listen_subscriptions) stream naming the
+    /// task, where each `notifications/tasks` carries the whole task and a
+    /// completion arrives with its result already attached.
     pub async fn task_wait(&self, task_id: &str) -> Result<TaskObject> {
         if self.uses_final_protocol().await {
             let result = self.wait_for_final_task(task_id).await?;
@@ -1470,6 +1653,44 @@ impl McpClient {
     }
 
     /// List all tools, following pagination cursors until exhausted.
+    ///
+    /// The pages are separate requests, so a catalogue that changes while the
+    /// walk is in progress can yield a list that never existed at any single
+    /// moment. That is inherent to cursor pagination rather than something
+    /// this method could fix; a client that needs a consistent view should
+    /// re-list after `notifications/tools/list_changed`.
+    ///
+    /// ```rust
+    /// use tower_mcp::client::{ChannelTransport, McpClient};
+    /// use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), tower_mcp::BoxError> {
+    /// let mut server = McpRouter::new()
+    ///     .server_info("many-tools", "1.0.0")
+    ///     // One tool per page, so the walk has to follow a cursor.
+    ///     .page_size(1);
+    /// for name in ["alpha", "beta", "gamma"] {
+    ///     server = server.tool(
+    ///         ToolBuilder::new(name)
+    ///             .description("A tool")
+    ///             .no_params_handler(|| async { Ok(CallToolResult::text("ok")) })
+    ///             .build(),
+    ///     );
+    /// }
+    ///
+    /// let client = McpClient::connect(ChannelTransport::new(server)).await?;
+    /// client.initialize("my-client", "1.0.0").await?;
+    ///
+    /// let page = client.list_tools().await?;
+    /// assert_eq!(page.tools.len(), 1);
+    /// assert!(page.next_cursor.is_some(), "there is more to fetch");
+    ///
+    /// assert_eq!(client.list_all_tools().await?.len(), 3);
+    /// # client.shutdown().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn list_all_tools(&self) -> Result<Vec<ToolDefinition>> {
         let mut all = Vec::new();
         let mut cursor = None;
@@ -1535,7 +1756,50 @@ impl McpClient {
     /// If the tool result indicates an error (`is_error` is true), returns
     /// an error with the text content as the message.
     ///
-    /// For more control over the result, use [`call_tool()`](Self::call_tool).
+    /// The convenience costs information in both directions. Non-text content
+    /// (images, embedded resources, structured output) is dropped rather than
+    /// rendered, and a tool's domain error arrives as `Err` here where
+    /// [`call_tool`](Self::call_tool) reports it as a result, which makes it
+    /// indistinguishable from a transport failure at the call site. Reach for
+    /// this when a tool is known to answer in plain text and the caller treats
+    /// any problem the same way.
+    ///
+    /// ```rust
+    /// use tower_mcp::client::{ChannelTransport, McpClient};
+    /// use tower_mcp::{CallToolResult, McpRouter, ToolBuilder};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), tower_mcp::BoxError> {
+    /// let motd = ToolBuilder::new("motd")
+    ///     .description("Message of the day")
+    ///     .no_params_handler(|| async { Ok(CallToolResult::text("be excellent")) })
+    ///     .build();
+    /// let refuse = ToolBuilder::new("refuse")
+    ///     .description("Always reports a domain error")
+    ///     .no_params_handler(|| async { Ok(CallToolResult::error("not today")) })
+    ///     .build();
+    ///
+    /// let server = McpRouter::new()
+    ///     .server_info("greeter", "1.0.0")
+    ///     .tool(motd)
+    ///     .tool(refuse);
+    /// let client = McpClient::connect(ChannelTransport::new(server)).await?;
+    /// client.initialize("my-client", "1.0.0").await?;
+    ///
+    /// assert_eq!(
+    ///     client.call_tool_text("motd", serde_json::json!({})).await?,
+    ///     "be excellent"
+    /// );
+    ///
+    /// let error = client
+    ///     .call_tool_text("refuse", serde_json::json!({}))
+    ///     .await
+    ///     .expect_err("an is_error result becomes an Err here");
+    /// assert!(error.to_string().contains("not today"));
+    /// # client.shutdown().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub async fn call_tool_text(&self, name: &str, arguments: serde_json::Value) -> Result<String> {
         let result = self.call_tool(name, arguments).await?;
         if result.is_error {
@@ -1725,6 +1989,14 @@ impl McpClient {
     }
 
     /// Gracefully shut down the client and close the transport.
+    ///
+    /// Asks the message loop to stop and waits for it to finish, so the
+    /// transport closes in an orderly way and a subprocess server sees its
+    /// stdin end rather than a severed pipe.
+    ///
+    /// Dropping the client instead aborts the loop immediately. Any request
+    /// still awaiting a response is abandoned, which is fine for a process
+    /// that is exiting anyway and wrong for one that keeps running.
     pub async fn shutdown(mut self) -> Result<()> {
         let _ = self.command_tx.send(LoopCommand::Shutdown).await;
         if let Some(task) = self.task.take() {

--- a/crates/tower-mcp/src/guides/client.rs
+++ b/crates/tower-mcp/src/guides/client.rs
@@ -20,7 +20,8 @@ continue with the [OAuth authorization guide](crate::guides::oauth).
 |---|---|---|---|
 | Your application launches a local MCP server | `StdioClientTransport` | none | The normal choice for CLI tools and editor-managed subprocesses. Keep protocol messages on stdout and server logs on stderr. |
 | Your application connects to a remote Streamable HTTP endpoint | `HttpClientTransport` | `http-client` | Supports JSON and SSE responses, legacy sessions and resumption, final-protocol headers, and pluggable authentication. |
-| You have an application-specific connection | implement `ClientTransport` | none | Useful for in-memory channels or a custom framing/connection layer. |
+| The server is an [`McpRouter`](crate::McpRouter) in the same process | [`ChannelTransport`](crate::client::ChannelTransport) | none | No sockets or subprocesses. Used for tests, and for a co-located client such as a REPL or editor integration. |
+| You have an application-specific connection | implement [`ClientTransport`](crate::client::ClientTransport) | none | Useful for a custom framing or connection layer. |
 
 tower-mcp does not currently provide a WebSocket client transport. The
 `websocket` feature is server-side.

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -192,6 +192,19 @@
 //! - [Examples index](https://github.com/joshrotenberg/tower-mcp/blob/main/examples/README.md) —
 //!   runnable server, client, transport, middleware, OAuth, and extension patterns.
 //!
+//! ## Module Overviews
+//!
+//! Several modules carry an overview of their own alongside the item docs:
+//!
+//! - [`client`]: connecting, choosing between the two session lifecycles, and
+//!   the common requests.
+//! - [`async_task`]: task lifecycle, the [`TaskStore`] contract, input
+//!   requests and resumption (SEP-2663).
+//! - [`auth`]: header-credential authentication for HTTP servers; see
+//!   [`oauth`] for OAuth 2.1 resource-server behavior.
+//! - [`transport::stdio`]: protocol lifecycles, request concurrency, and
+//!   server notifications over a line-delimited stream.
+//!
 //! ## Middleware Placement Guide
 //!
 //! tower-mcp supports Tower middleware at multiple levels. Choose based on scope:


### PR DESCRIPTION
## What

Rustdoc pass over the three modules with the crate's thinnest example coverage. 70 public items between them and 4 doc examples, two of which were `ignore` blocks that had drifted from the API.

| file | public items | examples before | examples after |
|---|---:|---:|---:|
| `async_task.rs` | 27 | 1 (`no_run`) | 12 |
| `auth.rs` | 22 | 2 (1 real, 2 `ignore`) | 7 |
| `client/mod.rs` | 21 | 2 (`no_run`) | 5 |

Every added example is a running doctest, not `no_run`. Crate doctests go from 181 to 200 passing.

## async_task

New module overview covering the task lifecycle, which terminal state a finished call reaches, and how `input_required` and resumption work end to end. The completed/failed split was the hardest thing to reconstruct from item docs alone:

- an `is_error` result **completes** a task, because the tool ran and reported a domain error
- a handler returning `Err` also completes it, because the router converts that into an `is_error` result
- `failed` is for the task machinery failing: a park that cannot take, a store that cannot resume, a tool deregistered while its task waited

Examples added to `MemoryTaskStore::cleanup_expired`, `owner_matches`, and the `TaskStore` methods a server drives directly: `require_input` (including a rejected key reuse), `apply_input_responses` (partial answers, ignored keys), `resume_context`, `complete_task`, `fail_task`, `cancel_task`. The trait gains an implementor example whose point is that a decorator must forward the defaulted methods: inheriting `resume_context`'s default silently disables resumption for the store it wraps.

## auth

Module overview rewritten. It described a `BearerTokenValidator` trait that does not exist, and its only example never showed the layer installed. The replacement says where `AuthLayer` goes (outside the transport, on the HTTP request, not inside `HttpTransport::layer`) and what a rejection looks like.

Three behaviours that were previously only visible in the source:

- `ApiKeyValidator::add_key` is copy-on-write, so it does not affect a validator already cloned into a layer
- `extract_api_key` treats any space-free header value as a raw credential, and matches schemes case-sensitively
- `AuthConfig::is_public` matches by prefix, not by path segment, so `/healthz-internal` is public when `/health` is listed

`AuthConfig` was documented as a builder for auth middleware configurations. Nothing in the crate reads it, so it is now documented as policy an application applies itself, with `OAuthLayer::public_path` named as the enforced equivalent.

## client

New overview of the connect-then-lifecycle split and what differs between the two lifecycles. `McpClient`, `McpClientBuilder`, `call_tool`, `call_tool_text`, and `list_all_tools` gain examples that run against an in-process router over `ChannelTransport`, so they are checked rather than merely compiled. `call_tool_text` documents what its convenience costs, `list_tools` points at `list_all_tools` for paginated servers, and `shutdown` contrasts with dropping the client, which aborts the loop.

The client guide's transport table now lists `ChannelTransport` instead of telling readers to implement `ClientTransport` for in-process use.

## Cross-links

`lib.rs` gains a Module Overviews section pointing at `client`, `async_task`, `auth`, and `transport::stdio`.

## Not changed

Docs only. No behaviour change, no signature change.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features` (clean)
- `cargo test --workspace --all-features`
- `cargo test -p tower-mcp --all-features --doc` (200 passed, 0 failed)
- `RUSTDOCFLAGS="-Dwarnings -Dmissing-docs" cargo doc -p tower-mcp --all-features --no-deps`

## Notes for review

Two things found while reading, reported rather than fixed:

1. CI does not run doctests. `cargo test --all-targets --all-features` excludes them, and the `doc` job only runs `cargo doc`. The 19 new examples are therefore unguarded against future drift unless a `--doc` step is added.
2. `cargo test -p tower-mcp --doc` at default features fails on 4 pre-existing doctests in `guides/oauth.rs`, which reference `oauth-client`-gated items without gating. Unrelated to this change; the new examples pass in both configurations.