### PR TITLE
fix(server): make resources.subscribe reflect configured and version support

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -541,6 +541,9 @@ struct McpRouterInner {
     /// Resource templates for dynamic resource matching (keyed by uri_template)
     resource_templates: Vec<Arc<ResourceTemplate>>,
     prompts: HashMap<String, Arc<Prompt>>,
+    /// Whether to advertise `resources.subscribe`. Defaults to true, which
+    /// is what this router has always advertised when resources exist (#1261).
+    advertise_resource_subscriptions: bool,
     /// In-flight requests for cancellation tracking (shared across clones)
     in_flight: Arc<RwLock<HashMap<RequestId, CancellationToken>>>,
     /// Channel for sending notifications to connected clients
@@ -716,6 +719,7 @@ impl McpRouter {
                 resources: HashMap::new(),
                 resource_templates: Vec::new(),
                 prompts: HashMap::new(),
+                advertise_resource_subscriptions: true,
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 notification_tx: None,
                 #[cfg(all(feature = "http", feature = "stateless"))]
@@ -1254,6 +1258,34 @@ impl McpRouter {
         };
         token.cancel();
         true
+    }
+
+    /// Whether to advertise `resources.subscribe` when resources exist.
+    ///
+    /// Defaults to `true`, which is what this router has always advertised as
+    /// soon as any resource or template is registered. Pass `false` for a
+    /// server that exposes read-only resources and no update stream, so it
+    /// does not promise a subscription it will not honour (#1261).
+    ///
+    /// This affects advertisement only. `resources/subscribe` continues to be
+    /// routed either way, so a client that ignores the capability and calls it
+    /// anyway behaves as before.
+    ///
+    /// The 2026-07-28 revision has no `resources/subscribe` method at all, so
+    /// the capability is never advertised on that lifecycle regardless of this
+    /// setting.
+    ///
+    /// ```rust
+    /// use tower_mcp::{McpRouter, ResourceBuilder};
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("read-only", "1.0.0")
+    ///     .resource(ResourceBuilder::new("mem://one").name("one").text("hi"))
+    ///     .resource_subscriptions(false);
+    /// ```
+    pub fn resource_subscriptions(mut self, advertise: bool) -> Self {
+        Arc::make_mut(&mut self.inner).advertise_resource_subscriptions = advertise;
+        self
     }
 
     /// Set server info
@@ -2444,7 +2476,7 @@ impl McpRouter {
             },
             resources: if has_resources || has_dynamic_resources {
                 Some(ResourcesCapability {
-                    subscribe: true,
+                    subscribe: self.inner.advertise_resource_subscriptions,
                     list_changed: has_notifications,
                 })
             } else {
@@ -2529,6 +2561,13 @@ impl McpRouter {
         let mut capabilities = self.capabilities();
         if protocol_version == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28) {
             capabilities.tasks = None;
+            // `resources/subscribe` and `resources/unsubscribe` are not part
+            // of this revision, and the inspector already classifies them as
+            // unavailable here. Advertising the capability would promise a
+            // method the same build refuses to route (#1261).
+            if let Some(resources) = capabilities.resources.as_mut() {
+                resources.subscribe = false;
+            }
             if !self.final_tasks_enabled()
                 && let Some(extensions) = capabilities.extensions.as_mut()
             {

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -3215,12 +3215,83 @@ async fn test_subscription_capability_advertised() {
 
     match resp.inner {
         Ok(McpResponse::Initialize(result)) => {
-            // Should have resources capability with subscribe enabled
+            // Subscriptions are advertised by default on the legacy
+            // lifecycle, which is where the methods exist.
             let resources_cap = result.capabilities.resources.unwrap();
             assert!(resources_cap.subscribe);
         }
         _ => panic!("Expected Initialize response"),
     }
+}
+
+/// #1261: `subscribe` was hardcoded true as soon as any resource existed, so
+/// a server exposing read-only resources could not say otherwise.
+#[test]
+fn resource_subscriptions_can_be_declined() {
+    let router = McpRouter::new()
+        .server_info("read-only", "1.0")
+        .resource(
+            crate::resource::ResourceBuilder::new("mem://one")
+                .name("one")
+                .text("hi"),
+        )
+        .resource_subscriptions(false);
+
+    let resources = router.capabilities().resources.expect("resources exist");
+    assert!(
+        !resources.subscribe,
+        "a server that declined subscriptions must not advertise them"
+    );
+
+    // The default is unchanged.
+    let default_router = McpRouter::new().server_info("default", "1.0").resource(
+        crate::resource::ResourceBuilder::new("mem://one")
+            .name("one")
+            .text("hi"),
+    );
+    assert!(default_router.capabilities().resources.unwrap().subscribe);
+}
+
+/// The 2026-07-28 revision has no `resources/subscribe`, and this crate's own
+/// inspector classifies the method as unavailable there. Advertising it would
+/// promise a method the same build refuses to route (#1261).
+#[test]
+fn the_final_protocol_never_advertises_resource_subscriptions() {
+    for advertise in [true, false] {
+        let router = McpRouter::new()
+            .server_info("final", "1.0")
+            .resource(
+                crate::resource::ResourceBuilder::new("mem://one")
+                    .name("one")
+                    .text("hi"),
+            )
+            .resource_subscriptions(advertise);
+
+        let final_caps =
+            router.capabilities_for_protocol(Some(crate::protocol::PROTOCOL_VERSION_2026_07_28));
+        assert!(
+            !final_caps.resources.expect("resources exist").subscribe,
+            "advertise={advertise} must not surface subscribe on 2026-07-28"
+        );
+
+        // The legacy lifecycle still reflects the setting.
+        let legacy_caps = router.capabilities_for_protocol(Some("2025-11-25"));
+        assert_eq!(
+            legacy_caps.resources.expect("resources exist").subscribe,
+            advertise,
+            "the legacy lifecycle must honour the setting"
+        );
+    }
+}
+
+/// A server with no resources advertises no resources capability at all, so
+/// there is nothing for the setting to affect.
+#[test]
+fn declining_subscriptions_does_not_invent_a_resources_capability() {
+    let router = McpRouter::new()
+        .server_info("no-resources", "1.0")
+        .resource_subscriptions(false);
+    assert!(router.capabilities().resources.is_none());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Claiming #1261. Intent below; commits to follow.

## What

`McpRouter::capabilities()` hardcodes `subscribe: true` whenever any resource or template is registered (`router.rs:2447`), so a server with resources cannot truthfully say it does not support resource subscriptions.

Two separate problems sit on that one line.

**It contradicts our own inspector on 2026-07-28.** `crates/tower-mcp-types/src/inspection/mcp.rs:1364` asserts `resources/subscribe` is classified *unavailable* on the final protocol. So `server/discover` advertises a capability whose methods the same build refuses to route. A client is told yes and then told the method does not exist.

**It is not configurable on any lifecycle.** An application exposing read-only resources with no update stream has no way to advertise that.

## Plan

- add a router setting so a server can decline to advertise resource subscriptions, defaulting to the current behaviour so nothing breaks
- force `subscribe: false` on 2026-07-28 in `capabilities_for_protocol`, which is already the seam that strips the legacy `tasks` shape for that version
- tests across the matrix: legacy default, legacy opted out, and final on both settings

The existing router unit test locks in the unconditional `true` but only exercises the legacy `initialize` lifecycle, so it needs updating rather than deleting.

Downstream blocker for agent-mcp, which requires `subscribe: false`.