### PR TITLE
fix(client): keep the stdio client alive when a server writes invalid UTF-8

### DIFF
--- a/crates/tower-mcp/src/client/stdio.rs
+++ b/crates/tower-mcp/src/client/stdio.rs
@@ -3,6 +3,27 @@
 //! Provides [`StdioClientTransport`] which spawns a child process and
 //! communicates using line-delimited JSON over stdin/stdout.
 //!
+//! # Malformed output from the server
+//!
+//! Frames are delimited by newline bytes and decoded one at a time, so a
+//! frame the server writes malformed costs that frame and nothing else. A
+//! frame that is not valid UTF-8, a stray debug print or a mis-encoded log
+//! line on stdout, is logged and discarded, and the transport reads on.
+//!
+//! Discarding is what a client has available. The server side answers the
+//! same input with a JSON-RPC parse error and keeps serving (#1271); a client
+//! has nobody to send that to. The alternative, reporting it as a transport
+//! error, ends the connection and fails every pending request, which lets a
+//! server that is otherwise working correctly disconnect its client with one
+//! stray byte (#1296). It is also the treatment the layer above already gives
+//! JSON that does not parse: warn, drop the message, keep the connection.
+//!
+//! One consequence is worth stating plainly. If the discarded frame held the
+//! response to a pending request, that request is not failed early; it waits
+//! for its own timeout, exactly as it would have if the server had never
+//! answered. Failing it early would need the request id, which is inside the
+//! bytes that would not decode.
+//!
 //! # Example
 //!
 //! ```rust,no_run
@@ -18,11 +39,12 @@
 use std::process::Stdio;
 
 use async_trait::async_trait;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, Lines};
+use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 
 use super::transport::ClientTransport;
 use crate::error::{Error, Result};
+use crate::framing::{FrameReader, InputFrame};
 
 /// Client transport that communicates with a subprocess via stdio.
 ///
@@ -33,11 +55,13 @@ use crate::error::{Error, Result};
 pub struct StdioClientTransport {
     child: Option<Child>,
     stdin: Option<tokio::process::ChildStdin>,
-    // `Lines::next_line` retains a partially read frame when its future is
-    // cancelled by the client's `select!` loop. A bare `read_line` future can
+    // `FrameReader` retains a partially read frame when its future is
+    // cancelled by the client's `select!` loop. A bare `read_until` future can
     // discard those bytes while leaving the newline behind, turning a valid
     // response into an empty frame when outgoing commands arrive concurrently.
-    stdout: Lines<BufReader<tokio::process::ChildStdout>>,
+    // It also frames over bytes rather than decoded text, so output the
+    // decoder rejects costs one frame instead of the connection (#1296).
+    stdout: FrameReader<tokio::process::ChildStdout>,
 }
 
 impl StdioClientTransport {
@@ -96,7 +120,7 @@ impl StdioClientTransport {
         Ok(Self {
             child: Some(child),
             stdin: Some(stdin),
-            stdout: BufReader::new(stdout).lines(),
+            stdout: FrameReader::new(stdout),
         })
     }
 
@@ -125,7 +149,7 @@ impl StdioClientTransport {
         Ok(Self {
             child: Some(child),
             stdin: Some(stdin),
-            stdout: BufReader::new(stdout).lines(),
+            stdout: FrameReader::new(stdout),
         })
     }
 }
@@ -153,13 +177,39 @@ impl ClientTransport for StdioClientTransport {
         Ok(())
     }
 
