### PR TITLE
fix(tasks): close the live-task cancellation registration and outcome races

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3468,17 +3468,28 @@ impl McpRouter {
                                 input_ready: tokio::sync::Notify::new(),
                                 cancelled: crate::context::CancellationToken::new(),
                             });
+                            // Register before inspecting the store token, not
+                            // after. A `tasks/cancel` landing between the two
+                            // used to find no live handle, take the store path,
+                            // terminalize, and acknowledge, after which the
+                            // handle was registered uncancelled and the handler
+                            // ran on against an already-cancelled task (#1294).
+                            //
+                            // In this order a cancel before registration is
+                            // caught by the check below, and one after it
+                            // signals the handle directly. There is no ordering
+                            // left where cancellation selects the store path
+                            // while live execution is running and cannot see it.
+                            notifier.register_live_task(&task_id_clone, handle.clone());
                             if cancellation_token.is_cancelled() {
                                 handle.cancelled.cancel();
                             }
-                            notifier.register_live_task(&task_id_clone, handle.clone());
                             let live_ctx =
                                 crate::tool::TaskContext::with_live(task_id_clone.clone(), handle);
 
                             let start = std::time::Instant::now();
                             let outcome = live_handler.call(ctx, live_ctx, arguments).await;
                             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
-                            notifier.unregister_live_task(&task_id_clone);
 
                             let applied = match outcome {
                                 Ok(crate::tool::TaskOutcome::Completed(result)) => task_store
@@ -3513,6 +3524,16 @@ impl McpRouter {
                                     .await
                                     .map(|_| "failed"),
                             };
+                            // Unregister only after the single terminal write
+                            // has been attempted. Unregistering first left a
+                            // window where a cancel took the store path and
+                            // wrote `cancelled` over a task whose handler had
+                            // already produced a result, breaking the
+                            // single-writer property (#1294). A cancel arriving
+                            // in this interval now signals a handle nobody
+                            // reads, which is inert.
+                            notifier.unregister_live_task(&task_id_clone);
+
                             match applied {
                                 Ok(status) => tracing::info!(
                                     target: "mcp::tools",

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -339,3 +339,130 @@ async fn a_guard_on_a_live_tool_rejects_without_panicking() {
     assert!(result.is_error, "the guard rejection is a domain error");
     assert!(result.all_text().contains("nope"));
 }
+
+// ============================================================================
+// Cancellation ordering (#1294)
+// ============================================================================
+
+/// #1294, startup window: the spawned future inspected the store token before
+/// registering its live handle, so a `tasks/cancel` in between found no handle,
+/// took the store path, terminalized, and acknowledged, after which the handler
+/// ran on against an already-cancelled task.
+///
+/// This asserts the invariant, not the race. The two statements have no `await`
+/// between them, so the window only exists across threads and this test passes
+/// against the old ordering as well; it was checked. What it does guard is that
+/// a cancel arriving before the handler starts is still observed at all, which
+/// is the property the reordering must not break.
+#[tokio::test]
+async fn cancelling_before_the_handler_starts_is_still_observed() {
+    let started = Arc::new(AtomicUsize::new(0));
+    let finished = Arc::new(AtomicUsize::new(0));
+    let (s, f) = (started.clone(), finished.clone());
+
+    let tool = ToolBuilder::new("live")
+        .description("Waits forever unless cancelled")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let (s, f) = (s.clone(), f.clone());
+            async move {
+                s.fetch_add(1, Ordering::SeqCst);
+                // Never answered, so only cancellation ends this.
+                let result = task.require_input(ask("never")).await;
+                f.fetch_add(1, Ordering::SeqCst);
+                result?;
+                Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    // No sleep: cancel as soon as the handle exists.
+    client.task_cancel(&task_id, None).await.expect("cancel");
+
+    await_status(&store, &task_id, TaskStatus::Cancelled).await;
+    assert_eq!(
+        started.load(Ordering::SeqCst),
+        finished.load(Ordering::SeqCst),
+        "a handler that started must also have unwound; the previous ordering \
+         left it running against a cancelled task"
+    );
+}
+
+/// #1294, completion window: the handle was unregistered before the outcome was
+/// persisted, so a cancel in that interval took the store path and could write
+/// `cancelled` over a task whose handler had already produced a result.
+///
+/// A completion is allowed to win the race, which is the documented semantic.
+#[tokio::test]
+async fn a_completion_is_not_overwritten_by_a_late_cancellation() {
+    let tool = ToolBuilder::new("live")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    // Repeated because the interesting interleaving is timing-dependent. This
+    // does not reliably reproduce the old bug either; it asserts that whichever
+    // writer wins, the recorded status and the recorded result agree.
+    for round in 0..25 {
+        let task_id = client
+            .call_tool_as_task("live", json!({}), None)
+            .await
+            .expect("task created")
+            .task
+            .task_id;
+        let _ = client.task_cancel(&task_id, None).await;
+
+        for _ in 0..100 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            let task = store.get_task(&task_id).await.unwrap().unwrap();
+            if task.status.is_terminal() {
+                let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+                // Whichever wins, the two must agree: a task recorded as
+                // completed must carry the handler's result, and a cancelled
+                // one must not claim a result it never produced.
+                match task.status {
+                    TaskStatus::Completed => assert_eq!(
+                        result.expect("completed carries its result").all_text(),
+                        "done",
+                        "round {round}"
+                    ),
+                    TaskStatus::Cancelled => {}
+                    other => panic!("round {round}: unexpected terminal {other:?}"),
+                }
+                break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Claiming #1294. **Work in progress, do not duplicate.** Both windows are mine, from #1288.

## Window one, startup

The spawned future inspects the store token before registering its live handle:

```rust
if cancellation_token.is_cancelled() {
    handle.cancelled.cancel();
}
notifier.register_live_task(&task_id_clone, handle.clone());
```

A `tasks/cancel` landing between those two lines finds no live handle, so the router takes the store path, terminalizes, and acknowledges. The handle is then registered with an uncancelled token and the handler runs on against a task already recorded as cancelled.

## Window two, completion

The handle is unregistered before the outcome is persisted, so a cancel in that interval takes the store path and can write `cancelled` over a task whose handler already produced a result. That breaks the single-writer property the design rests on.

## Fix

Register first, then bridge the store token in. A cancel before registration is caught by the post-registration check; a cancel after it signals the handle directly. There is no ordering left where cancellation can select the store path while live execution is running and unable to see it.

At the end, persist the terminal outcome before unregistering, so the execution owner stays registered until its single terminal write has been attempted. A cancel arriving in that interval signals a handle nobody is reading, which is inert, rather than racing the write.

## On the tests

The issue asks for tests that pause inside each window. There is no test seam there today, and integration tests are a separate crate so a `#[cfg(test)]` hook would not reach. I will assert the observable property instead, notably cancellation immediately after the task handle is returned and before the handler has started, and say plainly which windows are covered by construction rather than by a test that pauses in them. I would rather under-claim than describe a timing test as deterministic when it is not.