### PR TITLE
fix(stdio): never answer a notification, and stop leaking a type name

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -623,8 +623,45 @@ async fn process_line(
     router: &McpRouter,
     line: &str,
 ) -> Result<Option<JsonRpcResponseMessage>> {
-    // Check if it's a notification (no id field)
     let parsed: serde_json::Value = serde_json::from_str(line)?;
+
+    // Classify before validating. A frame carrying no id has nowhere to put a
+    // response, so answering one is a JSON-RPC violation whatever validation
+    // would have said about it. Validating first meant a malformed
+    // notification came back as an error the client could not correlate
+    // (#1272).
+    if !parsed.is_array() && parsed.get("id").is_none() {
+        let method = parsed.get("method").and_then(|m| m.as_str());
+        if let Err(error) =
+            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+        {
+            // Still worth surfacing, just not to the client.
+            tracing::debug!(method, %error, "rejected an invalid notification");
+            return Ok(None);
+        }
+        match serde_json::from_str::<JsonRpcNotification>(line) {
+            Ok(notification) => handle_notification(router, notification)?,
+            Err(_) => tracing::debug!(method, "unparseable notification"),
+        }
+        return Ok(None);
+    }
+
+    // A response carries an id, no method, and one of `result` or `error`.
+    // All three matter: an id with no method and neither of those is an
+    // invalid *request* and must still be refused. `BidirectionalStdioTransport`
+    // uses the same test, so the two transports agree on what a response is.
+    //
+    // This transport never sends requests, so a response arriving is the
+    // peer's mistake. Ignoring it beats answering, which previously produced
+    // a parse error naming an internal type (#1272).
+    if !parsed.is_array()
+        && parsed.get("method").is_none()
+        && (parsed.get("result").is_some() || parsed.get("error").is_some())
+    {
+        tracing::debug!("ignoring an unexpected JSON-RPC response frame");
+        return Ok(None);
+    }
+
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
@@ -632,16 +669,15 @@ async fn process_line(
             JsonRpcResponse::error(None, error),
         )));
     }
-    if !parsed.is_array()
-        && parsed.get("id").is_none()
-        && let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(line)
-    {
-        handle_notification(router, notification)?;
-        return Ok(None);
-    }
 
-    // Parse and process as a request (single or batch)
-    let message: JsonRpcMessage = serde_json::from_str(line)?;
+    // Parse and process as a request (single or batch). The serde error is
+    // deliberately not surfaced: for an untagged enum it names the Rust type,
+    // which has no business on the wire.
+    let Ok(message) = serde_json::from_str::<JsonRpcMessage>(line) else {
+        return Ok(Some(JsonRpcResponseMessage::Single(parse_error_response(
+            "not a valid JSON-RPC request",
+        ))));
+    };
     let response = service.call_message(message).await?;
     Ok(Some(response))
 }

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -911,6 +911,21 @@ where
 {
     let parsed: serde_json::Value = serde_json::from_str(text)?;
 
+    // A notification cannot be answered, so a validation failure on one is
+    // logged rather than sent back (#1272). Requests fall through.
+    if !parsed.is_array()
+        && parsed.get("id").is_none()
+        && let Err(error) =
+            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+    {
+        tracing::debug!(
+            method = parsed.get("method").and_then(|m| m.as_str()),
+            %error,
+            "rejected an invalid notification"
+        );
+        return Ok(());
+    }
+
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
@@ -1076,8 +1091,29 @@ async fn process_message(
     router: &McpRouter,
     text: &str,
 ) -> Result<Option<crate::protocol::JsonRpcResponseMessage>> {
-    // Check if it's a notification (no id field)
     let parsed: serde_json::Value = serde_json::from_str(text)?;
+
+    // Classify before validating: a frame with no id has nowhere to put a
+    // response, so answering one is a JSON-RPC violation regardless of what
+    // validation says. Same fix as the stdio transport (#1272).
+    if !parsed.is_array() && parsed.get("id").is_none() {
+        let method = parsed.get("method").and_then(|m| m.as_str());
+        if let Err(error) =
+            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+        {
+            tracing::debug!(method, %error, "rejected an invalid notification");
+            return Ok(None);
+        }
+        match serde_json::from_str::<JsonRpcNotification>(text) {
+            Ok(notification) => {
+                let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
+                router.handle_notification(mcp_notification);
+            }
+            Err(_) => tracing::debug!(method, "unparseable notification"),
+        }
+        return Ok(None);
+    }
+
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
@@ -1085,17 +1121,14 @@ async fn process_message(
             JsonRpcResponse::error(None, error),
         )));
     }
