### PR TITLE
refactor(router): move the task helpers beside the methods that use them

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -76,21 +76,6 @@ impl Drop for LiveTaskRegistration {
     }
 }
 
-fn task_store_error(e: TaskStoreError) -> Error {
-    Error::JsonRpc(JsonRpcError::internal_error(format!(
-        "Task store error: {}",
-        e
-    )))
-}
-
-async fn discard_unprepared_task(store: &Arc<dyn TaskStore>, task_id: &str) {
-    if !matches!(store.discard_task(task_id).await, Ok(true)) {
-        let _ = store
-            .cancel_task(task_id, Some("task preparation failed"))
-            .await;
-    }
-}
-
 /// Whether this request is using the final, stateless 2026-07-28 lifecycle.
 ///
 /// Stable sessionful requests retain the crate's legacy task behavior; final
@@ -373,43 +358,6 @@ impl std::fmt::Display for MergeConflicts {
 
 impl std::error::Error for MergeConflicts {}
 
-/// Whether this request's client declared the final Tasks extension.
-///
-/// Final requests carry client capabilities per request, so negotiation is
-/// decided from the request itself rather than from session state.
-#[cfg(feature = "stateless")]
-fn client_declares_tasks(extensions: &crate::context::Extensions) -> bool {
-    final_client_capabilities(extensions).is_some_and(|capabilities| {
-        capabilities.extensions.as_ref().is_some_and(|declared| {
-            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
-        })
-    })
-}
-
-#[cfg(not(feature = "stateless"))]
-fn client_declares_tasks(_extensions: &crate::context::Extensions) -> bool {
-    false
-}
-
-/// Decode the wire `inputResponses` map into typed responses.
-///
-/// A key whose value does not match any known response shape is dropped here
-/// rather than failing the request: the store treats an unmatched key as
-/// ignorable, and SEP-2663 requires ignoring responses that do not correspond
-/// to an outstanding request.
-fn decode_input_responses(
-    responses: &std::collections::HashMap<String, serde_json::Value>,
-) -> crate::protocol::InputResponses {
-    responses
-        .iter()
-        .filter_map(|(key, value)| {
-            serde_json::from_value(value.clone())
-                .ok()
-                .map(|response| (key.clone(), response))
-        })
-        .collect()
-}
-
 /// The authenticated principal for this request, if any.
 ///
 /// Sourced from the OAuth `sub` claim that the HTTP and WebSocket transports
@@ -426,44 +374,6 @@ fn request_principal(extensions: &crate::context::Extensions) -> Option<String> 
 #[cfg(not(feature = "oauth"))]
 fn request_principal(_extensions: &crate::context::Extensions) -> Option<String> {
     None
-}
-
-/// Error for a task the server cannot serve.
-///
-/// Unknown and expired tasks are deliberately indistinguishable, so a caller
-/// cannot probe for the existence of a task whose retention window closed.
-/// The error an owner gets for a task the store still holds but whose TTL
-/// elapsed.
-///
-/// Deliberately distinct from [`unknown_task_error`] in its `data`, and
-/// deliberately only ever produced after the caller has been shown to own the
-/// task. A caller who does not own it gets `unknown_task_error`, which is
-/// also what a genuinely unknown id gets, so the two cannot be told apart
-/// from outside (#1249).
-fn expired_task_error(task_id: &str) -> JsonRpcError {
-    let mut error = JsonRpcError::invalid_params(format!("Task expired: {task_id}"));
-    error.data = Some(serde_json::json!({ "reason": "task_expired" }));
-    error
-}
-
-fn unknown_task_error(task_id: &str) -> JsonRpcError {
-    JsonRpcError::invalid_params(format!("Task not found: {task_id}"))
-}
-
-/// The client capability shape a server names in a `-32021` when it cannot
-/// service a request without the Tasks extension.
-pub(crate) fn tasks_client_capabilities() -> crate::protocol::ClientCapabilities {
-    crate::protocol::ClientCapabilities {
-        extensions: Some(
-            [(
-                tower_mcp_types::protocol::TASKS_EXTENSION_ID.to_string(),
-                serde_json::json!({}),
-            )]
-            .into_iter()
-            .collect(),
-        ),
-        ..Default::default()
-    }
 }
 
 #[cfg(feature = "stateless")]
@@ -517,106 +427,6 @@ fn client_capabilities_satisfy(actual: &ClientCapabilities, required: &ClientCap
         roots.remove("listChanged");
     }
     json_value_contains(&actual, &required)
-}
-
-#[cfg(feature = "stateless")]
-fn validate_input_required_result(
-    extensions: &crate::context::Extensions,
-    result: &InputRequiredResult,
-) -> Result<()> {
-    result.validate().map_err(|message| {
-        Error::invalid_params(format!("invalid InputRequiredResult: {message}"))
-    })?;
-
-    let meta = extensions
-        .get::<crate::stateless::StatelessRequestMeta>()
-        .filter(|meta| {
-            meta.protocol_version.as_deref() == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
-        })
-        .ok_or_else(|| {
-            Error::invalid_params(
-                "InputRequiredResult is only supported by the 2026-07-28 request lifecycle",
-            )
-        })?;
-    let actual = meta.client_capabilities.as_ref().ok_or_else(|| {
-        Error::invalid_params("clientCapabilities is required for InputRequiredResult")
-    })?;
-
-    if let Some(requests) = &result.input_requests {
-        for request in requests.values() {
-            let (supported, required) = match request {
-                InputRequest::CreateMessage(params) => {
-                    let requires_tools = params.tools.is_some();
-                    let requires_context = params
-                        .include_context
-                        .is_some_and(|mode| mode != IncludeContext::None);
-                    let required_sampling = SamplingCapability {
-                        tools: requires_tools.then(SamplingToolsCapability::default),
-                        context: requires_context.then(SamplingContextCapability::default),
-                        ..SamplingCapability::default()
-                    };
-                    let supported = actual.sampling.as_ref().is_some_and(|sampling| {
-                        (!requires_tools || sampling.tools.is_some())
-                            && (!requires_context || sampling.context.is_some())
-                    });
-                    (
-                        supported,
-                        ClientCapabilities {
-                            sampling: Some(required_sampling),
-                            ..ClientCapabilities::default()
-                        },
-                    )
-                }
-                InputRequest::ListRoots(_) => (
-                    actual.roots.is_some(),
-                    ClientCapabilities {
-                        roots: Some(RootsCapability::default()),
-                        ..ClientCapabilities::default()
-                    },
-                ),
-                InputRequest::Elicit(ElicitRequestParams::Form(_)) => {
-                    let supported = actual.elicitation.as_ref().is_some_and(|elicitation| {
-                        elicitation.form.is_some()
-                            || (elicitation.form.is_none() && elicitation.url.is_none())
-                    });
-                    (
-                        supported,
-                        ClientCapabilities {
-                            elicitation: Some(ElicitationCapability {
-                                form: Some(ElicitationFormCapability::default()),
-                                ..ElicitationCapability::default()
-                            }),
-                            ..ClientCapabilities::default()
-                        },
-                    )
-                }
-                InputRequest::Elicit(ElicitRequestParams::Url(_)) => (
-                    actual
-                        .elicitation
-                        .as_ref()
-                        .is_some_and(|elicitation| elicitation.url.is_some()),
-                    ClientCapabilities {
-                        elicitation: Some(ElicitationCapability {
-                            url: Some(ElicitationUrlCapability::default()),
-                            ..ElicitationCapability::default()
-                        }),
-                        ..ClientCapabilities::default()
-                    },
-                ),
-                _ => {
-                    return Err(Error::invalid_params(
-                        "unsupported input request method in InputRequiredResult",
-                    ));
-                }
-            };
-            if !supported {
-                return Err(Error::JsonRpc(
-                    JsonRpcError::missing_required_client_capability(required),
-                ));
-            }
-        }
-    }
-    Ok(())
 }
 
 /// Apply pagination to a collected list of items.
