### PR TITLE
fix(router): key the in-flight registry by dispatch, not request id

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -6,6 +6,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::task::{Context, Poll};
 
@@ -581,8 +582,16 @@ struct McpRouterInner {
     /// the router needs a handle to wake it when `tasks/update` commits and
     /// to signal it when `tasks/cancel` arrives.
     live_tasks: Arc<Mutex<HashMap<String, Arc<crate::tool::LiveTask>>>>,
-    /// In-flight requests for cancellation tracking (shared across clones)
-    in_flight: Arc<RwLock<HashMap<RequestId, CancellationToken>>>,
+    /// In-flight requests for cancellation tracking (shared across clones).
+    ///
+    /// Keyed by request id for lookup, but each id holds one entry per
+    /// *dispatch*. A client should not reuse an id that is still in flight,
+    /// but when one does, the twins have to coexist: keyed by id alone the
+    /// second registration evicted the first and the first became
+    /// uncancellable (#1270).
+    in_flight: Arc<RwLock<HashMap<RequestId, Vec<InFlightDispatch>>>>,
+    /// Source of the per-dispatch ids in `in_flight`, shared across clones.
+    next_dispatch: Arc<AtomicU64>,
     /// Channel for sending notifications to connected clients
     notification_tx: Option<NotificationSender>,
     /// Transport-lifetime sink for final HTTP subscription notifications.
@@ -759,6 +768,7 @@ impl McpRouter {
                 advertise_resource_subscriptions: true,
                 live_tasks: Arc::new(Mutex::new(HashMap::new())),
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
+                next_dispatch: Arc::new(AtomicU64::new(0)),
                 notification_tx: None,
                 #[cfg(all(feature = "http", feature = "stateless"))]
                 modern_notification_sink: Arc::new(RwLock::new(None)),
@@ -1270,32 +1280,89 @@ impl McpRouter {
         // Set up log level filtering
         let ctx = ctx.with_min_log_level(self.inner.min_log_level.clone());
 
-        // Register for cancellation tracking
-        let token = ctx.cancellation_token();
-        if let Ok(mut in_flight) = self.inner.in_flight.write() {
-            in_flight.insert(request_id, token);
-        }
+        // Register for cancellation tracking. `Service::call` mints the
+        // dispatch id and threads it through the extensions so the guard it
+        // holds and this registration name the same entry; a caller driving
+        // the router directly gets a fresh one.
+        let dispatch = per_request
+            .get::<DispatchId>()
+            .copied()
+            .unwrap_or_else(|| self.next_dispatch());
+        self.register_in_flight(request_id, dispatch, ctx.cancellation_token());
 
         ctx
     }
 
-    /// Remove a request from tracking (called when request completes)
+    /// Allocate a dispatch id, unique for the lifetime of this router.
+    fn next_dispatch(&self) -> DispatchId {
+        DispatchId(
+            self.inner
+                .next_dispatch
+                .fetch_add(1, AtomicOrdering::Relaxed),
+        )
+    }
+
+    /// Track one dispatch for cancellation.
+    ///
+    /// Appends rather than overwrites: a client that reuses an id which is
+    /// still in flight gets both requests tracked, so cancelling the id can
+    /// still reach both (#1270).
+    fn register_in_flight(
+        &self,
+        request_id: RequestId,
+        dispatch: DispatchId,
+        token: CancellationToken,
+    ) {
+        if let Ok(mut in_flight) = self.inner.in_flight.write() {
+            in_flight
+                .entry(request_id)
+                .or_default()
+                .push(InFlightDispatch { dispatch, token });
+        }
+    }
+
+    /// Stop tracking one dispatch, leaving any twin under the same id alone.
+    fn complete_dispatch(&self, request_id: &RequestId, dispatch: DispatchId) {
+        if let Ok(mut in_flight) = self.inner.in_flight.write()
+            && let Some(entries) = in_flight.get_mut(request_id)
+        {
+            entries.retain(|entry| entry.dispatch != dispatch);
+            if entries.is_empty() {
+                in_flight.remove(request_id);
+            }
+        }
+    }
+
+    /// Remove a request from tracking (called when request completes).
+    ///
+    /// Untracks *every* dispatch under `request_id`, which is the only
+    /// granularity this signature offers. Requests dispatched through
+    /// [`Service::call`] do not need it: each holds a guard that untracks its
+    /// own dispatch when the future completes, is dropped, or unwinds. It
+    /// remains for callers driving [`McpRouter::create_context`] and request
+    /// handling themselves.
     pub fn complete_request(&self, request_id: &RequestId) {
         if let Ok(mut in_flight) = self.inner.in_flight.write() {
             in_flight.remove(request_id);
         }
     }
 
-    /// Cancel a tracked request
+    /// Cancel a tracked request.
+    ///
+    /// Cancels every dispatch still running under `request_id`. The id is the
+    /// only handle a client has, so a client that reused one in flight gets
+    /// both stopped rather than an arbitrary one.
     fn cancel_request(&self, request_id: &RequestId) -> bool {
         let Ok(in_flight) = self.inner.in_flight.read() else {
             return false;
         };
-        let Some(token) = in_flight.get(request_id) else {
+        let Some(entries) = in_flight.get(request_id) else {
             return false;
         };
-        token.cancel();
-        true
+        for entry in entries {
+            entry.token.cancel();
+        }
+        !entries.is_empty()
     }
 
     /// Whether to advertise `resources.subscribe` when resources exist.
@@ -4847,6 +4914,40 @@ impl RouterResponse {
     }
 }
 
+/// Identifies one dispatch of one request, unique for a router's lifetime.
+///
+/// The request id cannot play this role: a client may reuse one that is still
+/// in flight, and two requests sharing an id must still be tracked separately
+/// (#1270). Minted by [`Service::call`] and passed to the handler through the
+/// request extensions so the registration and the guard name the same entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DispatchId(u64);
+
+/// One tracked dispatch in the router's in-flight registry.
+struct InFlightDispatch {
+    dispatch: DispatchId,
+    token: CancellationToken,
+}
+
+/// Untracks a single dispatch when the request future ends, however it ends.
+///
+/// Removal used to sit on the success path in [`Service::call`], so a future
+/// dropped before that point (a timeout layer firing, an HTTP client
+/// disconnecting, a handler unwinding) left its entry in the registry for the
+/// process lifetime. `Drop` runs on every one of those paths.
+struct InFlightGuard {
+    router: McpRouter,
+    request_id: RequestId,
+    dispatch: DispatchId,
+}
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.router
+            .complete_dispatch(&self.request_id, self.dispatch);
+    }
+}
+
 impl Service<RouterRequest> for McpRouter {
     type Response = RouterResponse;
     type Error = std::convert::Infallible; // Errors are in the response
@@ -4857,13 +4958,22 @@ impl Service<RouterRequest> for McpRouter {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: RouterRequest) -> Self::Future {
+    fn call(&mut self, mut req: RouterRequest) -> Self::Future {
         let router = self.clone();
         let request_id = req.id.clone();
+
+        // Name the dispatch before `handle` builds its context, so the
+        // registration inside and the guard out here refer to the same entry.
+        let dispatch = router.next_dispatch();
+        req.extensions.insert(dispatch);
+
         Box::pin(async move {
+            let _tracked = InFlightGuard {
+                router: router.clone(),
+                request_id: request_id.clone(),
+                dispatch,
+            };
             let result = router.handle(req.id, req.inner, req.extensions).await;
-            // Clean up tracking after request completes
-            router.complete_request(&request_id);
             Ok(RouterResponse {
                 id: request_id,
                 // Map tower-mcp errors to JSON-RPC errors:

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -2798,6 +2798,109 @@ async fn test_task_lifecycle_complete() {
     }
 }
 
+/// Build a router whose one tool parks for longer than any test will wait.
+async fn parked_router() -> McpRouter {
+    let parked = ToolBuilder::new("park")
+        .description("Never finishes on its own")
+        .handler(|_input: serde_json::Value| async move {
+            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            Ok(CallToolResult::text("unreachable"))
+        })
+        .build();
+    let mut router = McpRouter::new().tool(parked);
+    init_router(&mut router).await;
+    router
+}
+
+fn park_request(id: i64) -> RouterRequest {
+    RouterRequest {
+        id: RequestId::Number(id),
+        inner: McpRequest::CallTool(CallToolParams {
+            name: "park".to_string(),
+            arguments: serde_json::json!({}),
+            input_responses: None,
+            request_state: None,
+            meta: None,
+            task: None,
+        }),
+        extensions: Extensions::new(),
+    }
+}
+
+fn tracked_dispatches(router: &McpRouter, id: &RequestId) -> usize {
+    router
+        .inner
+        .in_flight
+        .read()
+        .unwrap()
+        .get(id)
+        .map_or(0, Vec::len)
+}
+
+/// #1270: tracking was removed on the success path in `Service::call`, so a
+/// future dropped before reaching it left its entry behind for the process
+/// lifetime. A timeout layer firing or an HTTP client disconnecting does
+/// exactly that.
+#[tokio::test]
+async fn dropping_a_request_future_untracks_it() {
+    let router = parked_router().await;
+    let id = RequestId::Number(1);
+
+    let mut service = router.clone();
+    let mut future = Box::pin(service.call(park_request(1)));
+
+    // Poll it far enough to reach the handler, which parks.
+    let polled = tokio::time::timeout(std::time::Duration::from_millis(100), &mut future).await;
+    assert!(polled.is_err(), "the parked handler must not have finished");
+    assert_eq!(
+        tracked_dispatches(&router, &id),
+        1,
+        "an in-flight request must be tracked, or this test proves nothing"
+    );
+
+    drop(future);
+
+    assert_eq!(
+        tracked_dispatches(&router, &id),
+        0,
+        "dropping the future must untrack the request"
+    );
+    assert!(router.inner.in_flight.read().unwrap().is_empty());
+}
+
+/// The counterpart to the two duplicate-id tests in `adversarial_input.rs`,
+/// asserted against the registry rather than through the wire: twins under one
+/// id coexist, and each drop removes only its own dispatch.
+#[tokio::test]
+async fn twin_dispatches_under_one_id_are_tracked_and_removed_independently() {
+    let router = parked_router().await;
+    let id = RequestId::Number(7);
+
+    let mut first_service = router.clone();
+    let mut first = Box::pin(first_service.call(park_request(7)));
+    let _ = tokio::time::timeout(std::time::Duration::from_millis(100), &mut first).await;
+
+    let mut second_service = router.clone();
+    let mut second = Box::pin(second_service.call(park_request(7)));
+    let _ = tokio::time::timeout(std::time::Duration::from_millis(100), &mut second).await;
+
+    assert_eq!(
+        tracked_dispatches(&router, &id),
+        2,
+        "the second registration must not evict the first"
+    );
+
+    drop(first);
+    assert_eq!(
+        tracked_dispatches(&router, &id),
+        1,
+        "one request ending must leave its twin tracked"
+    );
+
+    drop(second);
+    assert_eq!(tracked_dispatches(&router, &id), 0);
+}
+
 #[tokio::test]
 async fn test_task_cancellation() {
     // Use a slow tool to test cancellation

--- a/crates/tower-mcp/tests/adversarial_input.rs
+++ b/crates/tower-mcp/tests/adversarial_input.rs
@@ -5,10 +5,11 @@
 //! on the wire: duplicate ids, stale notifications, malformed envelopes,
 //! out-of-order lifecycle traffic, and handlers that misbehave.
 //!
-//! Three tests are `#[ignore]`d. Each one asserts the behaviour the code should
-//! have and fails against the behaviour it has today; the attribute carries
-//! the reason. Run them with `cargo test --test adversarial_input -- --ignored`
-//! to reproduce every finding.
+//! One test is `#[ignore]`d. It asserts the behaviour the code should have and
+//! fails against the behaviour it has today; the attribute carries the reason.
+//! Run it with `cargo test --test adversarial_input -- --ignored`. Tests whose
+//! finding has since been fixed keep the issue number in their doc comment, so
+//! the regression each one guards stays legible.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -300,11 +301,10 @@ async fn concurrent_calls_under_distinct_ids_are_independently_cancellable() {
 /// Two in-flight requests share one id. Cancelling that id must reach every
 /// request still running under it: the id is the only handle a client has.
 ///
-/// Today `McpRouter` tracks in-flight work in a `HashMap<RequestId, _>`, so
-/// the second registration evicts the first and only the last request to
-/// arrive is reachable. The first runs to completion after its cancellation.
+/// `McpRouter` tracks in-flight work per dispatch, keyed by id for lookup, so
+/// the twins coexist. Keyed by id alone the second registration evicted the
+/// first and only the last arrival was reachable (#1270).
 #[tokio::test]
-#[ignore = "BUG: McpRouter::in_flight is keyed by RequestId alone, so a duplicate id evicts the first request's cancellation token"]
 async fn cancelling_a_duplicated_id_reaches_every_request_using_it() {
     let mut server = Server::with_router(base_router());
     server.initialize().await;
@@ -334,10 +334,10 @@ async fn cancelling_a_duplicated_id_reaches_every_request_using_it() {
 /// A short call and a long call share an id. When the short one answers, the
 /// long one is still running under that id and must stay cancellable.
 ///
-/// Today the short call's completion removes the map entry the long call
-/// installed, so the later cancellation finds nothing to cancel.
+/// Each request untracks only its own dispatch. Removing the whole id entry
+/// on completion took the long call's registration with it, so the later
+/// cancellation found nothing to cancel (#1270).
 #[tokio::test]
-#[ignore = "BUG: McpRouter::complete_request removes the whole id entry, untracking a still-running request that shares the id"]
 async fn completing_one_request_does_not_untrack_its_id_twin() {
     let mut server = Server::with_router(base_router());
     server.initialize().await;


### PR DESCRIPTION
Closes #1270.

`in_flight: HashMap<RequestId, CancellationToken>` has exactly one slot per
request id, which produces three problems.

Two are covered by `#[ignore]`d tests in `adversarial_input.rs`:

1. A second request under an in-flight id evicts the first's token, so
   cancelling that id reaches only the last arrival.
2. `complete_request` removes the whole entry, so when one request finishes
   its still-running twin becomes uncancellable.

The third was reported but not reproduced: the entry is removed on the
success path in `Service::call`, so a future dropped before that point (a
timeout layer firing, an HTTP client disconnect, a panic) leaves the entry
behind for the process lifetime.

## Approach

Key the registry by dispatch rather than by id, keeping the id for lookup,
and remove on drop rather than on the success path.

- `Service::call` mints a monotonic dispatch id and passes it through the
  request extensions, so the context built inside `handle` registers under
  it.
- Registration appends rather than overwrites, so twins coexist.
- `cancel_request` cancels every dispatch under the id. The id is the only
  handle a client has, so a client that reused one gets both stopped.
- An RAII guard held in `Service::call` removes exactly its own dispatch,
  on completion, drop, or unwind.

`complete_request` stays public with its current blunt meaning (it removes
every dispatch under the id, the only granularity its signature offers) and
is no longer what the transport path relies on.

## Plan

- [ ] per-dispatch registry keyed by `(RequestId, dispatch)`
- [ ] cancel fans out across dispatches sharing an id
- [ ] RAII guard replaces the success-path removal
- [ ] un-`#[ignore]` the two tests
- [ ] a test for the leak, which had none
