### PR TITLE
fix(stdio): keep the transport alive when stdin carries invalid UTF-8

### DIFF
--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -468,6 +468,106 @@ fn clean_input_line(line: &str) -> &str {
     line.strip_prefix('\u{feff}').unwrap_or(line).trim()
 }
 
+/// One newline-delimited frame read from an input stream.
+///
+/// Framing happens over bytes, not over decoded text. `0x0A` cannot appear
+/// inside a multi-byte UTF-8 sequence, so the newline that ends a frame is
+/// unambiguous even when the bytes around it are not decodable, and input
+/// the decoder rejects costs exactly the frame it landed in.
+enum InputFrame {
+    /// A frame that decoded as UTF-8, taking the ordinary path from here.
+    Line(String),
+    /// A frame that is not valid UTF-8.
+    ///
+    /// The frame is discarded rather than repaired. A lossy decode would
+    /// hand the JSON parser text the peer never sent, so a stray byte inside
+    /// a string argument would be served as a request with silently altered
+    /// content. Discarding gives the peer the answer malformed JSON already
+    /// gets: a parse error, and a loop that keeps running (#797, #1271).
+    Undecodable,
+}
+
+/// The parse-error message for a frame whose bytes are not valid UTF-8.
+const UNDECODABLE_FRAME: &str = "invalid UTF-8 in input frame";
+
+/// Strip the delimiter from one raw frame and decode it.
+fn decode_input_frame(mut raw: Vec<u8>) -> InputFrame {
+    if raw.last() == Some(&b'\n') {
+        raw.pop();
+        if raw.last() == Some(&b'\r') {
+            raw.pop();
+        }
+    }
+    match String::from_utf8(raw) {
+        Ok(line) => InputFrame::Line(line),
+        Err(_) => InputFrame::Undecodable,
+    }
+}
+
+/// Build the `-32700` frame that answers an undecodable frame, logging the
+/// discard on the way through so every transport reports it identically.
+fn undecodable_frame_response() -> Result<String> {
+    tracing::warn!("{UNDECODABLE_FRAME}, discarding it");
+    serde_json::to_string(&parse_error_response(UNDECODABLE_FRAME))
+        .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))
+}
+
+/// Newline-delimited frame reader over an async byte stream.
+///
+/// This exists instead of [`tokio::io::Lines`] because `Lines` decodes before
+/// it frames: one byte that is not valid UTF-8 surfaces as `InvalidData`, and
+/// the read loops turn that into a transport error that ends the session for
+/// every other request on the connection (#1271).
+///
+/// Cancellation behaves the way `Lines::next_line` does, which the `select!`
+/// loops depend on: bytes read before a lost race stay in `buf`, and the next
+/// call continues the same frame rather than starting a new one.
+struct FrameReader<R> {
+    reader: BufReader<R>,
+    buf: Vec<u8>,
+}
+
+impl<R> FrameReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Read the next frame, or `None` once the input is exhausted.
+    ///
+    /// Cancel-safe in the sense the type documents.
+    async fn next_frame(&mut self) -> Result<Option<InputFrame>> {
+        let read = self
+            .reader
+            .read_until(b'\n', &mut self.buf)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
+        // Nothing read and nothing held back: end of input. Bytes still held
+        // are a final frame that arrived without its delimiter.
+        if read == 0 && self.buf.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(decode_input_frame(std::mem::take(&mut self.buf))))
+    }
+}
+
+/// Blocking counterpart of [`FrameReader::next_frame`], for the sync transport.
+fn read_frame_blocking<R: BufRead>(reader: &mut R) -> Result<Option<InputFrame>> {
+    let mut raw = Vec::new();
+    let read = reader
+        .read_until(b'\n', &mut raw)
+        .map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
+    if read == 0 {
+        return Ok(None);
+    }
+    Ok(Some(decode_input_frame(raw)))
+}
+
 /// Build a JSON-RPC parse-error response from a parser/dispatch error message.
 ///
 /// Per JSON-RPC 2.0, a parse error sets `code` to `-32700` and `id` to
