### PR TITLE
fix(client): strip a UTF-8 BOM on the client receive paths

### DIFF
--- a/crates/tower-mcp/src/client/http.rs
+++ b/crates/tower-mcp/src/client/http.rs
@@ -1937,7 +1937,9 @@ fn json_request_ids_match(left: &serde_json::Value, right: &serde_json::Value) -
 }
 
 fn extract_json_messages(body: &str) -> Vec<String> {
-    let trimmed = body.trim();
+    // A BOM ahead of the body would defeat both the SSE sniff below and the
+    // JSON parse after it (#1303).
+    let trimmed = crate::framing::clean_input_line(body);
     if trimmed.is_empty() {
         return Vec::new();
     }
@@ -1989,6 +1991,12 @@ struct SseParser {
     data_len: usize,
     /// Maximum buffered size for a single event.
     max_event_size: usize,
+    /// Whether any chunk has been fed yet.
+    ///
+    /// A BOM is only a BOM at the very start of the stream; the same bytes
+    /// later in it are a zero-width no-break space inside someone's data
+    /// (#1303).
+    at_stream_start: bool,
 }
 
 impl SseParser {
@@ -2007,6 +2015,7 @@ impl SseParser {
             current_retry: None,
             data_len: 0,
             max_event_size,
+            at_stream_start: true,
         }
     }
 
@@ -2016,6 +2025,13 @@ impl SseParser {
     /// single in-progress event exceed the configured limit. The parser
     /// should not be fed further after an error.
     fn feed(&mut self, text: &str) -> Result<Vec<SseEvent>> {
+        // A leading BOM would make the first field name unrecognisable, so an
+        // event whose first line is `data:` would be dropped whole (#1303).
+        let text = if std::mem::take(&mut self.at_stream_start) {
+            text.strip_prefix('\u{feff}').unwrap_or(text)
+        } else {
+            text
+        };
         self.buffer.push_str(text);
         let mut events = Vec::new();
 
@@ -2088,6 +2104,50 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].id, Some("1".to_string()));
         assert_eq!(events[0].data, "{\"hello\":\"world\"}");
+    }
+
+    /// #1303: a BOM ahead of the stream makes the first field name
+    /// unrecognisable, so an event opening with `data:` is dropped whole.
+    #[test]
+    fn test_parse_strips_a_bom_at_the_start_of_the_stream() {
+        let mut parser = SseParser::new();
+        let events = parser
+            .feed("\u{feff}data: {\"hello\":\"world\"}\n\n")
+            .unwrap();
+
+        assert_eq!(events.len(), 1, "the opening event must survive a BOM");
+        assert_eq!(events[0].data, "{\"hello\":\"world\"}");
+    }
+
+    /// Only at the start. The same bytes later in the stream are a zero-width
+    /// no-break space inside someone's data, and altering it would hand the
+    /// caller content the server never sent.
+    #[test]
+    fn test_parse_keeps_a_bom_inside_the_stream() {
+        let mut parser = SseParser::new();
+        assert!(parser.feed("data: first\n\n").unwrap().len() == 1);
+
+        let events = parser.feed("data: \u{feff}second\n\n").unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "\u{feff}second");
+    }
+
+    /// #1303: the same gap on the non-streaming path, where a BOM would
+    /// defeat both the SSE sniff and the JSON parse behind it.
+    #[test]
+    fn test_extract_json_messages_strips_a_leading_bom() {
+        let json = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+        assert_eq!(
+            extract_json_messages(&format!("\u{feff}{json}")),
+            vec![json.to_string()],
+        );
+
+        let sse = extract_json_messages(&format!("\u{feff}data: {json}\n\n"));
+        assert_eq!(
+            sse,
+            vec![json.to_string()],
+            "a BOM must not hide an SSE body"
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/src/client/stdio.rs
+++ b/crates/tower-mcp/src/client/stdio.rs
@@ -44,7 +44,7 @@ use tokio::process::{Child, Command};
 
 use super::transport::ClientTransport;
 use crate::error::{Error, Result};
-use crate::framing::{FrameReader, InputFrame};
+use crate::framing::{FrameReader, InputFrame, clean_input_line};
 
 /// Client transport that communicates with a subprocess via stdio.
 ///
@@ -200,7 +200,9 @@ impl ClientTransport for StdioClientTransport {
             };
 
             match frame {
-                InputFrame::Line(line) => return Ok(Some(line.trim().to_string())),
+                InputFrame::Line(line) => {
+                    return Ok(Some(clean_input_line(&line).to_string()));
+                }
                 InputFrame::Undecodable => {
                     tracing::warn!(
                         "invalid UTF-8 in a frame from the server, discarding it; \
@@ -406,6 +408,30 @@ mod tests {
 
         assert_eq!(line.trim(), "diagnostic");
         assert!(transport.take_stderr().is_none());
+    }
+
+    /// #1303: the server strips a BOM before parsing and the client did not,
+    /// so the same frame was handled on one end of the connection and dropped
+    /// on the other. The frame most likely to carry one is the `initialize`
+    /// response, whose loss leaves the handshake waiting for a timeout.
+    #[tokio::test]
+    async fn test_recv_strips_a_leading_bom() {
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            r#"printf '\357\273\277{"jsonrpc":"2.0","id":1,"result":{}}\n'"#,
+        ]);
+
+        let mut transport = StdioClientTransport::spawn_command(&mut cmd).await.unwrap();
+        let frame = transport
+            .recv()
+            .await
+            .unwrap()
+            .expect("the frame must arrive");
+
+        assert_eq!(frame, r#"{"jsonrpc":"2.0","id":1,"result":{}}"#);
+        serde_json::from_str::<serde_json::Value>(&frame)
+            .expect("and it must parse, which is the point");
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/client/websocket.rs
+++ b/crates/tower-mcp/src/client/websocket.rs
@@ -150,7 +150,11 @@ impl WebSocketClientTransport {
             while let Some(message) = source.next().await {
                 match message {
                     Ok(Message::Text(text)) => {
-                        if incoming_tx.send(text.to_string()).await.is_err() {
+                        // A server whose runtime prefixes its output with a
+                        // BOM writes one here too, and the JSON parser
+                        // rejects the whole frame over it (#1303).
+                        let text = crate::framing::clean_input_line(&text).to_string();
+                        if incoming_tx.send(text).await.is_err() {
                             break;
                         }
                     }

--- a/crates/tower-mcp/src/framing.rs
+++ b/crates/tower-mcp/src/framing.rs
@@ -106,6 +106,19 @@ pub(crate) fn read_frame_blocking<R: BufRead>(reader: &mut R) -> Result<Option<I
     Ok(Some(decode_input_frame(raw)))
 }
 
+/// Strip an optional UTF-8 BOM, then trim whitespace.
+///
+/// Windows tools sometimes prefix the first stdout line with a UTF-8 BOM
+/// (`\u{feff}`). Without stripping it, the JSON parser sees an unexpected
+/// character at offset 0 and rejects the whole message.
+///
+/// `trim` alone will not do: U+FEFF has not carried the Unicode
+/// `White_Space` property since 4.0.1. Both ends of a connection read frames
+/// a peer wrote, so both call this rather than keeping a copy each (#1303).
+pub(crate) fn clean_input_line(line: &str) -> &str {
+    line.strip_prefix('\u{feff}').unwrap_or(line).trim()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,5 +202,44 @@ mod tests {
             .await
             .unwrap();
         assert_line(frames.next_frame().await.unwrap(), frame);
+    }
+
+    // =========================================================================
+    // clean_input_line tests
+    // =========================================================================
+
+    #[test]
+    fn test_clean_input_line_no_bom() {
+        assert_eq!(
+            clean_input_line(r#"{"jsonrpc":"2.0"}"#),
+            r#"{"jsonrpc":"2.0"}"#
+        );
+    }
+
+    #[test]
+    fn test_clean_input_line_strips_leading_bom() {
+        let with_bom = "\u{feff}{\"jsonrpc\":\"2.0\"}";
+        assert_eq!(clean_input_line(with_bom), r#"{"jsonrpc":"2.0"}"#);
+    }
+
+    #[test]
+    fn test_clean_input_line_strips_bom_then_trims() {
+        // BOM, then whitespace, then content, then trailing newline.
+        let input = "\u{feff}   {\"id\":1}\n";
+        assert_eq!(clean_input_line(input), r#"{"id":1}"#);
+    }
+
+    #[test]
+    fn test_clean_input_line_does_not_strip_internal_bom() {
+        // Only a *leading* BOM is stripped; one inside the payload stays.
+        let input = "{\"text\":\"hi\u{feff}there\"}";
+        assert_eq!(clean_input_line(input), input);
+    }
+
+    #[test]
+    fn test_clean_input_line_empty() {
+        assert_eq!(clean_input_line(""), "");
+        assert_eq!(clean_input_line("\u{feff}"), "");
+        assert_eq!(clean_input_line("   \n\t"), "");
     }
 }

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -69,7 +69,7 @@ use crate::context::{
 use tower_service::Service;
 
 use crate::error::{Error, Result};
-use crate::framing::{FrameReader, InputFrame, read_frame_blocking};
+use crate::framing::{FrameReader, InputFrame, clean_input_line, read_frame_blocking};
 use crate::jsonrpc::JsonRpcService;
 #[cfg(feature = "stateless")]
 use crate::protocol::{Implementation, SubscriptionFilter};
@@ -466,15 +466,6 @@ impl StdioSubscriptions {
             })
             .collect()
     }
-}
-
-/// Strip an optional UTF-8 BOM, then trim whitespace.
-///
-/// Windows tools sometimes prefix the first stdout line with a UTF-8 BOM
-/// (`\u{feff}`). Without stripping it, the JSON parser sees an unexpected
-/// character at offset 0 and rejects the whole message.
-fn clean_input_line(line: &str) -> &str {
-    line.strip_prefix('\u{feff}').unwrap_or(line).trim()
 }
 
 /// The parse-error message for a frame whose bytes are not valid UTF-8.
@@ -2653,45 +2644,6 @@ mod tests {
         let result = process_line(&mut service, &router, line).await;
 
         assert!(result.is_err());
-    }
-
-    // =========================================================================
-    // clean_input_line tests
-    // =========================================================================
-
-    #[test]
-    fn test_clean_input_line_no_bom() {
-        assert_eq!(
-            clean_input_line(r#"{"jsonrpc":"2.0"}"#),
-            r#"{"jsonrpc":"2.0"}"#
-        );
-    }
-
-    #[test]
-    fn test_clean_input_line_strips_leading_bom() {
-        let with_bom = "\u{feff}{\"jsonrpc\":\"2.0\"}";
-        assert_eq!(clean_input_line(with_bom), r#"{"jsonrpc":"2.0"}"#);
-    }
-
-    #[test]
-    fn test_clean_input_line_strips_bom_then_trims() {
-        // BOM, then whitespace, then content, then trailing newline.
-        let input = "\u{feff}   {\"id\":1}\n";
-        assert_eq!(clean_input_line(input), r#"{"id":1}"#);
-    }
-
-    #[test]
-    fn test_clean_input_line_does_not_strip_internal_bom() {
-        // Only a *leading* BOM is stripped; one inside the payload stays.
-        let input = "{\"text\":\"hi\u{feff}there\"}";
-        assert_eq!(clean_input_line(input), input);
-    }
-
-    #[test]
-    fn test_clean_input_line_empty() {
-        assert_eq!(clean_input_line(""), "");
-        assert_eq!(clean_input_line("\u{feff}"), "");
-        assert_eq!(clean_input_line("   \n\t"), "");
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/websocket_client.rs
+++ b/crates/tower-mcp/tests/websocket_client.rs
@@ -163,3 +163,48 @@ async fn connecting_to_a_dead_endpoint_fails_immediately() {
         "the error should name the stage that failed: {error}"
     );
 }
+
+/// #1303: a server whose runtime prefixes its output with a UTF-8 BOM writes
+/// one into its text frames too, and the JSON parser rejects the whole frame
+/// over it. `trim` does not remove a BOM, so the client has to strip it the
+/// way the server side already does.
+#[tokio::test]
+async fn a_bom_prefixed_frame_from_the_server_is_stripped() {
+    use axum::extract::ws::{Message, WebSocketUpgrade};
+    use tower_mcp::client::ClientTransport;
+
+    const FRAME: &str = r#"{"jsonrpc":"2.0","id":1,"result":{}}"#;
+
+    // A bare WebSocket endpoint that writes one BOM-prefixed frame. The
+    // crate's own server never emits one, which is the point: this is what a
+    // peer we do not control does.
+    let app = axum::Router::new().route(
+        "/",
+        axum::routing::get(|upgrade: WebSocketUpgrade| async move {
+            upgrade.on_upgrade(|mut socket| async move {
+                let _ = socket
+                    .send(Message::Text(format!("\u{feff}{FRAME}").into()))
+                    .await;
+            })
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut transport = WebSocketClientTransport::connect(&format!("ws://{addr}/"))
+        .await
+        .expect("connect");
+    let received = tokio::time::timeout(Duration::from_secs(5), transport.recv())
+        .await
+        .expect("a frame must arrive")
+        .expect("recv")
+        .expect("the frame must not be dropped");
+
+    assert_eq!(received, FRAME);
+    serde_json::from_str::<serde_json::Value>(&received)
+        .expect("and it must parse, which is the point");
+}


### PR DESCRIPTION
Closes #1303.

The server strips a leading UTF-8 BOM before parsing. `clean_input_line`
exists for exactly that: a Windows-hosted tool sometimes prefixes its first
stdout line with `\u{feff}`, and the JSON parser rejects the whole message
over it.

The client does not. `trim` does not remove a BOM, since U+FEFF has not
carried the Unicode `White_Space` property since 4.0.1. So the same frame is
handled on one side of the connection and dropped on the other, and the
frame most likely to carry a BOM is the `initialize` response, which leaves
the handshake waiting for a timeout instead of failing with something that
points at the cause.

## Approach

Move `clean_input_line` to `crate::framing`, next to the other helpers both
ends share, and use it on every client receive path rather than adding a
second copy:

- `client/stdio.rs` reads frames a server wrote, the case the issue names.
- `client/http.rs` parses response bodies, at least as likely to carry one.
- `client/websocket.rs` parses text frames.

## Plan

- [ ] move `clean_input_line` into `crate::framing`
- [ ] apply it on the stdio, HTTP, and WebSocket client receive paths
- [ ] tests driving a BOM-prefixed frame through each