+    /// Read the next message the server wrote.
+    ///
+    /// Frames that are not valid UTF-8 are logged and skipped rather than
+    /// reported, so `Err` keeps meaning the connection is over and `Ok(None)`
+    /// keeps meaning EOF. See the module docs for why, and for what the skip
+    /// costs a request whose response was in the discarded frame.
+    ///
+    /// Cancel-safe: the client's message loop polls this inside a `select!`,
+    /// and bytes read before a lost race stay buffered for the next call.
+    /// Skipping happens between reads, so a cancellation can only lose a
+    /// frame that was going to be discarded anyway.
     async fn recv(&mut self) -> Result<Option<String>> {
-        let line = self
-            .stdout
-            .next_line()
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to read: {}", e)))?;
-        Ok(line.map(|line| line.trim().to_string()))
+        loop {
+            let Some(frame) = self
+                .stdout
+                .next_frame()
+                .await
+                .map_err(|e| Error::Transport(format!("Failed to read: {}", e)))?
+            else {
+                return Ok(None);
+            };
+
+            match frame {
+                InputFrame::Line(line) => return Ok(Some(line.trim().to_string())),
+                InputFrame::Undecodable => {
+                    tracing::warn!(
+                        "invalid UTF-8 in a frame from the server, discarding it; \
+                         a response carried in it will not arrive and its request \
+                         will wait for its timeout"
+                    );
+                }
+            }
+        }
     }
 
     fn is_connected(&self) -> bool {
@@ -195,6 +245,7 @@ impl ClientTransport for StdioClientTransport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::{AsyncBufReadExt, BufReader};
 
     #[tokio::test]
     async fn test_spawn_nonexistent_program() {
@@ -237,22 +288,85 @@ mod tests {
         assert_eq!(result, None);
     }
 
-    #[tokio::test]
-    async fn line_reader_preserves_partial_frame_when_receive_is_cancelled() {
-        let (mut writer, reader) = tokio::io::duplex(256);
-        let mut lines = BufReader::new(reader).lines();
-        let frame = r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#;
+    // =========================================================================
+    // Output that will not decode (#1296)
+    //
+    // A stray byte on the server's stdout used to surface as `InvalidData`,
+    // which `recv` turned into `Error::Transport`. The client's message loop
+    // treats `Err` as the connection being over: it breaks and fails every
+    // pending request. These pin that one bad frame now costs one frame.
+    // =========================================================================
 
-        writer.write_all(frame.as_bytes()).await.unwrap();
+    /// Spawn a shell that writes exactly `script` to stdout.
+    ///
+    /// Octal escapes keep `printf` portable across the shells CI runs.
+    async fn spawn_writer(script: &str) -> StdioClientTransport {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", script]);
+        StdioClientTransport::spawn_command(&mut cmd).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_frame_is_skipped_and_the_next_one_is_delivered() {
+        let response = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        let mut transport =
+            spawn_writer(r#"printf '\377\376\n'; printf '{"jsonrpc":"2.0","id":1,"result":{}}\n'"#)
+                .await;
+
+        assert_eq!(
+            transport.recv().await.unwrap().as_deref(),
+            Some(response),
+            "the frame after a bad one must still be delivered"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_undecodable_frames_do_not_end_the_transport() {
+        let response = r#"{"jsonrpc":"2.0","id":7,"result":{}}"#;
+        let mut transport = spawn_writer(
+            r#"printf '\377\n\376\n\377\376\n'; printf '{"jsonrpc":"2.0","id":7,"result":{}}\n'"#,
+        )
+        .await;
+
+        assert_eq!(transport.recv().await.unwrap().as_deref(), Some(response));
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_frame_before_eof_reports_eof_rather_than_an_error() {
+        // A server whose last output does not decode has still closed
+        // cleanly. Reporting an error here would fail pending requests that
+        // EOF handling is supposed to close out normally.
+        let mut transport = spawn_writer(r#"printf '\377\376\n'"#).await;
+
+        assert_eq!(transport.recv().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn an_undecodable_final_frame_without_a_newline_reports_eof() {
+        let mut transport = spawn_writer(r#"printf '\377\376'"#).await;
+
+        assert_eq!(transport.recv().await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_partial_frame_survives_a_cancelled_receive() {
+        // The client's message loop polls `recv` inside a `select!`, so a
+        // frame that loses the race has to survive to the next call rather
+        // than arriving split in two.
+        let frame = r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#;
+        let mut transport = spawn_writer(
+            r#"printf '{"jsonrpc":"2.0","id":2,'; sleep 0.2; printf '"result":{"tools":[]}}\n'"#,
+        )
+        .await;
+
         assert!(
-            tokio::time::timeout(std::time::Duration::from_millis(10), lines.next_line())
+            tokio::time::timeout(std::time::Duration::from_millis(50), transport.recv())
                 .await
                 .is_err(),
             "a partial frame must remain pending until its newline arrives"
         );
 
-        writer.write_all(b"\n").await.unwrap();
-        assert_eq!(lines.next_line().await.unwrap().as_deref(), Some(frame));
+        assert_eq!(transport.recv().await.unwrap().as_deref(), Some(frame));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/client/transport.rs
+++ b/crates/tower-mcp/src/client/transport.rs
@@ -57,6 +57,13 @@ pub trait ClientTransport: Send + 'static {
     ///
     /// Returns `Ok(Some(json))` for a message, `Ok(None)` for clean EOF/close,
     /// or `Err(...)` for transport errors.
+    ///
+    /// Both non-message returns end the connection: the client's message loop
+    /// stops reading and fails every pending request. Reserve them for the
+    /// connection actually being over. A single message that arrives damaged,
+    /// such as one the transport cannot decode, is not that; log it, drop it,
+    /// and return the next one. [`StdioClientTransport`](super::StdioClientTransport)
+    /// documents the reasoning in full.
     async fn recv(&mut self) -> Result<Option<String>>;
 
     /// Check if the transport is still connected.

--- a/crates/tower-mcp/src/framing.rs
+++ b/crates/tower-mcp/src/framing.rs
@@ -1,0 +1,193 @@
+//! Newline-delimited frame reading over bytes.
+//!
+//! Both ends of a stdio connection read the same wire format, and both have
+//! to survive a peer that puts bytes on it that will not decode. Framing
+//! happens over bytes rather than over decoded text so that a bad byte costs
+//! one frame instead of the connection; see [`InputFrame`] for why.
+//!
+//! What happens to a frame that does not decode is the caller's decision,
+//! because the two ends have different answers available to them. A server
+//! answers with a JSON-RPC parse error (`-32700`) and keeps serving. A client
+//! has nobody to answer, so it logs the discard and reads the next frame.
+
+use std::io::BufRead;
+
+use tokio::io::{AsyncBufReadExt, BufReader};
+
+use crate::error::{Error, Result};
+
+/// One newline-delimited frame read from an input stream.
+///
+/// Framing happens over bytes, not over decoded text. `0x0A` cannot appear
+/// inside a multi-byte UTF-8 sequence, so the newline that ends a frame is
+/// unambiguous even when the bytes around it are not decodable, and input
+/// the decoder rejects costs exactly the frame it landed in.
+pub(crate) enum InputFrame {
+    /// A frame that decoded as UTF-8, taking the ordinary path from here.
+    Line(String),
+    /// A frame that is not valid UTF-8.
+    ///
+    /// The frame is discarded rather than repaired. A lossy decode would
+    /// hand the JSON parser text the peer never sent, so a stray byte inside
+    /// a string argument would be served as a request with silently altered
+    /// content. Discarding gives the peer the answer malformed JSON already
+    /// gets: the frame is lost and the loop keeps running (#797, #1271,
+    /// #1296).
+    Undecodable,
+}
+
+/// Strip the delimiter from one raw frame and decode it.
+pub(crate) fn decode_input_frame(mut raw: Vec<u8>) -> InputFrame {
+    if raw.last() == Some(&b'\n') {
+        raw.pop();
+        if raw.last() == Some(&b'\r') {
+            raw.pop();
+        }
+    }
+    match String::from_utf8(raw) {
+        Ok(line) => InputFrame::Line(line),
+        Err(_) => InputFrame::Undecodable,
+    }
+}
+
+/// Newline-delimited frame reader over an async byte stream.
+///
+/// This exists instead of [`tokio::io::Lines`] because `Lines` decodes before
+/// it frames: one byte that is not valid UTF-8 surfaces as `InvalidData`, and
+/// the read loops turn that into a transport error that ends the session for
+/// every other request on the connection (#1271, #1296).
+///
+/// Cancellation behaves the way `Lines::next_line` does, which the `select!`
+/// loops on both ends depend on: bytes read before a lost race stay in `buf`,
+/// and the next call continues the same frame rather than starting a new one.
+pub(crate) struct FrameReader<R> {
+    reader: BufReader<R>,
+    buf: Vec<u8>,
+}
+
+impl<R> FrameReader<R>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            buf: Vec::new(),
+        }
+    }
+
+    /// Read the next frame, or `None` once the input is exhausted.
+    ///
+    /// Cancel-safe in the sense the type documents.
+    pub(crate) async fn next_frame(&mut self) -> Result<Option<InputFrame>> {
+        let read = self
+            .reader
+            .read_until(b'\n', &mut self.buf)
+            .await
+            .map_err(|e| Error::Transport(format!("Failed to read input frame: {}", e)))?;
+        // Nothing read and nothing held back: end of input. Bytes still held
+        // are a final frame that arrived without its delimiter.
+        if read == 0 && self.buf.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(decode_input_frame(std::mem::take(&mut self.buf))))
+    }
+}
+
+/// Blocking counterpart of [`FrameReader::next_frame`], for the sync transport.
+pub(crate) fn read_frame_blocking<R: BufRead>(reader: &mut R) -> Result<Option<InputFrame>> {
+    let mut raw = Vec::new();
+    let read = reader
+        .read_until(b'\n', &mut raw)
+        .map_err(|e| Error::Transport(format!("Failed to read input frame: {}", e)))?;
+    if read == 0 {
+        return Ok(None);
+    }
+    Ok(Some(decode_input_frame(raw)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Assert one frame decoded to exactly `expected`.
+    fn assert_line(frame: Option<InputFrame>, expected: &str) {
+        match frame {
+            Some(InputFrame::Line(line)) => assert_eq!(line, expected),
+            Some(InputFrame::Undecodable) => panic!("{expected:?} must decode"),
+            None => panic!("expected a frame, got end of input"),
+        }
+    }
+
+    /// Assert one frame was rejected by the decoder.
+    fn assert_undecodable(frame: Option<InputFrame>) {
+        assert!(
+            matches!(frame, Some(InputFrame::Undecodable)),
+            "expected an undecodable frame"
+        );
+    }
+
+    #[test]
+    fn decoding_strips_the_delimiter_in_both_line_endings() {
+        assert_line(Some(decode_input_frame(b"{}\n".to_vec())), "{}");
+        assert_line(Some(decode_input_frame(b"{}\r\n".to_vec())), "{}");
+        // A frame that arrived without its delimiter, at end of input.
+        assert_line(Some(decode_input_frame(b"{}".to_vec())), "{}");
+    }
+
+    #[test]
+    fn decoding_rejects_bytes_rather_than_repairing_them() {
+        // A lossy decode would turn this into a frame the peer never sent.
+        assert_undecodable(Some(decode_input_frame(vec![0xff, 0xfe, b'\n'])));
+    }
+
+    #[tokio::test]
+    async fn a_bad_frame_costs_only_itself() {
+        let input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
+        let mut frames = FrameReader::new(input);
+
+        assert_undecodable(frames.next_frame().await.unwrap());
+        assert_line(frames.next_frame().await.unwrap(), "{\"id\":1}");
+        assert!(
+            frames.next_frame().await.unwrap().is_none(),
+            "end of input must be reported once the frames are consumed"
+        );
+    }
+
+    #[test]
+    fn the_blocking_reader_treats_a_bad_frame_the_same_way() {
+        let mut input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
+
+        assert_undecodable(read_frame_blocking(&mut input).unwrap());
+        assert_line(read_frame_blocking(&mut input).unwrap(), "{\"id\":1}");
+        assert!(read_frame_blocking(&mut input).unwrap().is_none());
+    }
+
+    /// The `select!` loops on both ends poll `next_frame` against other
+    /// branches, so a frame that loses the race has to survive to the next
+    /// call rather than being split in two.
+    #[tokio::test]
+    async fn a_partial_frame_survives_a_cancelled_read() {
+        let (mut writer, reader) = tokio::io::duplex(256);
+        let mut frames = FrameReader::new(reader);
+        let frame = r#"{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}"#;
+
+        tokio::io::AsyncWriteExt::write_all(&mut writer, &frame.as_bytes()[..10])
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), frames.next_frame())
+                .await
+                .is_err(),
+            "a partial frame must remain pending until its newline arrives"
+        );
+
+        tokio::io::AsyncWriteExt::write_all(&mut writer, &frame.as_bytes()[10..])
+            .await
+            .unwrap();
+        tokio::io::AsyncWriteExt::write_all(&mut writer, b"\n")
+            .await
+            .unwrap();
+        assert_line(frames.next_frame().await.unwrap(), frame);
+    }
+}

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -506,6 +506,7 @@ pub mod event_store;
 pub mod extension;
 pub mod extract;
 pub mod filter;
+mod framing;
 pub mod guides;
 pub mod inspection;
 pub mod jsonrpc;

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -55,10 +55,10 @@
 //! untagged form.
 
 use std::collections::HashMap;
-use std::io::{self, BufRead, Write};
+use std::io::{self, Write};
 use std::sync::Arc;
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::{Mutex, Semaphore, mpsc, oneshot};
 
 use crate::context::{
@@ -69,6 +69,7 @@ use crate::context::{
 use tower_service::Service;
 
 use crate::error::{Error, Result};
+use crate::framing::{FrameReader, InputFrame, read_frame_blocking};
 use crate::jsonrpc::JsonRpcService;
 #[cfg(feature = "stateless")]
 use crate::protocol::{Implementation, SubscriptionFilter};
@@ -476,104 +477,19 @@ fn clean_input_line(line: &str) -> &str {
     line.strip_prefix('\u{feff}').unwrap_or(line).trim()
 }
 
-/// One newline-delimited frame read from an input stream.
-///
-/// Framing happens over bytes, not over decoded text. `0x0A` cannot appear
-/// inside a multi-byte UTF-8 sequence, so the newline that ends a frame is
-/// unambiguous even when the bytes around it are not decodable, and input
-/// the decoder rejects costs exactly the frame it landed in.
-enum InputFrame {
-    /// A frame that decoded as UTF-8, taking the ordinary path from here.
-    Line(String),
-    /// A frame that is not valid UTF-8.
-    ///
-    /// The frame is discarded rather than repaired. A lossy decode would
-    /// hand the JSON parser text the peer never sent, so a stray byte inside
-    /// a string argument would be served as a request with silently altered
-    /// content. Discarding gives the peer the answer malformed JSON already
-    /// gets: a parse error, and a loop that keeps running (#797, #1271).
-    Undecodable,
-}
-
 /// The parse-error message for a frame whose bytes are not valid UTF-8.
 const UNDECODABLE_FRAME: &str = "invalid UTF-8 in input frame";
 
-/// Strip the delimiter from one raw frame and decode it.
-fn decode_input_frame(mut raw: Vec<u8>) -> InputFrame {
-    if raw.last() == Some(&b'\n') {
-        raw.pop();
-        if raw.last() == Some(&b'\r') {
-            raw.pop();
-        }
-    }
-    match String::from_utf8(raw) {
-        Ok(line) => InputFrame::Line(line),
-        Err(_) => InputFrame::Undecodable,
-    }
-}
-
 /// Build the `-32700` frame that answers an undecodable frame, logging the
 /// discard on the way through so every transport reports it identically.
+///
+/// This is the server's half of the [`crate::framing`] contract: a client
+/// reading the same frames has nobody to send this to and skips instead
+/// (#1296).
 fn undecodable_frame_response() -> Result<String> {
     tracing::warn!("{UNDECODABLE_FRAME}, discarding it");
     serde_json::to_string(&parse_error_response(UNDECODABLE_FRAME))
         .map_err(|e| Error::Transport(format!("Failed to serialize error: {}", e)))
-}
-
-/// Newline-delimited frame reader over an async byte stream.
-///
-/// This exists instead of [`tokio::io::Lines`] because `Lines` decodes before
-/// it frames: one byte that is not valid UTF-8 surfaces as `InvalidData`, and
-/// the read loops turn that into a transport error that ends the session for
-/// every other request on the connection (#1271).
-///
-/// Cancellation behaves the way `Lines::next_line` does, which the `select!`
-/// loops depend on: bytes read before a lost race stay in `buf`, and the next
-/// call continues the same frame rather than starting a new one.
-struct FrameReader<R> {
-    reader: BufReader<R>,
-    buf: Vec<u8>,
-}
-
-impl<R> FrameReader<R>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    fn new(reader: R) -> Self {
-        Self {
-            reader: BufReader::new(reader),
-            buf: Vec::new(),
-        }
-    }
-
-    /// Read the next frame, or `None` once the input is exhausted.
-    ///
-    /// Cancel-safe in the sense the type documents.
-    async fn next_frame(&mut self) -> Result<Option<InputFrame>> {
-        let read = self
-            .reader
-            .read_until(b'\n', &mut self.buf)
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
-        // Nothing read and nothing held back: end of input. Bytes still held
-        // are a final frame that arrived without its delimiter.
-        if read == 0 && self.buf.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(decode_input_frame(std::mem::take(&mut self.buf))))
-    }
-}
-
-/// Blocking counterpart of [`FrameReader::next_frame`], for the sync transport.
-fn read_frame_blocking<R: BufRead>(reader: &mut R) -> Result<Option<InputFrame>> {
-    let mut raw = Vec::new();
-    let read = reader
-        .read_until(b'\n', &mut raw)
-        .map_err(|e| Error::Transport(format!("Failed to read from stdin: {}", e)))?;
-    if read == 0 {
-        return Ok(None);
-    }
-    Ok(Some(decode_input_frame(raw)))
 }
 
 /// Build a JSON-RPC parse-error response from a parser/dispatch error message.
@@ -2508,64 +2424,10 @@ mod tests {
     }
 
     // =========================================================================
-    // Frame reading -- byte framing survives input that will not decode
-    // (#1271). The blocking reader is covered here because
-    // `SyncStdioTransport::run_blocking` owns the real stdin and cannot be
-    // driven from a test.
+    // Frame reading -- the reader itself is covered in `crate::framing`; what
+    // belongs here is the server's answer to a frame that will not decode
+    // (#1271).
     // =========================================================================
-
-    /// Assert one frame decoded to exactly `expected`.
-    fn assert_line(frame: Option<InputFrame>, expected: &str) {
-        match frame {
-            Some(InputFrame::Line(line)) => assert_eq!(line, expected),
-            Some(InputFrame::Undecodable) => panic!("{expected:?} must decode"),
-            None => panic!("expected a frame, got end of input"),
-        }
-    }
-
-    /// Assert one frame was rejected by the decoder.
-    fn assert_undecodable(frame: Option<InputFrame>) {
-        assert!(
-            matches!(frame, Some(InputFrame::Undecodable)),
-            "expected an undecodable frame"
-        );
-    }
-
-    #[test]
-    fn decoding_strips_the_delimiter_in_both_line_endings() {
-        assert_line(Some(decode_input_frame(b"{}\n".to_vec())), "{}");
-        assert_line(Some(decode_input_frame(b"{}\r\n".to_vec())), "{}");
-        // A frame that arrived without its delimiter, at end of input.
-        assert_line(Some(decode_input_frame(b"{}".to_vec())), "{}");
-    }
-
-    #[test]
-    fn decoding_rejects_bytes_rather_than_repairing_them() {
-        // A lossy decode would turn this into a frame the peer never sent.
-        assert_undecodable(Some(decode_input_frame(vec![0xff, 0xfe, b'\n'])));
-    }
-
-    #[tokio::test]
-    async fn a_bad_frame_costs_only_itself() {
-        let input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
-        let mut frames = FrameReader::new(input);
-
-        assert_undecodable(frames.next_frame().await.unwrap());
-        assert_line(frames.next_frame().await.unwrap(), "{\"id\":1}");
-        assert!(
-            frames.next_frame().await.unwrap().is_none(),
-            "end of input must be reported once the frames are consumed"
-        );
-    }
-
-    #[test]
-    fn the_blocking_reader_treats_a_bad_frame_the_same_way() {
-        let mut input: &[u8] = b"\xff\xfe\n{\"id\":1}\n";
-
-        assert_undecodable(read_frame_blocking(&mut input).unwrap());
-        assert_line(read_frame_blocking(&mut input).unwrap(), "{\"id\":1}");
-        assert!(read_frame_blocking(&mut input).unwrap().is_none());
-    }
 
     #[test]
     fn an_undecodable_frame_is_answered_with_a_parse_error() {


### PR DESCRIPTION
Fixes #1296. Mirror of #1271 / PR #1292 on the client side.

## The bug

`StdioClientTransport::recv` read with `Lines::next_line`, which decodes
before it frames. One byte of invalid UTF-8 on the child server's stdout, a
stray debug print or a mis-encoded log line, surfaced as `InvalidData`, the
`?` turned it into `Error::Transport`, and the client's message loop treats
that as the connection ending:

```rust
Err(e) => {
    tracing::error!(error = %e, "Transport receive error");
    break;
}
```

The loop breaks, `fail_all_pending` fires, and every in-flight and future
request on that connection fails. A server that is otherwise working
correctly could disconnect its client with a single stray byte.

## What the client does instead

The server's answer in #1292 was a `-32700` response. A client has nobody to
send that to, so it needs a different one: log the discard and skip the
frame, keeping the connection.

That is not a new contract, it is the one the client already applies one
layer up. `handle_incoming` answers JSON that does not parse with a warning
and a `return`, and the loop keeps running. Bytes that do not decode are the
same class of malformed input a layer down, and now get the same treatment.
`Err` stays reserved for the connection actually being over, and `Ok(None)`
for EOF, including EOF that arrives right after a frame that would not
decode.

The cost is stated rather than hidden, in the module docs and on `recv`: if
the discarded frame held the response to a pending request, that request is
not failed early. It waits for its own timeout, exactly as it would have if
the server had never answered. Failing it early would need the request id,
which is inside the bytes that would not decode.

`ClientTransport::recv` also now says what `Err` and `Ok(None)` cost, so a
custom transport does not reach for either on a single damaged message.

## Shared framing

`FrameReader`, `InputFrame` and `decode_input_frame` were private to
`transport/stdio.rs`. They move to a new crate-private `framing` module,
used by both ends, rather than being written twice. The pieces specific to
the server's answer, `UNDECODABLE_FRAME` and `undecodable_frame_response`,
stay in `transport/stdio.rs`, because the `-32700` is the part the client
does not share. The refactor is its own commit and changes no behaviour.

Cancel-safety carries over unchanged, and the client loop depends on it:
`recv` is polled inside a `select!`, so bytes read before a lost race have
to stay buffered for the next call. Skipping happens between reads, so a
cancellation can only lose a frame that was already going to be discarded.

## Done

- [x] Move the byte-framing helpers into `crate::framing`, with their tests
- [x] Point `transport/stdio.rs` at the shared module, no behaviour change
- [x] Read frames as bytes in `StdioClientTransport::recv`, skipping frames
      that do not decode and continuing to the next one
- [x] Document the contract on the client transport and on
      `ClientTransport::recv`, including what `Err` costs the caller
- [x] Tests: skip and continue, repeated bad frames, bad frame then EOF, bad
      final frame with no newline, cancel-safety
- [x] Check the other client transports for the same shape

## Testing

Four tests in `client/stdio.rs` drive a real child process that writes the
bad bytes, so they exercise the transport end to end rather than the reader
in isolation. All four fail against the previous behaviour and pass with the
fix; the cancel-safety test passes either way, since it guards a property
this change preserves rather than adds.

I dropped the live-`McpClient` integration test the plan called for.
`StdioClientTransport` is only constructible from a `Child`, so such a test
needs a real MCP server subprocess, and the options were a hand-written
shell script replying with canned handshake frames, or a fixture binary
added to the published crate. Both cost more than they prove here: the
message loop's only reaction to a bad frame is whatever `recv` returns, and
these tests pin exactly that.

## Other client transports

Checked, no change needed:

- `client/websocket.rs` reads `Message::Text(String)`, already decoded and
  validated by tungstenite. Invalid UTF-8 in a text frame is a WebSocket
  protocol error that closes the connection per RFC 6455.
- `client/http.rs` reads bodies with `response.text()` and
  `String::from_utf8_lossy`, neither of which errors on undecodable bytes.
- `transport/childproc.rs` uses `read_line`, so it has the decode-before-
  frame shape, but its error is already scoped to one `send_request` call
  and not to the connection, matching how it treats a response that does not
  parse. Tokio's `read_line` restores the original buffer contents and
  consumes the bad bytes, so the stream stays framed at the next newline.

## Validation

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -D
warnings`, `cargo test --workspace --all-features` and `cargo doc` with
`-D warnings` all clean locally.
