### PR TITLE
feat(tool): expose RequestContext to live task handlers

### DIFF
--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -472,6 +472,39 @@ pub(crate) trait LiveToolHandler: Send + Sync {
     ) -> Result<TaskOutcome>;
 }
 
+/// The input schema a live registration derives from its input type.
+fn live_input_schema<I: JsonSchema>() -> Value {
+    serde_json::to_value(schemars::schema_for!(I))
+        .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
+}
+
+struct FnLiveToolHandlerWithContext<I, F> {
+    handler: F,
+    _input: std::marker::PhantomData<fn() -> I>,
+}
+
+#[async_trait::async_trait]
+impl<I, F, Fut> LiveToolHandler for FnLiveToolHandlerWithContext<I, F>
+where
+    I: DeserializeOwned + Send + Sync + 'static,
+    F: Fn(RequestContext, TaskContext, I) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<TaskOutcome>> + Send,
+{
+    async fn call(
+        &self,
+        ctx: RequestContext,
+        task: TaskContext,
+        arguments: Value,
+    ) -> Result<TaskOutcome> {
+        let input: I = serde_json::from_value(arguments).map_err(|e| {
+            crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                "invalid arguments: {e}"
+            )))
+        })?;
+        (self.handler)(ctx, task, input).await
+    }
+}
+
 /// Applies a guard to a live handler.
 ///
 /// Mirrors `GuardedMrtrToolHandler`. Without this, `Tool::with_guard` on a
