### PR TITLE
feat(transport): add serve_with_shutdown to the transports that own a listener

### DIFF
--- a/crates/tower-mcp/src/deployment.rs
+++ b/crates/tower-mcp/src/deployment.rs
@@ -75,23 +75,49 @@
 //!
 //! ## Graceful shutdown
 //!
-//! `axum::serve` supports graceful shutdown via its `with_graceful_shutdown`
-//! method. Use `into_router()` so you own the server lifecycle:
+//! Every transport that binds its own listener takes a shutdown future.
+//! Once it resolves, the listener stops accepting, requests already in
+//! flight are answered, and `serve_with_shutdown` returns:
 //!
 //! ```rust,no_run
 //! # use tower_mcp::{HttpTransport, McpRouter};
 //! # async fn run() -> Result<(), tower_mcp::BoxError> {
 //! let router = McpRouter::new().server_info("my-server", "1.0.0");
-//! let app = HttpTransport::new(router).into_router();
-//! let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await?;
 //!
-//! axum::serve(listener, app)
-//!     .with_graceful_shutdown(async {
+//! HttpTransport::new(router)
+//!     .serve_with_shutdown("0.0.0.0:3000", async {
 //!         tokio::signal::ctrl_c().await.ok();
 //!     })
 //!     .await?;
 //! # Ok(()) }
 //! ```
+//!
+//! The wait for in-flight work is unbounded by default, so nothing already
+//! accepted is dropped. A client holding an SSE notification stream open is
+//! also an in-flight request, and it can outlast the shutdown that started
+//! it. [`drain_timeout`](crate::HttpTransport::drain_timeout) bounds that
+//! wait:
+//!
+//! ```rust,no_run
+//! # use std::time::Duration;
+//! # use tower_mcp::{HttpTransport, McpRouter};
+//! # async fn run() -> Result<(), tower_mcp::BoxError> {
+//! # let router = McpRouter::new().server_info("my-server", "1.0.0");
+//! HttpTransport::new(router)
+//!     .drain_timeout(Duration::from_secs(10))
+//!     .serve_with_shutdown("0.0.0.0:3000", async {
+//!         tokio::signal::ctrl_c().await.ok();
+//!     })
+//!     .await?;
+//! # Ok(()) }
+//! ```
+//!
+//! `UnixSocketTransport` and `WebSocketTransport` take the same shutdown
+//! future. A WebSocket leaves axum's connection tracking when it is
+//! upgraded, so that transport has no `drain_timeout`: shutting down stops
+//! new clients getting in, and open sockets run until their clients hang up.
+//! If you serve the router yourself with `into_router()`, the equivalent of
+//! all this is `axum::serve(..).with_graceful_shutdown(..)`.
 //!
 //! # Health Checks
 //!

--- a/crates/tower-mcp/src/guides/deployment.rs
+++ b/crates/tower-mcp/src/guides/deployment.rs
@@ -292,7 +292,34 @@ external authorization server, session store, event store, or downstream tool
 dependency is ready. Add a separate application readiness route when those
 dependencies should gate traffic.
 
