### PR TITLE
feat(tasks): owner-aware task presence distinguishing expired from missing

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -680,6 +680,7 @@ pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<JsonRpcError
 /// use tower_mcp::async_task::{
 ///     AppliedInputResponses, CancellationToken, MemoryTaskStore, Result, TaskOwner,
 ///     TaskResumeContext, TaskSnapshot, TaskStore,
+///     TaskPresence,
 /// };
 /// use tower_mcp::error::JsonRpcError;
 /// use tower_mcp::protocol::{InputRequests, InputResponses, TaskObject, TaskStatus};
@@ -714,6 +715,12 @@ pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<JsonRpcError
 ///     }
 ///     async fn task_owner(&self, id: &str) -> Result<Option<TaskOwner>> {
 ///         self.inner.task_owner(id).await
+///     }
+///     // Forward this too when the wrapped store retains tombstones, or the
+///     // default turns its `Expired` into `Missing` and the decorator
+///     // silently removes the distinction (#1249).
+///     async fn task_presence(&self, id: &str) -> Result<TaskPresence> {
+///         self.inner.task_presence(id).await
 ///     }
 ///     async fn get_task(&self, id: &str) -> Result<Option<TaskObject>> {
 ///         self.inner.get_task(id).await

--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -525,6 +525,54 @@ impl Default for CancellationToken {
     }
 }
 
+/// Whether a task is present, expired, or was never known.
+///
+/// `Option` collapses the last two, so an application retaining expired
+/// tombstones cannot tell a caller "that task expired" rather than "no such
+/// task" (#1249).
+///
+/// # The owner is carried for a reason
+///
+/// `Expired` keeps the owner because authorization has to happen *before* the
+/// distinction is revealed. A present or expired task belonging to another
+/// principal must remain indistinguishable from `Missing` to that caller, or
+/// `tasks/get` becomes an existence oracle: anyone could probe ids and learn
+/// which ones belong to somebody. Only the matching owner sees `Expired`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TaskPresence {
+    /// The task exists and has not expired.
+    Present {
+        /// Principal that created it.
+        owner: TaskOwner,
+    },
+    /// The task existed and its TTL elapsed.
+    ///
+    /// Only reported by a store that retains expired records. One that drops
+    /// them answers `Missing`, which is correct for it.
+    Expired {
+        /// Principal that created it, needed to authorize before disclosing.
+        owner: TaskOwner,
+    },
+    /// No such task, or the store no longer retains it.
+    Missing,
+}
+
+impl TaskPresence {
+    /// The owner, for a task the store still knows about.
+    pub fn owner(&self) -> Option<&TaskOwner> {
+        match self {
+            Self::Present { owner } | Self::Expired { owner } => Some(owner),
+            Self::Missing => None,
+        }
+    }
+
+    /// Whether the store knows this task at all, expired or not.
+    pub fn is_known(&self) -> bool {
+        !matches!(self, Self::Missing)
+    }
+}
+
 /// Errors returned by [`TaskStore`] implementations.
 ///
 /// Encode and decode errors come from (de)serializing task state, and
@@ -1009,6 +1057,36 @@ pub trait TaskStore: Send + Sync + 'static {
         responses: InputResponses,
     ) -> Result<Option<AppliedInputResponses>>;
 
+    /// Resolve a task to present, expired, or missing, with its owner.
+    ///
+    /// The router uses this both to authorize an operation and to classify an
+    /// absent result afterwards, so a store that retains expired records can
+    /// tell its owner "that task expired" instead of "no such task" (#1249).
+    ///
+    /// Defaults to today's behaviour, treating anything `task_owner` does not
+    /// return as [`TaskPresence::Missing`], so existing stores compile and
+    /// behave unchanged. Override it when the store retains tombstones.
+    ///
+    /// # Implementing this
+    ///
+    /// Report `Expired` only for a record the store still holds; dropping
+    /// expired records and answering `Missing` is correct.
+    ///
+    /// The owner must be returned for `Expired` as well as `Present`. The
+    /// router authorizes before disclosing the difference, and it cannot do
+    /// that without knowing who owns an expired task.
+    ///
+    /// The lookup should be atomic with respect to expiry where the backend
+    /// allows it: the router resolves a second time after an operation returns
+    /// nothing, and a store whose active and tombstone lookups can disagree
+    /// may answer `Missing` for a task that expired mid-operation.
+    async fn task_presence(&self, task_id: &str) -> Result<TaskPresence> {
+        Ok(match self.task_owner(task_id).await? {
+            Some(owner) => TaskPresence::Present { owner },
+            None => TaskPresence::Missing,
+        })
+    }
+
     /// Every answer accumulated for a task so far, keyed as issued.
     ///
     /// A live handler reads this after being woken, so that what it observes