@@ -4627,6 +4437,15 @@ impl Service<RouterRequest> for McpRouter {
 
 mod notify;
 mod task_ops;
+
+use task_ops::{
+    client_declares_tasks, decode_input_responses, discard_unprepared_task, task_store_error,
+    tasks_client_capabilities,
+};
+// Gated in `task_ops` too, so importing it unconditionally breaks the default
+// build that `--all-features` never exercises.
+#[cfg(feature = "stateless")]
+use task_ops::validate_input_required_result;
 
 #[cfg(test)]
 mod tests;

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -459,3 +459,201 @@ impl McpRouter {
         }
     }
 }
+
+// ===========================================================================
+// Task helpers
+// ===========================================================================
+//
+// Free functions whose only callers are the methods above. They sat at the top
+// of `router.rs`, above the type they serve, rather than beside the group that
+// uses them (#1256).
+
+pub(super) fn task_store_error(e: TaskStoreError) -> Error {
+    Error::JsonRpc(JsonRpcError::internal_error(format!(
+        "Task store error: {}",
+        e
+    )))
+}
+
+pub(super) async fn discard_unprepared_task(store: &Arc<dyn TaskStore>, task_id: &str) {
+    if !matches!(store.discard_task(task_id).await, Ok(true)) {
+        let _ = store
+            .cancel_task(task_id, Some("task preparation failed"))
+            .await;
+    }
+}
+
+/// Whether this request's client declared the final Tasks extension.
+///
+/// Final requests carry client capabilities per request, so negotiation is
+/// decided from the request itself rather than from session state.
+#[cfg(feature = "stateless")]
+pub(super) fn client_declares_tasks(extensions: &crate::context::Extensions) -> bool {
+    final_client_capabilities(extensions).is_some_and(|capabilities| {
+        capabilities.extensions.as_ref().is_some_and(|declared| {
+            declared.contains_key(tower_mcp_types::protocol::TASKS_EXTENSION_ID)
+        })
+    })
+}
+
+#[cfg(not(feature = "stateless"))]
+pub(super) fn client_declares_tasks(_extensions: &crate::context::Extensions) -> bool {
+    false
+}
+
+/// Decode the wire `inputResponses` map into typed responses.
+///
+/// A key whose value does not match any known response shape is dropped here
+/// rather than failing the request: the store treats an unmatched key as
+/// ignorable, and SEP-2663 requires ignoring responses that do not correspond
+/// to an outstanding request.
+pub(super) fn decode_input_responses(
+    responses: &std::collections::HashMap<String, serde_json::Value>,
+) -> crate::protocol::InputResponses {
+    responses
+        .iter()
+        .filter_map(|(key, value)| {
+            serde_json::from_value(value.clone())
+                .ok()
+                .map(|response| (key.clone(), response))
+        })
+        .collect()
+}
+
+/// Error for a task the server cannot serve.
+///
+/// Unknown and expired tasks are deliberately indistinguishable, so a caller
+/// cannot probe for the existence of a task whose retention window closed.
+/// The error an owner gets for a task the store still holds but whose TTL
+/// elapsed.
+///
+/// Deliberately distinct from [`unknown_task_error`] in its `data`, and
+/// deliberately only ever produced after the caller has been shown to own the
+/// task. A caller who does not own it gets `unknown_task_error`, which is
+/// also what a genuinely unknown id gets, so the two cannot be told apart
+/// from outside (#1249).
+fn expired_task_error(task_id: &str) -> JsonRpcError {
+    let mut error = JsonRpcError::invalid_params(format!("Task expired: {task_id}"));
+    error.data = Some(serde_json::json!({ "reason": "task_expired" }));
+    error
+}
+
+fn unknown_task_error(task_id: &str) -> JsonRpcError {
+    JsonRpcError::invalid_params(format!("Task not found: {task_id}"))
+}
+
+/// The client capability shape a server names in a `-32021` when it cannot
+/// service a request without the Tasks extension.
+pub(crate) fn tasks_client_capabilities() -> crate::protocol::ClientCapabilities {
+    crate::protocol::ClientCapabilities {
+        extensions: Some(
+            [(
+                tower_mcp_types::protocol::TASKS_EXTENSION_ID.to_string(),
+                serde_json::json!({}),
+            )]
+            .into_iter()
+            .collect(),
+        ),
+        ..Default::default()
+    }
+}
+
+#[cfg(feature = "stateless")]
+pub(super) fn validate_input_required_result(
+    extensions: &crate::context::Extensions,
+    result: &InputRequiredResult,
+) -> Result<()> {
+    result.validate().map_err(|message| {
+        Error::invalid_params(format!("invalid InputRequiredResult: {message}"))
+    })?;
+
+    let meta = extensions
+        .get::<crate::stateless::StatelessRequestMeta>()
+        .filter(|meta| {
+            meta.protocol_version.as_deref() == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
+        })
+        .ok_or_else(|| {
+            Error::invalid_params(
+                "InputRequiredResult is only supported by the 2026-07-28 request lifecycle",
+            )
+        })?;
+    let actual = meta.client_capabilities.as_ref().ok_or_else(|| {
+        Error::invalid_params("clientCapabilities is required for InputRequiredResult")
+    })?;
+
+    if let Some(requests) = &result.input_requests {
+        for request in requests.values() {
+            let (supported, required) = match request {
+                InputRequest::CreateMessage(params) => {
+                    let requires_tools = params.tools.is_some();
+                    let requires_context = params
+                        .include_context
+                        .is_some_and(|mode| mode != IncludeContext::None);
+                    let required_sampling = SamplingCapability {
+                        tools: requires_tools.then(SamplingToolsCapability::default),
+                        context: requires_context.then(SamplingContextCapability::default),
+                        ..SamplingCapability::default()
+                    };
+                    let supported = actual.sampling.as_ref().is_some_and(|sampling| {
+                        (!requires_tools || sampling.tools.is_some())
+                            && (!requires_context || sampling.context.is_some())
+                    });
+                    (
+                        supported,
+                        ClientCapabilities {
+                            sampling: Some(required_sampling),
+                            ..ClientCapabilities::default()
+                        },
+                    )
+                }
+                InputRequest::ListRoots(_) => (
+                    actual.roots.is_some(),
+                    ClientCapabilities {
+                        roots: Some(RootsCapability::default()),
+                        ..ClientCapabilities::default()
+                    },
+                ),
+                InputRequest::Elicit(ElicitRequestParams::Form(_)) => {
+                    let supported = actual.elicitation.as_ref().is_some_and(|elicitation| {
+                        elicitation.form.is_some()
+                            || (elicitation.form.is_none() && elicitation.url.is_none())
+                    });
+                    (
+                        supported,
+                        ClientCapabilities {
+                            elicitation: Some(ElicitationCapability {
+                                form: Some(ElicitationFormCapability::default()),
+                                ..ElicitationCapability::default()
+                            }),
+                            ..ClientCapabilities::default()
+                        },
+                    )
+                }
+                InputRequest::Elicit(ElicitRequestParams::Url(_)) => (
+                    actual
+                        .elicitation
+                        .as_ref()
+                        .is_some_and(|elicitation| elicitation.url.is_some()),
+                    ClientCapabilities {
+                        elicitation: Some(ElicitationCapability {
+                            url: Some(ElicitationUrlCapability::default()),
+                            ..ElicitationCapability::default()
+                        }),
+                        ..ClientCapabilities::default()
+                    },
+                ),
+                _ => {
+                    return Err(Error::invalid_params(
+                        "unsupported input request method in InputRequiredResult",
+                    ));
+                }
+            };
+            if !supported {
+                return Err(Error::JsonRpc(
+                    JsonRpcError::missing_required_client_capability(required),
+                ));
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
Refs #1256, continuing phase 2 from #1319 and #1320.

`router.rs` 4636 -> 4454 lines. Nine free functions join
`router/task_ops.rs`, where their only callers already live: they had been
sitting at the top of `router.rs`, above the type they serve, which is the
arrangement the issue calls out.

`task_store_error`, `discard_unprepared_task`, both `client_declares_tasks`
cfg variants, `decode_input_responses`, `expired_task_error`,
`unknown_task_error`, `tasks_client_capabilities`, and
`validate_input_required_result`.

## Visibility got tighter, not looser

Seven are `pub(super)` so `router.rs` keeps calling them unqualified through
a `use`. `tasks_client_capabilities` was already `pub(crate)` and stays.

`expired_task_error` and `unknown_task_error` turned out to have no caller
outside the task group at all, so they are now private to it. The move made
that visible; before it, nothing distinguished them from the helpers the
router genuinely shares.

## The default build caught the real hazard

`validate_input_required_result` is `#[cfg(feature = "stateless")]`. An
unconditional `use` of it compiles perfectly under `--all-features` and
breaks every build without that feature, which is exactly the shape that
slips through when only the all-features build is checked. The import is
gated to match, and the branch is verified on default, `--all-features`, and
four intermediate feature sets.

1030 lib tests before and after.

## Where phase 2 stands

`router.rs` is 4454 lines, from 10461. The `MergeConflict` types and the
cursor/pagination trio are the next small moves; the construction/registration
and dispatch groups are the large remaining ones.