-Own the axum server lifecycle when you need graceful shutdown:
+For graceful shutdown, give the transport a shutdown future. Once it
+resolves the listener stops accepting, requests already in flight are
+answered, and `serve_with_shutdown` returns:
+
+```rust,no_run
+use std::time::Duration;
+
+use tower_mcp::{BoxError, HttpTransport, McpRouter};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    HttpTransport::new(McpRouter::new())
+        .drain_timeout(Duration::from_secs(10))
+        .serve_with_shutdown("0.0.0.0:3000", async {
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await?;
+    Ok(())
+}
+```
+
+`drain_timeout` bounds the wait for requests still in flight. It is
+unbounded by default, and a client holding an SSE notification stream open
+counts as in flight, so a server that has to stop within a deadline should
+set it.
+
+Own the axum lifecycle instead when the MCP endpoint is one route among
+several, or is mounted somewhere other than the root:
 
 ```rust,no_run
 use tower_mcp::{BoxError, HttpTransport, McpRouter};

--- a/crates/tower-mcp/src/transport/graceful.rs
+++ b/crates/tower-mcp/src/transport/graceful.rs
@@ -1,0 +1,75 @@
+//! Graceful shutdown for the transports that own their listener (#1285).
+//!
+//! `HttpTransport::serve`, `WebSocketTransport::serve`, and
+//! `UnixSocketTransport::serve` each own the `axum::serve` call, which is why
+//! none of them could be stopped: the caller never holds the server. Each one
+//! now delegates here, generic over the listener so the TCP and Unix-domain
+//! paths cannot drift apart.
+
+use std::future::{Future, IntoFuture};
+use std::time::Duration;
+
+use crate::error::Error;
+
+/// Serve `router` on `listener`, stop accepting once `signal` resolves, and
+/// return when the connections still open have finished.
+///
+/// `drain_timeout` bounds that last step. `None` waits for every open
+/// connection, which is what `axum::serve(..).with_graceful_shutdown(..)`
+/// does on its own. That wait has no natural end for a transport that holds
+/// connections open by design: an SSE notification stream or an idle
+/// WebSocket is a live connection until the client hangs up.
+///
+/// `Some(limit)` stops waiting after `limit` and returns. It does not close
+/// the connections that are still open: axum serves each one on its own
+/// task, so nothing here can reach them. What it returns is control, which
+/// is what the caller was blocked on. The listener is already gone either
+/// way, because axum drops it as soon as the signal fires.
+pub(crate) async fn serve_with_shutdown<L>(
+    listener: L,
+    router: axum::Router,
+    signal: impl Future<Output = ()> + Send + 'static,
+    drain_timeout: Option<Duration>,
+) -> crate::Result<()>
+where
+    L: axum::serve::Listener,
+    L::Addr: std::fmt::Debug,
+{
+    // Fires when the caller's signal does, so the deadline below covers only
+    // the drain rather than the whole life of the server.
+    let (draining_tx, draining_rx) = tokio::sync::oneshot::channel::<()>();
+
+    let serve = axum::serve(listener, router)
+        .with_graceful_shutdown(async move {
+            signal.await;
+            let _ = draining_tx.send(());
+        })
+        .into_future();
+
+    let result = match drain_timeout {
+        None => serve.await,
+        Some(limit) => {
+            let deadline = async move {
+                if draining_rx.await.is_err() {
+                    // The shutdown future was dropped along with the server,
+                    // so there is no drain left to bound.
+                    std::future::pending::<()>().await;
+                }
+                tokio::time::sleep(limit).await;
+            };
+
+            tokio::select! {
+                result = serve => result,
+                () = deadline => {
+                    tracing::warn!(
+                        timeout_ms = limit.as_millis() as u64,
+                        "graceful shutdown timed out; returning with connections still open"
+                    );
+                    Ok(())
+                }
+            }
+        }
+    };
+
+    result.map_err(|e| Error::Transport(format!("Server error: {}", e)))
+}

--- a/crates/tower-mcp/src/transport/graceful.rs
+++ b/crates/tower-mcp/src/transport/graceful.rs
@@ -17,8 +17,8 @@ use crate::error::Error;
 /// `drain_timeout` bounds that last step. `None` waits for every open
 /// connection, which is what `axum::serve(..).with_graceful_shutdown(..)`
 /// does on its own. That wait has no natural end for a transport that holds
-/// connections open by design: an SSE notification stream or an idle
-/// WebSocket is a live connection until the client hangs up.
+/// connections open by design: an SSE notification stream is an in-flight
+/// response until its client hangs up.
 ///
 /// `Some(limit)` stops waiting after `limit` and returns. It does not close
 /// the connections that are still open: axum serves each one on its own

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -1596,6 +1596,10 @@ pub struct HttpTransport {
     ///
     /// See [`HttpTransport::max_body_size()`] for details.
     max_body_size: usize,
+    /// How long [`HttpTransport::serve_with_shutdown()`] waits for open
+    /// connections once the shutdown signal fires. `None` waits for all of
+    /// them.
+    drain_timeout: Option<Duration>,
 }
 
 impl HttpTransport {
@@ -1629,6 +1633,7 @@ impl HttpTransport {
             sse_responses: false,
             extension_bridges: Vec::new(),
             max_body_size: DEFAULT_MAX_BODY_SIZE,
+            drain_timeout: None,
         }
     }
 
@@ -1730,6 +1735,7 @@ impl HttpTransport {
             sse_responses: false,
             extension_bridges: Vec::new(),
             max_body_size: DEFAULT_MAX_BODY_SIZE,
+            drain_timeout: None,
         }
     }
 
@@ -2509,22 +2515,81 @@ impl HttpTransport {
         (router, handle)
     }
 
-    /// Serve the transport on the given address
+    /// Bound how long [`serve_with_shutdown`](Self::serve_with_shutdown)
+    /// waits for open connections after the shutdown signal fires.
+    ///
+    /// By default it waits for all of them, so a request in flight when the
+    /// signal arrives is still answered. That is the right default and it
+    /// stays the default.
+    ///
+    /// Set a bound when a connection might not close on its own. An SSE
+    /// notification stream is the case that matters here: it is a live
+    /// connection until its client hangs up, so an unbounded drain can
+    /// outlast the shutdown that started it. Reaching the bound returns
+    /// rather than waiting further, which is preferable to never returning.
+    /// This mirrors
+    /// [`StdioTransport::drain_timeout`](crate::transport::stdio::StdioTransport::drain_timeout).
+    ///
+    /// Returning does not close the connections that are still open; axum
+    /// serves each on its own task. The listener is closed either way, as
+    /// soon as the signal fires, so nothing new is accepted while the drain
+    /// runs.
+    pub fn drain_timeout(mut self, timeout: Duration) -> Self {
+        self.drain_timeout = Some(timeout);
+        self
+    }
+
+    /// Serve the transport on the given address, forever.
     ///
     /// This is a convenience method that creates a TCP listener and serves the transport.
+    ///
+    /// This future never resolves on its own. Use
+    /// [`serve_with_shutdown`](Self::serve_with_shutdown) in any process that
+    /// has to stop the server without exiting.
     pub async fn serve(self, addr: &str) -> Result<()> {
+        self.serve_with_shutdown(addr, std::future::pending::<()>())
+            .await
+    }
+
+    /// Serve the transport on the given address until `signal` resolves.
+    ///
+    /// The signal has the same shape as
+    /// `axum::serve(..).with_graceful_shutdown(..)`, because that is what it
+    /// drives: once it resolves the listener stops accepting, connections
+    /// already open are given a chance to finish, and then this future
+    /// returns. Binding still happens up front, so a bind error is reported
+    /// before the signal is ever awaited.
+    ///
+    /// Set [`drain_timeout`](Self::drain_timeout) to bound the wait for open
+    /// connections. Without it a client holding an SSE stream open keeps the
+    /// server alive.
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{HttpTransport, McpRouter};
+    ///
+    /// # async fn example() -> Result<(), tower_mcp::BoxError> {
+    /// HttpTransport::new(McpRouter::new())
+    ///     .serve_with_shutdown("127.0.0.1:3000", async {
+    ///         tokio::signal::ctrl_c().await.ok();
+    ///     })
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn serve_with_shutdown<F>(self, addr: &str, signal: F) -> Result<()>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(|e| Error::Transport(format!("Failed to bind to {}: {}", addr, e)))?;
 
         tracing::info!("MCP HTTP transport listening on {}", addr);
 
+        let drain_timeout = self.drain_timeout;
         let router = self.into_router();
-        axum::serve(listener, router)
+        crate::transport::graceful::serve_with_shutdown(listener, router, signal, drain_timeout)
             .await
-            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
-
-        Ok(())
     }
 
     /// Add the OAuth Protected Resource Metadata well-known route if configured.

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -29,6 +29,9 @@ pub mod childproc;
 #[cfg(any(feature = "http", feature = "websocket"))]
 pub(crate) mod extension_bridge;
 
+#[cfg(any(feature = "http", feature = "websocket"))]
+pub(crate) mod graceful;
+
 pub mod service;
 
 pub use service::{CatchError, InjectAnnotations};

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -22,10 +22,13 @@
 //! }
 //! ```
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::error::Error;
 use crate::router::McpRouter;
