### PR TITLE
feat(tasks): live task execution that keeps the handler future alive

### DIFF
--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -506,6 +506,14 @@ pub enum Error {
     #[error("Transport error: {0}")]
     Transport(String),
 
+    /// A live task was cancelled while its handler was waiting.
+    ///
+    /// Returned by the awaiting methods on `TaskContext` so a handler that
+    /// propagates with `?` unwinds correctly without writing a `select!`.
+    /// The router maps it to a cancelled task rather than a failed one.
+    #[error("Task cancelled")]
+    TaskCancelled,
+
     /// The server indicated the session has expired or is not found.
     ///
     /// This corresponds to JSON-RPC error code `-32005` (SessionNotFound)

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -986,6 +986,35 @@ pub trait TaskStore: Send + Sync + 'static {
         responses: InputResponses,
     ) -> Result<Option<AppliedInputResponses>>;
 
+    /// Every answer accumulated for a task so far, keyed as issued.
+    ///
+    /// A live handler reads this after being woken, so that what it observes
+    /// is exactly what was durably recorded (#1246). Defaults to reading
+    /// through [`resume_context`](Self::resume_context), so a store that
+    /// already supports resumption needs no change.
+    async fn input_responses(&self, task_id: &str) -> Result<Option<InputResponses>> {
+        Ok(self
+            .resume_context(task_id)
+            .await?
+            .map(|resume| resume.input_responses))
+    }
+
+    /// Set a task's non-terminal status and message.
+    ///
+    /// Terminal states are reached through [`complete_task`](Self::complete_task),
+    /// [`fail_task`](Self::fail_task), and [`cancel_task`](Self::cancel_task);
+    /// this is for progress reporting while a task is still running. Returns
+    /// `Ok(false)` if the task is unknown, expired, or already terminal.
+    async fn set_status(
+        &self,
+        task_id: &str,
+        status: TaskStatus,
+        message: Option<&str>,
+    ) -> Result<bool> {
+        let _ = (task_id, status, message);
+        Ok(false)
+    }
+
     /// Everything needed to re-invoke a task's handler after its input
     /// requests were answered.
     ///
@@ -1517,6 +1546,34 @@ impl TaskStore for MemoryTaskStore {
             task.status_message = Some("Task resumed".to_string());
         }
         Ok(Some(applied))
