### PR TITLE
fix(extract): mention bridge_extension in the missing-extension message

### DIFF
--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -255,8 +255,10 @@ impl std::fmt::Display for ExtensionRejection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Extension of type `{}` not found. Did you call `router.with_state()` or `router.with_extension()`?",
-            self.type_name
+            "Extension of type `{name}` not found. Did you call `router.with_state()`, \
+             `router.with_extension()`, or `transport.bridge_extension::<{name}>()` for a \
+             type a tower layer inserts into the request?",
+            name = self.type_name
         )
     }
 }
@@ -517,6 +519,12 @@ impl<S> FromToolRequest<S> for RawArgs {
 /// This extractor retrieves data that was added to the router via
 /// [`crate::McpRouter::with_state()`] or [`crate::McpRouter::with_extension()`], or
 /// inserted by middleware into the request context's extensions.
+///
+/// A type that a tower layer attaches to the HTTP request arrives by a third
+/// route: registering it with
+/// [`HttpTransport::bridge_extension`](crate::HttpTransport::bridge_extension)
+/// (or its `WebSocketTransport` equivalent) is what copies it into the
+/// per-request extensions. See `examples/middleware_extension.rs`.
 ///
 /// # Example
 ///
@@ -1614,7 +1622,19 @@ mod tests {
         let rejection = ExtensionRejection::not_found::<String>();
         assert!(rejection.type_name().contains("String"));
         assert!(rejection.to_string().contains("not found"));
-        assert!(rejection.to_string().contains("with_state"));
+
+        // Every way an extension can arrive is worth suggesting: a type a
+        // tower layer inserted is missing because `bridge_extension` was not
+        // called, and `with_state` is no help there.
+        let message = rejection.to_string();
+        assert!(message.contains("with_state"));
+        assert!(message.contains("with_extension"));
+        // The turbofish is the thing the user has to type, so it carries the
+        // type name rather than leaving them to fill it in.
+        assert!(message.contains(&format!(
+            "bridge_extension::<{}>()",
+            std::any::type_name::<String>()
+        )));
 
         // Test conversion to Error
         let error: Error = rejection.into();


### PR DESCRIPTION
`ExtensionRejection`'s message lists two ways an extension can arrive:

```
Extension of type `foo::Caller` not found. Did you call `router.with_state()` or `router.with_extension()`?
```

Since #1243 there is a third: `HttpTransport::bridge_extension::<T>()` /
`WebSocketTransport::bridge_extension::<T>()`, which copies a type out of the
HTTP request's extensions into the per-request MCP extensions. That is the
path #1242 asked for, and it is the one a user is on when a tower layer
inserts the value.

A user who wires the layer, forgets the registration, and hits this message is
pointed at `with_state()`, which is not what is missing.

## Plan

- Add the transport bridge to the suggestion list in the `Display` impl for
  `ExtensionRejection` in `crates/tower-mcp/src/extract.rs`.
- Update `test_extension_rejection`, which asserts on the message text.
- Check the `Extension` extractor's rustdoc, which lists the same two sources.