+use crate::transport::graceful::serve_with_shutdown;
 use crate::transport::http::{HttpTransport, SessionConfig, SessionHandle};
 use crate::{ProtocolSupport, ProtocolSupportError};
 
@@ -41,6 +44,10 @@ use crate::{ProtocolSupport, ProtocolSupportError};
 pub struct UnixSocketTransport {
     inner: HttpTransport,
     cleanup_on_bind: bool,
+    /// How long [`serve_with_shutdown`](Self::serve_with_shutdown) waits for
+    /// open connections once the shutdown signal fires. `None` waits for all
+    /// of them.
+    drain_timeout: Option<Duration>,
 }
 
 impl UnixSocketTransport {
@@ -49,6 +56,7 @@ impl UnixSocketTransport {
         Self {
             inner: HttpTransport::new(router),
             cleanup_on_bind: true,
+            drain_timeout: None,
         }
     }
 
@@ -69,6 +77,7 @@ impl UnixSocketTransport {
         Self {
             inner: HttpTransport::from_service(service),
             cleanup_on_bind: true,
+            drain_timeout: None,
         }
     }
 
@@ -214,6 +223,18 @@ impl UnixSocketTransport {
         self
     }
 
+    /// Bound how long [`serve_with_shutdown`](Self::serve_with_shutdown)
+    /// waits for open connections after the shutdown signal fires.
+    ///
+    /// See [`HttpTransport::drain_timeout`], which this mirrors. The bound
+    /// matters here for the same reason: an SSE notification stream stays
+    /// open until its client hangs up, so an unbounded drain can outlive the
+    /// shutdown that triggered it.
+    pub fn drain_timeout(mut self, timeout: Duration) -> Self {
+        self.drain_timeout = Some(timeout);
+        self
+    }
+
     /// Build the axum router for this transport.
     ///
     /// Use this when you want to serve the router yourself with a custom
@@ -228,13 +249,60 @@ impl UnixSocketTransport {
         self.inner.into_router_with_handle()
     }
 
-    /// Serve the transport on the given Unix socket path.
+    /// Serve the transport on the given Unix socket path, forever.
     ///
     /// If `cleanup_on_bind` is enabled (the default), any existing file at
     /// `path` is removed before binding. The socket file is **not**
     /// automatically removed on shutdown -- callers should handle cleanup
     /// if needed (e.g., via a signal handler or `Drop` guard).
+    ///
+    /// This future never resolves on its own. Use
+    /// [`serve_with_shutdown`](Self::serve_with_shutdown) in any process that
+    /// has to stop the server without exiting.
     pub async fn serve<P: AsRef<Path>>(self, path: P) -> crate::Result<()> {
+        self.serve_with_shutdown(path, std::future::pending::<()>())
+            .await
+    }
+
+    /// Serve the transport on the given Unix socket path until `signal`
+    /// resolves.
+    ///
+    /// The signal has the same shape as
+    /// `axum::serve(..).with_graceful_shutdown(..)`, because that is what it
+    /// drives: once it resolves the listener stops accepting, connections
+    /// already open are given a chance to finish, and then this future
+    /// returns. Binding still happens up front, so a bind error is reported
+    /// before the signal is ever awaited.
+    ///
+    /// Set [`drain_timeout`](Self::drain_timeout) to bound the wait for open
+    /// connections. Without it a client holding an SSE stream open keeps the
+    /// server alive.
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{McpRouter, UnixSocketTransport};
+    ///
+    /// # async fn example() -> Result<(), tower_mcp::BoxError> {
+    /// let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+    /// let server = tokio::spawn(async move {
+    ///     UnixSocketTransport::new(McpRouter::new())
+    ///         .serve_with_shutdown("/tmp/mcp.sock", async {
+    ///             rx.await.ok();
+    ///         })
+    ///         .await
+    /// });
+    ///
+    /// // Later, from wherever the stop decision is made.
+    /// tx.send(()).ok();
+    /// server.await??;
+    /// std::fs::remove_file("/tmp/mcp.sock").ok();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn serve_with_shutdown<P, F>(self, path: P, signal: F) -> crate::Result<()>
+    where
+        P: AsRef<Path>,
+        F: Future<Output = ()> + Send + 'static,
+    {
         let path = path.as_ref().to_path_buf();
 
         if self.cleanup_on_bind {
@@ -251,12 +319,9 @@ impl UnixSocketTransport {
 
         tracing::info!("MCP Unix socket transport listening on {}", path.display());
 
+        let drain_timeout = self.drain_timeout;
         let router = self.inner.into_router();
-        axum::serve(listener, router)
-            .await
-            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
-
-        Ok(())
+        serve_with_shutdown(listener, router, signal, drain_timeout).await
     }
 }
 

--- a/crates/tower-mcp/src/transport/unix.rs
+++ b/crates/tower-mcp/src/transport/unix.rs
@@ -28,7 +28,6 @@ use std::time::Duration;
 
 use crate::error::Error;
 use crate::router::McpRouter;
-use crate::transport::graceful::serve_with_shutdown;
 use crate::transport::http::{HttpTransport, SessionConfig, SessionHandle};
 use crate::{ProtocolSupport, ProtocolSupportError};
 
@@ -321,7 +320,8 @@ impl UnixSocketTransport {
 
         let drain_timeout = self.drain_timeout;
         let router = self.inner.into_router();
-        serve_with_shutdown(listener, router, signal, drain_timeout).await
+        crate::transport::graceful::serve_with_shutdown(listener, router, signal, drain_timeout)
+            .await
     }
 }
 

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -68,7 +68,9 @@
 //! ```
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     Router,
@@ -242,6 +244,10 @@ pub struct WebSocketTransport {
     protocol_support: ProtocolSupport,
     #[cfg(feature = "oauth")]
     oauth_config: Option<crate::oauth::ProtectedResourceMetadata>,
+    /// How long [`WebSocketTransport::serve_with_shutdown()`] waits for open
+    /// connections once the shutdown signal fires. `None` waits for all of
+    /// them.
+    drain_timeout: Option<Duration>,
 }
 
 impl WebSocketTransport {
@@ -270,6 +276,7 @@ impl WebSocketTransport {
             protocol_support: ProtocolSupport::default(),
             #[cfg(feature = "oauth")]
             oauth_config: None,
+            drain_timeout: None,
         }
     }
 
@@ -471,20 +478,72 @@ impl WebSocketTransport {
         router
     }
 
-    /// Serve the transport on the given address
+    /// Bound how long [`serve_with_shutdown`](Self::serve_with_shutdown)
+    /// waits for open connections after the shutdown signal fires.
+    ///
+    /// Setting this matters more here than on the other transports. Every
+    /// client of this transport holds a WebSocket open for as long as it
+    /// intends to talk to the server, and a graceful shutdown waits for
+    /// connections to close. With no bound, one idle client is enough to keep
+    /// the server running after it was told to stop.
+    ///
+    /// Reaching the bound returns rather than waiting further. See
+    /// [`HttpTransport::drain_timeout`](crate::HttpTransport::drain_timeout).
+    pub fn drain_timeout(mut self, timeout: Duration) -> Self {
+        self.drain_timeout = Some(timeout);
+        self
+    }
+
+    /// Serve the transport on the given address, forever.
+    ///
+    /// This future never resolves on its own. Use
+    /// [`serve_with_shutdown`](Self::serve_with_shutdown) in any process that
+    /// has to stop the server without exiting.
     pub async fn serve(self, addr: &str) -> Result<()> {
+        self.serve_with_shutdown(addr, std::future::pending::<()>())
+            .await
+    }
+
+    /// Serve the transport on the given address until `signal` resolves.
+    ///
+    /// The signal has the same shape as
+    /// `axum::serve(..).with_graceful_shutdown(..)`, because that is what it
+    /// drives: once it resolves the listener stops accepting, connections
+    /// already open are given a chance to finish, and then this future
+    /// returns. Binding still happens up front, so a bind error is reported
+    /// before the signal is ever awaited.
+    ///
+    /// Pair it with [`drain_timeout`](Self::drain_timeout): a connected
+    /// client that is simply idle never closes its socket, and the drain
+    /// waits for it.
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{McpRouter, WebSocketTransport};
+    ///
+    /// # async fn example() -> Result<(), tower_mcp::BoxError> {
+    /// WebSocketTransport::new(McpRouter::new())
+    ///     .drain_timeout(std::time::Duration::from_secs(5))
+    ///     .serve_with_shutdown("127.0.0.1:3000", async {
+    ///         tokio::signal::ctrl_c().await.ok();
+    ///     })
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn serve_with_shutdown<F>(self, addr: &str, signal: F) -> Result<()>
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(|e| Error::Transport(format!("Failed to bind to {}: {}", addr, e)))?;
 
         tracing::info!("MCP WebSocket transport listening on {}", addr);
 
+        let drain_timeout = self.drain_timeout;
         let router = self.into_router();
-        axum::serve(listener, router)
+        crate::transport::graceful::serve_with_shutdown(listener, router, signal, drain_timeout)
             .await
-            .map_err(|e| Error::Transport(format!("Server error: {}", e)))?;
-
-        Ok(())
     }
 }
 

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -70,7 +70,6 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::{
     Router,
@@ -244,10 +243,6 @@ pub struct WebSocketTransport {
     protocol_support: ProtocolSupport,
     #[cfg(feature = "oauth")]
     oauth_config: Option<crate::oauth::ProtectedResourceMetadata>,
-    /// How long [`WebSocketTransport::serve_with_shutdown()`] waits for open
-    /// connections once the shutdown signal fires. `None` waits for all of
-    /// them.
-    drain_timeout: Option<Duration>,
 }
 
 impl WebSocketTransport {
@@ -276,7 +271,6 @@ impl WebSocketTransport {
             protocol_support: ProtocolSupport::default(),
             #[cfg(feature = "oauth")]
             oauth_config: None,
-            drain_timeout: None,
         }
     }
 
@@ -478,22 +472,6 @@ impl WebSocketTransport {
         router
     }
 
-    /// Bound how long [`serve_with_shutdown`](Self::serve_with_shutdown)
-    /// waits for open connections after the shutdown signal fires.
-    ///
-    /// Setting this matters more here than on the other transports. Every
-    /// client of this transport holds a WebSocket open for as long as it
-    /// intends to talk to the server, and a graceful shutdown waits for
-    /// connections to close. With no bound, one idle client is enough to keep
-    /// the server running after it was told to stop.
-    ///
-    /// Reaching the bound returns rather than waiting further. See
-    /// [`HttpTransport::drain_timeout`](crate::HttpTransport::drain_timeout).
-    pub fn drain_timeout(mut self, timeout: Duration) -> Self {
-        self.drain_timeout = Some(timeout);
-        self
-    }
-
     /// Serve the transport on the given address, forever.
     ///
     /// This future never resolves on its own. Use
@@ -508,21 +486,29 @@ impl WebSocketTransport {
     ///
     /// The signal has the same shape as
     /// `axum::serve(..).with_graceful_shutdown(..)`, because that is what it
-    /// drives: once it resolves the listener stops accepting, connections
-    /// already open are given a chance to finish, and then this future
+    /// drives: once it resolves the listener stops accepting and this future
     /// returns. Binding still happens up front, so a bind error is reported
     /// before the signal is ever awaited.
     ///
-    /// Pair it with [`drain_timeout`](Self::drain_timeout): a connected
-    /// client that is simply idle never closes its socket, and the drain
-    /// waits for it.
+    /// # Open sockets are not part of the shutdown
+    ///
+    /// This transport has no equivalent of
+    /// [`HttpTransport::drain_timeout`](crate::HttpTransport::drain_timeout),
+    /// because there is nothing here for a bound to cut short. A WebSocket
+    /// leaves the connection axum is tracking the moment it is upgraded, and
+    /// runs from then on in a task of its own. Shutting down therefore
+    /// neither waits for open sockets nor closes them: it stops new clients
+    /// getting in and hands control back, and the sockets already up live
+    /// until their clients hang up or the process exits.
+    ///
+    /// A server that has to close them itself should keep its own record of
+    /// live connections, as it would for any other broadcast.
     ///
     /// ```rust,no_run
     /// use tower_mcp::{McpRouter, WebSocketTransport};
     ///
     /// # async fn example() -> Result<(), tower_mcp::BoxError> {
     /// WebSocketTransport::new(McpRouter::new())
-    ///     .drain_timeout(std::time::Duration::from_secs(5))
     ///     .serve_with_shutdown("127.0.0.1:3000", async {
     ///         tokio::signal::ctrl_c().await.ok();
     ///     })
@@ -540,10 +526,8 @@ impl WebSocketTransport {
 
         tracing::info!("MCP WebSocket transport listening on {}", addr);
 
-        let drain_timeout = self.drain_timeout;
         let router = self.into_router();
-        crate::transport::graceful::serve_with_shutdown(listener, router, signal, drain_timeout)
-            .await
+        crate::transport::graceful::serve_with_shutdown(listener, router, signal, None).await
     }
 }
 

--- a/crates/tower-mcp/tests/graceful_shutdown.rs
+++ b/crates/tower-mcp/tests/graceful_shutdown.rs
@@ -1,0 +1,301 @@
+//! Graceful shutdown for the transports that own their listener (#1285).
+//!
+//! `UnixSocketTransport` is covered in `unix_socket.rs`, alongside the rest
+//! of its coverage. Here are the HTTP and WebSocket halves, plus both sides
+//! of the drain contract the shared implementation has to get right: an
+//! unbounded shutdown answers what is already in flight, and a bounded one
+//! stops waiting for it.
+//!
+//! Every wait in this file is bounded. The failure being guarded against is
+//! a future that never resolves, so a hang has to surface as a failed
+//! assertion rather than a stuck test run.
+
+#![cfg(any(feature = "http", feature = "websocket"))]
+
+use std::time::Duration;
+
+/// An ephemeral port, released before the transport binds it.
+///
+/// `serve_with_shutdown` binds the address itself and does not report which
+/// one it got, so the port has to be picked before the server starts.
+async fn free_port() -> u16 {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind an ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+#[cfg(feature = "http")]
+mod http {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use tokio::sync::{Notify, oneshot};
+    use tower_mcp::{CallToolResult, HttpTransport, McpRouter, ToolBuilder};
+
+    const PROTOCOL_VERSION: &str = "2025-11-25";
+
+    /// A tool that does not return until the test releases it, so a request
+    /// can be held in flight across a shutdown.
+    struct ParkedTool {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    impl ParkedTool {
+        fn new() -> Self {
+            Self {
+                started: Arc::new(Notify::new()),
+                release: Arc::new(Notify::new()),
+            }
+        }
+
+        fn router(&self) -> McpRouter {
+            let started = self.started.clone();
+            let release = self.release.clone();
+            let park = ToolBuilder::new("park")
+                .description("Blocks until the test releases it")
+                .handler(move |_input: serde_json::Value| {
+                    let started = started.clone();
+                    let release = release.clone();
+                    async move {
+                        // notify_one stores a permit, so this cannot race
+                        // the test's own await.
+                        started.notify_one();
+                        release.notified().await;
+                        Ok(CallToolResult::text("released"))
+                    }
+                })
+                .build();
+
+            McpRouter::new()
+                .server_info("http-shutdown-test", "1.0.0")
+                .tool(park)
+        }
+
+        /// Resolves once the handler is running.
+        async fn started(&self) {
+            self.started.notified().await;
+        }
+
+        fn release(&self) {
+            self.release.notify_one();
+        }
+    }
+
+    /// Block until the server answers its health probe, so no test races the
+    /// bind.
+    async fn wait_until_serving(port: u16) {
+        let health = format!("http://127.0.0.1:{port}/health");
+        let client = reqwest::Client::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while tokio::time::Instant::now() < deadline {
+            if let Ok(response) = client.get(&health).send().await
+                && response.status().is_success()
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("server on port {port} never started serving");
+    }
+
+    /// Call the parked tool. Resolves only once the handler is released.
+    async fn call_park(port: u16) -> serde_json::Value {
+        reqwest::Client::new()
+            .post(format!("http://127.0.0.1:{port}/"))
+            .header("content-type", "application/json")
+            .header("accept", "application/json")
+            .header("MCP-Protocol-Version", PROTOCOL_VERSION)
+            .json(&serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "park", "arguments": {}}
+            }))
+            .send()
+            .await
+            .expect("send tools/call")
+            .json()
+            .await
+            .expect("decode tools/call response")
+    }
+
+    /// The unbounded default. The signal closes the listener but does not
+    /// abandon a request that is already running: it is answered, and only
+    /// then does `serve_with_shutdown` return.
+    ///
+    /// This is the other half of `drain_timeout`'s pair. It is what makes
+    /// the bounded test meaningful, because it shows the drain really does
+    /// block on an in-flight request.
+    #[tokio::test]
+    async fn shutdown_waits_for_a_request_that_is_already_running() {
+        let park = ParkedTool::new();
+        let port = free_port().await;
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+
+        let router = park.router();
+        let mut server = tokio::spawn(async move {
+            HttpTransport::new(router)
+                .serve_with_shutdown(&format!("127.0.0.1:{port}"), async move {
+                    stop_rx.await.ok();
+                })
+                .await
+        });
+
+        wait_until_serving(port).await;
+        let call = tokio::spawn(async move { call_park(port).await });
+
+        park.started().await;
+        stop_tx.send(()).expect("send shutdown signal");
+
+        // The signal alone must not end the request the server accepted.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(300), &mut server)
+                .await
+                .is_err(),
+            "serve_with_shutdown returned while a request was still running"
+        );
+
+        park.release();
+
+        let served = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("serve_with_shutdown never returned after the request finished")
+            .expect("server task panicked");
+        served.expect("serve_with_shutdown reported an error");
+
+        let body = call.await.expect("client task panicked");
+        assert_eq!(
+            body["result"]["content"][0]["text"], "released",
+            "the in-flight request was dropped instead of answered: {body}"
+        );
+    }
+
+    /// `drain_timeout` bounds that wait. The parked handler is never
+    /// released, so without the bound this test would hang.
+    #[tokio::test]
+    async fn drain_timeout_returns_while_a_request_is_still_in_flight() {
+        let park = ParkedTool::new();
+        let port = free_port().await;
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+
+        let router = park.router();
+        let server = tokio::spawn(async move {
+            HttpTransport::new(router)
+                .drain_timeout(Duration::from_millis(200))
+                .serve_with_shutdown(&format!("127.0.0.1:{port}"), async move {
+                    stop_rx.await.ok();
+                })
+                .await
+        });
+
+        wait_until_serving(port).await;
+        let call = tokio::spawn(async move { call_park(port).await });
+
+        park.started().await;
+        stop_tx.send(()).expect("send shutdown signal");
+
+        let served = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("drain_timeout did not bound the wait for an in-flight request")
+            .expect("server task panicked");
+        served.expect("serve_with_shutdown reported an error");
+
+        // The bound is what ended the wait: the request it was waiting on is
+        // still unanswered.
+        assert!(
+            !call.is_finished(),
+            "the parked request completed, so the drain was never actually blocked"
+        );
+
+        call.abort();
+        park.release();
+    }
+}
+
+#[cfg(feature = "websocket")]
+mod websocket {
+    use super::*;
+
+    use tokio::sync::oneshot;
+    use tower_mcp::client::{McpClient, WebSocketClientTransport};
+    use tower_mcp::{CallToolResult, McpRouter, ToolBuilder, WebSocketTransport};
+
+    fn router() -> McpRouter {
+        let echo = ToolBuilder::new("echo")
+            .description("Echo a value")
+            .handler(|v: serde_json::Value| async move { Ok(CallToolResult::text(v.to_string())) })
+            .build();
+
+        McpRouter::new()
+            .server_info("ws-shutdown-test", "1.0.0")
+            .tool(echo)
+    }
+
+    async fn connect(url: &str) -> WebSocketClientTransport {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match WebSocketClientTransport::connect(url).await {
+                Ok(transport) => return transport,
+                Err(e) if tokio::time::Instant::now() >= deadline => {
+                    panic!("never connected to {url}: {e}")
+                }
+                Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+    }
+
+    /// Shutting down with a client still connected returns, and stops new
+    /// clients getting in.
+    ///
+    /// It returns without waiting for that client, which is why this
+    /// transport has no `drain_timeout`: an upgraded WebSocket has already
+    /// left the connection axum tracks, so there is no drain for a bound to
+    /// cut short. The socket itself stays up, on its own task, until its
+    /// client hangs up or the process exits.
+    #[tokio::test]
+    async fn shutdown_returns_and_stops_accepting_with_a_client_connected() {
+        let port = free_port().await;
+        let (stop_tx, stop_rx) = oneshot::channel::<()>();
+
+        let server = tokio::spawn(async move {
+            WebSocketTransport::new(router())
+                .serve_with_shutdown(&format!("127.0.0.1:{port}"), async move {
+                    stop_rx.await.ok();
+                })
+                .await
+        });
+
+        let url = format!("ws://127.0.0.1:{port}/");
+        let client = McpClient::connect(connect(&url).await)
+            .await
+            .expect("build client");
+        let initialized = client
+            .initialize("shutdown-test", "1.0.0")
+            .await
+            .expect("initialize");
+        assert_eq!(initialized.server_info.name, "ws-shutdown-test");
+
+        stop_tx.send(()).expect("send shutdown signal");
+
+        let served = tokio::time::timeout(Duration::from_secs(5), server)
+            .await
+            .expect("serve_with_shutdown never returned after the signal")
+            .expect("server task panicked");
+        served.expect("serve_with_shutdown reported an error");
+
+        // The client held its socket for the whole shutdown, which is what
+        // makes this more than the no-clients case.
+        drop(client);
+
+        // Returning is not the whole claim: the listener has to be gone too.
+        assert!(
+            WebSocketClientTransport::connect(&url).await.is_err(),
+            "the port still accepted a connection after shutdown"
+        );
+    }
+}

--- a/crates/tower-mcp/tests/unix_socket.rs
+++ b/crates/tower-mcp/tests/unix_socket.rs
@@ -81,6 +81,11 @@ async fn serve_in_background(transport: UnixSocketTransport, path: &Path) {
         }
     });
 
