### PR TITLE
fix(tool): re-export McpTool, McpResource, and McpPrompt from the crate root

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -602,7 +602,9 @@ pub use middleware::{
 pub use mrtr::{MrtrRequest, RequestStateCodec, RequestStateError};
 #[cfg(feature = "stateless")]
 pub use prompt::MrtrPromptHandler;
-pub use prompt::{BoxPromptService, Prompt, PromptBuilder, PromptHandler, PromptRequest};
+pub use prompt::{
+    BoxPromptService, McpPrompt, Prompt, PromptBuilder, PromptHandler, PromptRequest,
+};
 #[allow(deprecated)]
 pub use protocol::{
     BooleanSchema, CallToolParams, CallToolResult, CancelTaskParams, CancelledParams,
@@ -647,7 +649,7 @@ pub use registry::{
     DynamicToolRegistry,
 };
 pub use resource::{
-    BoxResourceService, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
+    BoxResourceService, McpResource, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
     ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,
 };
 #[cfg(feature = "stateless")]
@@ -660,7 +662,7 @@ pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;
 pub use tool::{
-    BoxToolService, GuardLayer, NoParams, TaskContext, TaskPreparation, Tool, ToolBuilder,
+    BoxToolService, GuardLayer, McpTool, NoParams, TaskContext, TaskPreparation, Tool, ToolBuilder,
     ToolHandler, ToolRequest,
 };
 pub use transport::{

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -1196,9 +1196,7 @@ impl PromptHandler for ServiceContextHandler {
 ///
 /// ```rust
 /// use std::collections::HashMap;
-/// use tower_mcp::prompt::McpPrompt;
-/// use tower_mcp::protocol::{GetPromptResult, PromptArgument, PromptMessage, PromptRole, Content};
-/// use tower_mcp::error::Result;
+/// use tower_mcp::{Content, GetPromptResult, McpPrompt, PromptArgument, PromptMessage, PromptRole, Result};
 ///
 /// struct CodeReviewPrompt;
 ///

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -1472,9 +1472,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use tower_mcp::resource::McpResource;
-/// use tower_mcp::protocol::{ReadResourceResult, ResourceContent};
-/// use tower_mcp::error::Result;
+/// use tower_mcp::{McpResource, ReadResourceResult, ResourceContent, Result};
 ///
 /// struct ConfigResource {
 ///     config: String,

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -2370,8 +2370,7 @@ where
 /// # Example
 ///
 /// ```rust
-/// use tower_mcp::tool::McpTool;
-/// use tower_mcp::error::Result;
+/// use tower_mcp::{McpTool, Result};
 /// use schemars::JsonSchema;
 /// use serde::{Deserialize, Serialize};
 ///

--- a/crates/tower-mcp/tests/crate_root_traits.rs
+++ b/crates/tower-mcp/tests/crate_root_traits.rs
@@ -1,0 +1,182 @@
+//! The trait-based way to define a tool, resource, or prompt must be usable
+//! from the crate root.
+//!
+//! `McpTool`, `McpResource`, and `McpPrompt` are the documented alternative to
+//! the builders, but each one's doc example named it through its own module
+//! (`tower_mcp::tool::McpTool`). That path resolves whether or not `lib.rs`
+//! re-exports the trait, so nothing compiled ever depended on
+//! `tower_mcp::McpTool` and all three were missing from the crate root.
+//!
+//! Same shape as #1240 (`notification_channel`) and #1258 (`JsonRpcError`):
+//! the internal path works, so the crate-root path goes unexercised and the
+//! omission survives. A doc example cannot stand in for this test, because
+//! doctests do not run in CI (#1275).
+//!
+//! Every import below is deliberately `tower_mcp::Item`. Rewriting any of
+//! them to `tower_mcp::tool::Item` would defeat the point of the file.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+use tower_mcp::schemars::JsonSchema;
+use tower_mcp::{
+    Content, GetPromptResult, McpPrompt, McpResource, McpRouter, McpTool, PromptArgument,
+    PromptMessage, PromptRole, ReadResourceResult, ResourceContent, Result, ToolAnnotations,
+};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AddInput {
+    a: i64,
+    b: i64,
+}
+
+struct AddTool;
+
+impl McpTool for AddTool {
+    const NAME: &'static str = "add";
+    const DESCRIPTION: &'static str = "Add two numbers";
+
+    type Input = AddInput;
+    type Output = i64;
+
+    async fn call(&self, input: Self::Input) -> Result<Self::Output> {
+        Ok(input.a + input.b)
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(ToolAnnotations {
+            read_only_hint: true,
+            ..Default::default()
+        })
+    }
+}
+
+struct ConfigResource;
+
+impl McpResource for ConfigResource {
+    const URI: &'static str = "file:///config.json";
+    const NAME: &'static str = "Configuration";
+    const DESCRIPTION: Option<&'static str> = Some("Application configuration");
+    const MIME_TYPE: Option<&'static str> = Some("application/json");
+
+    async fn read(&self) -> Result<ReadResourceResult> {
+        Ok(ReadResourceResult {
+            contents: vec![ResourceContent {
+                uri: Self::URI.to_string(),
+                mime_type: Self::MIME_TYPE.map(|mime| mime.to_string()),
+                text: Some("{}".to_string()),
+                blob: None,
+                meta: None,
+            }],
+            meta: None,
+            ..Default::default()
+        })
+    }
+}
+
+struct GreetPrompt;
+
+impl McpPrompt for GreetPrompt {
+    const NAME: &'static str = "greet";
+    const DESCRIPTION: &'static str = "Greet someone";
+
+    fn arguments(&self) -> Vec<PromptArgument> {
+        vec![PromptArgument {
+            name: "name".to_string(),
+            description: Some("Who to greet".to_string()),
+            required: true,
+        }]
+    }
+
+    async fn get(&self, arguments: HashMap<String, String>) -> Result<GetPromptResult> {
+        let name = arguments.get("name").map_or("world", String::as_str);
+        Ok(GetPromptResult {
+            description: Some(Self::DESCRIPTION.to_string()),
+            messages: vec![PromptMessage {
+                role: PromptRole::User,
+                content: Content::Text {
+                    text: format!("Hello, {name}"),
+                    annotations: None,
+                    meta: None,
+                },
+                meta: None,
+            }],
+            meta: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn a_trait_defined_tool_carries_its_metadata_and_runs() {
+    let tool = AddTool.into_tool();
+
+    let definition = tool.definition();
+    assert_eq!(definition.name, "add");
+    assert_eq!(definition.description.as_deref(), Some("Add two numbers"));
+    assert!(
+        definition
+            .annotations
+            .as_ref()
+            .is_some_and(|annotations| annotations.read_only_hint),
+        "the trait's annotations() override should reach the definition"
+    );
+
+    let result = tool.call(serde_json::json!({"a": 2, "b": 3})).await;
+    assert!(!result.is_error);
+    assert_eq!(
+        result.structured_content,
+        Some(serde_json::json!(5)),
+        "the trait's Output should reach the result unchanged"
+    );
+}
+
+#[tokio::test]
+async fn a_trait_defined_resource_carries_its_metadata_and_reads() {
+    let resource = ConfigResource.into_resource();
+
+    let definition = resource.definition();
+    assert_eq!(definition.uri, "file:///config.json");
+    assert_eq!(definition.name, "Configuration");
+    assert_eq!(definition.mime_type.as_deref(), Some("application/json"));
+
+    let result = resource.read().await;
+    assert_eq!(result.contents.len(), 1);
+    assert_eq!(result.contents[0].text.as_deref(), Some("{}"));
+}
+
+#[tokio::test]
+async fn a_trait_defined_prompt_carries_its_arguments_and_expands() {
+    let prompt = GreetPrompt.into_prompt();
+
+    let definition = prompt.definition();
+    assert_eq!(definition.name, "greet");
+    assert_eq!(definition.arguments.len(), 1);
+    assert_eq!(definition.arguments[0].name, "name");
+
+    let result = prompt
+        .get(HashMap::from([("name".to_string(), "Ada".to_string())]))
+        .await
+        .expect("prompt expansion");
+    assert_eq!(result.messages.len(), 1);
+    let Content::Text { text, .. } = &result.messages[0].content else {
+        panic!("expected a text message");
+    };
+    assert_eq!(text, "Hello, Ada");
+}
+
+#[test]
+fn all_three_register_on_a_router() {
+    // That the router accepts all three is itself the assertion: `tool`,
+    // `resource`, and `prompt` take the concrete types the traits produce, so
+    // this stops compiling if `into_tool` and friends stop lining up with the
+    // registration API. `tool_annotations_map` is the one registry read the
+    // router exposes, and it confirms the tool landed under its own name.
+    let router = McpRouter::new()
+        .tool(AddTool.into_tool())
+        .resource(ConfigResource.into_resource())
+        .prompt(GreetPrompt.into_prompt());
+
+    let annotations = router.tool_annotations_map();
+    assert!(annotations.get("add").is_some(), "the tool should register");
+    assert!(annotations.is_read_only("add"));
+}


### PR DESCRIPTION
## Problem

`McpTool` is one of the two documented ways to define a tool. `crates/tower-mcp/src/tool.rs` line 6 calls it out in the module header:

> 2. **Trait-based** - Implement `McpTool` for full control

It is not in the crate root's `pub use tool::{...}` list. That list carries `BoxToolService`, `GuardLayer`, `NoParams`, `TaskContext`, `TaskPreparation`, `Tool`, `ToolBuilder`, `ToolHandler`, and `ToolRequest`, so `tower_mcp::ToolBuilder` resolves and `tower_mcp::McpTool` does not.

The trait's own doc example spells the internal path (`use tower_mcp::tool::McpTool;`), which is why nothing caught it. Same shape as #1240 (`notification_channel`) and the `JsonRpcError` gap fixed in #1267 for #1258: the internal path works, so no compiled code ever names the crate-root path and the omission survives.

The sibling traits have the identical gap. `McpResource` (`resource.rs:1507`) and `McpPrompt` (`prompt.rs:1247`) are the trait-based entry points for the other two capability kinds, both public, neither re-exported, both documented via their internal path. They are the same one-line fix and are included here rather than split into two follow-up PRs.

## Change

- Add `McpTool`, `McpResource`, and `McpPrompt` to the crate-root `pub use` lists in `lib.rs`.
- Move the three doc examples to the crate-root path.
- Add `crates/tower-mcp/tests/crate_root_traits.rs`: implements all three traits importing only from `tower_mcp::`, so the re-exports are load-bearing for a compiled test. Doctests do not run in CI (#1275), so a doc example alone would not guard this.

## Audit of the rest of `tool.rs`

`McpToolHandler` stays private. It is a private wrapper passed by value into `Tool::from_handler`, which is itself private and generic over `H: ToolHandler`, so the type never appears in a public signature. Same for `McpResourceHandler` and `McpPromptHandler`.

Public in `tool.rs` and not re-exported, left as-is:

| Item | Why not |
| --- | --- |
| `BoxFuture` | Declared identically in `tool.rs`, `resource.rs`, and `prompt.rs`. All three cannot be flattened into the crate root without a name collision, the same constraint the `event_store`/`session_store` `Result` pair has. Needs a single shared alias first, which is a separate change. |
| `ToolCatchError`, `GuardService` | Tower plumbing. Obtained by inference from `GuardLayer`/`Tool`, never named by a caller. |
| `ToolCatchErrorFuture` | Already `#[doc(hidden)]`. |
| `ToolBuilderWithHandler`, `ToolBuilderWithMrtrHandler`, `ToolBuilderWithMrtrLayer`, `ToolBuilderWithNoParamsHandler`, `ToolBuilderWithNoParamsHandlerLayer`, `ToolBuilderWithLayer` | Intermediate builder states. They appear as return types but are consumed by chained calls, not named. Re-exporting six of them adds crate-root noise for no reachable use. |

The list was cross-checked mechanically, by diffing every `pub` type declared in `tool.rs` against the names in the crate root's `tool` re-export.

README needs no change. The `use tower_mcp::tool::McpTool;` at line 222 was removed by #1268 along with the rest of the trait-based section, so the README no longer names the trait.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`, and `cargo test --workspace --all-features` are all clean. The three edited doc examples were confirmed to run and pass under `cargo test --doc`, which CI does not currently do.