@@ -1393,6 +1471,25 @@ impl TaskStore for MemoryTaskStore {
                 .map(|t| t.owner.clone())
         } else {
             None
+        })
+    }
+
+    /// This store keeps expired records until `cleanup_expired` runs, so it
+    /// can tell an owner that a task expired rather than that it never
+    /// existed (#1249). One read resolves both, so expiry cannot change
+    /// between deciding presence and reading the owner.
+    async fn task_presence(&self, task_id: &str) -> Result<TaskPresence> {
+        let Ok(tasks) = self.tasks.read() else {
+            return Ok(TaskPresence::Missing);
+        };
+        Ok(match tasks.get(task_id) {
+            Some(task) if task.is_expired() => TaskPresence::Expired {
+                owner: task.owner.clone(),
+            },
+            Some(task) => TaskPresence::Present {
+                owner: task.owner.clone(),
+            },
+            None => TaskPresence::Missing,
         })
     }
 

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -566,7 +566,7 @@ pub use apps::{
     McpUiResourceCsp, McpUiResourceMeta, McpUiToolMeta, McpUiToolVisibility, mcp_app_tool_result,
     mcp_apps_extension,
 };
-pub use async_task::{MemoryTaskStore, Task, TaskStore};
+pub use async_task::{MemoryTaskStore, Task, TaskPresence, TaskStore};
 pub use client::{
     ChannelTransport, ClientHandler, ClientTransport, McpClient, McpClientBuilder,
     NotificationHandler, StdioClientTransport,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2628,6 +2628,36 @@ impl McpRouter {
             .contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
     }
 
+    /// Classify an operation that found nothing, after authorization passed.
+    ///
+    /// The task was present when it was authorized, so an operation that then
+    /// found nothing means it expired in between. Resolving a second time
+    /// tells the owner that, rather than reporting a task that existed moments
+    /// ago as though it never had (#1249).
+    ///
+    /// Ownership is rechecked rather than assumed. The first resolution
+    /// established it, and task ids are unguessable and not reused, so this is
+    /// belt and braces; it costs one lookup and removes any argument about
+    /// whether a store could return a differently-owned record here.
+    async fn classify_absent_task(
+        &self,
+        task_id: &str,
+        extensions: &crate::context::Extensions,
+    ) -> Error {
+        let Ok(presence) = self.inner.task_store.task_presence(task_id).await else {
+            return Error::JsonRpc(unknown_task_error(task_id));
+        };
+        let owns = presence.owner().is_some_and(|owner| {
+            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
+        });
+        match presence {
+            crate::async_task::TaskPresence::Expired { .. } if owns => {
+                Error::JsonRpc(expired_task_error(task_id))
+            }
+            _ => Error::JsonRpc(unknown_task_error(task_id)),
+        }
+    }
+
     /// Reject a final task method that was not negotiated by both peers.
     ///
     /// An unnegotiated method is reported as absent rather than forbidden:
@@ -4238,18 +4268,19 @@ impl McpRouter {
                 // `failed` includes the JSON-RPC error. This replaced the
                 // removed blocking `tasks/result` method as the way clients
                 // retrieve a task's outcome.
-                let (mut task, result, error) = self
+                let Some((mut task, result, error)) = self
                     .inner
                     .task_store
                     .get_task_result(&params.task_id)
                     .await
                     .map_err(task_store_error)?
-                    .ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Task not found: {}",
-                            params.task_id
-                        )))
-                    })?;
+                else {
+                    // Present when it was authorized, absent now, so it
+                    // expired in between (#1249).
+                    return Err(self
+                        .classify_absent_task(&params.task_id, &extensions)
+                        .await);
+                };
 
                 match task.status {
                     TaskStatus::Completed => task.result = result,
@@ -4274,7 +4305,7 @@ impl McpRouter {
                     // Partial responses are the normal case: the store
                     // consumes what matches an outstanding request and ignores
                     // unknown, already-answered, and superseded keys.
-                    let applied = self
+                    let Some(applied) = self
                         .inner
                         .task_store
                         .apply_input_responses(
@@ -4283,7 +4314,26 @@ impl McpRouter {
                         )
                         .await
                         .map_err(task_store_error)?
-                        .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                    else {
+                        // Nothing left to apply. A task the store still knows
+                        // and has not expired is a late or duplicate update,
+                        // so it gets the ordinary empty acknowledgement, which
+                        // makes a client retry idempotent (#1249).
+                        return match self
+                            .inner
+                            .task_store
+                            .task_presence(&params.task_id)
+                            .await
+                            .map_err(task_store_error)?
+                        {
+                            crate::async_task::TaskPresence::Present { .. } => Ok(
+                                McpResponse::FinalTaskAck(crate::tasks::TaskAcknowledgement::new()),
+                            ),
+                            _ => Err(self
+                                .classify_absent_task(&params.task_id, &extensions)
+                                .await),
+                        };
+                    };
                     // Answering the last outstanding request resumes the task,
                     // so the status a subscriber sees changes here even though
                     // the ack itself is empty.
@@ -4322,7 +4372,7 @@ impl McpRouter {
                 // every key, so dropping them wholesale left a server whose
                 // store models input requests with a working flow on
                 // 2026-07-28 and a silent stall on 2025-11-25 (#1188).
-                let applied = self
+                let Some(applied) = self
                     .inner
                     .task_store
                     .apply_input_responses(
@@ -4331,12 +4381,26 @@ impl McpRouter {
                     )
                     .await
                     .map_err(task_store_error)?
-                    .ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Task not found: {}",
-                            params.task_id
-                        )))
-                    })?;
+                else {
+                    // Nothing left to apply. A task the store still knows and
+                    // has not expired is a late or duplicate update, so it
+                    // gets the ordinary empty acknowledgement, which makes a
+                    // client retry idempotent rather than a not-found (#1249).
+                    return match self
+                        .inner
+                        .task_store
+                        .task_presence(&params.task_id)
+                        .await
+                        .map_err(task_store_error)?
+                    {
+                        crate::async_task::TaskPresence::Present { .. } => {
+                            Ok(McpResponse::UpdateTask(EmptyResult {}))
+                        }
+                        _ => Err(self
+                            .classify_absent_task(&params.task_id, &extensions)
+                            .await),
+                    };
+                };
                 // A final-protocol subscriber watching this task should see it
                 // resume regardless of which lifecycle the updating client
                 // used. Self-guards when the extension is not enabled.