@@ -1059,11 +1159,11 @@ impl StdioTransport {
         R: tokio::io::AsyncRead + Unpin + Send,
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
-        // Keep the line buffer across cancelled `select!` branches. Tokio's
-        // `read_line` future can discard a partial JSON frame when a
-        // notification or control message wins the race; `next_line` stores
-        // that partial frame in `Lines` until the following poll.
-        let mut lines = BufReader::new(reader).lines();
+        // Keep the frame buffer across cancelled `select!` branches. A bare
+        // `read_until` future can discard a partial JSON frame when a
+        // notification or control message wins the race; `FrameReader` holds
+        // that partial frame until the following poll.
+        let mut frames = FrameReader::new(reader);
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
@@ -1086,14 +1186,15 @@ impl StdioTransport {
         loop {
             tokio::select! {
                 // Handle incoming messages from stdin
-                result = lines.next_line() => {
-                    let line = result.map_err(|e| {
-                        Error::Transport(format!("Failed to read from stdin: {}", e))
-                    })?;
-                    let Some(line) = line else {
+                result = frames.next_frame() => {
+                    let Some(frame) = result? else {
                         // EOF
                         tracing::info!("Stdin closed, shutting down");
                         break;
+                    };
+                    let InputFrame::Line(line) = frame else {
+                        write_line_to_stdout(&mut writer, &undecodable_frame_response()?).await?;
+                        continue;
                     };
 
                     let trimmed = clean_input_line(&line);
@@ -1444,7 +1545,7 @@ where
         R: tokio::io::AsyncRead + Unpin + Send,
         W: tokio::io::AsyncWrite + Unpin + Send,
     {
-        let mut lines = BufReader::new(reader).lines();
+        let mut frames = FrameReader::new(reader);
         #[cfg(feature = "stateless")]
         let mut subscriptions =
             StdioSubscriptions::default().with_observer(self.subscription_observer.clone());
@@ -1465,13 +1566,17 @@ where
             // Use select! if we have a notification receiver, otherwise just read
             if let Some(ref mut notif_rx) = self.notification_rx {
                 tokio::select! {
-                    result = lines.next_line() => {
-                        let line = result.map_err(|e| {
-                            Error::Transport(format!("Failed to read from stdin: {}", e))
-                        })?;
-                        let Some(line) = line else {
+                    result = frames.next_frame() => {
+                        let Some(frame) = result? else {
                             tracing::info!("Stdin closed, shutting down");
                             break;
+                        };
+                        // Answered through `out_tx` like every other frame
+                        // this loop produces, so the read loop stays the
+                        // only writer.
+                        let InputFrame::Line(line) = frame else {
+                            let _ = out_tx.send(undecodable_frame_response()?);
+                            continue;
                         };
 
                         Self::process_input(
@@ -1518,13 +1623,14 @@ where
                 }
             } else {
                 tokio::select! {
-                    result = lines.next_line() => {
-                        let line = result.map_err(|e| {
-                            Error::Transport(format!("Failed to read from stdin: {}", e))
-                        })?;
-                        let Some(line) = line else {
+                    result = frames.next_frame() => {
+                        let Some(frame) = result? else {
                             tracing::info!("Stdin closed, shutting down");
                             break;
+                        };
+                        let InputFrame::Line(line) = frame else {
+                            let _ = out_tx.send(undecodable_frame_response()?);
+                            continue;
                         };
                         Self::process_input(
                             &mut self.service,
@@ -1795,13 +1901,24 @@ impl SyncStdioTransport {
             .map_err(|e| Error::Transport(format!("Failed to create runtime: {}", e)))?;
 
         let stdin = io::stdin();
+        let mut input = stdin.lock();
         let mut stdout = io::stdout();
 
         tracing::info!("Sync stdio transport started");
 
-        for line in stdin.lock().lines() {
-            let line =
-                line.map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
+        while let Some(frame) = read_frame_blocking(&mut input)? {
+            let line = match frame {
+                InputFrame::Line(line) => line,
+                InputFrame::Undecodable => {
+                    let response_json = undecodable_frame_response()?;
+                    writeln!(stdout, "{}", response_json)
+                        .map_err(|e| Error::Transport(format!("Failed to write error: {}", e)))?;
+                    stdout
+                        .flush()
+                        .map_err(|e| Error::Transport(format!("Failed to flush stdout: {}", e)))?;
+                    continue;
+                }
+            };
 
             let trimmed = clean_input_line(&line);
             if trimmed.is_empty() {
@@ -2006,7 +2123,7 @@ impl BidirectionalStdioTransport {
         W: tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
         let writer = Arc::new(Mutex::new(writer));
-        let mut lines = BufReader::new(reader).lines();
+        let mut frames = FrameReader::new(reader);
         #[cfg(feature = "stateless")]
         let mut subscriptions = StdioSubscriptions {
             server_info: Some(self.router.implementation()),
@@ -2019,13 +2136,14 @@ impl BidirectionalStdioTransport {
         loop {
             tokio::select! {
                 // Handle incoming messages from stdin
-                result = lines.next_line() => {
-                    let line = result.map_err(|e| {
-                        Error::Transport(format!("Failed to read from stdin: {}", e))
-                    })?;
-                    let Some(line) = line else {
+                result = frames.next_frame() => {
+                    let Some(frame) = result? else {
                         tracing::info!("Stdin closed, shutting down");
                         break;
+                    };
+                    let InputFrame::Line(line) = frame else {
+                        self.write_line(&undecodable_frame_response()?, writer.clone()).await?;
+                        continue;
                     };
 
                     let trimmed = clean_input_line(&line);
@@ -2379,6 +2497,75 @@ mod tests {
             !s.contains('\n'),
             "serialized parse-error response must be single-line, got: {s:?}"
         );
+    }
+
+    // =========================================================================
+    // Frame reading -- byte framing survives input that will not decode
+    // (#1271). The blocking reader is covered here because
+    // `SyncStdioTransport::run_blocking` owns the real stdin and cannot be
+    // driven from a test.
+    // =========================================================================
+
+    /// Assert one frame decoded to exactly `expected`.
+    fn assert_line(frame: Option<InputFrame>, expected: &str) {
+        match frame {
+            Some(InputFrame::Line(line)) => assert_eq!(line, expected),
+            Some(InputFrame::Undecodable) => panic!("{expected:?} must decode"),
+            None => panic!("expected a frame, got end of input"),
+        }
+    }
+
+    /// Assert one frame was rejected by the decoder.
+    fn assert_undecodable(frame: Option<InputFrame>) {
+        assert!(
+            matches!(frame, Some(InputFrame::Undecodable)),
+            "expected an undecodable frame"
+        );
+    }
+
+    #[test]
+    fn decoding_strips_the_delimiter_in_both_line_endings() {
+        assert_line(Some(decode_input_frame(b"{}\n".to_vec())), "{}");
+        assert_line(Some(decode_input_frame(b"{}\r\n".to_vec())), "{}");
+        // A frame that arrived without its delimiter, at end of input.
+        assert_line(Some(decode_input_frame(b"{}".to_vec())), "{}");
+    }
+
+    #[test]
+    fn decoding_rejects_bytes_rather_than_repairing_them() {
+        // A lossy decode would turn this into a frame the peer never sent.
+        assert_undecodable(Some(decode_input_frame(vec![0xff, 0xfe, b'\n'])));
+    }
+
+    #[tokio::test]
+    async fn a_bad_frame_costs_only_itself() {
+        let input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
+        let mut frames = FrameReader::new(input);
+
+        assert_undecodable(frames.next_frame().await.unwrap());
+        assert_line(frames.next_frame().await.unwrap(), "{\"id\":1}");
+        assert!(
+            frames.next_frame().await.unwrap().is_none(),
+            "end of input must be reported once the frames are consumed"
+        );
+    }
+
+    #[test]
+    fn the_blocking_reader_treats_a_bad_frame_the_same_way() {
+        let mut input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
+
+        assert_undecodable(read_frame_blocking(&mut input).unwrap());
+        assert_line(read_frame_blocking(&mut input).unwrap(), "{\"id\":1}");
+        assert!(read_frame_blocking(&mut input).unwrap().is_none());
+    }
+
+    #[test]
+    fn an_undecodable_frame_is_answered_with_a_parse_error() {
+        let json: serde_json::Value =
+            serde_json::from_str(&undecodable_frame_response().unwrap()).unwrap();
+        assert_jsonrpc_error_response(&json);
+        assert!(json["id"].is_null(), "nothing to correlate against: {json}");
+        assert_eq!(json["error"]["code"].as_i64().unwrap(), -32700);
     }
 
     // =========================================================================

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -28,6 +28,14 @@
 //! Use [`StdioTransport::max_concurrent_requests`] to bound how many run at
 //! once, or to return to strictly serial handling with `1`.
 //!
+//! # Malformed input
+//!
+//! Frames are delimited by newline bytes and decoded one at a time, so a
+//! frame the peer sends malformed costs that frame and nothing else. Both
+//! JSON that does not parse and bytes that are not valid UTF-8 are answered
+//! with a JSON-RPC parse error (`-32700`, null id) and discarded; the loop
+//! keeps reading and later requests are served normally.
+//!
 //! # Bidirectional Support
 //!
 //! For legacy protocols, [`BidirectionalStdioTransport`] enables

--- a/crates/tower-mcp/tests/adversarial_input.rs
+++ b/crates/tower-mcp/tests/adversarial_input.rs
@@ -5,7 +5,7 @@
 //! on the wire: duplicate ids, stale notifications, malformed envelopes,
 //! out-of-order lifecycle traffic, and handlers that misbehave.
 //!
-//! Six tests are `#[ignore]`d. Each one asserts the behaviour the code should
+//! Three tests are `#[ignore]`d. Each one asserts the behaviour the code should
 //! have and fails against the behaviour it has today; the attribute carries
 //! the reason. Run them with `cargo test --test adversarial_input -- --ignored`
 //! to reproduce every finding.
@@ -624,13 +624,8 @@ async fn a_batch_with_a_broken_member_still_answers() {
 /// A single byte that is not valid UTF-8 is malformed input from the peer,
 /// exactly like malformed JSON. It must not terminate the transport: #797
 /// established that a parse error keeps the loop alive, and the byte layer
-/// is the same contract one level down.
-///
-/// Today `lines.next_line()` surfaces `InvalidData` and the `?` on it ends
-/// `run_with_streams` with a transport error, so one byte from a client kills
-/// the server for every other request on that connection.
+/// is the same contract one level down (#1271).
 #[tokio::test]
-#[ignore = "BUG: one invalid UTF-8 byte on stdin terminates run_with_streams instead of producing a parse error"]
 async fn invalid_utf8_on_stdin_does_not_kill_the_transport() {
     let mut server = Server::with_router(base_router());
     server.initialize().await;

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -2104,3 +2104,168 @@ mod shutdown {
             .expect("join");
     }
 }
+
+// ============================================================================
+// Invalid UTF-8 on stdin (#1271)
+// ============================================================================
+//
+// A byte that will not decode is malformed input from the peer, the same
+// class as malformed JSON. #797 pinned that a parse error keeps the loop
+// alive; these pin the same contract one layer down, on every transport that
+// reads newline-delimited frames. Before the fix, `Lines::next_line` surfaced
+// `InvalidData`, the `?` on it ended `run_with_streams`, and the request
+// behind the bad byte was never answered.
+
+mod invalid_utf8 {
+    use super::*;
+    use tower_mcp::GenericStdioTransport;
+
+    /// Answered with a result on a fresh transport, no handshake needed.
+    const PING: &[u8] = br#"{"jsonrpc":"2.0","id":42,"method":"ping"}"#;
+
+    /// Write a frame that cannot be decoded, then a valid ping, and read both
+    /// answers back.
+    async fn answers_after_a_bad_byte<F, Fut>(run: F) -> Vec<serde_json::Value>
+    where
+        F: FnOnce(tokio::io::DuplexStream, tokio::io::DuplexStream) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        tokio::spawn(run(server_stdin, server_stdout));
+
+        stdin_writer.write_all(&[0xff, 0xfe, b'\n']).await.unwrap();
+        stdin_writer.write_all(PING).await.unwrap();
+        stdin_writer.write_all(b"\n").await.unwrap();
+        stdin_writer.flush().await.unwrap();
+        drop(stdin_writer);
+
+        timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 2),
+        )
+        .await
+        .expect("the transport must survive the bad byte and answer the ping")
+    }
+
+    /// The bad frame is answered with `-32700` and discarded; the frame
+    /// behind it is served normally.
+    fn assert_parse_error_then_ping(frames: &[serde_json::Value]) {
+        assert_eq!(
+            frames.len(),
+            2,
+            "expected a parse error and a ping answer, got: {frames:?}"
+        );
+        assert_jsonrpc_error_response(&frames[0]);
+        assert!(
+            frames[0]["id"].is_null(),
+            "a discarded frame has no recoverable id: {}",
+            frames[0]
+        );
+        assert_eq!(frames[0]["error"]["code"].as_i64().unwrap(), -32700);
+        assert_eq!(
+            frames[1]["id"], 42,
+            "the request after the bad byte must be served: {}",
+            frames[1]
+        );
+        assert!(
+            frames[1].get("result").is_some(),
+            "ping must return a successful result frame, got: {}",
+            frames[1]
+        );
+    }
+
+    #[tokio::test]
+    async fn stdio_transport_answers_and_keeps_serving() {
+        let frames = answers_after_a_bad_byte(|stdin, stdout| async move {
+            let mut transport = StdioTransport::new(router());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+        assert_parse_error_then_ping(&frames);
+    }
+
+    /// A layer converts the transport to the generic one, which reads on its
+    /// own `select!` arm.
+    #[tokio::test]
+    async fn a_layered_transport_answers_and_keeps_serving() {
+        let frames = answers_after_a_bad_byte(|stdin, stdout| async move {
+            let mut transport =
+                StdioTransport::new(router()).layer(tower::layer::util::Identity::new());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+        assert_parse_error_then_ping(&frames);
+    }
+
+    /// The generic transport has a second `select!` shape for the case with
+    /// no outbound notification channel, and it reads on its own arm too.
+    #[tokio::test]
+    async fn a_generic_transport_without_notifications_answers_and_keeps_serving() {
+        let frames = answers_after_a_bad_byte(|stdin, stdout| async move {
+            let mut transport = GenericStdioTransport::new(router());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+        assert_parse_error_then_ping(&frames);
+    }
+
+    #[tokio::test]
+    async fn bidi_transport_answers_and_keeps_serving() {
+        let frames = answers_after_a_bad_byte(|stdin, stdout| async move {
+            let mut transport = BidirectionalStdioTransport::new(router());
+            let _ = transport.run_with_streams(stdin, stdout).await;
+        })
+        .await;
+        assert_parse_error_then_ping(&frames);
+    }
+
+    /// Framing is done over bytes, so a multi-byte character split across two
+    /// reads is still one frame with one character in it, not two undecodable
+    /// halves. The id comes back verbatim, which is the proof.
+    #[tokio::test]
+    async fn a_multibyte_character_split_across_reads_still_decodes() {
+        let mut transport = StdioTransport::new(router());
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+        });
+
+        let frame = "{\"jsonrpc\":\"2.0\",\"id\":\"caf\u{e9}\",\"method\":\"ping\"}\n";
+        // Between the two bytes of the `é`, so neither half decodes alone.
+        let split = frame.find('\u{e9}').expect("the frame carries the char") + 1;
+        stdin_writer
+            .write_all(&frame.as_bytes()[..split])
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        stdin_writer
+            .write_all(&frame.as_bytes()[split..])
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+        drop(stdin_writer);
+
+        let frames = timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 1),
+        )
+        .await
+        .expect("the split frame must be answered");
+        assert_eq!(frames.len(), 1, "expected one answer, got: {frames:?}");
+        assert_eq!(
+            frames[0]["id"], "caf\u{e9}",
+            "the character must survive the split: {}",
+            frames[0]
+        );
+        assert!(
+            frames[0].get("result").is_some(),
+            "ping must return a successful result frame, got: {}",
+            frames[0]
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1271.

## The bug

One byte that would not decode ended the read loop. `Lines::next_line` decodes before it frames, so it surfaced `InvalidData`, the `?` on it turned that into `Error::Transport`, and `run_with_streams` returned `Err`. Every later request on that connection went unanswered, from a single stray byte any peer could put on the pipe.

Malformed JSON already does not do this. #797 established that a parse error produces a `-32700` response and the loop keeps running, with tests pinning it. Bytes that will not decode are the same class of hostile input one layer down, and now get the same answer.

## The design decision: byte framing, strict decode, discard the frame

The issue asked which of two options to take when the bytes are not decodable, since the line boundary itself may be unreliable. Both parts are settled here:

**Frame over bytes, not over text.** `0x0A` cannot appear inside a multi-byte UTF-8 sequence, since every continuation byte is `>= 0x80`. So the newline that delimits a frame is unambiguous at the byte level even when the bytes around it are not decodable. The line boundary is only unreliable if you look for it after decoding, which is exactly what `Lines` does. Framing first bounds the damage to the frame the bad bytes landed in, with no need to hunt for a resynchronisation point.

**Decode strictly and discard, rather than decode lossily.** A lossy decode (`from_utf8_lossy`) would hand the JSON parser text the peer never sent. A stray byte inside a string argument would become `U+FFFD` and the frame would still parse, so the request would be dispatched and served with silently altered content. Nobody is told. Discarding costs nothing that a peer can legitimately rely on (the frame was already unrecoverable) and gives it the answer malformed JSON already gets: `-32700`, null id, loop keeps running.

`FrameReader` keeps the cancellation behaviour `Lines` had, which the `select!` loops depend on: bytes read before a lost race stay buffered, and the next call continues the same frame instead of starting a new one. That property is pinned by `stdio_transport_preserves_partial_frame_when_read_is_cancelled`, which still passes, and by a new test that splits a multi-byte character across two reads.

## Transports changed

All five read sites in `crates/tower-mcp/src/transport/stdio.rs`:

| Transport | Site | Where the `-32700` goes |
|---|---|---|
| `StdioTransport` | `run_with_streams` | written directly by the read loop |
| `GenericStdioTransport` | `run_with_streams`, notification `select!` shape | `out_tx`, like every other frame that loop produces |
| `GenericStdioTransport` | `run_with_streams`, no-notification `select!` shape | `out_tx` |
| `SyncStdioTransport` | `run_blocking` | written to stdout inline |
| `BidirectionalStdioTransport` | `run_with_streams` | the shared `Arc<Mutex<W>>` writer |

Valid input takes exactly the path it took before: the decoded line still goes through `clean_input_line` (BOM strip and trim) and into the same dispatch.

## Tests

`invalid_utf8_on_stdin_does_not_kill_the_transport` in `crates/tower-mcp/tests/adversarial_input.rs` is un-`#[ignore]`d, and a new `invalid_utf8` module in `crates/tower-mcp/tests/stdio_loop.rs` covers the sibling transports. Each writes `0xff 0xfe \n` followed by a valid `ping` and asserts both the `-32700` frame and the answer to the request behind it, which is the assertion the issue asked for.

Verified by restoring the pre-fix `stdio.rs` with the tests in place:

- Before: `adversarial_input` 1 failed (`the transport must survive an invalid byte and keep serving`); `stdio_loop invalid_utf8` 4 failed, 1 passed, each failure `expected a parse error and a ping answer, got: []`.
- After: `adversarial_input` 1 passed; `stdio_loop invalid_utf8` 5 passed.

The one test that passes either way is `a_multibyte_character_split_across_reads_still_decodes`, which guards the new reader rather than the old bug.

`SyncStdioTransport::run_blocking` owns the real stdin and cannot be driven from a test, so its reader is covered by unit tests on `read_frame_blocking` in the module, alongside `FrameReader` and the decode helper.

#797's tests are untouched and still pass, as does the rest of the workspace: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, and `cargo test --workspace --all-features --doc`.