### PR TITLE
ci: run doctests, and gate the guides that need features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,12 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-targets --all-features
+      # `--all-targets` excludes doctests, so without this step no doc
+      # example is ever executed (#1275). Run both feature sets: all-features
+      # covers every example, and default catches an example that silently
+      # depends on a feature the reader may not have enabled.
+      - run: cargo test --workspace --all-features --doc
+      - run: cargo test -p tower-mcp --doc
 
   msrv:
     name: MSRV (1.90)

--- a/crates/tower-mcp/src/guides.rs
+++ b/crates/tower-mcp/src/guides.rs
@@ -14,8 +14,16 @@
 //! - [`mcp_apps`] — typed MCP Apps resources, negotiation, fallback, CSP,
 //!   permissions, and visibility.
 
+// Each guide is gated on the features its examples use. The guides are
+// doc-only, so this is invisible to callers, and it stops a default-features
+// reader being shown a page of examples they cannot compile. docs.rs builds
+// with all features, so every guide still renders there (#1275).
+#[cfg(feature = "http-client")]
 pub mod client;
+#[cfg(feature = "http")]
 pub mod deployment;
+#[cfg(feature = "mcp-apps")]
 pub mod mcp_apps;
+#[cfg(feature = "oauth-client")]
 pub mod oauth;
 pub mod protocol_versions;

--- a/crates/tower-mcp/src/guides/protocol_versions.rs
+++ b/crates/tower-mcp/src/guides/protocol_versions.rs
@@ -75,8 +75,13 @@ fn main() -> Result<(), BoxError> {
     let stable = ProtocolSupport::stable();
     assert!(stable.contains("2025-11-25"));
 
+    // Selectable only when the revision is compiled in, which is exactly
+    // what the paragraph above describes.
+#   #[cfg(feature = "protocol-2026-07-28")]
+#   {
     let final_only = ProtocolSupport::try_new(["2026-07-28"])?;
     assert_eq!(final_only.preferred(), "2026-07-28");
+#   }
     Ok(())
 }
 ```
@@ -108,20 +113,26 @@ snippets also require `protocol-2026-07-28`.
 ### Stable-only server
 
 ```rust
+# #[cfg(feature = "http")]
 use tower_mcp::{HttpTransport, McpRouter, ProtocolSupport};
 
+# #[cfg(feature = "http")]
 fn main() {
     let transport = HttpTransport::new(McpRouter::new())
         .protocol_support(ProtocolSupport::stable());
     drop(transport);
 }
+# #[cfg(not(feature = "http"))]
+# fn main() {}
 ```
 
 ### Final-only server
 
 ```rust
+# #[cfg(feature = "http")]
 use tower_mcp::{BoxError, HttpTransport, McpRouter, ProtocolSupport};
 
+# #[cfg(feature = "http")]
 fn main() -> Result<(), BoxError> {
     let support = ProtocolSupport::try_new(["2026-07-28"])?;
     let transport = HttpTransport::new(McpRouter::new())
@@ -129,13 +140,17 @@ fn main() -> Result<(), BoxError> {
     drop(transport);
     Ok(())
 }
+# #[cfg(not(feature = "http"))]
+# fn main() {}
 ```
 
 ### Explicit dual-era server
 
 ```rust
+# #[cfg(feature = "http")]
 use tower_mcp::{BoxError, HttpTransport, McpRouter, ProtocolSupport};
 
+# #[cfg(feature = "http")]
 fn main() -> Result<(), BoxError> {
     let support = ProtocolSupport::try_new([
         "2026-07-28",
@@ -147,6 +162,8 @@ fn main() -> Result<(), BoxError> {
     drop(transport);
     Ok(())
 }
+# #[cfg(not(feature = "http"))]
+# fn main() {}
 ```
 
 The order is advertised as preference order. `protocol_versions(...)` is a


### PR DESCRIPTION
Claiming #1275. Intent below; commits to follow.

## What

CI runs `cargo test --all-targets --all-features`. `--all-targets` excludes doctests, and the `doc` job only runs `cargo doc`. So no doc example has ever been executed in CI. After the recent documentation work that is roughly 200 of them, and they are the part of the docs most likely to rot and most likely to be copied verbatim.

## The blocker is larger than the issue said

The issue estimated four failing doctests in `guides/oauth.rs`. Actual count at default features is **18 failures across four guides**: `oauth`, `mcp_apps`, `deployment`, and `client`. They reference `HttpTransport`, `tower_mcp::oauth`, `OAuthAuthorizationFlow`, `McpAppResourceBuilder`, `with_mcp_apps`, and `axum`, none of which exist without their features.

That is a documentation bug in its own right, not just a CI obstacle: a default-features user browsing docs.rs sees a `guides::oauth` page whose every example references types they cannot compile against.

## Plan

- gate each guide module on the features its examples need. The guides are doc-only (`#![doc = r####"..."####]` with no public items), so gating is invisible to callers and no API changes. docs.rs builds with all features, so the guides still render there.
- add a doctest step to CI.

I will settle the exact per-guide feature set empirically rather than by guessing, and say in the final description which gate each guide got and why.