@@ -4370,12 +4434,17 @@ impl McpRouter {
                     // The final ack does not require a terminal transition:
                     // cancelling an already-terminal task is acknowledged, and
                     // the observable status is polled via `tasks/get`.
-                    self.inner
+                    let cancelled = self
+                        .inner
                         .task_store
                         .cancel_task(&params.task_id, params.reason.as_deref())
                         .await
-                        .map_err(task_store_error)?
-                        .ok_or_else(|| Error::JsonRpc(unknown_task_error(&params.task_id)))?;
+                        .map_err(task_store_error)?;
+                    if cancelled.is_none() {
+                        return Err(self
+                            .classify_absent_task(&params.task_id, &extensions)
+                            .await);
+                    }
                     self.notify_task_state(&params.task_id).await;
                     return Ok(McpResponse::FinalTaskAck(
                         crate::tasks::TaskAcknowledgement::new(),
@@ -4392,18 +4461,17 @@ impl McpRouter {
                 }
 
                 // First check if the task exists and is not already terminal
-                let current = self
+                let Some(current) = self
                     .inner
                     .task_store
                     .get_task(&params.task_id)
                     .await
                     .map_err(task_store_error)?
-                    .ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Task not found: {}",
-                            params.task_id
-                        )))
-                    })?;
+                else {
+                    return Err(self
+                        .classify_absent_task(&params.task_id, &extensions)
+                        .await);
+                };
 
                 if current.status.is_terminal() {
                     return Err(Error::JsonRpc(JsonRpcError::invalid_params(format!(
@@ -4412,17 +4480,17 @@ impl McpRouter {
                     ))));
                 }
 
-                self.inner
+                let cancelled = self
+                    .inner
                     .task_store
                     .cancel_task(&params.task_id, params.reason.as_deref())
                     .await
-                    .map_err(task_store_error)?
-                    .ok_or_else(|| {
-                        Error::JsonRpc(JsonRpcError::invalid_params(format!(
-                            "Task not found: {}",
-                            params.task_id
-                        )))
-                    })?;
+                    .map_err(task_store_error)?;
+                if cancelled.is_none() {
+                    return Err(self
+                        .classify_absent_task(&params.task_id, &extensions)
+                        .await);
+                }
 
                 // SEP-2663 (final): the cancel acknowledgment MUST be an empty
                 // result. The observable status is polled via `tasks/get` and

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -274,6 +274,20 @@ fn request_principal(_extensions: &crate::context::Extensions) -> Option<String>
 ///
 /// Unknown and expired tasks are deliberately indistinguishable, so a caller
 /// cannot probe for the existence of a task whose retention window closed.
+/// The error an owner gets for a task the store still holds but whose TTL
+/// elapsed.
+///
+/// Deliberately distinct from [`unknown_task_error`] in its `data`, and
+/// deliberately only ever produced after the caller has been shown to own the
+/// task. A caller who does not own it gets `unknown_task_error`, which is
+/// also what a genuinely unknown id gets, so the two cannot be told apart
+/// from outside (#1249).
+fn expired_task_error(task_id: &str) -> JsonRpcError {
+    let mut error = JsonRpcError::invalid_params(format!("Task expired: {task_id}"));
+    error.data = Some(serde_json::json!({ "reason": "task_expired" }));
+    error
+}
+
 fn unknown_task_error(task_id: &str) -> JsonRpcError {
     JsonRpcError::invalid_params(format!("Task not found: {task_id}"))
 }
@@ -2644,16 +2658,28 @@ impl McpRouter {
         task_id: &str,
         extensions: &crate::context::Extensions,
     ) -> Result<()> {
-        let owner = self
+        // Resolved through presence so an expired task can be reported as
+        // such to its owner. Everyone else must still see exactly what they
+        // see for an id that was never issued, so the owner check happens
+        // before any of that distinction escapes (#1249).
+        let presence = self
             .inner
             .task_store
-            .task_owner(task_id)
+            .task_presence(task_id)
             .await
-            .map_err(task_store_error)?
-            .ok_or_else(|| Error::JsonRpc(unknown_task_error(task_id)))?;
+            .map_err(task_store_error)?;
+        let Some(owner) = presence.owner() else {
+            return Err(Error::JsonRpc(unknown_task_error(task_id)));
+        };
 
-        if crate::async_task::owner_matches(&owner, request_principal(extensions).as_deref()) {
-            Ok(())
+        if crate::async_task::owner_matches(owner, request_principal(extensions).as_deref()) {
+            match presence {
+                // The owner is told the difference; nobody else reaches here.
+                crate::async_task::TaskPresence::Expired { .. } => {
+                    Err(Error::JsonRpc(expired_task_error(task_id)))
+                }
+                _ => Ok(()),
+            }
         } else {
             tracing::debug!(
                 target: "mcp::tasks",

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -5976,3 +5976,121 @@ async fn test_discover_does_not_require_initialization() {
         resp
     );
 }
+
+/// #1249: an expired task is distinguishable from a missing one, but only to
+/// its owner. To anyone else both must answer exactly as an id that was never
+/// issued does, or `tasks/get` becomes an existence oracle: probe ids, and the
+/// ones that answer differently belong to somebody.
+///
+/// This drives the router rather than the store, which is the level the
+/// authorization decision is made at. A store-level test cannot see this bug:
+/// I wrote one first, installed an implementation that disclosed expiry before
+/// checking ownership, and the store-level test passed anyway.
+#[cfg(all(feature = "oauth", feature = "stateless"))]
+#[tokio::test]
+async fn expiry_is_disclosed_to_the_owner_and_to_nobody_else() {
+    fn as_principal(subject: &str) -> Extensions {
+        let mut extensions = tasks_client_extensions();
+        extensions.insert(crate::oauth::token::TokenClaims {
+            sub: Some(subject.to_string()),
+            iss: None,
+            aud: None,
+            exp: None,
+            scope: None,
+            client_id: None,
+            extra: HashMap::new(),
+        });
+        extensions
+    }
+
+    let store = std::sync::Arc::new(crate::async_task::MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(
+            ToolBuilder::new("optional_task")
+                .task_support(TaskSupportMode::Optional)
+                .handler(|input: AddInput| async move {
+                    Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                })
+                .build(),
+        )
+        .with_tasks();
+
+    // Alice creates a task, then it expires.
+    let McpResponse::FinalCreateTask(created) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::CallTool(CallToolParams {
+                name: "optional_task".to_string(),
+                arguments: serde_json::json!({"a": 1, "b": 2}),
+                input_responses: None,
+                request_state: None,
+                meta: None,
+                task: None,
+            }),
+            as_principal("alice"),
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("Expected a final create-task response");
+    };
+    let task_id = created.task.metadata.task_id.clone();
+    assert!(store.set_ttl(&task_id, 1).await.unwrap());
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    let get = |id: String, who: Extensions| {
+        let router = router.clone();
+        async move {
+            router
+                .handle(
+                    RequestId::Number(9),
+                    McpRequest::GetTaskInfo(GetTaskInfoParams {
+                        task_id: id,
+                        meta: None,
+                    }),
+                    who,
+                )
+                .await
+        }
+    };
+
+    // The owner is told it expired.
+    let owner_saw = get(task_id.clone(), as_principal("alice")).await;
+    let Err(crate::error::Error::JsonRpc(owner_error)) = owner_saw else {
+        panic!("the owner must be told the task expired");
+    };
+    assert_eq!(
+        owner_error.data,
+        Some(serde_json::json!({ "reason": "task_expired" })),
+        "the owner's error must carry the expiry discriminator"
+    );
+
+    // Nobody else can tell it from an id that was never issued. Comparing the
+    // whole error, not just the code, because a discriminator in `data` or a
+    // differing message would leak just as effectively.
+    let stranger_saw = get(task_id.clone(), as_principal("bob")).await;
+    let never_issued = get("never-issued".to_string(), as_principal("bob")).await;
+    let (
+        Err(crate::error::Error::JsonRpc(stranger_error)),
+        Err(crate::error::Error::JsonRpc(missing_error)),
+    ) = (stranger_saw, never_issued)
+    else {
+        panic!("both must be refused");
+    };
+    assert_eq!(
+        stranger_error.code, missing_error.code,
+        "an unauthorized caller must not learn the task exists"
+    );
+    assert_eq!(
+        stranger_error.data, missing_error.data,
+        "nor from the error data"
+    );
+    // The message embeds the id the caller supplied, which tells them nothing
+    // they did not already know, so compare the shape with the id removed.
+    assert_eq!(
+        stranger_error.message.replace(&task_id, "<id>"),
+        missing_error.message.replace("never-issued", "<id>"),
+        "nor from the message, once the caller's own id is factored out"
+    );
+}

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -6094,3 +6094,140 @@ async fn expiry_is_disclosed_to_the_owner_and_to_nobody_else() {
         "nor from the message, once the caller's own id is factored out"
     );
 }
+
+/// #1249: a task that expires between authorization and the operation is
+/// reported to its owner as expired, not as one that never existed. The
+/// operation returning nothing is not enough to conclude "missing"; resolving
+/// a second time is what distinguishes the two.
+#[cfg(all(feature = "oauth", feature = "stateless"))]
+#[tokio::test]
+async fn an_operation_that_finds_nothing_reports_expiry_to_the_owner() {
+    fn as_principal(subject: &str) -> Extensions {
+        let mut extensions = tasks_client_extensions();
+        extensions.insert(crate::oauth::token::TokenClaims {
+            sub: Some(subject.to_string()),
+            iss: None,
+            aud: None,
+            exp: None,
+            scope: None,
+            client_id: None,
+            extra: HashMap::new(),
+        });
+        extensions
+    }
+
+    let store = std::sync::Arc::new(crate::async_task::MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(
+            ToolBuilder::new("optional_task")
+                .task_support(TaskSupportMode::Optional)
+                .handler(|input: AddInput| async move {
+                    Ok(CallToolResult::text(format!("{}", input.a + input.b)))
+                })
+                .build(),
+        )
+        .with_tasks();
+
+    let McpResponse::FinalCreateTask(created) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::CallTool(CallToolParams {
+                name: "optional_task".to_string(),
+                arguments: serde_json::json!({"a": 1, "b": 2}),
+                input_responses: None,
+                request_state: None,
+                meta: None,
+                task: None,
+            }),
+            as_principal("alice"),
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("Expected a final create-task response");
+    };
+    let task_id = created.task.metadata.task_id.clone();
+    assert!(store.set_ttl(&task_id, 1).await.unwrap());
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    // Each of get, update, and cancel must reach the same conclusion.
+    for (offset, request) in [
+        McpRequest::GetTaskInfo(GetTaskInfoParams {
+            task_id: task_id.clone(),
+            meta: None,
+        }),
+        McpRequest::UpdateTask(UpdateTaskParams {
+            task_id: task_id.clone(),
+            input_responses: Default::default(),
+            meta: None,
+        }),
+        McpRequest::CancelTask(CancelTaskParams {
+            task_id: task_id.clone(),
+            reason: None,
+            meta: None,
+        }),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let Err(crate::error::Error::JsonRpc(error)) = router
+            .handle(
+                RequestId::Number(10 + offset as i64),
+                request,
+                as_principal("alice"),
+            )
+            .await
+        else {
+            panic!("operation {offset} on an expired task must be refused");
+        };
+        assert_eq!(
+            error.data,
+            Some(serde_json::json!({ "reason": "task_expired" })),
+            "operation {offset} must tell the owner the task expired"
+        );
+    }
+}
+
+/// #1249: a late or duplicate `tasks/update` against a task the store still
+/// knows, and which has not expired, has nothing left to apply. That is an
+/// acknowledgement, not a not-found, so a client retry is idempotent.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn a_duplicate_update_on_a_terminal_task_is_acknowledged() {
+    let store = std::sync::Arc::new(crate::async_task::MemoryTaskStore::new());
+    let (task_id, _) = store
+        .create_task("work", serde_json::json!({}), Some(60_000), None)
+        .await
+        .unwrap();
+    // Terminal, so there is nothing an update could apply.
+    assert!(
+        store
+            .complete_task(&task_id, CallToolResult::text("done"))
+            .await
+            .unwrap()
+    );
+
+    let router = McpRouter::new().task_store(store.clone()).with_tasks();
+    let response = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::UpdateTask(UpdateTaskParams {
+                task_id: task_id.clone(),
+                input_responses: Default::default(),
+                meta: None,
+            }),
+            tasks_client_extensions(),
+        )
+        .await;
+
+    // The ack's shape depends on the lifecycle; both are acknowledgements.
+    assert!(
+        matches!(
+            response,
+            Ok(McpResponse::UpdateTask(_)) | Ok(McpResponse::FinalTaskAck(_))
+        ),
+        "a known, unexpired task with nothing to apply is acknowledged, not \
+         reported missing: {response:?}"
+    );
+}

--- a/crates/tower-mcp/tests/task_presence.rs
+++ b/crates/tower-mcp/tests/task_presence.rs
@@ -1,0 +1,219 @@
+//! Distinguishing an expired task from one that never existed (#1249).
+//!
+//! The distinction is useful to the owner and must never leak to anyone else.
+//! `tasks/get` on another principal's task id has to answer exactly as it does
+//! for an id that was never issued, whether that task is present, expired, or
+//! absent. Otherwise it becomes an existence oracle: a caller can enumerate
+//! task ids and learn which ones belong to somebody.
+//!
+//! These are store-level tests: they check that presence resolves correctly
+//! and carries the owner. They deliberately do NOT prove the security
+//! property, and it is worth being precise about why. The authorization
+//! decision lives in the router, so a store-level test cannot see an
+//! implementation that discloses expiry before checking ownership. I wrote one
+//! that tried, installed exactly that bug, and watched it pass.
+//!
+//! The test that does prove it is
+//! `router::tests::expiry_is_disclosed_to_the_owner_and_to_nobody_else`, which
+//! drives the router with two principals and was confirmed to fail against the
+//! naive implementation.
+
+#![cfg(feature = "stateless")]
+
+use std::sync::Arc;
+
+use serde_json::json;
+use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+use tower_mcp::async_task::{TaskPresence, owner_matches};
+use tower_mcp::protocol::CallToolResult;
+
+/// The whole point: an id belonging to someone else answers identically
+/// whether that task is present, expired, or was never issued.
+///
+/// This currently passes because everything collapses to "not found". It must
+/// keep passing once expired becomes distinguishable to the owner.
+#[tokio::test]
+async fn another_principals_tasks_are_indistinguishable_from_missing() {
+    let store = Arc::new(MemoryTaskStore::new());
+
+    // Owned by "alice", one long-lived and one that expires immediately.
+    let (present, _) = store
+        .create_task("work", json!({}), Some(60_000), Some("alice".into()))
+        .await
+        .expect("create");
+    let (expired, _) = store
+        .create_task("work", json!({}), Some(1), Some("alice".into()))
+        .await
+        .expect("create");
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    // Nothing was ever issued under this id.
+    let missing = "never-issued";
+
+    // As far as any other principal is concerned, all three are the same.
+    for id in [present.as_str(), expired.as_str(), missing] {
+        let owner = store.task_owner(id).await.expect("owner lookup");
+        let visible_to_bob = owner
+            .as_ref()
+            .is_some_and(|o| owner_matches(o, Some("bob")));
+        assert!(
+            !visible_to_bob,
+            "id {id} must not be attributable to another principal"
+        );
+    }
+}
+
+/// The owner gets the distinction the feature exists for.
+#[tokio::test]
+async fn the_owner_can_tell_expired_from_missing() {
+    let store = MemoryTaskStore::new();
+    let (expired, _) = store
+        .create_task("work", json!({}), Some(1), Some("alice".into()))
+        .await
+        .expect("create");
+    let (present, _) = store
+        .create_task("work", json!({}), Some(60_000), Some("alice".into()))
+        .await
+        .expect("create");
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+    assert!(
+        matches!(
+            store.task_presence(&expired).await.unwrap(),
+            TaskPresence::Expired { .. }
+        ),
+        "a retained record whose TTL elapsed is expired, not missing"
+    );
+    assert!(matches!(
+        store.task_presence(&present).await.unwrap(),
+        TaskPresence::Present { .. }
+    ));
+    assert_eq!(
+        store.task_presence("never-issued").await.unwrap(),
+        TaskPresence::Missing
+    );
+
+    // The owner travels with both, which is what lets the router authorize
+    // before disclosing the difference.
+    for id in [&expired, &present] {
+        assert_eq!(
+            store.task_presence(id).await.unwrap().owner(),
+            Some(&Some("alice".to_string())),
+            "presence must carry the owner for {id}"
+        );
+    }
+}
+
+/// A store that drops expired records answers `Missing`, which is correct for
+/// it. The default keeps every existing store compiling and behaving as before.
+#[tokio::test]
+async fn the_default_reports_missing_for_a_store_without_tombstones() {
+    struct Forgetful;
+
+    #[async_trait::async_trait]
+    impl TaskStore for Forgetful {
+        async fn create_task(
+            &self,
+            _tool: &str,
+            _args: serde_json::Value,
+            _ttl: Option<u64>,
+            _owner: Option<String>,
+        ) -> tower_mcp::async_task::Result<(String, tower_mcp::async_task::CancellationToken)>
+        {
+            unimplemented!("not exercised")
+        }
+        async fn task_owner(
+            &self,
+            _task_id: &str,
+        ) -> tower_mcp::async_task::Result<Option<Option<String>>> {
+            // Expired and unknown are the same to this store.
+            Ok(None)
+        }
+        async fn get_task(
+            &self,
+            _task_id: &str,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::protocol::TaskObject>> {
+            Ok(None)
+        }
+        async fn set_task_meta(
+            &self,
+            _task_id: &str,
+            _meta: serde_json::Value,
+        ) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn discard_task(&self, _task_id: &str) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn get_task_result(
+            &self,
+            _task_id: &str,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::async_task::TaskSnapshot>> {
+            Ok(None)
+        }
+        async fn wait_for_completion(
+            &self,
+            _task_id: &str,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::async_task::TaskSnapshot>> {
+            Ok(None)
+        }
+        async fn list_tasks(
+            &self,
+            _status: Option<tower_mcp::protocol::TaskStatus>,
+        ) -> tower_mcp::async_task::Result<Vec<tower_mcp::protocol::TaskObject>> {
+            Ok(Vec::new())
+        }
+        async fn require_input(
+            &self,
+            _task_id: &str,
+            _requests: tower_mcp::protocol::InputRequests,
+            _message: Option<&str>,
+        ) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn outstanding_input_requests(
+            &self,
+            _task_id: &str,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::protocol::InputRequests>> {
+            Ok(None)
+        }
+        async fn apply_input_responses(
+            &self,
+            _task_id: &str,
+            _responses: tower_mcp::protocol::InputResponses,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::async_task::AppliedInputResponses>>
+        {
+            Ok(None)
+        }
+        async fn set_ttl(&self, _task_id: &str, _ttl: u64) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn complete_task(
+            &self,
+            _task_id: &str,
+            _result: CallToolResult,
+        ) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn fail_task(
+            &self,
+            _task_id: &str,
+            _error: tower_mcp::JsonRpcError,
+        ) -> tower_mcp::async_task::Result<bool> {
+            Ok(false)
+        }
+        async fn cancel_task(
+            &self,
+            _task_id: &str,
+            _reason: Option<&str>,
+        ) -> tower_mcp::async_task::Result<Option<tower_mcp::protocol::TaskObject>> {
+            Ok(None)
+        }
+    }
+
+    assert_eq!(
+        Forgetful.task_presence("anything").await.unwrap(),
+        TaskPresence::Missing,
+        "the default must preserve today's behaviour for a store that keeps no tombstones"
+    );
+}


### PR DESCRIPTION
Claiming #1249. **Work in progress, do not duplicate.**

Implementing the design in the issue discussion, not the original issue text. The original scoped this to a typed `get_task` return, which is insufficient: ownership lookup and get/update/cancel all collapse expired and missing today.

## Shape

```rust
pub enum TaskPresence {
    Present { owner: TaskOwner },
    Expired { owner: TaskOwner },
    Missing,
}
```

Defaulted `task_presence` on `TaskStore`, so existing stores compile unchanged and keep today `None => Missing` behaviour. The router resolves and authorizes through it, and when an existing operation then returns `None` or `false`, resolves once more to classify. That second resolution closes the expire-between-authorization-and-operation race while leaving successful operations linearized at their store call.

## The security property is the actual requirement

`Expired` carries the owner because **authorization has to happen before the distinction is revealed**. A present or expired task belonging to another principal must stay indistinguishable from `Missing`, or `tasks/get` becomes an existence oracle for other owners task ids.

I am writing that test first and confirming it fails against a naive implementation before building the rest. A security property that has not been seen to fail is not pinned.

## Also in scope

A late or duplicate `tasks/update` against a known, unexpired, terminal task returns the empty successful acknowledgement rather than not-found. The task is known and there is nothing left to apply, which makes retries idempotent.

## Compatibility

`MemoryTaskStore` overrides `task_presence` since it already retains expired entries. Decorators need documenting to forward it when the wrapped store supports tombstones. `task_owner` stays as the compatibility primitive.