+    wait_until_connectable(path).await;
+}
+
+/// Block until the socket accepts a connection, so tests never race the bind.
+async fn wait_until_connectable(path: &Path) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     while tokio::time::Instant::now() < deadline {
         if UnixStream::connect(path).await.is_ok() {
@@ -279,6 +284,155 @@ async fn builder_configuration_produces_a_usable_router() {
     let (_router, handle) = transport.into_router_with_handle();
     assert_eq!(handle.session_count().await, 0);
     assert!(handle.list_sessions().await.is_empty());
+}
+
+/// The gap #1285 was filed for: `serve` owns the accept loop and never
+/// returns, so a process that starts one cannot stop it without exiting.
+///
+/// A hang is the failure this guards against, so every wait here is bounded
+/// and the test fails on the timeout rather than blocking the suite.
+#[tokio::test]
+async fn serve_with_shutdown_returns_and_stops_accepting() {
+    let socket = SocketPath::new("shutdown");
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_path = socket.path().to_path_buf();
+
+    let server = tokio::spawn(
+        UnixSocketTransport::new(test_router())
+            .disable_origin_validation()
+            .serve_with_shutdown(serve_path, async move {
+                stop_rx.await.ok();
+            }),
+    );
+
+    // The server is genuinely up: a real MCP round trip is answered first, so
+    // what stops below is a working server rather than a failed bind.
+    wait_until_connectable(socket.path()).await;
+    let init = post_json(socket.path(), &[], &initialize_request()).await;
+    assert_eq!(init["result"]["serverInfo"]["name"], "unix-socket-test");
+
+    stop_tx.send(()).expect("send shutdown signal");
+
+    let served = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("serve_with_shutdown never returned after the signal")
+        .expect("server task panicked");
+    served.expect("serve_with_shutdown reported an error");
+
+    // Returning is not the whole claim: the listener has to be gone too, or
+    // the caller has stopped waiting on a server that is still accepting.
+    assert!(
+        UnixStream::connect(socket.path()).await.is_err(),
+        "socket still accepted a connection after shutdown"
+    );
+}
+
+/// `drain_timeout` bounds the wait for connections that are still open.
+///
+/// The parked handler never finishes, so without the bound this test would
+/// hang: that is exactly the case the bound exists for. The other half of
+/// the pair, that an unbounded shutdown really does wait for an in-flight
+/// request rather than returning early, is in `graceful_shutdown.rs`.
+#[tokio::test]
+async fn drain_timeout_returns_while_a_request_is_still_in_flight() {
+    let socket = SocketPath::new("drain");
+    let park = ParkedTool::new();
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let serve_path = socket.path().to_path_buf();
+
+    let server = tokio::spawn(
+        UnixSocketTransport::new(park.router())
+            .disable_origin_validation()
+            .drain_timeout(Duration::from_millis(200))
+            .serve_with_shutdown(serve_path, async move {
+                stop_rx.await.ok();
+            }),
+    );
+
+    wait_until_connectable(socket.path()).await;
+
+    let call_path = socket.path().to_path_buf();
+    let call = tokio::spawn(async move {
+        post(
+            &call_path,
+            &[("MCP-Protocol-Version", PROTOCOL_VERSION)],
+            &serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "park", "arguments": {}}
+            })
+            .to_string(),
+        )
+        .await
+    });
+
+    park.started().await;
+    stop_tx.send(()).expect("send shutdown signal");
+
+    let served = tokio::time::timeout(Duration::from_secs(5), server)
+        .await
+        .expect("drain_timeout did not bound the wait for an open connection")
+        .expect("server task panicked");
+    served.expect("serve_with_shutdown reported an error");
+
+    // The bound is what ended the wait: the request it was waiting on is
+    // still unanswered.
+    assert!(
+        !call.is_finished(),
+        "the parked request completed, so the drain was never actually blocked"
+    );
+
+    call.abort();
+    park.release();
+}
+
+/// A tool that does not return until the test releases it, so a request can
+/// be held in flight across a shutdown.
+struct ParkedTool {
+    started: std::sync::Arc<tokio::sync::Notify>,
+    release: std::sync::Arc<tokio::sync::Notify>,
+}
+
+impl ParkedTool {
+    fn new() -> Self {
+        Self {
+            started: std::sync::Arc::new(tokio::sync::Notify::new()),
+            release: std::sync::Arc::new(tokio::sync::Notify::new()),
+        }
+    }
+
+    fn router(&self) -> McpRouter {
+        let started = self.started.clone();
+        let release = self.release.clone();
+        let park = ToolBuilder::new("park")
+            .description("Blocks until the test releases it")
+            .handler(move |_input: serde_json::Value| {
+                let started = started.clone();
+                let release = release.clone();
+                async move {
+                    // notify_one stores a permit, so this cannot race the
+                    // test's own await.
+                    started.notify_one();
+                    release.notified().await;
+                    Ok(CallToolResult::text("released"))
+                }
+            })
+            .build();
+
+        McpRouter::new()
+            .server_info("unix-socket-test", "1.0.0")
+            .tool(park)
+    }
+
+    /// Resolves once the handler is running.
+    async fn started(&self) {
+        self.started.notified().await;
+    }
+
+    fn release(&self) {
+        self.release.notify_one();
+    }
 }
 
 /// `from_service` accepts a pre-built service, the same as `HttpTransport`.

