### PR TITLE
refactor(resource,prompt)!: make the handler traits crate-private

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -614,11 +614,7 @@ pub use middleware::{
 };
 #[cfg(feature = "stateless")]
 pub use mrtr::{MrtrRequest, RequestStateCodec, RequestStateError};
-#[cfg(feature = "stateless")]
-pub use prompt::MrtrPromptHandler;
-pub use prompt::{
-    BoxPromptService, McpPrompt, Prompt, PromptBuilder, PromptHandler, PromptRequest,
-};
+pub use prompt::{BoxPromptService, McpPrompt, Prompt, PromptBuilder, PromptRequest};
 #[allow(deprecated)]
 pub use protocol::{
     BooleanSchema, CallToolParams, CallToolResult, CancelTaskParams, CancelledParams,
@@ -663,11 +659,9 @@ pub use registry::{
     DynamicToolRegistry,
 };
 pub use resource::{
-    BoxResourceService, McpResource, Resource, ResourceBuilder, ResourceHandler, ResourceRequest,
-    ResourceTemplate, ResourceTemplateBuilder, ResourceTemplateHandler,
+    BoxResourceService, McpResource, Resource, ResourceBuilder, ResourceRequest, ResourceTemplate,
+    ResourceTemplateBuilder,
 };
-#[cfg(feature = "stateless")]
-pub use resource::{MrtrResourceHandler, MrtrResourceTemplateHandler};
 pub use router::{
     McpRouter, MergeConflict, MergeConflictKind, MergeConflicts, PanicPolicy, RouterRequest,
     RouterResponse, ToolAnnotationsMap,

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -408,7 +408,7 @@ where
 /// implementation of this trait, and the router drives every prompt through
 /// it. No public constructor accepts an implementation, so a prompt written as
 /// a type rather than a closure implements [`McpPrompt`] instead.
-pub trait PromptHandler: Send + Sync {
+pub(crate) trait PromptHandler: Send + Sync {
     /// Get the prompt with the given arguments
     fn get(&self, arguments: HashMap<String, String>) -> BoxFuture<'_, Result<GetPromptResult>>;
 
@@ -432,7 +432,7 @@ pub trait PromptHandler: Send + Sync {
 
 /// Prompt handler that may return an SEP-2322 input-required continuation.
 #[cfg(feature = "stateless")]
-pub trait MrtrPromptHandler: Send + Sync {
+pub(crate) trait MrtrPromptHandler: Send + Sync {
     /// Resolve a prompt attempt with continuation values available through
     /// the request context.
     fn get(

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -327,7 +327,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 /// the router reads every resource through it. No public constructor accepts
 /// an implementation, so a resource written as a type rather than a closure
 /// implements [`McpResource`] instead.
-pub trait ResourceHandler: Send + Sync {
+pub(crate) trait ResourceHandler: Send + Sync {
     /// Read the resource contents
     fn read(&self) -> BoxFuture<'_, Result<ReadResourceResult>>;
 
@@ -338,16 +338,11 @@ pub trait ResourceHandler: Send + Sync {
     fn read_with_context(&self, _ctx: RequestContext) -> BoxFuture<'_, Result<ReadResourceResult>> {
         self.read()
     }
-
-    /// Returns true if this handler uses context (for optimization)
-    fn uses_context(&self) -> bool {
-        false
-    }
 }
 
 /// Resource handler that may return an SEP-2322 input-required continuation.
 #[cfg(feature = "stateless")]
-pub trait MrtrResourceHandler: Send + Sync {
+pub(crate) trait MrtrResourceHandler: Send + Sync {
     /// Read a resource attempt with continuation values in the context.
     fn read(
         &self,
@@ -1637,10 +1632,6 @@ where
     fn read_with_context(&self, ctx: RequestContext) -> BoxFuture<'_, Result<ReadResourceResult>> {
         Box::pin((self.handler)(ctx))
     }
-
-    fn uses_context(&self) -> bool {
-        true
-    }
 }
 
 #[cfg(feature = "stateless")]
@@ -1764,7 +1755,7 @@ impl<T: McpResource> ResourceHandler for McpResourceHandler<T> {
 /// Templates are built from closures through
 /// [`ResourceTemplateBuilder::handler`]; no public constructor accepts an
 /// implementation of this trait.
-pub trait ResourceTemplateHandler: Send + Sync {
+pub(crate) trait ResourceTemplateHandler: Send + Sync {
     /// Read a resource with the given URI variables extracted from the template
     fn read(
         &self,
@@ -1775,7 +1766,7 @@ pub trait ResourceTemplateHandler: Send + Sync {
 
 /// Resource-template handler that may return an SEP-2322 continuation.
 #[cfg(feature = "stateless")]
-pub trait MrtrResourceTemplateHandler: Send + Sync {
+pub(crate) trait MrtrResourceTemplateHandler: Send + Sync {
     /// Read a matched template resource with retry values in the context.
     fn read(
         &self,


### PR DESCRIPTION
Closes #1282, the remaining finding after #1315 took the other two.

`ResourceHandler`, `ResourceTemplateHandler`, and `PromptHandler` were public
traits with no public constructor accepting an implementation. A user could
implement one and find nowhere to pass it.

Adding constructors would create a second low-level registration API to
support indefinitely, alongside the closures, the builders, and
`McpResource` / `McpPrompt` that these adapt behind. So they stop being
public.

The MRTR counterparts are in the identical position and go with them:
`MrtrResourceHandler`, `MrtrResourceTemplateHandler`, `MrtrPromptHandler`.

## Two things the change surfaced

**Dead code.** With `ResourceHandler` crate-private, the compiler could see
that `uses_context` has no caller. The prompt equivalent *is* used, which is
why this only showed up on the resource side. Removed, with its one impl.

**An orphaned-attribute trap, which I walked into.** Two of the removed
exports were `#[cfg(feature = "stateless")]`, each on its own line above the
`pub use`. Deleting the `pub use` left the attribute gating the *next*
export, so `McpRouter` and the prompt types silently became
stateless-only. `--all-features` compiled perfectly; the default build did
not. Both attributes are removed, and the branch is verified on default,
`--all-features`, `stateless`, and `http,oauth`.

## Breaking change, and how small it is

The six traits are no longer exported. Nothing could be built with them, so
any code naming one was naming it in a `use` or a bound it could not satisfy.
The supported paths are unchanged.

## Left alone deliberately

`ToolHandler` and `MrtrToolHandler` are in exactly the same position: public,
adapted behind `McpTool` and the closures, with `from_handler` private. I did
not touch them, because neither the issue nor the decision on it covered
tools. Say the word and it is a three-line follow-up.