### PR TITLE
fix(tool): preserve live handlers through clone and prefix

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3476,7 +3476,7 @@ impl McpRouter {
                                 crate::tool::TaskContext::with_live(task_id_clone.clone(), handle);
 
                             let start = std::time::Instant::now();
-                            let outcome = live_handler.call(live_ctx, arguments).await;
+                            let outcome = live_handler.call(ctx, live_ctx, arguments).await;
                             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
                             notifier.unregister_live_task(&task_id_clone);
 

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -464,7 +464,42 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// exists so the router can hold one type-erased (#1246).
 #[async_trait::async_trait]
 pub(crate) trait LiveToolHandler: Send + Sync {
-    async fn call(&self, task: TaskContext, arguments: Value) -> Result<TaskOutcome>;
+    async fn call(
+        &self,
+        ctx: RequestContext,
+        task: TaskContext,
+        arguments: Value,
+    ) -> Result<TaskOutcome>;
+}
+
+/// Applies a guard to a live handler.
+///
+/// Mirrors `GuardedMrtrToolHandler`. Without this, `Tool::with_guard` on a
+/// live tool reached an `expect` on the absent service and panicked (#1295).
+struct GuardedLiveToolHandler<G> {
+    guard: G,
+    inner: Arc<dyn LiveToolHandler>,
+}
+
+#[async_trait::async_trait]
+impl<G> LiveToolHandler for GuardedLiveToolHandler<G>
+where
+    G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
+{
+    async fn call(
+        &self,
+        ctx: RequestContext,
+        task: TaskContext,
+        arguments: Value,
+    ) -> Result<TaskOutcome> {
+        let request = ToolRequest::new(ctx, arguments);
+        match (self.guard)(&request) {
+            Ok(()) => self.inner.call(request.ctx, task, request.args).await,
+            // A rejected call completes with a domain error, matching what a
+            // guarded ordinary or MRTR tool does.
+            Err(message) => Ok(TaskOutcome::Completed(CallToolResult::error(message))),
+        }
+    }
 }
 
 struct FnLiveToolHandler<I, F> {
@@ -479,7 +514,12 @@ where
     F: Fn(TaskContext, I) -> Fut + Send + Sync,
     Fut: Future<Output = Result<TaskOutcome>> + Send,
 {
-    async fn call(&self, task: TaskContext, arguments: Value) -> Result<TaskOutcome> {
+    async fn call(
+        &self,
+        _ctx: RequestContext,
+        task: TaskContext,
+        arguments: Value,
+    ) -> Result<TaskOutcome> {
         let input: I = serde_json::from_value(arguments).map_err(|e| {
             crate::error::Error::Tool(crate::error::ToolError::new(format!(
                 "invalid arguments: {e}"
@@ -1085,7 +1125,7 @@ unsafe impl Sync for Tool {}
 impl Clone for Tool {
     fn clone(&self) -> Self {
         Self {
-            live_handler: None,
+            live_handler: self.live_handler.clone(),
             name: self.name.clone(),
             title: self.title.clone(),
             description: self.description.clone(),
@@ -1295,6 +1335,13 @@ impl Tool {
     where
         G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
     {
+        if let Some(inner) = self.live_handler.clone() {
+            return Tool {
+                live_handler: Some(Arc::new(GuardedLiveToolHandler { guard, inner })),
+                ..self
+            };
+        }
+
         #[cfg(feature = "stateless")]
         if let Some(inner) = self.mrtr_handler.clone() {
             return Tool {
@@ -1344,7 +1391,7 @@ impl Tool {
     /// ```
     pub fn with_name_prefix(&self, prefix: &str) -> Self {
         Self {
-            live_handler: None,
+            live_handler: self.live_handler.clone(),
             name: format!("{}.{}", prefix, self.name),
             title: self.title.clone(),
             description: self.description.clone(),

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -235,3 +235,107 @@ async fn cancellation_is_confirmed_by_the_handler_rather_than_imposed() {
         "the handler ran its teardown rather than being abandoned"
     );
 }
+
+// ============================================================================
+// Clone, prefix, and nest (#1295)
+// ============================================================================
+
+/// #1295: `Tool::clone` and `Tool::with_name_prefix` set `live_handler: None`,
+/// so a cloned or prefixed live tool still advertised
+/// `TaskSupportMode::Required` while having neither a live handler nor an
+/// ordinary service. Ordinary router lookup clones `Arc<Tool>` and stayed
+/// correct, which is why nothing caught it.
+///
+/// This asserts the nested tool actually runs a task to completion. Checking
+/// that the field survived would pass even if the clone were otherwise broken.
+#[tokio::test]
+async fn a_nested_live_tool_still_runs() {
+    let tool = ToolBuilder::new("run")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ran")))
+        })
+        .build();
+
+    let inner = McpRouter::new().server_info("inner", "1.0.0").tool(tool);
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let outer = McpRouter::new()
+        .server_info("outer", "1.0.0")
+        .task_store(store.clone())
+        .nest("provider", inner)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(outer))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let names: Vec<String> = client
+        .list_tools()
+        .await
+        .expect("list")
+        .tools
+        .into_iter()
+        .map(|t| t.name)
+        .collect();
+    assert!(
+        names.iter().any(|n| n == "provider.run"),
+        "nested tool must be listed: {names:?}"
+    );
+
+    let task_id = client
+        .call_tool_as_task("provider.run", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        result.unwrap().all_text(),
+        "ran",
+        "the nested live handler must actually execute"
+    );
+}
+
+/// A guard on a live tool must reject through the ordinary domain-error path
+/// rather than panicking on the absent service.
+#[tokio::test]
+async fn a_guard_on_a_live_tool_rejects_without_panicking() {
+    let tool = ToolBuilder::new("guarded")
+        .description("Always rejected")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(
+                "should not run",
+            )))
+        })
+        .build()
+        .with_guard(|_req: &tower_mcp::ToolRequest| Err("nope".to_string()));
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("guarded", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("guarded", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let result = result.expect("a rejected call still produces a result");
+    assert!(result.is_error, "the guard rejection is a domain error");
+    assert!(result.all_text().contains("nope"));
+}


### PR DESCRIPTION
Claiming #1295. **Work in progress, do not duplicate.**

Confirmed, and it is my own mechanical damage from #1288. When I added the `live_handler` field I inserted `live_handler: None` into every `Self { ... }` literal in `tool.rs` by script. Four of those were correct (the two `from_*_handler` constructors, which genuinely have no live handler). Two were not:

- `Tool::clone` (`tool.rs:1088`)
- `Tool::with_name_prefix` (`tool.rs:1347`)

Both should propagate `self.live_handler.clone()`, since it is already an `Arc` and every other handler form is preserved.

The result advertises `TaskSupportMode::Required` while having neither a live handler nor an ordinary service, so `McpRouter::nest()` silently produces a broken tool. Ordinary router lookup clones `Arc<Tool>` and stays correct, which is why nothing caught it.

## Plan

- propagate the handler in both places
- decide `with_guard`, which currently reaches `service.expect("tool must have a complete or MRTR handler")` on a live tool. Support it or return a typed error, but it must not panic
- test that a nested live tool actually runs a task to completion, not merely that the field is `Some`

That last point is the one that matters: asserting the field survives would pass even if the clone were otherwise broken.