--- a/examples/unix_socket_server.rs
+++ b/examples/unix_socket_server.rs
@@ -118,7 +118,20 @@ mod app {
             .layer(TimeoutLayer::new(Duration::from_secs(30)));
 
         tracing::info!("Starting Unix socket MCP server on {}", socket_path);
-        transport.serve(socket_path).await?;
+
+        // Ctrl-C stops the accept loop and lets `serve_with_shutdown`
+        // return, which is what makes the cleanup below reachable. Plain
+        // `serve` never returns.
+        transport
+            .serve_with_shutdown(socket_path, async {
+                tokio::signal::ctrl_c().await.ok();
+                tracing::info!("Shutting down");
+            })
+            .await?;
+
+        // The transport does not unlink the socket file, so the server that
+        // created it does.
+        std::fs::remove_file(socket_path).ok();
 
         Ok(())
     }


### PR DESCRIPTION
Closes #1285.

## Problem

`UnixSocketTransport::serve` owned the `axum::serve` call and never returned.
There was no way to stop it, so `kyehn/torvox` dropped the transport and
hand-rolled `into_router()` + `axum::serve(...).with_graceful_shutdown(...)`
instead. Our own deployment guides documented that hand-rolled form as the way
to shut a server down, which is an admission that the convenience method is
unusable in any process that can stop.

