### PR TITLE
fix(prompt): reject a prompts/get missing a required argument

### DIFF
--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -479,6 +479,53 @@ impl Clone for Prompt {
     }
 }
 
+/// Reject a `prompts/get` that omits an argument the prompt declares required.
+///
+/// The spec requires missing required arguments to produce `-32602`, and
+/// `prompts/list` already tells clients which ones are required, so the router
+/// was advertising a guarantee nothing provided and leaving every handler to
+/// re-implement the same check (#1281).
+///
+/// Deliberately narrow. Arguments are unvalidated strings by design, so this
+/// checks presence and nothing else:
+///
+/// - an empty string is present, since emptiness is a value the handler may
+///   legitimately want;
+/// - an omitted optional argument is fine;
+/// - unknown extra keys are accepted, because the protocol does not say prompt
+///   arguments are a closed set.
+///
+/// Missing names come back sorted, so the error is the same whichever way the
+/// map iterated.
+pub(crate) fn missing_required_arguments(
+    declared: &[PromptArgument],
+    supplied: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut missing: Vec<String> = declared
+        .iter()
+        .filter(|argument| argument.required && !supplied.contains_key(&argument.name))
+        .map(|argument| argument.name.clone())
+        .collect();
+    missing.sort();
+    missing
+}
+
+/// The `-32602` for a `prompts/get` missing required arguments.
+///
+/// The names travel in `data.missingArguments` as well as the message, so a
+/// client can act on them without parsing prose.
+pub(crate) fn missing_arguments_error(
+    name: &str,
+    missing: &[String],
+) -> crate::error::JsonRpcError {
+    crate::error::JsonRpcError::invalid_params(format!(
+        "prompt '{name}' is missing required argument{}: {}",
+        if missing.len() == 1 { "" } else { "s" },
+        missing.join(", ")
+    ))
+    .with_data(serde_json::json!({ "missingArguments": missing }))
+}
+
 impl std::fmt::Debug for Prompt {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Prompt")

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -3725,6 +3725,18 @@ impl McpRouter {
                     return Err(filter.denial_error(&params.name));
                 }
 
+                // Before dispatch, so every path shares one check: layered and
+                // unlayered, ordinary and MRTR. A handler never sees a request
+                // missing an argument it declared required (#1281).
+                let missing =
+                    crate::prompt::missing_required_arguments(&prompt.arguments, &params.arguments);
+                if !missing.is_empty() {
+                    return Err(Error::JsonRpc(crate::prompt::missing_arguments_error(
+                        &params.name,
+                        &missing,
+                    )));
+                }
+
                 tracing::debug!(name = %params.name, "Getting prompt");
                 let ctx = self.create_context_with_extensions(request_id, None, &extensions);
                 #[cfg(feature = "stateless")]

--- a/crates/tower-mcp/tests/prompt_required_arguments.rs
+++ b/crates/tower-mcp/tests/prompt_required_arguments.rs
@@ -1,0 +1,144 @@
+//! Required prompt arguments are enforced centrally (#1281).
+//!
+//! `PromptBuilder` lets a server declare an argument required, and that flows
+//! into `prompts/list`, so clients are told it is required. The router never
+//! checked, which left every handler re-implementing the same validation or
+//! reading a missing argument as absent and producing something wrong.
+//!
+//! The spec requires a missing required argument to produce `-32602`, so the
+//! check lives in the router ahead of dispatch: one place, shared by the
+//! layered and unlayered paths alike.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde_json::json;
+use tower_mcp::protocol::{Content, GetPromptResult, PromptMessage, PromptRole};
+use tower_mcp::{McpRouter, PromptBuilder};
+
+fn message(text: &str) -> GetPromptResult {
+    GetPromptResult {
+        description: None,
+        messages: vec![PromptMessage {
+            role: PromptRole::User,
+            content: Content::Text {
+                text: text.to_string(),
+                annotations: None,
+                meta: None,
+            },
+            meta: None,
+        }],
+        meta: None,
+    }
+}
+
+/// A prompt with one required and one optional argument, optionally layered.
+fn router(layered: bool) -> McpRouter {
+    let build = || {
+        PromptBuilder::new("greet")
+            .description("Greets someone")
+            .required_arg("name", "Who to greet")
+            .optional_arg("title", "An honorific")
+    };
+    let prompt = if layered {
+        build()
+            .handler(|args: HashMap<String, String>| async move {
+                Ok(message(&format!(
+                    "hello {}",
+                    args.get("name").cloned().unwrap_or_default()
+                )))
+            })
+            .layer(tower::timeout::TimeoutLayer::new(Duration::from_secs(30)))
+    } else {
+        build()
+            .handler(|args: HashMap<String, String>| async move {
+                Ok(message(&format!(
+                    "hello {}",
+                    args.get("name").cloned().unwrap_or_default()
+                )))
+            })
+            .build()
+    };
+    McpRouter::new()
+        .server_info("prompts", "1.0.0")
+        .prompt(prompt)
+}
+
+async fn get(router: &McpRouter, arguments: serde_json::Value) -> serde_json::Value {
+    let client = tower_mcp::client::McpClient::connect(tower_mcp::client::ChannelTransport::new(
+        router.clone(),
+    ))
+    .await
+    .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let arguments: HashMap<String, String> = serde_json::from_value(arguments).expect("arguments");
+    match client.get_prompt("greet", Some(arguments)).await {
+        Ok(result) => json!({ "ok": serde_json::to_value(result).unwrap() }),
+        Err(error) => json!({ "err": error.to_string() }),
+    }
+}
+
+/// The headline: omitting a declared-required argument is `-32602`, and the
+/// handler is never reached.
+#[tokio::test]
+async fn a_missing_required_argument_is_rejected() {
+    for layered in [false, true] {
+        let outcome = get(&router(layered), json!({})).await;
+        let error = outcome["err"]
+            .as_str()
+            .unwrap_or_else(|| panic!("layered={layered}: expected an error, got {outcome}"));
+        assert!(
+            error.contains("-32602") || error.to_lowercase().contains("invalid params"),
+            "layered={layered}: expected invalid params, got {error}"
+        );
+        assert!(
+            error.contains("name"),
+            "layered={layered}: the error must name the missing argument: {error}"
+        );
+    }
+}
+
+/// Layering must not change the answer. This is the same assertion as above,
+/// stated as the property #1280 is about: middleware composes without altering
+/// the semantics of what it wraps.
+#[tokio::test]
+async fn layered_and_unlayered_prompts_agree() {
+    let unlayered = get(&router(false), json!({})).await;
+    let layered = get(&router(true), json!({})).await;
+    assert!(unlayered.get("err").is_some() && layered.get("err").is_some());
+
+    let unlayered_ok = get(&router(false), json!({"name": "ada"})).await;
+    let layered_ok = get(&router(true), json!({"name": "ada"})).await;
+    assert_eq!(
+        unlayered_ok["ok"]["messages"][0]["content"]["text"],
+        layered_ok["ok"]["messages"][0]["content"]["text"],
+    );
+}
+
+/// An empty string is a value, not an omission. A handler may legitimately
+/// want one, and the router has no business deciding otherwise.
+#[tokio::test]
+async fn an_empty_string_counts_as_present() {
+    let outcome = get(&router(false), json!({"name": ""})).await;
+    assert!(
+        outcome.get("ok").is_some(),
+        "an empty value is supplied, not missing: {outcome}"
+    );
+}
+
+/// Optional arguments may be omitted, and unknown ones are not rejected: the
+/// protocol does not say prompt arguments are a closed set.
+#[tokio::test]
+async fn optional_omissions_and_unknown_extras_are_accepted() {
+    let omitted = get(&router(false), json!({"name": "ada"})).await;
+    assert!(
+        omitted.get("ok").is_some(),
+        "optional may be omitted: {omitted}"
+    );
+
+    let extra = get(&router(false), json!({"name": "ada", "unexpected": "x"})).await;
+    assert!(
+        extra.get("ok").is_some(),
+        "extra keys are not rejected: {extra}"
+    );
+}


### PR DESCRIPTION
Closes #1281. **Not** #1280, despite your asking for them stacked; see the
bottom for why and what I found.

`PromptBuilder` lets a server declare an argument required and that flows into
`prompts/list`, so clients are told it is required. The router never checked,
which left every handler re-implementing the same validation or reading a
missing required argument as absent and producing something wrong.

The check is now central, in the router ahead of dispatch. One place, so the
layered and unlayered paths and the ordinary and MRTR paths all share it, and
a handler never sees a request missing an argument it declared required.

Narrow by design, since arguments are unvalidated strings:

- an empty string is **present**, because emptiness is a value a handler may
  legitimately want
- an omitted optional argument is accepted
- unknown extra keys are accepted, because the protocol does not say prompt
  arguments are a closed set

Missing names come back sorted, in the message and in `data.missingArguments`,
so the error is stable whichever way the map iterated and a client can act on
it without parsing prose.

## What the mutation check showed

Removing the validation makes the test fail with the exact output the issue
describes:

```
expected an error, got {"ok":{"messages":[{"role":"user","content":{"text":"hello "}}]}}
```

That is the handler reading a missing required argument as empty. Worth noting
the first version of the test had the handler `.unwrap()` the key, which
without the check **panicked and hung** rather than failing. Rewriting it to
read the argument the way a defensive handler has to made the failure the
realistic one.

## Why #1280 is not here

It needs a structural change rather than a check, and I would rather land this
correctly than bundle it.

`ResourceCatchError` and `PromptCatchError` exist so a handler can be wrapped
as a service and have middleware compose around it. Both are
`Error = Infallible`, which is what lets the boxed service types be uniform,
so today the only place an error can go is into the response as content or as
an assistant message. That is the bug: the error has nowhere else to live.

The fix is to make the response carry the failure, which is the pattern the
transport layer already uses (`RouterResponse.inner` is a `Result`). Concretely:
the service response becomes `Result<_, JsonRpcError>`, the handler wrapper
converts its own `crate::Error` into the inner `Err` so a structured MCP error
survives intact, and genuine middleware failures stay service-level errors that
get sanitized to `-32603`. That split falls out of the design rather than
needing a downcast, and it gives your "preserve structured, sanitize opaque"
requirement for free.

It touches `resource.rs`, `prompt.rs`, both MRTR variants, and the router
dispatch for `resources/read` and `prompts/get`. Next PR.