-    if !parsed.is_array()
-        && parsed.get("id").is_none()
-        && let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text)
-    {
-        let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
-        router.handle_notification(mcp_notification);
-        return Ok(None);
-    }
 
-    // Parse and process as a request
-    let message: JsonRpcMessage = serde_json::from_str(text)?;
+    // Parse and process as a request. The serde error is not surfaced: for an
+    // untagged enum it names the Rust type (#1272).
+    let Ok(message) = serde_json::from_str::<JsonRpcMessage>(text) else {
+        return Ok(Some(crate::protocol::JsonRpcResponseMessage::Single(
+            crate::transport::stdio::parse_error_response("not a valid JSON-RPC request"),
+        )));
+    };
     let response = service.call_message(message).await?;
     Ok(Some(response))
 }

--- a/crates/tower-mcp/tests/adversarial_input.rs
+++ b/crates/tower-mcp/tests/adversarial_input.rs
@@ -692,7 +692,6 @@ async fn an_unknown_notification_method_is_ignored() {
 /// whether the frame is a notification, so a validation failure is answered
 /// with an unsolicited `-32602` carrying a null id.
 #[tokio::test]
-#[ignore = "BUG: a notification that fails MCP inspection is answered with a JSON-RPC error, which JSON-RPC 2.0 forbids"]
 async fn a_notification_with_invalid_params_is_not_answered() {
     let mut server = Server::with_router(base_router());
     server.initialize().await;
@@ -713,7 +712,6 @@ async fn a_notification_with_invalid_params_is_not_answered() {
 /// `JsonRpcMessage`, and is answered with `-32700` whose message leaks the
 /// internal Rust type name.
 #[tokio::test]
-#[ignore = "BUG: StdioTransport answers a stray JSON-RPC response frame with -32700 instead of ignoring it"]
 async fn a_stray_response_frame_is_not_answered() {
     let mut server = Server::with_router(base_router());
     server.initialize().await;


### PR DESCRIPTION
Claiming #1272. Intent below; commits to follow.

## What

Both findings come from one ordering problem in `process_line`.

**Notifications get answered.** Validation runs before the frame is classified:

```rust
let parsed: serde_json::Value = serde_json::from_str(line)?;
if let Err(error) = service.inspect_incoming_value(&parsed, ...) {
    return Ok(Some(JsonRpcResponseMessage::Single(
        JsonRpcResponse::error(None, error),
    )));
}
if !parsed.is_array() && parsed.get("id").is_none() { ... }
```

By the time it knows there is no id, it has already produced a response. So `notifications/cancelled` with empty params comes back as `-32602`. JSON-RPC 2.0 forbids replying to a notification: there is no id to correlate against.

**A stray response frame leaks an internal type name.** `serde_json::from_str::<JsonRpcMessage>(line)?` fails on a response frame, and the serde error names the untagged enum, so `JsonRpcMessage` reaches the wire inside a `-32700` message.

## Plan

- classify before validating, so a frame with no id can never produce a response no matter what validation says. Validation still runs; its failure is logged instead of answered.
- handle response frames explicitly rather than letting them fall into the parse-error path. An unexpected response should be ignored, not answered.
- make sure no error message carries an internal type name, independently of the above.

`BidirectionalStdioTransport` and `WebSocketTransport` share the ordering; HTTP already classifies first and is correct. I will check whether the same fix belongs in the other two or whether their paths differ.

Found by the adversarial input pass in #1266, which left failing `#[ignore]`d tests naming both bugs. Those get un-ignored here.