`HttpTransport::serve` and `WebSocketTransport::serve` had the same shape and
the same gap.

## API

`serve_with_shutdown(target, signal)` on all three transports, taking any
`Future<Output = ()> + Send + 'static`, the same shape as
`axum::serve(..).with_graceful_shutdown(..)`:

```rust
transport.serve_with_shutdown("0.0.0.0:3000", async {
    tokio::signal::ctrl_c().await.ok();
}).await?;
```

Binding happens before the signal is awaited, so a bind error still surfaces
as an error rather than as a server that never starts.

Each existing `serve` now delegates with `std::future::pending()`, so
behaviour is unchanged and there is one code path. The implementation lives in
`transport::graceful`, generic over `axum::serve::Listener` so the TCP and
Unix-domain paths cannot drift.

`drain_timeout(Duration)` on `HttpTransport` and `UnixSocketTransport` bounds
the post-signal wait. Unbounded is the default and stays the default, so a
request in flight when the signal arrives is still answered. The bound exists
because an SSE notification stream is an in-flight response until its client
hangs up, which can outlast the shutdown that started it. It mirrors
`StdioTransport::drain_timeout` from #1252 / #1260: same name, same
unbounded-by-default rule, same reason.

## All three transports, but only two get the bound

Unix, HTTP, and WebSocket each own a listener, so all three get
`serve_with_shutdown`.

