### PR TITLE
feat(tasks): split require_input into park_input and PendingInput::wait

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -676,8 +676,8 @@ pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;
 pub use tool::{
-    BoxToolService, GuardLayer, McpTool, NoParams, TaskContext, TaskOutcome, TaskPreparation, Tool,
-    ToolBuilder, ToolHandler, ToolRequest,
+    BoxToolService, GuardLayer, McpTool, NoParams, PendingInput, TaskContext, TaskOutcome,
+    TaskPreparation, Tool, ToolBuilder, ToolHandler, ToolRequest,
 };
 pub use transport::{
     BidirectionalStdioTransport, CatchError, GenericStdioTransport, StdioTransport,

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -677,7 +677,7 @@ impl TaskContext {
     /// Request keys must be unique over the task's lifetime (SEP-2663), so
     /// reusing a spent key is an error rather than a fresh question.
     pub async fn require_input(&self, requests: InputRequests) -> Result<InputResponses> {
-        self.require_input_inner(requests, None).await
+        self.park_input(requests).await?.wait().await
     }
 
     /// [`require_input`](Self::require_input) with a status message for
@@ -687,15 +687,75 @@ impl TaskContext {
         requests: InputRequests,
         message: impl Into<String>,
     ) -> Result<InputResponses> {
-        self.require_input_inner(requests, Some(message.into()))
+        self.park_input_with_message(requests, message)
+            .await?
+            .wait()
             .await
     }
 
-    async fn require_input_inner(
+    /// Commit the request for input, and return without waiting for it.
+    ///
+    /// The first half of [`require_input`](Self::require_input), which is
+    /// exactly these two calls back to back:
+    ///
+    /// ```rust,no_run
+    /// # use tower_mcp::{InputRequests, InputResponses, TaskContext};
+    /// # async fn example(ctx: TaskContext, requests: InputRequests)
+    /// #     -> tower_mcp::Result<InputResponses> {
+    /// let pending = ctx.park_input(requests).await?;
+    /// // Whatever has to happen once the task is durably parked but before
+    /// // this handler suspends: release admission permits, drop a lock, hand
+    /// // a worker slot back to a scheduler.
+    /// let responses = pending.wait().await?;
+    /// # Ok(responses)
+    /// # }
+    /// ```
+    ///
+    /// The split exists because those two things are not the same moment. An
+    /// execution owner running under admission control has to release its
+    /// permits *after* the `input_required` state is durable and *before* it
+    /// suspends, and a single combined call gives it nowhere to stand
+    /// (#1246).
+    ///
+    /// # The gap is safe
+    ///
+    /// Arbitrary code runs between this returning and
+    /// [`PendingInput::wait`], including code that awaits. A response or a
+    /// cancellation arriving in that window is not lost:
+    ///
+    /// - `wait` reads outstanding requests from the store before it awaits
+    ///   anything, and the store is what `tasks/update` commits to. Answers
+    ///   that landed in the gap are already there.
+    /// - The wakeup is a [`tokio::sync::Notify`] signalled with `notify_one`,
+    ///   which stores a permit when nobody is waiting. A signal in the gap is
+    ///   held, not dropped.
+    /// - Cancellation is a flag rather than an event, so `wait` observes one
+    ///   that was set in the gap.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`require_input`](Self::require_input) for the commit half: a
+    /// replay handler, an empty request set, a task already cancelled, or a
+    /// store that refuses the transition.
+    pub async fn park_input(&self, requests: InputRequests) -> Result<PendingInput> {
+        self.park_input_inner(requests, None).await
+    }
+
+    /// [`park_input`](Self::park_input) with a status message for clients
+    /// polling the task.
+    pub async fn park_input_with_message(
+        &self,
+        requests: InputRequests,
+        message: impl Into<String>,
+    ) -> Result<PendingInput> {
+        self.park_input_inner(requests, Some(message.into())).await
+    }
+
+    async fn park_input_inner(
         &self,
         requests: InputRequests,
         message: Option<String>,
-    ) -> Result<InputResponses> {
+    ) -> Result<PendingInput> {
         let live = self.live.as_ref().ok_or_else(|| {
             crate::error::Error::Tool(crate::error::ToolError::new(
                 "require_input needs a live task handler; a replay handler returns RequestOutcome::InputRequired instead",
@@ -712,9 +772,6 @@ impl TaskContext {
             return Err(crate::error::Error::TaskCancelled);
         }
 
-        // Created before the store write, so a `tasks/update` landing between
-        // the two is not missed.
-        let woken = live.input_ready.notified();
         let accepted = live
             .store
             .require_input(&self.task_id, requests, message.as_deref())
@@ -730,52 +787,11 @@ impl TaskContext {
             )));
         }
 
-        tokio::select! {
-            _ = woken => {}
-            _ = live.cancelled.cancelled() => {
-                return Err(crate::error::Error::TaskCancelled);
-            }
-        }
-
-        // A partial answer leaves some of these outstanding. Wait for the
-        // rest rather than reissuing, which would be key reuse.
-        loop {
-            let outstanding = live
-                .store
-                .outstanding_input_requests(&self.task_id)
-                .await
-                .map_err(|e| {
-                    crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                        "could not read outstanding requests: {e}"
-                    )))
-                })?
-                .unwrap_or_default();
-            if !outstanding.keys().any(|key| asked.contains(key)) {
-                break;
-            }
-            let woken = live.input_ready.notified();
-            tokio::select! {
-                _ = woken => {}
-                _ = live.cancelled.cancelled() => {
-                    return Err(crate::error::Error::TaskCancelled);
-                }
-            }
-        }
-
-        let all = live
-            .store
-            .input_responses(&self.task_id)
-            .await
-            .map_err(|e| {
-                crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                    "could not read input responses: {e}"
-                )))
-            })?
-            .unwrap_or_default();
-        Ok(all
-            .into_iter()
-            .filter(|(key, _)| asked.contains(key))
-            .collect())
+        Ok(PendingInput {
+            live: live.clone(),
+            task_id: self.task_id.clone(),
+            asked,
+        })
     }
 
     /// Record a non-terminal status for clients polling this task.
