### PR TITLE
fix(test): stop the version drift scan reading gitignored paths

### DIFF
--- a/crates/tower-mcp/tests/version_drift.rs
+++ b/crates/tower-mcp/tests/version_drift.rs
@@ -136,11 +136,57 @@ fn workspace_version(manifest: &str) -> String {
         .to_string()
 }
 
-/// Every file under `root` worth scanning.
+/// Every file worth scanning, as git sees the repository.
+///
+/// Enumerating tracked files rather than walking the filesystem is what keeps
+/// this honest: `.gitignore` holds local scratch (`/tmp/` carries repro servers
+/// and checkouts of other SDKs) and any of it can contain a `Cargo.toml` or a
+/// `.md` naming an old version. A hand-maintained skip list would drift from
+/// `.gitignore` the first time somebody added a directory.
+///
+/// Falls back to a filesystem walk when git is unavailable, which is the
+/// published crate archive. There is no scratch there, so the walk is safe.
+fn scannable_files(root: &Path) -> Vec<PathBuf> {
+    match tracked_files(root) {
+        Some(found) => found,
+        None => walk_files(root),
+    }
+}
+
+/// Tracked paths, or `None` when this is not a git checkout.
+fn tracked_files(root: &Path) -> Option<Vec<PathBuf>> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let mut found: Vec<PathBuf> = output
+        .stdout
+        .split(|byte| *byte == 0)
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| root.join(String::from_utf8_lossy(entry).as_ref()))
+        .filter(|path| {
+            SCANNED_EXTENSIONS
+                .iter()
+                .any(|ext| path.extension().is_some_and(|found| found == *ext))
+                && !path
+                    .file_name()
+                    .is_some_and(|name| is_exempt(&name.to_string_lossy()))
+        })
+        .collect();
+    found.sort();
+    Some(found)
+}
+
+/// Filesystem fallback for the published archive.
 ///
 /// Build output, the git directory, and the other dot directories are skipped;
 /// `.claude/worktrees` in particular holds whole extra checkouts.
-fn scannable_files(root: &Path) -> Vec<PathBuf> {
+fn walk_files(root: &Path) -> Vec<PathBuf> {
     let mut found = Vec::new();
     let mut pending = vec![root.to_path_buf()];
     while let Some(dir) = pending.pop() {


### PR DESCRIPTION
Follow-up to #1290, which is correct in substance but fails on a developer machine.

## What happens

`cargo test --workspace --all-features` on a clean `main`:

```
dependency declarations drifted from the 0.21 release line:
  tmp/repro-server/Cargo.toml:9: tower-mcp names 0.10, expected 0.21
```

`tmp/` is local scratch, gitignored at `.gitignore:10`, and holds repro servers and checkouts of other SDKs. Nothing in it is part of the repository.

CI was right to pass: a fresh checkout has no `tmp/`, so 27/27 was accurate rather than lucky. The failure only appears where someone has scratch, which is every machine actually being worked on.

**Not proposing a revert.** The check is worth having, it found nothing wrong, and #1290 does exactly what #1264 asked for. This is a defect in which files it reads.

## Cause

`scannable_files` walks the tree skipping `target` and dot-directories. That covers `.claude/worktrees` but nothing else in `.gitignore`, so any ignored directory with a `Cargo.toml` or a `.md` gets scanned as though it were ours.

## Plan

Enumerate tracked files instead of walking the filesystem, so ignoring is defined by git rather than by a hand-maintained skip list that will drift from `.gitignore`. Keep a fallback for the published crate archive, where there is no git directory, matching what `example_imports.rs` already does.

Then verify by putting a deliberately stale `tower-mcp = "0.10"` in an ignored path and confirming the scan does not see it, and in a tracked path and confirming it does.