### PR TITLE
feat(router): add configurable panic disclosure policy

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -669,8 +669,8 @@ pub use resource::{
 #[cfg(feature = "stateless")]
 pub use resource::{MrtrResourceHandler, MrtrResourceTemplateHandler};
 pub use router::{
-    McpRouter, MergeConflict, MergeConflictKind, MergeConflicts, RouterRequest, RouterResponse,
-    ToolAnnotationsMap,
+    McpRouter, MergeConflict, MergeConflictKind, MergeConflicts, PanicPolicy, RouterRequest,
+    RouterResponse, ToolAnnotationsMap,
 };
 pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -264,7 +264,7 @@ impl PanicPolicy {
         match &self.client_message {
             ClientPanicMessage::Detailed => format!(
                 "tool '{tool_name}' panicked: {}",
-                payload.expect("detailed panic policy always recovers the payload")
+                payload.unwrap_or("<redacted>")
             ),
             ClientPanicMessage::Fixed(message) => match self.client_tool_name.value(tool_name) {
                 Some(name) => format!("tool '{name}': {message}"),
@@ -3206,7 +3206,7 @@ impl McpRouter {
         let logged_tool = policy.log_tool_name.value(tool_name);
         let logged_payload = policy
             .include_payload_in_logs
-            .then(|| payload.as_deref().expect("log payload was recovered"));
+            .then(|| payload.as_deref().unwrap_or("<redacted>"));
 
         Self::log_caught_panic(logged_tool, logged_payload, task_id);
         policy.client_message(tool_name, payload.as_deref())

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -121,6 +121,163 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
     }
 }
 
+#[derive(Clone)]
+enum ClientPanicMessage {
+    Detailed,
+    Fixed(Arc<str>),
+}
+
+#[derive(Clone)]
+enum ToolNameDisclosure {
+    Omit,
+    Original,
+    Fixed(Arc<str>),
+}
+
+impl ToolNameDisclosure {
+    fn value<'a>(&'a self, original: &'a str) -> Option<&'a str> {
+        match self {
+            Self::Omit => None,
+            Self::Original => Some(original),
+            Self::Fixed(name) => Some(name),
+        }
+    }
+
+    fn mode(&self) -> &'static str {
+        match self {
+            Self::Omit => "omitted",
+            Self::Original => "original",
+            Self::Fixed(_) => "fixed",
+        }
+    }
+}
+
+/// Controls what Tower discloses after isolating a panicking tool handler.
+///
+/// Construct a redacted policy with [`PanicPolicy::redacted`], then opt in to
+/// individual disclosures only when they are safe for the application. Panic
+/// payloads are never included in a custom policy's client response.
+///
+/// Rust's process-global panic hook runs before Tower catches an unwind. This
+/// policy governs only Tower's client response and Tower-generated tracing
+/// event; it cannot redact output produced by an application-installed panic
+/// hook or by Rust's default panic hook.
+#[derive(Clone)]
+pub struct PanicPolicy {
+    client_message: ClientPanicMessage,
+    client_tool_name: ToolNameDisclosure,
+    log_tool_name: ToolNameDisclosure,
+    include_payload_in_logs: bool,
+}
+
+impl std::fmt::Debug for PanicPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let client_message = match self.client_message {
+            ClientPanicMessage::Detailed => "detailed",
+            ClientPanicMessage::Fixed(_) => "fixed",
+        };
+        f.debug_struct("PanicPolicy")
+            .field("client_message", &client_message)
+            .field("client_tool_name", &self.client_tool_name.mode())
+            .field("log_tool_name", &self.log_tool_name.mode())
+            .field("include_payload_in_logs", &self.include_payload_in_logs)
+            .finish()
+    }
+}
+
+impl PanicPolicy {
+    /// Create a policy whose client response is fixed application-supplied
+    /// text and whose Tower tracing event contains neither the tool name nor
+    /// the panic payload.
+    pub fn redacted(client_message: impl Into<String>) -> Self {
+        Self {
+            client_message: ClientPanicMessage::Fixed(Arc::from(client_message.into())),
+            client_tool_name: ToolNameDisclosure::Omit,
+            log_tool_name: ToolNameDisclosure::Omit,
+            include_payload_in_logs: false,
+        }
+    }
+
+    fn detailed() -> Self {
+        Self {
+            client_message: ClientPanicMessage::Detailed,
+            client_tool_name: ToolNameDisclosure::Original,
+            log_tool_name: ToolNameDisclosure::Original,
+            include_payload_in_logs: true,
+        }
+    }
+
+    /// Include the registered tool name in the client-visible error.
+    ///
+    /// With a redacted policy this changes the response from the exact fixed
+    /// message to `tool '<name>': <fixed message>`.
+    #[must_use]
+    pub fn include_tool_name_in_client_message(mut self, include: bool) -> Self {
+        self.client_tool_name = if include {
+            ToolNameDisclosure::Original
+        } else {
+            ToolNameDisclosure::Omit
+        };
+        self
+    }
+
+    /// Replace the registered tool name in the client-visible error with a
+    /// fixed application-selected label.
+    ///
+    /// This is useful when the original catalog name is sensitive but a
+    /// stable category such as `provider tool` is still useful to callers.
+    #[must_use]
+    pub fn client_tool_name(mut self, name: impl Into<String>) -> Self {
+        self.client_tool_name = ToolNameDisclosure::Fixed(Arc::from(name.into()));
+        self
+    }
+
+    /// Include the registered tool name in Tower's panic tracing event.
+    #[must_use]
+    pub fn include_tool_name_in_logs(mut self, include: bool) -> Self {
+        self.log_tool_name = if include {
+            ToolNameDisclosure::Original
+        } else {
+            ToolNameDisclosure::Omit
+        };
+        self
+    }
+
+    /// Replace the registered tool name in Tower's panic tracing event with
+    /// a fixed application-selected label.
+    #[must_use]
+    pub fn log_tool_name(mut self, name: impl Into<String>) -> Self {
+        self.log_tool_name = ToolNameDisclosure::Fixed(Arc::from(name.into()));
+        self
+    }
+
+    /// Include the recovered panic payload in Tower's panic tracing event.
+    ///
+    /// This switch never changes the client-visible error.
+    #[must_use]
+    pub fn include_payload_in_logs(mut self, include: bool) -> Self {
+        self.include_payload_in_logs = include;
+        self
+    }
+
+    fn client_message(&self, tool_name: &str, payload: Option<&str>) -> String {
+        match &self.client_message {
+            ClientPanicMessage::Detailed => format!(
+                "tool '{tool_name}' panicked: {}",
+                payload.expect("detailed panic policy always recovers the payload")
+            ),
+            ClientPanicMessage::Fixed(message) => match self.client_tool_name.value(tool_name) {
+                Some(name) => format!("tool '{name}': {message}"),
+                None => message.to_string(),
+            },
+        }
+    }
+
+    fn needs_payload(&self) -> bool {
+        matches!(self.client_message, ClientPanicMessage::Detailed) || self.include_payload_in_logs
+    }
+}
+
 /// The kind of capability a [`MergeConflict`] refers to.
 ///
 /// Ordered so that [`McpRouter::conflicts`] reports tools before resources