@@ -825,6 +841,129 @@ impl Clone for TaskContext {
             task_id: self.task_id.clone(),
             live: self.live.clone(),
         }
+    }
+}
+
+/// A task durably parked in `input_required`, not yet waited on.
+///
+/// Returned by [`TaskContext::park_input`]. The task is already parked when
+/// this exists: the store transition has committed and a client polling
+/// `tasks/get` can already see the questions. What has not happened yet is
+/// this handler suspending, which is the point of the split (#1246).
+///
+/// Deliberately not [`Clone`]. Two holders would both wait on one set of
+/// answers and one of them would consume them, so the type makes a second
+/// waiter unrepresentable rather than leaving it to a comment.
+#[must_use = "the task is parked in `input_required` until this is awaited; \
+              dropping it leaves the task parked with nothing waiting to \
+              resume it"]
+pub struct PendingInput {
+    live: Arc<LiveTask>,
+    task_id: String,
+    /// The keys this park asked about. Answers to earlier questions stay in
+    /// the store rather than being handed over again.
+    asked: Vec<String>,
+}
+
+impl std::fmt::Debug for PendingInput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PendingInput")
+            .field("task_id", &self.task_id)
+            .field("asked", &self.asked)
+            .finish_non_exhaustive()
+    }
+}
+
+impl PendingInput {
+    /// The server-generated task identifier.
+    pub fn task_id(&self) -> &str {
+        &self.task_id
+    }
+
+    /// The request keys this park is waiting on.
+    pub fn asked(&self) -> &[String] {
+        &self.asked
+    }
+
+    /// Suspend until every request in this park is answered.
+    ///
+    /// Only the answers to the keys this park asked about come back, keyed as
+    /// they were sent. A partial answer leaves the rest outstanding and this
+    /// keeps waiting rather than reissuing, which would be key reuse
+    /// (SEP-2663).
+    ///
+    /// Takes `self`, so a park cannot be waited on twice.
+    ///
+    /// # Nothing is lost in the gap
+    ///
+    /// Arbitrary code, including code that awaits, runs between
+    /// [`TaskContext::park_input`] and this call. Three things make that
+    /// window safe, and the order below is the order they are relied on:
+    ///
+    /// 1. Cancellation is a flag, so one raised in the gap is seen here.
+    /// 2. The loop reads outstanding requests from the store *before* it
+    ///    awaits anything. `tasks/update` commits to that store, so an answer
+    ///    that landed in the gap is already visible and this returns without
+    ///    suspending at all.
+    /// 3. Within the loop the wakeup is created before the read, so an answer
+    ///    landing between the read and the suspend is not missed either. The
+    ///    wakeup is `notify_one`, which stores a permit when nobody is
+    ///    waiting, so it is held rather than dropped.
+    ///
+    /// # Errors
+    ///
+    /// [`crate::Error::TaskCancelled`] if the task is cancelled while
+    /// waiting, so a handler that propagates with `?` unwinds correctly
+    /// without writing a `select!`. The router maps that to
+    /// [`TaskOutcome::Cancelled`].
+    pub async fn wait(self) -> Result<InputResponses> {
+        let live = &self.live;
+
+        if live.cancelled.is_cancelled() {
+            return Err(crate::error::Error::TaskCancelled);
+        }
+
+        loop {
+            // Created before the read, so an answer landing between the two
+            // is not missed: `notify_one` holds a permit for us.
+            let woken = live.input_ready.notified();
+
+            let outstanding = live
+                .store
+                .outstanding_input_requests(&self.task_id)
+                .await
+                .map_err(|e| {
+                    crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                        "could not read outstanding requests: {e}"
+                    )))
+                })?
+                .unwrap_or_default();
+            if !outstanding.keys().any(|key| self.asked.contains(key)) {
+                break;
+            }
+
+            tokio::select! {
+                _ = woken => {}
+                _ = live.cancelled.cancelled() => {
+                    return Err(crate::error::Error::TaskCancelled);
+                }
+            }
+        }
+
+        let all = live
+            .store
+            .input_responses(&self.task_id)
+            .await
+            .map_err(|e| {
+                crate::error::Error::Tool(crate::error::ToolError::new(format!(
+                    "could not read input responses: {e}"
+                )))
+            })?
+            .unwrap_or_default();
+        Ok(all
+            .into_iter()
+            .filter(|(key, _)| self.asked.contains(key))
+            .collect())
     }
 }
 

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -772,3 +772,181 @@ async fn the_simple_live_form_still_compiles_and_runs() {
         .task_id;
     await_status(&store, &task_id, TaskStatus::Completed).await;
 }