+    }
+
+    async fn set_status(
+        &self,
+        task_id: &str,
+        status: TaskStatus,
+        message: Option<&str>,
+    ) -> Result<bool> {
+        if status.is_terminal() {
+            return Err(TaskStoreError::InvalidTransition(format!(
+                "set_status is for non-terminal progress; use complete_task, fail_task, or cancel_task to reach {status:?}"
+            )));
+        }
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Ok(false);
+        };
+        let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
+            return Ok(false);
+        };
+        if task.status.is_terminal() {
+            return Ok(false);
+        }
+        task.status = status;
+        if let Some(message) = message {
+            task.status_message = Some(message.to_string());
+        }
+        task.last_updated_at_str = chrono_now_iso8601();
+        Ok(true)
     }
 
     async fn resume_context(&self, task_id: &str) -> Result<Option<TaskResumeContext>> {

--- a/crates/tower-mcp/src/extract.rs
+++ b/crates/tower-mcp/src/extract.rs
@@ -1062,6 +1062,7 @@ where
         let service = BoxCloneService::new(catch_error);
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,
@@ -1191,6 +1192,7 @@ where
         let service = BoxCloneService::new(catch_error);
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,
@@ -1300,6 +1302,7 @@ where
         let service = BoxCloneService::new(catch_error);
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -675,8 +675,8 @@ pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;
 pub use tool::{
-    BoxToolService, GuardLayer, McpTool, NoParams, TaskContext, TaskPreparation, Tool, ToolBuilder,
-    ToolHandler, ToolRequest,
+    BoxToolService, GuardLayer, McpTool, NoParams, TaskContext, TaskOutcome, TaskPreparation, Tool,
+    ToolBuilder, ToolHandler, ToolRequest,
 };
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -6,7 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use std::task::{Context, Poll};
 
 use tower_service::Service;
@@ -544,6 +544,12 @@ struct McpRouterInner {
     /// Whether to advertise `resources.subscribe`. Defaults to true, which
     /// is what this router has always advertised when resources exist (#1261).
     advertise_resource_subscriptions: bool,
+    /// Live tasks currently running, keyed by task id (#1246).
+    ///
+    /// A live handler parks inside its own future rather than returning, so
+    /// the router needs a handle to wake it when `tasks/update` commits and
+    /// to signal it when `tasks/cancel` arrives.
+    live_tasks: Arc<Mutex<HashMap<String, Arc<crate::tool::LiveTask>>>>,
     /// In-flight requests for cancellation tracking (shared across clones)
     in_flight: Arc<RwLock<HashMap<RequestId, CancellationToken>>>,
     /// Channel for sending notifications to connected clients
@@ -720,6 +726,7 @@ impl McpRouter {
                 resource_templates: Vec::new(),
                 prompts: HashMap::new(),
                 advertise_resource_subscriptions: true,
+                live_tasks: Arc::new(Mutex::new(HashMap::new())),
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 notification_tx: None,
                 #[cfg(all(feature = "http", feature = "stateless"))]
@@ -2804,6 +2811,56 @@ impl McpRouter {
         self.notify_task_state(task_id).await;
     }
 
+    /// Wake a live task whose input has just been committed.
+    ///
+    /// Returns false when the task is not live, which is how the caller knows
+    /// to fall back to replay (#1246).
+    fn wake_live_task(&self, task_id: &str) -> bool {
+        let Ok(live) = self.inner.live_tasks.lock() else {
+            return false;
+        };
+        match live.get(task_id) {
+            Some(handle) => {
+                // `notify_one`, not `notify_waiters`: a waiter only registers
+                // when its future is polled, so a `notify_waiters` landing
+                // between the store write and the await is lost. `notify_one`
+                // leaves a permit that the next await consumes.
+                handle.input_ready.notify_one();
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Signal a live task that cancellation was requested.
+    ///
+    /// The task stays non-terminal: its handler decides when it has finished
+    /// unwinding and says so by returning `TaskOutcome::Cancelled`.
+    fn signal_live_cancellation(&self, task_id: &str) -> bool {
+        let Ok(live) = self.inner.live_tasks.lock() else {
+            return false;
+        };
+        match live.get(task_id) {
+            Some(handle) => {
+                handle.cancelled.cancel();
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn register_live_task(&self, task_id: &str, handle: Arc<crate::tool::LiveTask>) {
+        if let Ok(mut live) = self.inner.live_tasks.lock() {
+            live.insert(task_id.to_string(), handle);
+        }
+    }
+
+    fn unregister_live_task(&self, task_id: &str) {
+        if let Ok(mut live) = self.inner.live_tasks.lock() {
+            live.remove(task_id);
+        }
+    }
+
     /// Re-invoke a task's handler after its input requests were answered.
     ///
     /// A task's client answers through `tasks/update` rather than by retrying
@@ -3330,7 +3387,15 @@ impl McpRouter {
                         .task_store
                         .create_task(
                             &params.name,
-                            params.arguments.clone(),
+                            // A live task is never replayed, so its arguments
+                            // are not needed and are deliberately not
+                            // persisted. That is how a server keeps prompts or
+                            // credentials out of durable task storage (#1246).
+                            if tool.live_handler.is_some() {
+                                serde_json::Value::Null
+                            } else {
+                                params.arguments.clone()
+                            },
                             task_ttl,
                             request_principal(&extensions),
                         )
@@ -3393,6 +3458,80 @@ impl McpRouter {
                     let tool_name = params.name.clone();
                     let notifier = self.clone();
                     tokio::spawn(async move {
+                        // A live handler owns its execution: it parks inside
+                        // its own future rather than returning, so it is never
+                        // replayed and nothing else writes its terminal state
+                        // (#1246).
+                        if let Some(live_handler) = tool.live_handler.clone() {
+                            let handle = std::sync::Arc::new(crate::tool::LiveTask {
+                                store: task_store.clone(),
+                                input_ready: tokio::sync::Notify::new(),
+                                cancelled: crate::context::CancellationToken::new(),
+                            });
+                            if cancellation_token.is_cancelled() {
+                                handle.cancelled.cancel();
+                            }
+                            notifier.register_live_task(&task_id_clone, handle.clone());
+                            let live_ctx =
+                                crate::tool::TaskContext::with_live(task_id_clone.clone(), handle);
+
+                            let start = std::time::Instant::now();
+                            let outcome = live_handler.call(live_ctx, arguments).await;
+                            let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+                            notifier.unregister_live_task(&task_id_clone);
+
+                            let applied = match outcome {
+                                Ok(crate::tool::TaskOutcome::Completed(result)) => task_store
+                                    .complete_task(&task_id_clone, result)
+                                    .await
+                                    .map(|_| "completed"),
+                                Ok(crate::tool::TaskOutcome::Failed(error)) => task_store
+                                    .fail_task(&task_id_clone, error)
+                                    .await
+                                    .map(|_| "failed"),
+                                Ok(crate::tool::TaskOutcome::Cancelled { message }) => task_store
+                                    .cancel_task(&task_id_clone, message.as_deref())
+                                    .await
+                                    .map(|_| "cancelled"),
+                                // Propagating the cancellation error is the
+                                // ordinary way a live handler unwinds, so it
+                                // ends the task cancelled rather than failed.
+                                Err(crate::error::Error::TaskCancelled) => task_store
+                                    .cancel_task(
+                                        &task_id_clone,
+                                        Some("handler observed cancellation"),
+                                    )
+                                    .await
+                                    .map(|_| "cancelled"),
+                                // An unclassified error is an execution
+                                // failure the handler declined to describe.
+                                Err(error) => task_store
+                                    .fail_task(
+                                        &task_id_clone,
+                                        JsonRpcError::internal_error(error.to_string()),
+                                    )
+                                    .await
+                                    .map(|_| "failed"),
+                            };
+                            match applied {
+                                Ok(status) => tracing::info!(
+                                    target: "mcp::tools",
+                                    tool = %tool_name,
+                                    task_id = %task_id_clone,
+                                    duration_ms,
+                                    status,
+                                    "live task finished"
+                                ),
+                                Err(e) => tracing::warn!(
+                                    task_id = %task_id_clone,
+                                    error = %e,
+                                    "failed to record live task outcome"
+                                ),
+                            }
+                            notifier.notify_task_state(&task_id_clone).await;
+                            return;
+                        }
+
                         // Check for cancellation before starting
                         if cancellation_token.is_cancelled() {
                             tracing::debug!(task_id = %task_id_clone, "Task cancelled before execution");
@@ -4062,7 +4201,13 @@ impl McpRouter {
                     // would otherwise start a second handler alongside the one
                     // still running (#1246).
                     if !applied.accepted.is_empty() && applied.is_complete() {
-                        self.resume_task(&params.task_id).await;
+                        // A live handler is parked inside its own future and
+                        // must be woken, not replayed. Waking only after the
+                        // store has committed is what guarantees it cannot
+                        // observe an answer that was not recorded (#1246).
+                        if !self.wake_live_task(&params.task_id) {
+                            self.resume_task(&params.task_id).await;
+                        }
                     }
                     return Ok(McpResponse::FinalTaskAck(
                         crate::tasks::TaskAcknowledgement::new(),
@@ -4077,7 +4222,8 @@ impl McpRouter {
                 // every key, so dropping them wholesale left a server whose
                 // store models input requests with a working flow on
                 // 2026-07-28 and a silent stall on 2025-11-25 (#1188).
-                self.inner
+                let applied = self
+                    .inner
                     .task_store
                     .apply_input_responses(
                         &params.task_id,
@@ -4095,6 +4241,14 @@ impl McpRouter {
                 // resume regardless of which lifecycle the updating client
                 // used. Self-guards when the extension is not enabled.
                 self.notify_task_state(&params.task_id).await;
+                // A live task parks inside its own future, so answering its
+                // input on this lifecycle has to wake it just as the final
+                // path does, or it waits forever (#1246). Waking only after
+                // the store has committed is what guarantees the handler
+                // cannot observe an unrecorded answer.
+                if !applied.accepted.is_empty() && applied.is_complete() {
+                    self.wake_live_task(&params.task_id);
+                }
                 Ok(McpResponse::UpdateTask(EmptyResult {}))
             }
 
@@ -4102,6 +4256,17 @@ impl McpRouter {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/cancel")?;
                     self.authorize_task(&params.task_id, &extensions).await?;
+                    // A live task is signalled and left non-terminal: its
+                    // handler owns the teardown and reports when it actually
+                    // stopped, so completion can still legitimately win the
+                    // race. SEP-2663 describes cancellation as eventually
+                    // consistent, which is exactly this (#1246).
+                    if self.signal_live_cancellation(&params.task_id) {
+                        self.notify_task_state(&params.task_id).await;
+                        return Ok(McpResponse::FinalTaskAck(
+                            crate::tasks::TaskAcknowledgement::new(),
+                        ));
+                    }
                     // The final ack does not require a terminal transition:
                     // cancelling an already-terminal task is acknowledged, and
                     // the observable status is polled via `tasks/get`.
@@ -4118,6 +4283,13 @@ impl McpRouter {
                 }
 
                 self.authorize_task(&params.task_id, &extensions).await?;
+
+                // Same reasoning as the final path: a live task owns its own
+                // teardown, so it is signalled and left non-terminal (#1246).
+                if self.signal_live_cancellation(&params.task_id) {
+                    self.notify_task_state(&params.task_id).await;
+                    return Ok(McpResponse::CancelTask(EmptyResult {}));
+                }
 
                 // First check if the task exists and is not already terminal
                 let current = self

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -596,7 +596,7 @@ impl TaskContext {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::TaskCancelled`](crate::Error::TaskCancelled) if the
+    /// Returns [`crate::Error::TaskCancelled`] if the
     /// task is cancelled while waiting, so a handler that propagates with `?`
     /// unwinds correctly without writing a `select!`. The router maps that
     /// error to [`TaskOutcome::Cancelled`].
@@ -1795,13 +1795,6 @@ impl ToolBuilder {
         }
     }
 
-    /// Set an SEP-2322 handler that may return either a complete tool result
-    /// or an input-required continuation.
-    ///
-    /// The handler receives [`RequestContext`], where
-    /// [`RequestContext::input_responses`] and
-    /// [`RequestContext::request_state`] expose values from a retry.
-    #[cfg(feature = "stateless")]
     /// Set a handler that owns its execution instead of being replayed.
     ///
     /// A task handler registered with [`mrtr_handler`](Self::mrtr_handler)
@@ -1869,6 +1862,13 @@ impl ToolBuilder {
         }
     }
 
+    /// Set an SEP-2322 handler that may return either a complete tool result
+    /// or an input-required continuation.
+    ///
+    /// The handler receives [`RequestContext`], where
+    /// [`RequestContext::input_responses`] and
+    /// [`RequestContext::request_state`] expose values from a retry.
+    #[cfg(feature = "stateless")]
     pub fn mrtr_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithMrtrHandler<I, F>
     where
         I: JsonSchema + DeserializeOwned + Send + Sync + 'static,

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -1802,6 +1802,73 @@ impl ToolBuilder {
     /// [`RequestContext::input_responses`] and
     /// [`RequestContext::request_state`] expose values from a retry.
     #[cfg(feature = "stateless")]
+    /// Set a handler that owns its execution instead of being replayed.
+    ///
+    /// A task handler registered with [`mrtr_handler`](Self::mrtr_handler)
+    /// ends when it asks for input, and the router re-invokes it from the top
+    /// once the answers arrive. That is right for a handler which is a
+    /// function of its arguments, and wrong for one that owns live state: a
+    /// subprocess, an open stream, a registered responder. Running it again
+    /// does not continue the operation, it starts a second one.
+    ///
+    /// A live handler stays alive instead. It awaits its answers:
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{CallToolResult, TaskContext, TaskOutcome, ToolBuilder};
+    /// use tower_mcp::protocol::InputRequests;
+    /// use serde::Deserialize;
+    /// use tower_mcp::schemars::JsonSchema;
+    ///
+    /// #[derive(Deserialize, JsonSchema)]
+    /// struct Run { prompt: String }
+    ///
+    /// # fn approval() -> InputRequests { Default::default() }
+    /// let tool = ToolBuilder::new("run")
+    ///     .description("Runs something long")
+    ///     .live_task_handler(|task: TaskContext, input: Run| async move {
+    ///         // Whatever this owns is still owned after the await.
+    ///         let answers = task.require_input(approval()).await?;
+    ///         let _ = (answers, input);
+    ///         Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+    ///     })
+    ///     .build();
+    /// ```
+    ///
+    /// The handler returns a [`TaskOutcome`] and the router applies it, so
+    /// nothing else writes terminal state and completion cannot race the
+    /// handler.
+    ///
+    /// # Consequences
+    ///
+    /// The tool is registered as [`TaskSupportMode::Required`], because a
+    /// live handler has no task to park against otherwise.
+    ///
+    /// No invocation arguments are persisted, since nothing replays them. A
+    /// server whose arguments carry prompts or credentials keeps them out of
+    /// durable storage by using a live handler.
+    ///
+    /// A live future does not survive its process. On restart, live tasks left
+    /// non-terminal have nothing behind them, and the application reconciles
+    /// them rather than the router guessing.
+    pub fn live_task_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveHandler<I, F>
+    where
+        I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+        F: Fn(TaskContext, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<TaskOutcome>> + Send + 'static,
+    {
+        ToolBuilderWithLiveHandler {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema_override: self.input_schema_override,
+            icons: self.icons,
+            annotations: self.annotations,
+            handler,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+
     pub fn mrtr_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithMrtrHandler<I, F>
     where
         I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
@@ -2060,6 +2127,60 @@ pub struct ToolBuilderWithMrtrHandler<I, F> {
     task_support: TaskSupportMode,
     handler: F,
     _phantom: std::marker::PhantomData<I>,
+}
+
+/// Builder state after a live task handler is set.
+///
+/// A live handler owns its execution, so it is only meaningful as a task and
+/// the tool is registered with [`TaskSupportMode::Required`] (#1246).
+pub struct ToolBuilderWithLiveHandler<I, F> {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    output_schema: Option<Value>,
+    input_schema_override: Option<Value>,
+    icons: Option<Vec<ToolIcon>>,
+    annotations: Option<ToolAnnotations>,
+    handler: F,
+    _phantom: std::marker::PhantomData<I>,
+}
+
+impl<I, F, Fut> ToolBuilderWithLiveHandler<I, F>
+where
+    I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+    F: Fn(TaskContext, I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<TaskOutcome>> + Send + 'static,
+{
+    /// Finish the tool.
+    pub fn build(self) -> Tool {
+        let input_schema = ensure_object_schema(self.input_schema_override.unwrap_or_else(|| {
+            serde_json::to_value(schemars::schema_for!(I))
+                .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+        }));
+        Tool {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            meta: None,
+            // A live handler cannot run without a task to park against, so
+            // requiring one is the honest contract rather than silently
+            // degrading when a client does not ask for a task.
+            task_support: TaskSupportMode::Required,
+            required_client_capabilities: None,
+            task_preparer: None,
+            service: None,
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+            live_handler: Some(Arc::new(FnLiveToolHandler {
+                handler: self.handler,
+                _input: std::marker::PhantomData::<fn() -> I>,
+            })),
+            input_schema,
+        }
+    }
 }
 
 /// Builder state after a layer has been applied to an MRTR handler.

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -55,8 +55,8 @@ use tokio::sync::Mutex;
 use crate::context::{Extensions, RequestContext};
 use crate::error::{Error, Result, ResultExt};
 use crate::protocol::{
-    CallToolResult, ClientCapabilities, RequestOutcome, TaskSupportMode, ToolAnnotations,
-    ToolDefinition, ToolExecution, ToolIcon,
+    CallToolResult, ClientCapabilities, InputRequests, InputResponses, RequestOutcome, TaskStatus,
+    TaskSupportMode, ToolAnnotations, ToolDefinition, ToolExecution, ToolIcon,
 };
 
 // =============================================================================
@@ -458,23 +458,300 @@ pub(crate) fn ensure_object_schema(mut schema: Value) -> Value {
 /// A boxed future for tool handlers
 pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+/// A tool handler that owns its execution rather than being replayed.
+///
+/// Implemented for closures by [`ToolBuilder::live_task_handler`]; the trait
+/// exists so the router can hold one type-erased (#1246).
+#[async_trait::async_trait]
+pub(crate) trait LiveToolHandler: Send + Sync {
+    async fn call(&self, task: TaskContext, arguments: Value) -> Result<TaskOutcome>;
+}
+
+struct FnLiveToolHandler<I, F> {
+    handler: F,
+    _input: std::marker::PhantomData<fn() -> I>,
+}
+
+#[async_trait::async_trait]
+impl<I, F, Fut> LiveToolHandler for FnLiveToolHandler<I, F>
+where
+    I: DeserializeOwned + Send + Sync + 'static,
+    F: Fn(TaskContext, I) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<TaskOutcome>> + Send,
+{
+    async fn call(&self, task: TaskContext, arguments: Value) -> Result<TaskOutcome> {
+        let input: I = serde_json::from_value(arguments).map_err(|e| {
+            crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                "invalid arguments: {e}"
+            )))
+        })?;
+        (self.handler)(task, input).await
+    }
+}
+
 /// Identity allocated for one task-backed tool execution.
 ///
 /// The same value is supplied to task preparation and inserted into the
 /// background handler's request extensions.
-#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TaskContext {
     task_id: String,
+    live: Option<Arc<LiveTask>>,
+}
+
+impl std::fmt::Debug for TaskContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskContext")
+            .field("task_id", &self.task_id)
+            .field("live", &self.live.is_some())
+            .finish()
+    }
+}
+
+/// Identity comparison. A task is its id; the live handle is machinery.
+impl PartialEq for TaskContext {
+    fn eq(&self, other: &Self) -> bool {
+        self.task_id == other.task_id
+    }
+}
+
+impl Eq for TaskContext {}
+
+/// What a live handler needs in order to park and be woken.
+///
+/// Held by both the running handler, through its [`TaskContext`], and the
+/// router, which signals it once `tasks/update` has committed.
+pub(crate) struct LiveTask {
+    pub(crate) store: Arc<dyn crate::async_task::TaskStore>,
+    /// Signalled after responses are durably recorded, never before.
+    pub(crate) input_ready: tokio::sync::Notify,
+    pub(crate) cancelled: crate::context::CancellationToken,
+}
+
+/// How a live task ended.
+///
+/// The handler returns this and the router applies it. Nothing else writes
+/// terminal state, so completion cannot race the handler and no transition
+/// needs a compare-and-swap. It also makes "returned without terminalizing"
+/// unrepresentable: the return type is the terminal state (#1246).
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum TaskOutcome {
+    /// The tool ran and produced a result.
+    ///
+    /// A result carrying `isError: true` still completes the task: the tool
+    /// ran and reported a domain error, which SEP-2663 distinguishes from an
+    /// execution failure.
+    Completed(CallToolResult),
+    /// Execution failed. The structured error reaches `tasks/get` intact.
+    Failed(crate::error::JsonRpcError),
+    /// The handler observed cancellation and finished unwinding.
+    ///
+    /// Returned by the handler rather than imposed by the store, so a task
+    /// stays non-terminal between the `tasks/cancel` acknowledgement and the
+    /// worker confirming it stopped.
+    Cancelled {
+        /// Optional detail for the task's status message.
+        message: Option<String>,
+    },
 }
 
 impl TaskContext {
     pub(crate) fn new(task_id: String) -> Self {
-        Self { task_id }
+        Self {
+            task_id,
+            live: None,
+        }
+    }
+
+    pub(crate) fn with_live(task_id: String, live: Arc<LiveTask>) -> Self {
+        Self {
+            task_id,
+            live: Some(live),
+        }
     }
 
     /// The server-generated task identifier.
     pub fn task_id(&self) -> &str {
         &self.task_id
+    }
+
+    /// Whether this context can park and await client input.
+    ///
+    /// True only inside a live handler. A replay handler returns
+    /// `RequestOutcome::InputRequired` instead and is re-invoked once the
+    /// answers arrive.
+    pub fn is_live(&self) -> bool {
+        self.live.is_some()
+    }
+
+    /// Ask the client for input and wait for it.
+    ///
+    /// Records the requests, parks the task in `input_required`, and returns
+    /// once every one of them is answered. The handler future stays alive
+    /// throughout, so whatever it owns (a subprocess, a stream, an in-flight
+    /// request) is still there when this returns (#1246).
+    ///
+    /// Only the answers to `requests` come back, keyed as they were sent.
+    /// Earlier answers stay in the store rather than being handed over again.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::TaskCancelled`](crate::Error::TaskCancelled) if the
+    /// task is cancelled while waiting, so a handler that propagates with `?`
+    /// unwinds correctly without writing a `select!`. The router maps that
+    /// error to [`TaskOutcome::Cancelled`].
+    ///
+    /// Request keys must be unique over the task's lifetime (SEP-2663), so
+    /// reusing a spent key is an error rather than a fresh question.
+    pub async fn require_input(&self, requests: InputRequests) -> Result<InputResponses> {
+        self.require_input_inner(requests, None).await
+    }
+
+    /// [`require_input`](Self::require_input) with a status message for
+    /// clients polling the task.
+    pub async fn require_input_with_message(
+        &self,
+        requests: InputRequests,
+        message: impl Into<String>,
+    ) -> Result<InputResponses> {
+        self.require_input_inner(requests, Some(message.into()))
+            .await
+    }
+
+    async fn require_input_inner(
+        &self,
+        requests: InputRequests,
+        message: Option<String>,
+    ) -> Result<InputResponses> {
+        let live = self.live.as_ref().ok_or_else(|| {
+            crate::error::Error::Tool(crate::error::ToolError::new(
+                "require_input needs a live task handler; a replay handler returns RequestOutcome::InputRequired instead",
+            ))
+        })?;
+        if requests.is_empty() {
+            return Err(crate::error::Error::Tool(crate::error::ToolError::new(
+                "require_input needs at least one request, or the task would wait for something that can never arrive",
+            )));
+        }
+        let asked: Vec<String> = requests.keys().cloned().collect();
+
+        if live.cancelled.is_cancelled() {
+            return Err(crate::error::Error::TaskCancelled);
+        }
+
+        // Created before the store write, so a `tasks/update` landing between
+        // the two is not missed.
+        let woken = live.input_ready.notified();
+        let accepted = live
+            .store
+            .require_input(&self.task_id, requests, message.as_deref())
+            .await
+            .map_err(|e| {
+                crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                    "could not park the task for input: {e}"
+                )))
+            })?;
+        if !accepted {
+            return Err(crate::error::Error::Tool(crate::error::ToolError::new(
+                "the task is already terminal, so it cannot ask for input",
+            )));
+        }
+
+        tokio::select! {
+            _ = woken => {}
+            _ = live.cancelled.cancelled() => {
+                return Err(crate::error::Error::TaskCancelled);
+            }
+        }
+
+        // A partial answer leaves some of these outstanding. Wait for the
+        // rest rather than reissuing, which would be key reuse.
+        loop {
+            let outstanding = live
+                .store
+                .outstanding_input_requests(&self.task_id)
+                .await
+                .map_err(|e| {
+                    crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                        "could not read outstanding requests: {e}"
+                    )))
+                })?
+                .unwrap_or_default();
+            if !outstanding.keys().any(|key| asked.contains(key)) {
+                break;
+            }
+            let woken = live.input_ready.notified();
+            tokio::select! {
+                _ = woken => {}
+                _ = live.cancelled.cancelled() => {
+                    return Err(crate::error::Error::TaskCancelled);
+                }
+            }
+        }
+
+        let all = live
+            .store
+            .input_responses(&self.task_id)
+            .await
+            .map_err(|e| {
+                crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                    "could not read input responses: {e}"
+                )))
+            })?
+            .unwrap_or_default();
+        Ok(all
+            .into_iter()
+            .filter(|(key, _)| asked.contains(key))
+            .collect())
+    }
+
+    /// Record a non-terminal status for clients polling this task.
+    pub async fn working(&self, message: impl Into<String>) -> Result<()> {
+        let live = self.live.as_ref().ok_or_else(|| {
+            crate::error::Error::Tool(crate::error::ToolError::new(
+                "working needs a live task handler",
+            ))
+        })?;
+        live.store
+            .set_status(&self.task_id, TaskStatus::Working, Some(&message.into()))
+            .await
+            .map_err(|e| {
+                crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                    "could not update task status: {e}"
+                )))
+            })?;
+        Ok(())
+    }
+
+    /// Whether this task has been asked to cancel.
+    ///
+    /// A live task stays non-terminal until its handler returns, so this being
+    /// true means the request arrived, not that the task is over.
+    pub fn is_cancelled(&self) -> bool {
+        self.live
+            .as_ref()
+            .is_some_and(|live| live.cancelled.is_cancelled())
+    }
+
+    /// Resolves when this task is asked to cancel.
+    ///
+    /// Only needed by a handler that interleaves teardown with its own work.
+    /// A handler that awaits [`require_input`](Self::require_input) gets
+    /// correct behaviour from the error it returns.
+    pub async fn cancelled(&self) {
+        match self.live.as_ref() {
+            Some(live) => live.cancelled.cancelled().await,
+            None => std::future::pending().await,
+        }
+    }
+}
+
+impl Clone for TaskContext {
+    fn clone(&self) -> Self {
+        Self {
+            task_id: self.task_id.clone(),
+            live: self.live.clone(),
+        }
     }
 }
 
@@ -775,6 +1052,8 @@ pub struct Tool {
     pub(crate) service: Option<BoxToolService>,
     #[cfg(feature = "stateless")]
     pub(crate) mrtr_handler: Option<Arc<dyn MrtrToolHandler>>,
+    /// Live handler, which owns its execution instead of being replayed (#1246).
+    pub(crate) live_handler: Option<Arc<dyn LiveToolHandler>>,
     /// JSON Schema for the tool's input
     pub(crate) input_schema: Value,
 }
@@ -806,6 +1085,7 @@ unsafe impl Sync for Tool {}
 impl Clone for Tool {
     fn clone(&self) -> Self {
         Self {
+            live_handler: None,
             name: self.name.clone(),
             title: self.title.clone(),
             description: self.description.clone(),
@@ -1064,6 +1344,7 @@ impl Tool {
     /// ```
     pub fn with_name_prefix(&self, prefix: &str) -> Self {
         Self {
+            live_handler: None,
             name: format!("{}.{}", prefix, self.name),
             title: self.title.clone(),
             description: self.description.clone(),
@@ -1101,6 +1382,7 @@ impl Tool {
         let service = BoxCloneService::new(catch_error);
 
         Self {
+            live_handler: None,
             name,
             title,
             description,
@@ -1134,6 +1416,7 @@ impl Tool {
         let input_schema =
             ensure_object_schema(input_schema_override.unwrap_or_else(|| handler.input_schema()));
         Self {
+            live_handler: None,
             name,
             title,
             description,
@@ -1903,6 +2186,7 @@ where
         let service = BoxCloneService::new(catch_error);
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,
@@ -2131,6 +2415,7 @@ where
         let service = BoxCloneService::new(MrtrToolCatchError::new(service));
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,
@@ -2232,6 +2517,7 @@ where
         let service = BoxCloneService::new(catch_error);
 
         Tool {
+            live_handler: None,
             name: self.name,
             title: self.title,
             description: self.description,

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -1,0 +1,237 @@
+//! Live task execution (#1246).
+//!
+//! The distinguishing property is that the handler future stays alive across
+//! an input round trip. A replayed handler is invoked again from the top,
+//! which for a handler owning a subprocess or an open stream starts a second
+//! operation instead of continuing the first. These tests assert the handler
+//! runs exactly once no matter how many rounds of input it asks for.
+
+#![cfg(feature = "stateless")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use serde::Deserialize;
+use serde_json::json;
+use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+use tower_mcp::client::{ChannelTransport, McpClient};
+use tower_mcp::protocol::{
+    ElicitAction, ElicitFormParams, ElicitFormSchema, ElicitRequestParams, ElicitResult,
+    InputRequest, InputRequests, InputResponse, TaskStatus,
+};
+use tower_mcp::schemars::JsonSchema;
+use tower_mcp::{CallToolResult, McpRouter, TaskContext, TaskOutcome, ToolBuilder};
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct NoArgs {}
+
+fn ask(key: &str) -> InputRequests {
+    let mut requests: InputRequests = Default::default();
+    requests.insert(
+        key.to_string(),
+        InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+            mode: None,
+            message: format!("answer {key}?"),
+            requested_schema: ElicitFormSchema::new(),
+            meta: None,
+        })),
+    );
+    requests
+}
+
+/// Wait for a task to reach a status, or panic with what it actually reached.
+async fn await_status(store: &MemoryTaskStore, id: &str, want: TaskStatus) {
+    for _ in 0..100 {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let task = store.get_task(id).await.unwrap().unwrap();
+        if task.status == want {
+            return;
+        }
+    }
+    let (task, result, error) = store.get_task_result(id).await.unwrap().unwrap();
+    panic!(
+        "wanted {want:?}, task sat at {:?} msg={:?} result={:?} error={:?}",
+        task.status, task.status_message, result, error
+    );
+}
+
+async fn answer(client: &McpClient, task_id: &str, key: &str) {
+    client
+        .task_update(
+            task_id,
+            [(
+                key.to_string(),
+                InputResponse::Elicit(ElicitResult {
+                    action: ElicitAction::Accept,
+                    content: None,
+                    meta: None,
+                }),
+            )]
+            .into_iter()
+            .collect(),
+        )
+        .await
+        .expect("update accepted");
+}
+
+/// The acceptance criterion from #1246: one invocation across several rounds.
+#[tokio::test]
+async fn a_live_handler_runs_once_across_multiple_input_rounds() {
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let counter = invocations.clone();
+
+    let tool = ToolBuilder::new("live")
+        .description("Asks twice, runs once")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let counter = counter.clone();
+            async move {
+                counter.fetch_add(1, Ordering::SeqCst);
+                // State local to this future. A replayed handler would lose it.
+                let mut seen = Vec::new();
+                let first = task.require_input(ask("one")).await?;
+                seen.extend(first.into_keys());
+                let second = task.require_input(ask("two")).await?;
+                seen.extend(second.into_keys());
+                seen.sort();
+                Ok(TaskOutcome::Completed(CallToolResult::text(seen.join(","))))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        1,
+        "the handler starts once"
+    );
+    answer(&client, &task_id, "one").await;
+
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+    answer(&client, &task_id, "two").await;
+
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        1,
+        "and is never invoked again, however many rounds it asks for"
+    );
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        result.unwrap().all_text(),
+        "one,two",
+        "state accumulated across both rounds survived, which replay could not do"
+    );
+}
+
+/// A live task records no invocation arguments, which is how a server keeps
+/// prompts or credentials out of durable storage.
+#[tokio::test]
+async fn a_live_task_persists_no_arguments() {
+    let tool = ToolBuilder::new("live")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: serde_json::Value| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ok")))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({"secret": "hunter2"}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let resume = store.resume_context(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        resume.arguments,
+        serde_json::Value::Null,
+        "the secret must never have been written to the store"
+    );
+}
+
+/// Cancellation is signalled, not imposed. The task stays non-terminal until
+/// the handler says it finished unwinding.
+#[tokio::test]
+async fn cancellation_is_confirmed_by_the_handler_rather_than_imposed() {
+    let tore_down = Arc::new(AtomicUsize::new(0));
+    let counter = tore_down.clone();
+
+    let tool = ToolBuilder::new("live")
+        .description("Waits, then unwinds on cancel")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let counter = counter.clone();
+            async move {
+                // Propagating with `?` is the ordinary way to unwind.
+                let result = task.require_input(ask("never")).await;
+                counter.fetch_add(1, Ordering::SeqCst);
+                result?;
+                Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+
+    client
+        .task_cancel(&task_id, None)
+        .await
+        .expect("cancel accepted");
+
+    await_status(&store, &task_id, TaskStatus::Cancelled).await;
+    assert_eq!(
+        tore_down.load(Ordering::SeqCst),
+        1,
+        "the handler ran its teardown rather than being abandoned"
+    );
+}


### PR DESCRIPTION
Claiming #1246. Intent below; commits to follow.

## The problem

A task handler that owns live native state cannot survive the current model. Returning `RequestOutcome::InputRequired` ends the future, and `tasks/update` re-invokes the tool from the top with the original arguments. For a pure function that is fine. For a handler that started a subprocess, opened an SDK stream, or registered a responder, running it again does not continue the operation, it starts a second one.

It also forces the store to persist full invocation arguments, because replay needs them, so a server whose tool arguments carry prompts or credentials has no way to keep them out of durable storage while using tasks.

## Direction

Keep the handler future alive across the input round trip. A live handler awaits its answer instead of returning:

```rust
let responses = task.require_input(requests).await?;
```

The future parks on that await. `tasks/update` persists, then wakes it. The subprocess, the stream, the responder, and every local in the handler are still there because the handler never ended.

This is the shape the reporter asked for, and it differs from the `TaskController` callback sketched in the issue. A callback receives `input_responses_persisted(task_id, ...)` after the handler has already terminated, leaving every application to correlate an answer back to a paused operation by task id. Awaiting in place makes that correlation structural: the answer arrives where the operation is.

## Planned API

```rust
pub enum TaskOutcome {
    Completed(CallToolResult),
    Failed(JsonRpcError),
    Cancelled { message: Option<String> },
}
```

The handler returns the outcome and the router applies it. Nothing else writes terminal state, so there is no race to manage rather than a race managed with compare-and-swap. It also makes "handler returned without terminalizing" unrepresentable.

Cancellation surfaces as an error from every awaiting context method, so ordinary `?` gives correct behaviour with no `select!`, and the router maps that error to `Cancelled` rather than `Failed`. That is what gives the deferred, confirmed cancellation the downstream gateway needs: `tasks/cancel` signals and acknowledges without terminalizing, the handler tears down and returns, the router terminalizes.

Replay stays the default and unchanged.

## Scope for this PR

Core mechanism only: the outcome type, a live `TaskContext` that can park and await, the wakeup path from `tasks/update`, registration on the tool builder, and live tasks recording no invocation arguments.

Deferred cancellation semantics, TTL waking a parked handler, and restart reconciliation helpers are follow-ups unless they fall out naturally. I will say explicitly what landed and what did not.