`WebSocketTransport` deliberately has no `drain_timeout`. Writing the test for
it surfaced why: axum's graceful shutdown never sees an upgraded WebSocket.
The connection task finishes at the upgrade and the socket runs on its own
task from then on, so the drain completes immediately with clients still
connected, and a bound would be a knob that could never fire. Shutting down
that transport stops new clients getting in and returns; sockets already up
live until their clients hang up or the process exits. That is now stated on
`WebSocketTransport::serve_with_shutdown` rather than left to be discovered.
Closing live sockets on shutdown is a separate behaviour with its own design
questions (close code, in-flight requests, session resumption) and is not in
this PR.

The same axum property bounds what `drain_timeout` can promise on the other
two: returning hands control back, it does not close connections still open,
because axum serves each on its own task. The listener is dropped as soon as
the signal fires either way, so nothing new is accepted while the drain runs.
The docs say this rather than implying the connections are killed.

## Tests

Five tests, each starting a real server, proving it serves, signalling it, and
failing on a timeout if the future does not resolve. A hang is the failure
being guarded against, so it surfaces as a failed assertion.

- `unix_socket.rs`: the headline case. Initialize over the socket, signal, the
  future returns, and `UnixStream::connect` is then refused, so the listener is
  really gone rather than merely unreferenced.
- `unix_socket.rs`: `drain_timeout` returns while a handler is parked, and
  asserts the parked request is still unfinished, so the bound is what ended
  the wait.
- `graceful_shutdown.rs`: the HTTP pair. Unbounded shutdown does not return
  while a request is running, then returns once it is answered, and the client
  gets its result. Bounded shutdown returns with that request still parked.
- `graceful_shutdown.rs`: WebSocket shutdown returns with a client connected,
  and the port stops accepting.

Non-vacuity was checked by mutation: making the implementation ignore the
signal fails all five with timeouts, while the six pre-existing Unix socket
tests still pass.

## Also

- Both deployment guides taught rebuilding the server around `axum::serve` to
  get a shutdown. They now lead with `serve_with_shutdown`, and the guide keeps
  the axum form for the case it is still needed: mounting the MCP endpoint
  somewhere other than the root.
- The Unix socket example shuts down on Ctrl-C and unlinks its socket file,
  which was unreachable before.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features`,
`cargo test --workspace --all-features`, `cargo test --workspace --all-features
--doc`, and `RUSTDOCFLAGS="-Dwarnings -Dmissing-docs" cargo doc -p tower-mcp
--all-features --no-deps` all clean. Also built with no default features, with
`http` only, and with `websocket` only.