### PR TITLE
fix(session): require an initialize request before initialized opens a session

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -4583,6 +4583,11 @@ impl McpRouter {
                     } else {
                         tracing::info!("Session initialized, entering operation phase");
                     }
+                } else if phase_before == crate::session::SessionPhase::Uninitialized {
+                    tracing::warn!(
+                        "Ignoring initialized notification: no initialize request has been \
+                         received for this session"
+                    );
                 } else {
                     tracing::warn!(
                         phase = ?self.session.phase(),

--- a/crates/tower-mcp/src/session.rs
+++ b/crates/tower-mcp/src/session.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use crate::router::Extensions;
 
@@ -68,6 +68,7 @@ impl From<u8> for SessionPhase {
 #[derive(Clone)]
 pub struct SessionState {
     phase: Arc<AtomicU8>,
+    handshake_started: Arc<AtomicBool>,
     extensions: Arc<RwLock<Extensions>>,
 }
 
@@ -82,6 +83,7 @@ impl SessionState {
     pub fn new() -> Self {
         Self {
             phase: Arc::new(AtomicU8::new(SessionPhase::Uninitialized as u8)),
+            handshake_started: Arc::new(AtomicBool::new(false)),
             extensions: Arc::new(RwLock::new(Extensions::new())),
         }
     }
@@ -138,10 +140,37 @@ impl SessionState {
         self.phase() == SessionPhase::Initialized
     }
 
+    /// Record that an `initialize` request has been received for this session.
+    ///
+    /// Transports that create a session *in response to* an `initialize` frame
+    /// call this at the front door, before the request is dispatched. That is
+    /// what lets [`mark_initialized`](Self::mark_initialized) tell the #458
+    /// race (the `initialized` notification overtook a dispatch that is still
+    /// running) apart from a client that never sent `initialize` at all.
+    ///
+    /// [`mark_initializing`](Self::mark_initializing) also sets this, so a
+    /// transport that dispatches `initialize` in frame order does not need to
+    /// call it. Idempotent, and never cleared.
+    pub fn mark_handshake_started(&self) {
+        self.handshake_started.store(true, Ordering::Release);
+    }
+
+    /// Whether an `initialize` request has been received for this session.
+    ///
+    /// False for a fresh session, and for one a client is trying to open with
+    /// an unsolicited `initialized` notification.
+    pub fn handshake_started(&self) -> bool {
+        self.handshake_started.load(Ordering::Acquire)
+    }
+
     /// Transition from Uninitialized to Initializing.
     /// Called after responding to an `initialize` request.
     /// Returns true if the transition was successful.
+    ///
+    /// Also records that the handshake has started, so the notification that
+    /// follows can complete it.
     pub fn mark_initializing(&self) -> bool {
+        self.mark_handshake_started();
         self.phase
             .compare_exchange(
                 SessionPhase::Uninitialized as u8,
@@ -155,11 +184,18 @@ impl SessionState {
     /// Transition to Initialized phase.
     /// Called when receiving an `initialized` notification.
     ///
-    /// Accepts transitions from both `Initializing` and `Uninitialized` states.
-    /// The `Uninitialized → Initialized` path handles a race condition in HTTP
-    /// transports where the client sends the `initialized` notification before
-    /// the server has finished processing the `initialize` request (the session
-    /// is stored in `Uninitialized` state before the request is dispatched).
+    /// Accepts `Initializing → Initialized`, and `Uninitialized → Initialized`
+    /// only once [`mark_handshake_started`](Self::mark_handshake_started) has
+    /// run. The latter path handles a race in HTTP transports where the client
+    /// sends the `initialized` notification before the server has finished
+    /// processing the `initialize` request (#458); the handshake flag is what
+    /// keeps it from also accepting a client that skipped `initialize`, which
+    /// would leave the server serving a peer whose protocol version and
+    /// capabilities it never learned.
+    ///
+    /// Transports that serve without a handshake by design (restored sessions,
+    /// `optional_sessions`, the stateless 2026-07-28 path) want
+    /// [`mark_preinitialized`](Self::mark_preinitialized) instead.
     ///
     /// Returns true if the transition was successful.
     pub fn mark_initialized(&self) -> bool {
@@ -177,9 +213,13 @@ impl SessionState {
             return true;
         }
 
-        // Handle the race: Uninitialized → Initialized
-        // This occurs when the initialized notification arrives before
-        // the initialize request has been fully processed.
+        // Handle the race: Uninitialized → Initialized, but only for a session
+        // that has actually seen an `initialize` request. Without that check a
+        // single unsolicited notification opens the whole surface.
+        if !self.handshake_started() {
+            return false;
+        }
+
         self.phase
             .compare_exchange(
                 SessionPhase::Uninitialized as u8,
@@ -188,6 +228,25 @@ impl SessionState {
                 Ordering::Acquire,
             )
             .is_ok()
+    }
+
+    /// Move the session straight to `Initialized`, no handshake required.
+    ///
+    /// For transports that serve requests without an `initialize` exchange
+    /// because the protocol or the deployment says they should: a session
+    /// restored from a store (it was initialized on another instance), the
+    /// `optional_sessions` opt-in for clients that do not carry a session ID
+    /// forward, and the stateless 2026-07-28 path, which has no handshake at
+    /// all.
+    ///
+    /// This is a server-side decision, unlike
+    /// [`mark_initialized`](Self::mark_initialized), which acts on a frame the
+    /// client sent. Returns true if the phase changed.
+    pub fn mark_preinitialized(&self) -> bool {
+        self.mark_handshake_started();
+        self.phase
+            .swap(SessionPhase::Initialized as u8, Ordering::AcqRel)
+            != SessionPhase::Initialized as u8
     }
 
     /// Check if a request method is allowed in the current phase.
@@ -214,6 +273,8 @@ mod tests {
     enum LifecycleOperation {
         MarkInitializing,
         MarkInitialized,
+        MarkHandshakeStarted,
+        MarkPreinitialized,
         CheckRequest(String),
     }
 
@@ -221,6 +282,8 @@ mod tests {
         prop_oneof![
             Just(LifecycleOperation::MarkInitializing),
             Just(LifecycleOperation::MarkInitialized),
+            Just(LifecycleOperation::MarkHandshakeStarted),
+            Just(LifecycleOperation::MarkPreinitialized),
             prop_oneof![
                 Just("initialize".to_string()),
                 Just("ping".to_string()),
@@ -243,22 +306,40 @@ mod tests {
         ) {
             let session = SessionState::new();
             let mut expected_phase = SessionPhase::Uninitialized;
+            let mut expected_handshake = false;
 
             for operation in operations {
                 match operation {
                     LifecycleOperation::MarkInitializing => {
                         let expected_success = expected_phase == SessionPhase::Uninitialized;
                         prop_assert_eq!(session.mark_initializing(), expected_success);
+                        expected_handshake = true;
                         if expected_success {
                             expected_phase = SessionPhase::Initializing;
                         }
                     }
                     LifecycleOperation::MarkInitialized => {
-                        let expected_success = expected_phase != SessionPhase::Initialized;
+                        // Uninitialized only advances once the handshake has
+                        // been recorded; Initializing always does.
+                        let expected_success = match expected_phase {
+                            SessionPhase::Initializing => true,
+                            SessionPhase::Uninitialized => expected_handshake,
+                            SessionPhase::Initialized => false,
+                        };
                         prop_assert_eq!(session.mark_initialized(), expected_success);
                         if expected_success {
                             expected_phase = SessionPhase::Initialized;
                         }
+                    }
+                    LifecycleOperation::MarkHandshakeStarted => {
+                        session.mark_handshake_started();
+                        expected_handshake = true;
+                    }
+                    LifecycleOperation::MarkPreinitialized => {
+                        let expected_success = expected_phase != SessionPhase::Initialized;
+                        prop_assert_eq!(session.mark_preinitialized(), expected_success);
+                        expected_handshake = true;
+                        expected_phase = SessionPhase::Initialized;
                     }
                     LifecycleOperation::CheckRequest(method) => {
                         let expected_allowed = expected_phase != SessionPhase::Uninitialized
@@ -273,10 +354,14 @@ mod tests {
                     }
                 }
                 prop_assert_eq!(session.phase(), expected_phase);
+                prop_assert_eq!(session.handshake_started(), expected_handshake);
                 prop_assert_eq!(
                     session.is_initialized(),
                     expected_phase == SessionPhase::Initialized
                 );
+                // The invariant the phase is a proxy for: a session can only
+                // be serving if an initialize was seen or the server waived it.
+                prop_assert!(expected_phase != SessionPhase::Initialized || expected_handshake);
             }
         }
     }
@@ -381,13 +466,15 @@ mod tests {
         assert_eq!(session1.get::<String>(), Some("world".to_string()));
     }
 
+    /// The #458 race: the `initialized` notification arrives before the
+    /// `initialize` request has finished dispatching, so the phase is still
+    /// Uninitialized. The transport recorded the handshake when it created the
+    /// session, so the notification still completes it.
     #[test]
-    fn test_mark_initialized_from_uninitialized() {
+    fn test_mark_initialized_from_uninitialized_after_handshake_started() {
         let session = SessionState::new();
+        session.mark_handshake_started();
 
-        // Start in Uninitialized, skip straight to Initialized
-        // This handles the race where `initialized` notification arrives
-        // before the `initialize` request is fully processed.
         assert_eq!(session.phase(), SessionPhase::Uninitialized);
         assert!(session.mark_initialized());
         assert_eq!(session.phase(), SessionPhase::Initialized);
@@ -396,6 +483,74 @@ mod tests {
         // All requests allowed
         assert!(session.is_request_allowed("tools/list"));
         assert!(session.is_request_allowed("ping"));
+    }
+
+    /// #1269: without a handshake there is nothing to complete. A client that
+    /// sends only the notification has negotiated no protocol version and
+    /// declared no capabilities, so the guard must hold.
+    #[test]
+    fn test_mark_initialized_from_uninitialized_without_handshake_is_refused() {
+        let session = SessionState::new();
+
+        assert!(!session.handshake_started());
+        assert!(!session.mark_initialized());
+        assert_eq!(session.phase(), SessionPhase::Uninitialized);
+        assert!(!session.is_initialized());
+
+        // The pre-initialize guard still applies.
+        assert!(!session.is_request_allowed("tools/list"));
+        assert!(session.is_request_allowed("initialize"));
+        assert!(session.is_request_allowed("ping"));
+
+        // And a repeat does not wear it down.
+        assert!(!session.mark_initialized());
+        assert!(!session.mark_initialized());
+        assert_eq!(session.phase(), SessionPhase::Uninitialized);
+    }
+
+    /// A refused notification must not poison the real handshake that follows.
+    #[test]
+    fn test_handshake_still_works_after_a_refused_notification() {
+        let session = SessionState::new();
+
+        assert!(!session.mark_initialized());
+        assert!(session.mark_initializing());
+        assert_eq!(session.phase(), SessionPhase::Initializing);
+        assert!(session.mark_initialized());
+        assert!(session.is_initialized());
+    }
+
+    /// Server-side promotion needs no handshake, and works from either phase.
+    #[test]
+    fn test_mark_preinitialized_skips_the_handshake() {
+        let session = SessionState::new();
+        assert!(session.mark_preinitialized());
+        assert_eq!(session.phase(), SessionPhase::Initialized);
+        assert!(session.handshake_started());
+        assert!(session.is_request_allowed("tools/list"));
+
+        // Already there: no change to report.
+        assert!(!session.mark_preinitialized());
+
+        // From Initializing as well.
+        let mid = SessionState::new();
+        mid.mark_initializing();
+        assert!(mid.mark_preinitialized());
+        assert_eq!(mid.phase(), SessionPhase::Initialized);
+    }
+
+    #[test]
+    fn test_handshake_flag_is_shared_across_clones() {
+        let session1 = SessionState::new();
+        let session2 = session1.clone();
+
+        assert!(!session2.handshake_started());
+        session1.mark_handshake_started();
+        assert!(session2.handshake_started());
+
+        // Which means the clone can absorb the race too.
+        assert!(session2.mark_initialized());
+        assert!(session1.is_initialized());
     }
 
     #[test]

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -508,7 +508,7 @@ impl Session {
     ) -> Self {
         // Skip the Initializing intermediate state — this session was
         // already initialized on the original instance.
-        router.session().mark_initialized();
+        router.session().mark_preinitialized();
 
         let (notifications_tx, _) = broadcast::channel(100);
         let (notif_sender, mut notif_receiver) = notification_channel(256);
@@ -872,11 +872,20 @@ impl SessionRegistry {
         }
     }
 
+    /// Create a session for an incoming `initialize` request.
+    ///
+    /// Only reached from the `is_init` branch of the POST handler, so the
+    /// handshake is recorded here, before the request is dispatched. A client
+    /// whose `initialized` notification overtakes that dispatch (#458) then
+    /// still completes the handshake, while one that never sent `initialize`
+    /// has no session for the notification to open.
     async fn create(
         &self,
         router: McpRouter,
         service_factory: ServiceFactory,
     ) -> Option<Arc<Session>> {
+        router.session().mark_handshake_started();
+
         let session = {
             let mut sessions = self.sessions.write().await;
 
@@ -940,7 +949,7 @@ impl SessionRegistry {
         service_factory: ServiceFactory,
     ) -> Option<Arc<Session>> {
         // Pre-initialize the router's session state so it won't reject requests
-        router.session().mark_initialized();
+        router.session().mark_preinitialized();
 
         let session = {
             let mut sessions = self.sessions.write().await;
@@ -3239,7 +3248,7 @@ async fn handle_post(
                     let ephemeral = router
                         .with_fresh_session()
                         .with_request_notification_sender(notif_tx);
-                    ephemeral.session().mark_initialized();
+                    ephemeral.session().mark_preinitialized();
                     JsonRpcService::new(factory(ephemeral))
                 }
                 ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
@@ -3446,7 +3455,7 @@ async fn handle_post(
             let mut service = match &state.service_source {
                 ServiceSource::Router { router, factory } => {
                     let ephemeral = router.with_fresh_session();
-                    ephemeral.session().mark_initialized();
+                    ephemeral.session().mark_preinitialized();
                     JsonRpcService::new(factory(ephemeral))
                 }
                 ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
@@ -4455,7 +4464,7 @@ async fn handle_modern_subscriptions_listen_sse(
     let service = match &state.service_source {
         ServiceSource::Router { router, factory } => {
             let ephemeral = router.with_fresh_session();
-            ephemeral.session().mark_initialized();
+            ephemeral.session().mark_preinitialized();
             JsonRpcService::new(factory(ephemeral))
         }
         ServiceSource::Service(mutex) => JsonRpcService::new(mutex.lock().unwrap().clone()),
@@ -6544,6 +6553,92 @@ mod tests {
             json.get("result").is_some(),
             "expected tools/list result, got {json}"
         );
+    }
+
+    fn test_session_registry() -> SessionRegistry {
+        SessionRegistry::new(
+            SessionConfig::default(),
+            false,
+            Arc::new(crate::session_store::MemorySessionStore::new()),
+            Arc::new(crate::event_store::MemoryEventStore::new()),
+            ServiceSource::Router {
+                router: create_test_router(),
+                factory: crate::transport::service::identity_factory(),
+            },
+            false,
+        )
+    }
+
+    /// #458: the `initialized` notification can beat the `initialize` dispatch,
+    /// so it finds the session still `Uninitialized`. The session exists only
+    /// because an `initialize` request arrived, so the handshake completes
+    /// anyway and the follow-up list requests are served.
+    ///
+    /// This is the case the `Uninitialized -> Initialized` path exists for, and
+    /// the one #1269 had to preserve while closing the bypass.
+    #[tokio::test]
+    async fn test_early_initialized_notification_still_completes_the_handshake() {
+        let registry = test_session_registry();
+        let session = registry
+            .create(
+                create_test_router().with_fresh_session(),
+                crate::transport::service::identity_factory(),
+            )
+            .await
+            .expect("session creation");
+
+        let SessionServiceSource::Router { router, .. } = &session.service_source else {
+            panic!("expected a router-backed session");
+        };
+
+        // The dispatch has not run yet, so the phase has not advanced.
+        assert_eq!(router.session().phase(), crate::SessionPhase::Uninitialized);
+        assert!(
+            router.session().handshake_started(),
+            "creating a session for an initialize request records the handshake"
+        );
+
+        session.handle_notification(McpNotification::Initialized);
+
+        assert!(
+            router.session().is_initialized(),
+            "the notification must still complete a handshake that is in flight"
+        );
+        assert!(router.session().is_request_allowed("tools/list"));
+    }
+
+    /// #1269, the other side of the same coin: a session that no `initialize`
+    /// ever reached is not opened by the notification alone.
+    #[tokio::test]
+    async fn test_initialized_notification_alone_does_not_open_a_session() {
+        let router = create_test_router().with_fresh_session();
+        assert!(!router.session().handshake_started());
+
+        router.handle_notification(McpNotification::Initialized);
+
+        assert_eq!(router.session().phase(), crate::SessionPhase::Uninitialized);
+        assert!(!router.session().is_request_allowed("tools/list"));
+    }
+
+    /// The `optional_sessions` opt-in still serves clients that skip the
+    /// handshake entirely. That is a server-side decision, so it goes through
+    /// `mark_preinitialized` rather than riding on the #458 race allowance.
+    #[tokio::test]
+    async fn test_optional_sessions_still_serves_without_a_handshake() {
+        let registry = test_session_registry();
+        let session = registry
+            .create_initialized(
+                create_test_router().with_fresh_session(),
+                crate::transport::service::identity_factory(),
+            )
+            .await
+            .expect("session creation");
+
+        let SessionServiceSource::Router { router, .. } = &session.service_source else {
+            panic!("expected a router-backed session");
+        };
+        assert!(router.session().is_initialized());
+        assert!(router.session().is_request_allowed("tools/list"));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/adversarial_input.rs
+++ b/crates/tower-mcp/tests/adversarial_input.rs
@@ -5,7 +5,7 @@
 //! on the wire: duplicate ids, stale notifications, malformed envelopes,
 //! out-of-order lifecycle traffic, and handlers that misbehave.
 //!
-//! Three tests are `#[ignore]`d. Each one asserts the behaviour the code should
+//! Two tests are `#[ignore]`d. Each one asserts the behaviour the code should
 //! have and fails against the behaviour it has today; the attribute carries
 //! the reason. Run them with `cargo test --test adversarial_input -- --ignored`
 //! to reproduce every finding.
@@ -747,12 +747,11 @@ async fn a_repeated_initialized_notification_is_harmless() {
 /// server has negotiated no protocol version and learned no client
 /// capabilities, so the pre-initialize guard still has to hold.
 ///
-/// Today `SessionState::mark_initialized` accepts `Uninitialized ->
-/// Initialized` to absorb an HTTP race (#458), and nothing distinguishes that
-/// race from a client that simply never sent `initialize`. One notification
-/// unlocks the whole surface.
+/// `SessionState::mark_initialized` accepts `Uninitialized -> Initialized` to
+/// absorb an HTTP race (#458), but only once an `initialize` request has been
+/// seen for the session. Without that, one notification would unlock the whole
+/// surface (#1269).
 #[tokio::test]
-#[ignore = "BUG: SessionState::mark_initialized promotes Uninitialized straight to Initialized, so notifications/initialized alone skips the handshake"]
 async fn initialized_before_initialize_does_not_open_the_session() {
     let mut server = Server::with_router(base_router());
 


### PR DESCRIPTION
Closes #1269.

`notifications/initialized` sent as the very first frame opens the session.
`tools/list` then returns the full tool list instead of `-32600`, with no
protocol version negotiated and no client capabilities declared.

The cause is `SessionState::mark_initialized`, which accepts
`Uninitialized -> Initialized` as well as `Initializing -> Initialized`.
That allowance is deliberate: #458 was a real report from Claude Code
2.1.34, where the `initialized` notification lost a race against the
`initialize` dispatch and the follow-up list requests were rejected. The
problem is that nothing distinguishes that race from a client that never
handshook at all.

## Approach

The two cases differ in a fact the server already knows: in the #458 race
an `initialize` request *was* received for the session, it just had not
finished dispatching. In the bug it never arrived.

So track that fact explicitly, separately from the phase:

- `SessionState` gains a `handshake_started` flag.
- `mark_initializing` sets it, so any transport that dispatches
  `initialize` in frame order (stdio, WebSocket) needs no change.
- `mark_initialized` keeps the `Uninitialized -> Initialized` path, but
  only when the flag is set. Without it the notification is ignored and
  the pre-initialize guard holds.
- Transports that create a session *because* an `initialize` frame arrived
  set the flag at the front door, before dispatch, which is what closes the
  #458 window rather than merely narrowing it.

Paths that legitimately serve without a handshake get an explicit method
rather than riding on the race allowance:

- `Session::restored` (the session was initialized on another instance)
- `create_initialized` (the `optional_sessions` opt-in)
- the three stateless 2026-07-28 ephemeral sessions, where the protocol
  has no handshake by design

## Plan

- [ ] `handshake_started` flag and `mark_preinitialized` on `SessionState`
- [ ] gate the `Uninitialized -> Initialized` path on the flag
- [ ] mark the flag in `SessionRegistry::create` (only reached for `initialize`)
- [ ] move the five pre-initialized call sites off `mark_initialized`
- [ ] un-`#[ignore]` `initialized_before_initialize_does_not_open_the_session`
- [ ] regression test for the #458 race itself, which had none
- [ ] update the lifecycle proptest model and the unit tests that assert
      the old behaviour