@@ -1890,22 +1923,97 @@ impl ToolBuilder {
     /// A live future does not survive its process. On restart, live tasks left
     /// non-terminal have nothing behind them, and the application reconciles
     /// them rather than the router guessing.
-    pub fn live_task_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveHandler<I, F>
+    pub fn live_task_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveHandler
     where
         I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
         F: Fn(TaskContext, I) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<TaskOutcome>> + Send + 'static,
     {
+        self.into_live(
+            Arc::new(FnLiveToolHandler {
+                handler,
+                _input: std::marker::PhantomData::<fn() -> I>,
+            }),
+            live_input_schema::<I>(),
+        )
+    }
+
+    /// A live task handler that also receives the request's context.
+    ///
+    /// Same as [`live_task_handler`](Self::live_task_handler), plus the
+    /// [`RequestContext`] of the `tools/call` that created the task. That is
+    /// how a live handler reads an authenticated principal, a trace id, or an
+    /// extension added by [`TaskPreparation`], without keeping its own
+    /// registry keyed by task id (#1301).
+    ///
+    /// # The context is the request's, not the task's
+    ///
+    /// The originating `tools/call` has already returned a task handle to the
+    /// client, so its cancellation token tracks *that request*. Reaching for
+    /// `ctx.cancelled()` when you mean task cancellation is wrong in both
+    /// directions: it can fire when a client disconnects from a call that was
+    /// already answered, and it does not fire when the task itself is
+    /// cancelled.
+    ///
+    /// Task cancellation is [`TaskContext`], which is what
+    /// [`TaskContext::require_input`] already returns
+    /// [`crate::Error::TaskCancelled`] from.
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{CallToolResult, RequestContext, TaskContext, TaskOutcome, ToolBuilder};
+    /// use serde::Deserialize;
+    /// use tower_mcp::schemars::JsonSchema;
+    ///
+    /// #[derive(Clone)]
+    /// struct Principal(String);
+    ///
+    /// #[derive(Deserialize, JsonSchema)]
+    /// struct Run { prompt: String }
+    ///
+    /// let tool = ToolBuilder::new("run")
+    ///     .description("Runs as the calling principal")
+    ///     .live_task_handler_with_context(
+    ///         |ctx: RequestContext, task: TaskContext, input: Run| async move {
+    ///             let who = ctx
+    ///                 .extension::<Principal>()
+    ///                 .map(|p| p.0.clone())
+    ///                 .unwrap_or_else(|| "anonymous".into());
+    ///             let _ = (task, input);
+    ///             Ok(TaskOutcome::Completed(CallToolResult::text(who)))
+    ///         },
+    ///     )
+    ///     .build();
+    /// ```
+    pub fn live_task_handler_with_context<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveHandler
+    where
+        I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
+        F: Fn(RequestContext, TaskContext, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<TaskOutcome>> + Send + 'static,
+    {
+        self.into_live(
+            Arc::new(FnLiveToolHandlerWithContext {
+                handler,
+                _input: std::marker::PhantomData::<fn() -> I>,
+            }),
+            live_input_schema::<I>(),
+        )
+    }
+
+    /// Shared tail of both live registration forms.
+    fn into_live(
+        self,
+        handler: Arc<dyn LiveToolHandler>,
+        derived_schema: Value,
+    ) -> ToolBuilderWithLiveHandler {
         ToolBuilderWithLiveHandler {
             name: self.name,
             title: self.title,
             description: self.description,
             output_schema: self.output_schema,
-            input_schema_override: self.input_schema_override,
+            input_schema: self.input_schema_override.unwrap_or(derived_schema),
             icons: self.icons,
             annotations: self.annotations,
             handler,
-            _phantom: std::marker::PhantomData,
         }
     }
 
@@ -2180,30 +2288,24 @@ pub struct ToolBuilderWithMrtrHandler<I, F> {
 ///
 /// A live handler owns its execution, so it is only meaningful as a task and
 /// the tool is registered with [`TaskSupportMode::Required`] (#1246).
-pub struct ToolBuilderWithLiveHandler<I, F> {
+/// Builder state after a live task handler is set.
+///
+/// Both registration forms build their adapter here and store one boxed
+/// handler, so they cannot drift and `build` has a single path.
+pub struct ToolBuilderWithLiveHandler {
     name: String,
     title: Option<String>,
     description: Option<String>,
     output_schema: Option<Value>,
-    input_schema_override: Option<Value>,
+    input_schema: Value,
     icons: Option<Vec<ToolIcon>>,
     annotations: Option<ToolAnnotations>,
-    handler: F,
-    _phantom: std::marker::PhantomData<I>,
+    handler: Arc<dyn LiveToolHandler>,
 }
 
-impl<I, F, Fut> ToolBuilderWithLiveHandler<I, F>
-where
-    I: JsonSchema + DeserializeOwned + Send + Sync + 'static,
-    F: Fn(TaskContext, I) -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<TaskOutcome>> + Send + 'static,
-{
+impl ToolBuilderWithLiveHandler {
     /// Finish the tool.
     pub fn build(self) -> Tool {
-        let input_schema = ensure_object_schema(self.input_schema_override.unwrap_or_else(|| {
-            serde_json::to_value(schemars::schema_for!(I))
-                .unwrap_or_else(|_| serde_json::json!({"type": "object"}))
-        }));
         Tool {
             name: self.name,
             title: self.title,
@@ -2221,11 +2323,8 @@ where
             service: None,
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
-            live_handler: Some(Arc::new(FnLiveToolHandler {
-                handler: self.handler,
-                _input: std::marker::PhantomData::<fn() -> I>,
-            })),
-            input_schema,
+            live_handler: Some(self.handler),
+            input_schema: ensure_object_schema(self.input_schema),
         }
     }
 }

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -20,7 +20,7 @@ use tower_mcp::protocol::{
     InputRequest, InputRequests, InputResponse, TaskStatus,
 };
 use tower_mcp::schemars::JsonSchema;
-use tower_mcp::{CallToolResult, McpRouter, TaskContext, TaskOutcome, ToolBuilder};
+use tower_mcp::{CallToolResult, McpRouter, RequestContext, TaskContext, TaskOutcome, ToolBuilder};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct NoArgs {}
@@ -572,4 +572,135 @@ async fn a_panicking_live_handler_releases_its_registry_entry() {
             task.status
         );
     }
+}
+
+// ============================================================================
+// Request context in live handlers (#1301)
+// ============================================================================
+
+#[derive(Debug, Clone, PartialEq)]
+struct Principal(String);
+
+/// #1301: the internal trait carried the `RequestContext` from #1298, but the
+/// public closure adapter discarded it, so a live handler could not read an
+/// authenticated principal, a trace id, or anything task preparation added
+/// without keeping its own registry keyed by task id.
+#[tokio::test]
+async fn a_contextual_live_handler_sees_a_preparation_extension() {
+    let tool = ToolBuilder::new("whoami")
+        .description("Reports the prepared principal")
+        .live_task_handler_with_context(
+            |ctx: RequestContext, _task: TaskContext, _input: NoArgs| async move {
+                let who = ctx
+                    .extension::<Principal>()
+                    .map(|p| p.0.clone())
+                    .unwrap_or_else(|| "absent".to_string());
+                Ok(TaskOutcome::Completed(CallToolResult::text(who)))
+            },
+        )
+        .build()
+        .with_task_preparation(|_task: TaskContext, _args: serde_json::Value| async move {
+            Ok(tower_mcp::TaskPreparation::new()
+                .with_extension(Principal("prepared-caller".to_string())))
+        });
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("ctx", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("whoami", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        result.unwrap().all_text(),
+        "prepared-caller",
+        "the preparation extension must reach the live handler"
+    );
+}
+
+/// #1295 was exactly this bug class for the simple form, so the contextual
+/// form is checked on the same transformation paths rather than assumed to
+/// inherit the fix.
+#[tokio::test]
+async fn a_contextual_live_handler_survives_nest_and_guard() {
+    let tool = ToolBuilder::new("run")
+        .description("Contextual")
+        .live_task_handler_with_context(
+            |_ctx: RequestContext, _task: TaskContext, _input: NoArgs| async move {
+                Ok(TaskOutcome::Completed(CallToolResult::text("ran")))
+            },
+        )
+        .build()
+        // A guard that admits everything still replaces the handler, so this
+        // exercises the guarded wrapper surviving the prefix as well.
+        .with_guard(|_req: &tower_mcp::ToolRequest| Ok(()));
+
+    let inner = McpRouter::new().server_info("inner", "1.0.0").tool(tool);
+    let store = Arc::new(MemoryTaskStore::new());
+    let outer = McpRouter::new()
+        .server_info("outer", "1.0.0")
+        .task_store(store.clone())
+        .nest("provider", inner)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(outer))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("provider.run", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(result.unwrap().all_text(), "ran");
+}
+
+/// The simple two-argument form stays source-compatible, which the other
+/// tests in this file already exercise; this pins it explicitly.
+#[tokio::test]
+async fn the_simple_live_form_still_compiles_and_runs() {
+    let tool = ToolBuilder::new("simple")
+        .description("Two-argument form")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("simple")))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("simple", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("simple", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
 }


### PR DESCRIPTION
Claiming #1301. **Work in progress, do not duplicate.** My gap: I threaded `RequestContext` into the internal trait in #1298 so guards could work, and left the public closure adapter discarding it.

## Plan

Add `live_task_handler_with_context` taking `Fn(RequestContext, TaskContext, I)`, keeping the existing two-argument form source-compatible, as the issue asks. Both entry points build their adapter at registration time and store one `Arc<dyn LiveToolHandler>`, so the two forms cannot drift and `build()` has a single path.

## The part that needs documenting, not just implementing

The `RequestContext` a live handler receives belongs to the originating `tools/call`, and that request has already returned a task handle to the client. So its cancellation token tracks *that request*, not the task.

A handler reaching for `ctx.cancelled()` when it means task cancellation would be subtly wrong: it may fire when the client disconnects from a call that has already been answered, or never fire when the task itself is cancelled. Task cancellation is `TaskContext`, which is what `require_input` already returns `Err(TaskCancelled)` from.

That is exactly the kind of thing someone gets wrong once and debugs for an afternoon, so the doc will say it directly rather than leaving both tokens visible and unexplained.

## Also verifying

The acceptance criteria include clone, prefix, nest, and guard preserving the contextual handler. #1295 was precisely that class of bug for the simple form, so the tests will cover the contextual one on the same paths rather than assuming it inherits the fix.