+
+// ============================================================================
+// Two-phase parking (#1246)
+// ============================================================================
+//
+// `park_input` commits the `input_required` transition and returns without
+// suspending, so an execution owner can release admission permits between the
+// commit and the wait. That opens a window in which arbitrary code runs, and
+// these two tests are the reason the window is safe to open: a response and a
+// cancellation are each delivered entirely inside it, and neither is lost.
+//
+// The handshake is deterministic rather than timed. `Notify::notify_one`
+// stores a permit when nobody is waiting, so neither side can miss the other
+// no matter which arrives first.
+
+/// An answer that lands after `park_input` and before `wait` must still be
+/// delivered. Nothing is waiting on the notification when it fires, so a
+/// design that relied on the wakeup alone would hang here forever.
+#[tokio::test]
+async fn an_answer_that_lands_before_wait_is_not_lost() {
+    let parked = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let handler_parked = parked.clone();
+    let handler_release = release.clone();
+
+    let tool = ToolBuilder::new("live")
+        .description("Parks, stands, then waits")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let parked = handler_parked.clone();
+            let release = handler_release.clone();
+            async move {
+                let pending = task.park_input(ask("one")).await?;
+                // Durably parked, and this handler has not suspended yet.
+                // An admission-controlled owner releases its permits here.
+                parked.notify_one();
+                release.notified().await;
+
+                let answers = pending.wait().await?;
+                let keys: Vec<String> = answers.into_keys().collect();
+                Ok(TaskOutcome::Completed(CallToolResult::text(keys.join(","))))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    // The park has committed, so the question is already visible to a client.
+    parked.notified().await;
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+
+    // Answer while the handler is standing between the two calls.
+    answer(&client, &task_id, "one").await;
+
+    release.notify_one();
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let text = serde_json::to_value(result.unwrap()).unwrap()["content"][0]["text"].clone();
+    assert_eq!(
+        text, "one",
+        "the answer arrived while nothing was waiting for it, and must still be delivered"
+    );
+}
+
+/// The same window, for cancellation. `wait` checks the flag before it awaits
+/// anything, so a cancellation raised in the gap ends the task rather than
+/// leaving it parked on a question nobody will answer.
+#[tokio::test]
+async fn a_cancellation_that_lands_before_wait_is_observed() {
+    let parked = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let handler_parked = parked.clone();
+    let handler_release = release.clone();
+
+    let tool = ToolBuilder::new("live")
+        .description("Parks, stands, then waits")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let parked = handler_parked.clone();
+            let release = handler_release.clone();
+            async move {
+                let pending = task.park_input(ask("never")).await?;
+                parked.notify_one();
+                release.notified().await;
+
+                // Propagates as TaskCancelled, which the router turns into a
+                // cancelled outcome without the handler writing a select!.
+                let _answers = pending.wait().await?;
+                Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    parked.notified().await;
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+
+    client
+        .task_cancel(&task_id, Some("changed my mind".to_string()))
+        .await
+        .expect("cancel accepted");
+
+    release.notify_one();
+    await_status(&store, &task_id, TaskStatus::Cancelled).await;
+}
+
+/// `require_input` is the two calls back to back, so it must keep behaving
+/// exactly as it did. This is the same round trip driven through the
+/// compatibility wrapper rather than the split.
+#[tokio::test]
+async fn require_input_still_parks_and_waits_in_one_call() {
+    let tool = ToolBuilder::new("live")
+        .description("Uses the combined call")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| async move {
+            let answers = task.require_input(ask("one")).await?;
+            let keys: Vec<String> = answers.into_keys().collect();
+            Ok(TaskOutcome::Completed(CallToolResult::text(keys.join(","))))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+    answer(&client, &task_id, "one").await;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let text = serde_json::to_value(result.unwrap()).unwrap()["content"][0]["text"].clone();
+    assert_eq!(text, "one");
+}


### PR DESCRIPTION
Refs #1246. The remaining hard blocker for admission/input ordering.

The durable `input_required` commit and the handler suspending are not the
same moment, and a single combined call gave an execution owner nowhere to
stand between them.

```rust
let pending = ctx.park_input(requests).await?; // durable commit
release_execution_permits();
let responses = pending.wait().await?;
```

`require_input` is now those two calls back to back, so nothing changes for a
handler that does not need the seam. `park_input_with_message` mirrors
`require_input_with_message`.

## PendingInput

`#[must_use]`, since dropping one leaves the task parked with nothing waiting
to resume it. Deliberately not `Clone`: two holders would both wait on one
set of answers and one would consume them, so a second waiter is
unrepresentable rather than merely discouraged. `wait` takes `self`, so a
park cannot be awaited twice.

## Why the gap is safe

Arbitrary code, including code that awaits, now runs between the two calls.
Three things cover it:

1. Cancellation is a flag, so one raised in the gap is seen.
2. `wait` reads outstanding requests from the store *before* awaiting
   anything. `tasks/update` commits to that store, so an answer that landed
   in the gap is already visible and `wait` returns without suspending.
3. Within the loop the wakeup is created before the read, and `notify_one`
   stores a permit when nobody is waiting.

## The store-first read is load-bearing, and the tests alone do not show it

Worth spelling out, because I nearly shipped this claim untested.

The answer-in-the-gap test **passes against a naive suspend-first `wait`**,
because the `notify_one` permit already covers that window. So the test on
its own does not demonstrate that reading the store first matters.

Weakening the notification to `notify_waiters`, which drops a signal nobody
is waiting for, separates them:

| `wait` reads | notification | result |
|---|---|---|
| store first | `notify_one` | passes |
| suspend first | `notify_one` | passes |
| store first | `notify_waiters` | **passes** |
| suspend first | `notify_waiters` | **fails**, task stuck at `Working` |

Two independent defenses, and the ordering is one of them rather than
decoration.

## Tests

- an answer delivered entirely inside the gap is not lost
- a cancellation raised entirely inside the gap ends the task
- `require_input` still parks and waits in one call

The handshake is deterministic, not timed: `Notify::notify_one` stores a
permit, so neither the test nor the handler can miss the other regardless of
which arrives first.

## Not covered

The other open #1246 requirement stands: the same tool still needs live Task
execution plus ordinary and MRTR fallback. That is a separate change.