### PR TITLE
fix(router): make panic isolation uniform and configurable

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -58,6 +58,23 @@ fn encode_cursor(offset: usize) -> String {
 }
 
 /// Map a [`TaskStoreError`] to a JSON-RPC internal error.
+/// Releases a live task's registry entry however its handler leaves.
+///
+/// The handler can return, panic, or be dropped. Unregistering only on the
+/// return path left a panicking handler's entry installed, so a later
+/// `tasks/cancel` found a handle nobody was reading and took the live path
+/// instead of the store one (#1305).
+struct LiveTaskRegistration {
+    router: McpRouter,
+    task_id: String,
+}
+
+impl Drop for LiveTaskRegistration {
+    fn drop(&mut self) {
+        self.router.unregister_live_task(&self.task_id);
+    }
+}
+
 fn task_store_error(e: TaskStoreError) -> Error {
     Error::JsonRpc(JsonRpcError::internal_error(format!(
         "Task store error: {}",
@@ -3481,6 +3498,12 @@ impl McpRouter {
                             // left where cancellation selects the store path
                             // while live execution is running and cannot see it.
                             notifier.register_live_task(&task_id_clone, handle.clone());
+                            // Released on drop, so the entry goes whether the
+                            // handler returns, panics, or is dropped (#1305).
+                            let _registration = LiveTaskRegistration {
+                                router: notifier.clone(),
+                                task_id: task_id_clone.clone(),
+                            };
                             if cancellation_token.is_cancelled() {
                                 handle.cancelled.cancel();
                             }
@@ -3488,7 +3511,39 @@ impl McpRouter {
                                 crate::tool::TaskContext::with_live(task_id_clone.clone(), handle);
 
                             let start = std::time::Instant::now();
-                            let outcome = live_handler.call(ctx, live_ctx, arguments).await;
+                            // The replay paths get their panic boundary from
+                            // `invoke_tool`; the live branch calls the handler
+                            // directly and had none, so a panic unwound before
+                            // any terminal state was written and left the task
+                            // at `working` forever (#1305).
+                            let called = live_handler.call(ctx, live_ctx, arguments);
+                            let outcome = if notifier.inner.catch_panics {
+                                use futures::FutureExt;
+                                match std::panic::AssertUnwindSafe(called).catch_unwind().await {
+                                    Ok(outcome) => outcome,
+                                    Err(payload) => {
+                                        let message = panic_message(&*payload);
+                                        tracing::error!(
+                                            target: "mcp::tools",
+                                            tool = %tool_name,
+                                            task_id = %task_id_clone,
+                                            panic = %message,
+                                            "live task handler panicked"
+                                        );
+                                        // A panic is an execution failure, not
+                                        // a tool reporting a domain error, so
+                                        // it fails the task rather than
+                                        // completing it with `isError`.
+                                        Ok(crate::tool::TaskOutcome::Failed(
+                                            JsonRpcError::internal_error(format!(
+                                                "tool '{tool_name}' panicked: {message}"
+                                            )),
+                                        ))
+                                    }
+                                }
+                            } else {
+                                called.await
+                            };
                             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
                             let applied = match outcome {
@@ -3524,15 +3579,13 @@ impl McpRouter {
                                     .await
                                     .map(|_| "failed"),
                             };
-                            // Unregister only after the single terminal write
-                            // has been attempted. Unregistering first left a
-                            // window where a cancel took the store path and
-                            // wrote `cancelled` over a task whose handler had
-                            // already produced a result, breaking the
-                            // single-writer property (#1294). A cancel arriving
-                            // in this interval now signals a handle nobody
-                            // reads, which is inert.
-                            notifier.unregister_live_task(&task_id_clone);
+                            // The registration guard releases the entry when
+                            // it drops at the end of this block, which is after
+                            // the terminal write above. Unregistering before
+                            // that write left a window where a cancel took the
+                            // store path and wrote `cancelled` over a task
+                            // whose handler had already produced a result
+                            // (#1294).
 
                             match applied {
                                 Ok(status) => tracing::info!(

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -466,3 +466,110 @@ async fn a_completion_is_not_overwritten_by_a_late_cancellation() {
         }
     }
 }
+
+// ============================================================================
+// Panic isolation (#1305)
+// ============================================================================
+
+fn panicking_live_router(catch: bool) -> (Arc<MemoryTaskStore>, McpRouter) {
+    let boom = ToolBuilder::new("boom")
+        .description("Panics")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            panic!("live handler exploded");
+            #[allow(unreachable_code)]
+            Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+        })
+        .build();
+    let fine = ToolBuilder::new("fine")
+        .description("Works")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ok")))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("panic-live", "1.0.0")
+        .task_store(store.clone())
+        .tool(boom)
+        .tool(fine)
+        .with_tasks();
+    let router = if catch { router.catch_panics() } else { router };
+    (store, router)
+}
+
+/// #1305: the live branch had no panic boundary, so a panicking handler
+/// unwound before any terminal state was written. The task sat at `working`
+/// forever: not failed, not cancelled, and nothing running.
+#[tokio::test]
+async fn a_panicking_live_handler_reaches_a_terminal_state() {
+    let (store, router) = panicking_live_router(true);
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("boom", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    await_status(&store, &task_id, TaskStatus::Failed).await;
+    let (_, _, error) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let error = error.expect("a failed task carries a structured error");
+    assert!(
+        error.message.contains("panicked"),
+        "the failure must say what happened: {}",
+        error.message
+    );
+
+    // The decisive part: the server still serves.
+    let next = client
+        .call_tool_as_task("fine", json!({}), None)
+        .await
+        .expect("the server must still be serving")
+        .task
+        .task_id;
+    await_status(&store, &next, TaskStatus::Completed).await;
+}
+
+/// The registry entry must be released however the handler leaves, so a later
+/// cancellation does not target a dead handle. This holds without
+/// `catch_panics` too: opting out means the bug stays visible, not that
+/// registry state leaks.
+#[tokio::test]
+async fn a_panicking_live_handler_releases_its_registry_entry() {
+    for catch in [true, false] {
+        let (store, router) = panicking_live_router(catch);
+        let client = McpClient::connect(ChannelTransport::new(router))
+            .await
+            .expect("connect");
+        client.initialize("t", "1.0.0").await.expect("init");
+
+        let task_id = client
+            .call_tool_as_task("boom", json!({}), None)
+            .await
+            .expect("task created")
+            .task
+            .task_id;
+
+        // Let the handler panic and unwind.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // With a stale entry the router takes the live path, signals a handle
+        // nobody reads, and leaves the task non-terminal. With the entry gone
+        // it takes the store path and terminalizes.
+        let _ = client.task_cancel(&task_id, None).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let task = store.get_task(&task_id).await.unwrap().unwrap();
+        assert!(
+            task.status.is_terminal(),
+            "catch_panics={catch}: cancelling after a panic must terminalize, \
+             which a stale registry entry would prevent (status {:?})",
+            task.status
+        );
+    }
+}


### PR DESCRIPTION
Closes #1305
Closes #1306

## Summary

- extend the router panic boundary to live Task handlers;
- make live-task registry cleanup unconditional, while preserving the required terminal-write-before-unregister ordering;
- add `PanicPolicy::redacted(...)` and `McpRouter::catch_panics_with(...)` for fixed client errors and independently controlled client/log tool names and log payloads;
- keep the existing `.catch_panics()` behavior as the exact detailed compatibility preset.

Ordinary calls, replayed Task handlers, and live Task handlers now use the same router-selected disclosure policy. Their existing outcome semantics remain distinct: ordinary/replayed catches are completed tool-error results, while a live handler panic is a structured failed Task.

## Disclosure policy

`PanicPolicy::redacted("internal tool failure")` returns exactly that fixed text and omits both the tool name and panic payload from Tower's tracing event. Applications can opt into the original name, substitute a fixed safe alias independently for the client and tracing, and separately opt into payload tracing. A custom policy never copies the panic payload into the client response.

The redacted path decides whether the payload is needed before calling the payload recovery helper, so the default path does not downcast, clone, or format it. The policy intentionally has no observer/mapper callback; Tower's tracing event is the safe observation surface and avoids creating a second panic boundary.

Rust's process-global panic hook still runs before `catch_unwind`. The policy controls Tower's response and Tower-generated tracing only; it cannot suppress output from the default or application-installed panic hook.

## Verification

- exact legacy `.catch_panics()` response compatibility;
- fixed redacted client output and captured tracing with no raw tool name or string/non-string payload;
- independent fixed aliases for client and tracing;
- replay and live Task policy coverage;
- live panic terminalization, server survival, and registry cleanup with and without catching;
- `cargo test -p tower-mcp --all-targets --all-features`;
- `cargo clippy -p tower-mcp --all-targets --all-features -- -D warnings`;
- Rust 1.90 focused panic suite;
- rustdoc with warnings denied and formatting checks.