@@ -549,9 +706,9 @@ struct McpRouterInner {
     /// URL of the server's website
     server_website_url: Option<String>,
     instructions: Option<String>,
-    /// Whether to convert a panicking tool handler into an error result
-    /// rather than letting it unwind out of the service (#1230).
-    catch_panics: bool,
+    /// How to convert a panicking tool handler into an error result rather
+    /// than letting it unwind out of the service (#1230, #1306).
+    panic_policy: Option<PanicPolicy>,
     auto_instructions: Option<AutoInstructionsConfig>,
     tools: HashMap<String, Arc<Tool>>,
     resources: HashMap<String, Arc<Resource>>,
@@ -736,7 +893,7 @@ impl McpRouter {
                 server_icons: None,
                 server_website_url: None,
                 instructions: None,
-                catch_panics: false,
+                panic_policy: None,
                 auto_instructions: None,
                 tools: HashMap::new(),
                 resources: HashMap::new(),
@@ -1395,14 +1552,40 @@ impl McpRouter {
     /// matters more than failing fast, which is true for a shared server and
     /// often false for a local one.
     ///
-    /// The caught panic becomes a `CallToolResult` with `is_error: true`
-    /// carrying the panic message, and is logged at error level with the tool
-    /// name so it is not silently swallowed.
+    /// For ordinary and replayed handlers, the caught panic becomes a
+    /// `CallToolResult` with `is_error: true` carrying the panic message. A
+    /// live Task handler instead reaches `failed` with the same detailed
+    /// message. Both are logged at error level with the tool name so the panic
+    /// is not silently swallowed.
     ///
     /// A panic that unwinds is caught; one that aborts the process (a
     /// double panic, or `panic = "abort"`) cannot be, by construction.
     pub fn catch_panics(mut self) -> Self {
-        Arc::make_mut(&mut self.inner).catch_panics = true;
+        Arc::make_mut(&mut self.inner).panic_policy = Some(PanicPolicy::detailed());
+        self
+    }
+
+    /// Convert a panicking tool handler into an error result using an
+    /// application-selected disclosure policy.
+    ///
+    /// [`PanicPolicy::redacted`] returns fixed client text and omits both the
+    /// tool name and panic payload from Tower's tracing event by default.
+    /// Unlike [`McpRouter::catch_panics`], a custom policy never includes the
+    /// panic payload in the client response.
+    ///
+    /// The policy applies to ordinary calls and both replayed and live Task
+    /// handlers registered on this router. Router-level configuration is not
+    /// imported when another router is merged or nested, so the receiving
+    /// router's policy governs the combined catalog.
+    ///
+    /// Rust's process-global panic hook runs before the unwind is caught, so
+    /// this controls Tower's client response and tracing event only. It does
+    /// not suppress application or default panic-hook output.
+    ///
+    /// A panic that aborts the process (a double panic, or
+    /// `panic = "abort"`) cannot be caught.
+    pub fn catch_panics_with(mut self, policy: PanicPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).panic_policy = Some(policy);
         self
     }
 
@@ -2971,9 +3154,10 @@ impl McpRouter {
 
     /// Invoke a tool, optionally converting a panic into an error result.
     ///
-    /// Enabled by [`McpRouter::catch_panics`]. Without it this is a direct
-    /// call and a panic unwinds as before, which is the default because a
-    /// panic is an invariant violation and hiding one is not always a favour.
+    /// Enabled by [`McpRouter::catch_panics`] or
+    /// [`McpRouter::catch_panics_with`]. Without either this is a direct call
+    /// and a panic unwinds as before, which is the default because a panic is
+    /// an invariant violation and hiding one is not always a favour.
     async fn invoke_tool(
         &self,
         tool: &crate::tool::Tool,
@@ -2981,35 +3165,99 @@ impl McpRouter {
         arguments: serde_json::Value,
         tool_name: &str,
     ) -> Result<crate::protocol::RequestOutcome<CallToolResult>> {
-        if !self.inner.catch_panics {
+        let Some(policy) = &self.inner.panic_policy else {
             return tool.call_outcome_with_context(ctx, arguments).await;
-        }
+        };
 
         use futures::FutureExt;
         // AssertUnwindSafe: the future may hold &mut across the await, which
         // Rust cannot prove safe to observe post-unwind. Any state a panicking
         // handler leaves behind belongs to that handler; the router's own
         // state is not mutated by this call.
-        let called = std::panic::AssertUnwindSafe(tool.call_outcome_with_context(ctx, arguments))
-            .catch_unwind()
-            .await;
+        let called = std::panic::AssertUnwindSafe(async move {
+            tool.call_outcome_with_context(ctx, arguments).await
+        })
+        .catch_unwind()
+        .await;
 
         match called {
             Ok(outcome) => outcome,
             Err(payload) => {
-                let message = panic_message(&*payload);
-                // Logged at error, not swallowed: an operator who opted into
-                // availability still needs to learn about the bug.
-                tracing::error!(
-                    target: "mcp::tools",
-                    tool = %tool_name,
-                    panic = %message,
-                    "tool handler panicked; returning an error result"
-                );
+                let message = self.handle_caught_panic(policy, tool_name, None, &*payload);
                 Ok(crate::protocol::RequestOutcome::Complete(
-                    CallToolResult::error(format!("tool '{tool_name}' panicked: {message}")),
+                    CallToolResult::error(message),
                 ))
             }
+        }
+    }
+
+    /// Apply the selected disclosure policy to a caught handler panic.
+    ///
+    /// Payload recovery is intentionally conditional: the fully redacted
+    /// path never downcasts, clones, or formats the panic payload.
+    fn handle_caught_panic(
+        &self,
+        policy: &PanicPolicy,
+        tool_name: &str,
+        task_id: Option<&str>,
+        payload: &(dyn std::any::Any + Send),
+    ) -> String {
+        let payload = policy.needs_payload().then(|| panic_message(payload));
+        let logged_tool = policy.log_tool_name.value(tool_name);
+        let logged_payload = policy
+            .include_payload_in_logs
+            .then(|| payload.as_deref().expect("log payload was recovered"));
+
+        Self::log_caught_panic(logged_tool, logged_payload, task_id);
+        policy.client_message(tool_name, payload.as_deref())
+    }
+
+    fn log_caught_panic(tool_name: Option<&str>, payload: Option<&str>, task_id: Option<&str>) {
+        match (tool_name, payload, task_id) {
+            (Some(tool_name), Some(payload), Some(task_id)) => tracing::error!(
+                target: "mcp::tools",
+                tool = %tool_name,
+                panic = %payload,
+                task_id = %task_id,
+                "tool handler panicked; returning an error result"
+            ),
+            (Some(tool_name), Some(payload), None) => tracing::error!(
+                target: "mcp::tools",
+                tool = %tool_name,
+                panic = %payload,
+                "tool handler panicked; returning an error result"
+            ),
+            (Some(tool_name), None, Some(task_id)) => tracing::error!(
+                target: "mcp::tools",
+                tool = %tool_name,
+                task_id = %task_id,
+                "tool handler panicked; returning an error result"
+            ),
+            (Some(tool_name), None, None) => tracing::error!(
+                target: "mcp::tools",
+                tool = %tool_name,
+                "tool handler panicked; returning an error result"
+            ),
+            (None, Some(payload), Some(task_id)) => tracing::error!(
+                target: "mcp::tools",
+                panic = %payload,
+                task_id = %task_id,
+                "tool handler panicked; returning an error result"
+            ),
+            (None, Some(payload), None) => tracing::error!(
+                target: "mcp::tools",
+                panic = %payload,
+                "tool handler panicked; returning an error result"
+            ),
+            (None, None, Some(task_id)) => tracing::error!(
+                target: "mcp::tools",
+                task_id = %task_id,
+                "tool handler panicked; returning an error result"
+            ),
+            (None, None, None) => tracing::error!(
+                target: "mcp::tools",
+                "tool handler panicked; returning an error result"
+            ),
         }
     }
 
@@ -3500,7 +3748,7 @@ impl McpRouter {
                             notifier.register_live_task(&task_id_clone, handle.clone());
                             // Released on drop, so the entry goes whether the
                             // handler returns, panics, or is dropped (#1305).
-                            let _registration = LiveTaskRegistration {
+                            let registration = LiveTaskRegistration {
                                 router: notifier.clone(),
                                 task_id: task_id_clone.clone(),
                             };
@@ -3516,33 +3764,33 @@ impl McpRouter {
                             // directly and had none, so a panic unwound before
                             // any terminal state was written and left the task
                             // at `working` forever (#1305).
-                            let called = live_handler.call(ctx, live_ctx, arguments);
-                            let outcome = if notifier.inner.catch_panics {
+                            let outcome = if let Some(policy) = &notifier.inner.panic_policy {
                                 use futures::FutureExt;
-                                match std::panic::AssertUnwindSafe(called).catch_unwind().await {
+                                let called = std::panic::AssertUnwindSafe(async move {
+                                    live_handler.call(ctx, live_ctx, arguments).await
+                                })
+                                .catch_unwind()
+                                .await;
+                                match called {
                                     Ok(outcome) => outcome,
                                     Err(payload) => {
-                                        let message = panic_message(&*payload);
-                                        tracing::error!(
-                                            target: "mcp::tools",
-                                            tool = %tool_name,
-                                            task_id = %task_id_clone,
-                                            panic = %message,
-                                            "live task handler panicked"
+                                        let message = notifier.handle_caught_panic(
+                                            policy,
+                                            &tool_name,
+                                            Some(&task_id_clone),
+                                            &*payload,
                                         );
                                         // A panic is an execution failure, not
                                         // a tool reporting a domain error, so
                                         // it fails the task rather than
                                         // completing it with `isError`.
                                         Ok(crate::tool::TaskOutcome::Failed(
-                                            JsonRpcError::internal_error(format!(
-                                                "tool '{tool_name}' panicked: {message}"
-                                            )),
+                                            JsonRpcError::internal_error(message),
                                         ))
                                     }
                                 }
                             } else {
-                                called.await
+                                live_handler.call(ctx, live_ctx, arguments).await
                             };
                             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
@@ -3579,13 +3827,13 @@ impl McpRouter {
                                     .await
                                     .map(|_| "failed"),
                             };
-                            // The registration guard releases the entry when
-                            // it drops at the end of this block, which is after
-                            // the terminal write above. Unregistering before
-                            // that write left a window where a cancel took the
-                            // store path and wrote `cancelled` over a task
-                            // whose handler had already produced a result
-                            // (#1294).
+                            // The terminal write must win before unregistering
+                            // (#1294), but the dead handle must not remain
+                            // visible through logging or notification awaits.
+                            // If the write failed, a later cancellation can
+                            // now take the store path instead of signalling a
+                            // handler that has already returned (#1305).
+                            drop(registration);
 
                             match applied {
                                 Ok(status) => tracing::info!(

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -1856,6 +1856,21 @@ fn panic_message_recovers_both_payload_shapes() {
     assert_eq!(panic_message(&*odd), "panicked with a non-string payload");
 }
 
+#[test]
+fn panic_policy_debug_does_not_disclose_its_fixed_client_message() {
+    let debug = format!(
+        "{:?}",
+        PanicPolicy::redacted("private incident text")
+            .include_tool_name_in_client_message(true)
+            .include_tool_name_in_logs(true)
+            .include_payload_in_logs(true)
+    );
+    assert!(debug.contains("client_message: \"fixed\""), "{debug}");
+    assert!(debug.contains("client_tool_name: \"original\""), "{debug}");
+    assert!(debug.contains("log_tool_name: \"original\""), "{debug}");
+    assert!(!debug.contains("private incident text"), "{debug}");
+}
+
 /// #1208: the full task input round trip. The handler asks, the task
 /// parks in `input_required` carrying the requests, the client answers
 /// with `tasks/update`, the router re-invokes the handler with the
@@ -1987,6 +2002,126 @@ async fn a_task_resumes_after_its_input_is_answered() {
     }
     let completed = completed.expect("the task must complete after resuming");
     assert_eq!(completed.all_text(), "approved");
+}
+
+/// #1306: replay uses the root router's selected panic disclosure policy,
+/// just like an ordinary call. The existing replay contract still records a
+/// caught panic as a completed tool error rather than changing task semantics.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn a_replayed_task_panic_uses_the_redacted_policy() {
+    use crate::async_task::{MemoryTaskStore, TaskStore};
+    use crate::protocol::{
+        ElicitFormParams, ElicitFormSchema, ElicitRequestParams, InputRequest, InputRequests,
+        InputRequiredResult, RequestOutcome,
+    };
+
+    const PAYLOAD: &str = "secret replay payload";
+    const SAFE_MESSAGE: &str = "internal tool failure";
+
+    let asks = ToolBuilder::new("private.replay")
+        .description("Panics after input")
+        .task_support(TaskSupportMode::Optional)
+        .mrtr_handler::<serde_json::Value, _, _>(|ctx, _input| async move {
+            if ctx.input_responses().is_some() {
+                panic!("{PAYLOAD}");
+            }
+            let mut requests: InputRequests = Default::default();
+            requests.insert(
+                "decision".to_string(),
+                InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                    mode: None,
+                    message: "approve?".to_string(),
+                    requested_schema: ElicitFormSchema::new(),
+                    meta: None,
+                })),
+            );
+            Ok(RequestOutcome::input_required(
+                InputRequiredResult::with_requests(requests),
+            ))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let mut router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(asks)
+        .with_tasks()
+        .catch_panics_with(PanicPolicy::redacted(SAFE_MESSAGE));
+    init_router(&mut router).await;
+
+    let created = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
+                name: "private.replay".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    let task_id = match created.inner {
+        Ok(McpResponse::FinalCreateTask(result)) => result.task.metadata.task_id,
+        other => panic!("expected a created task, got {other:?}"),
+    };
+
+    for _ in 0..50 {
+        let task = store.get_task(&task_id).await.unwrap().unwrap();
+        if task.status == TaskStatus::InputRequired {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        store.get_task(&task_id).await.unwrap().unwrap().status,
+        TaskStatus::InputRequired
+    );
+
+    let update = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(2),
+            inner: McpRequest::UpdateTask(UpdateTaskParams {
+                task_id: task_id.clone(),
+                input_responses: [(
+                    "decision".to_string(),
+                    serde_json::json!({"action": "accept"}),
+                )]
+                .into_iter()
+                .collect(),
+                meta: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    assert!(update.inner.is_ok(), "update must be acknowledged");
+
+    let mut completed = None;
+    for _ in 0..50 {
+        let (task, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+        if task.status == TaskStatus::Completed {
+            completed = result;
+            break;
+        }
+        assert_ne!(task.status, TaskStatus::Failed);
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    let completed = completed.expect("caught replay panic must complete as a tool error");
+    assert!(completed.is_error);
+    assert_eq!(completed.all_text(), SAFE_MESSAGE);
+    assert!(!completed.all_text().contains(PAYLOAD));
+    assert!(!completed.all_text().contains("private.replay"));
 }
 
 /// A store predating resumption cannot supply what a re-invocation needs,

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -861,7 +861,34 @@ mod cancellation {
 
 mod panics {
     use super::*;
+    use std::io::Write;
+    use std::sync::Mutex;
+    use tower_mcp::PanicPolicy;
     use tower_mcp::extract::Context;
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl CaptureWriter {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().expect("capture lock").clone())
+                .expect("tracing output is UTF-8")
+        }
+    }
 
     fn panicking_router(catch: bool) -> McpRouter {
         let boom = ToolBuilder::new("boom")
@@ -904,15 +931,10 @@ mod panics {
             .await
             .expect("the call must return, not kill the connection");
         assert!(result.is_error, "a caught panic is an error result");
-        assert!(
-            result.all_text().contains("panicked"),
-            "the message must say what happened: {}",
-            result.all_text()
-        );
-        assert!(
-            result.all_text().contains("SystemTime"),
-            "and carry the panic's own message: {}",
-            result.all_text()
+        assert_eq!(
+            result.all_text(),
+            "tool 'boom' panicked: overflow when adding duration to `SystemTime`",
+            "the compatibility builder keeps its detailed response"
         );
 
         // The decisive assertion: the connection survives and other tools
@@ -922,6 +944,155 @@ mod panics {
             .await
             .expect("the server must still be serving");
         assert_eq!(after.all_text(), "ok");
+    }
+
+    /// #1306: strict servers can isolate a panic without copying handler
+    /// data into either the client response or Tower's tracing event.
+    #[tokio::test(flavor = "current_thread")]
+    async fn a_redacted_policy_omits_string_and_non_string_panic_payloads() {
+        const TOOL_NAME: &str = "private.provider.operation";
+        const PAYLOAD: &str = "secret path /private/provider/home";
+        const SAFE_MESSAGE: &str = "internal tool failure";
+
+        let string_panic = ToolBuilder::new(TOOL_NAME)
+            .description("Panics with sensitive text")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                panic!("{PAYLOAD}");
+                #[allow(unreachable_code)]
+                Ok(CallToolResult::text("unreachable"))
+            })
+            .build();
+        let odd_panic = ToolBuilder::new("private.provider.non-string")
+            .description("Panics with an opaque payload")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                std::panic::panic_any(42_u8);
+                #[allow(unreachable_code)]
+                Ok(CallToolResult::text("unreachable"))
+            })
+            .build();
+        let fine = ToolBuilder::new("fine")
+            .description("Works")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                Ok(CallToolResult::text("ok"))
+            })
+            .build();
+
+        let captured = CaptureWriter::default();
+        let trace_output = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::ERROR)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+
+        let router = McpRouter::new()
+            .server_info("panic-test", "1.0.0")
+            .tool(string_panic)
+            .tool(odd_panic)
+            .tool(fine)
+            .catch_panics_with(PanicPolicy::redacted(SAFE_MESSAGE));
+        let client = McpClient::connect(ChannelTransport::new(router))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        for name in [TOOL_NAME, "private.provider.non-string"] {
+            let result = client
+                .call_tool(name, serde_json::json!({}))
+                .await
+                .expect("caught panic returns a result");
+            assert!(result.is_error);
+            assert_eq!(result.all_text(), SAFE_MESSAGE);
+        }
+
+        let after = client
+            .call_tool("fine", serde_json::json!({}))
+            .await
+            .expect("call");
+        assert_eq!(after.all_text(), "ok");
+
+        let traces = trace_output.contents();
+        assert!(traces.contains("tool handler panicked"), "{traces}");
+        assert!(!traces.contains(TOOL_NAME), "tool name leaked: {traces}");
+        assert!(!traces.contains(PAYLOAD), "panic payload leaked: {traces}");
+        assert!(
+            !traces.contains("non-string payload"),
+            "opaque panic payload was inspected: {traces}"
+        );
+    }
+
+    /// Client and tracing tool-name disclosure are separate switches.
+    #[tokio::test(flavor = "current_thread")]
+    async fn panic_policy_tool_name_disclosures_are_independent() {
+        const TOOL_NAME: &str = "private.provider.named";
+        const PAYLOAD: &str = "private panic payload";
+
+        let boom = ToolBuilder::new(TOOL_NAME)
+            .description("Panics")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                panic!("{PAYLOAD}");
+                #[allow(unreachable_code)]
+                Ok(CallToolResult::text("unreachable"))
+            })
+            .build();
+        let captured = CaptureWriter::default();
+        let trace_output = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::ERROR)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+
+        let router = McpRouter::new()
+            .server_info("panic-test", "1.0.0")
+            .tool(boom)
+            .catch_panics_with(
+                PanicPolicy::redacted("internal tool failure")
+                    .client_tool_name("client-safe-tool")
+                    .log_tool_name("log-safe-tool")
+                    .include_payload_in_logs(true),
+            );
+        let client = McpClient::connect(ChannelTransport::new(router))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        let result = client
+            .call_tool(TOOL_NAME, serde_json::json!({}))
+            .await
+            .expect("caught panic returns a result");
+        assert_eq!(
+            result.all_text(),
+            "tool 'client-safe-tool': internal tool failure"
+        );
+
+        let traces = trace_output.contents();
+        assert!(
+            traces.contains("log-safe-tool"),
+            "log alias absent: {traces}"
+        );
+        assert!(
+            !traces.contains("client-safe-tool"),
+            "client alias crossed into tracing: {traces}"
+        );
+        assert!(
+            !traces.contains(TOOL_NAME),
+            "raw tool name leaked: {traces}"
+        );
+        assert!(
+            traces.contains(PAYLOAD),
+            "the independently enabled log payload is absent: {traces}"
+        );
     }
 
     /// Off by default: opting in is a statement that availability matters

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -20,7 +20,7 @@ use tower_mcp::protocol::{
     InputRequest, InputRequests, InputResponse, TaskStatus,
 };
 use tower_mcp::schemars::JsonSchema;
-use tower_mcp::{CallToolResult, McpRouter, TaskContext, TaskOutcome, ToolBuilder};
+use tower_mcp::{CallToolResult, McpRouter, PanicPolicy, TaskContext, TaskOutcome, ToolBuilder};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct NoArgs {}
@@ -535,6 +535,64 @@ async fn a_panicking_live_handler_reaches_a_terminal_state() {
     await_status(&store, &next, TaskStatus::Completed).await;
 }
 
+/// #1306: live execution uses the same root-router disclosure policy as
+/// ordinary and replayed handlers while retaining its `failed` Task outcome.
+#[tokio::test]
+async fn a_panicking_live_handler_uses_the_redacted_policy() {
+    const TOOL_NAME: &str = "private.provider.live";
+    const PAYLOAD: &str = "secret live provider payload";
+    const SAFE_MESSAGE: &str = "internal tool failure";
+
+    let boom = ToolBuilder::new(TOOL_NAME)
+        .description("Panics")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            panic!("{PAYLOAD}");
+            #[allow(unreachable_code)]
+            Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+        })
+        .build();
+    let fine = ToolBuilder::new("fine")
+        .description("Works")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ok")))
+        })
+        .build();
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("panic-live", "1.0.0")
+        .task_store(store.clone())
+        .tool(boom)
+        .tool(fine)
+        .with_tasks()
+        .catch_panics_with(PanicPolicy::redacted(SAFE_MESSAGE));
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task(TOOL_NAME, json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Failed).await;
+
+    let (_, _, error) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let error = error.expect("a failed task carries a structured error");
+    assert_eq!(error.message, SAFE_MESSAGE);
+    assert!(!error.message.contains(TOOL_NAME));
+    assert!(!error.message.contains(PAYLOAD));
+
+    let next = client
+        .call_tool_as_task("fine", json!({}), None)
+        .await
+        .expect("the server must still be serving")
+        .task
+        .task_id;
+    await_status(&store, &next, TaskStatus::Completed).await;
+}
+
 /// The registry entry must be released however the handler leaves, so a later
 /// cancellation does not target a dead handle. This holds without
 /// `catch_panics` too: opting out means the bug stays visible, not that
@@ -561,7 +619,15 @@ async fn a_panicking_live_handler_releases_its_registry_entry() {
         // With a stale entry the router takes the live path, signals a handle
         // nobody reads, and leaves the task non-terminal. With the entry gone
         // it takes the store path and terminalizes.
-        let _ = client.task_cancel(&task_id, None).await;
+        let cancellation = client.task_cancel(&task_id, None).await;
+        if catch {
+            assert!(
+                cancellation.is_err(),
+                "a caught panic is already Failed; a successful legacy cancel would mean a stale live registration handled it"
+            );
+        } else {
+            cancellation.expect("an uncaught panic leaves a working task for store cancellation");
+        }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         let task = store.get_task(&task_id).await.unwrap().unwrap();


### PR DESCRIPTION
Closes #1306

Follow-up to #1307.

## Summary

- add `PanicPolicy::redacted(...)` and `McpRouter::catch_panics_with(...)` for fixed client errors and independently controlled client/log tool names and log payloads;
- apply the root router's selected policy uniformly to ordinary, replayed Task, and live Task handlers;
- preserve `.catch_panics()` as the exact detailed compatibility preset;
- tighten #1307 cleanup by dropping a finished live handler's registry entry immediately after its terminal write attempt, before logging or notification awaits.

Existing outcome semantics remain unchanged: ordinary and replayed catches are completed tool-error results, while a live handler panic is a structured failed Task.

## Disclosure policy

`PanicPolicy::redacted("internal tool failure")` returns exactly that fixed text and omits both the tool name and panic payload from Tower's tracing event. Applications can opt into the original name, substitute independent fixed safe aliases for the client and tracing, and separately opt into payload tracing. A custom policy never copies the panic payload into the client response.

The redacted path decides whether the payload is needed before calling the payload recovery helper, so the default path does not downcast, clone, or format it. The policy intentionally has no observer/mapper callback; Tower's tracing event is the safe observation surface and avoids creating a second panic boundary.

Rust's process-global panic hook still runs before `catch_unwind`. The policy controls Tower's response and Tower-generated tracing only; it cannot suppress output from the default or application-installed panic hook.

## Verification

- exact legacy `.catch_panics()` response compatibility;
- fixed redacted client output and captured tracing with no raw tool name or string/non-string payload;
- independent fixed aliases for client and tracing;
- replay and live Task policy coverage;
- live panic terminalization, server survival, and registry cleanup with and without catching;
- `cargo test -p tower-mcp --all-targets --all-features` (1,009 library tests plus every integration target);
- `cargo clippy -p tower-mcp --all-targets --all-features -- -D warnings`;
- Rust 1.90 focused panic suite;
- rustdoc with warnings denied and formatting checks.
