### PR TITLE
fix!: error semantics change depending on how a resource or prompt is registered (closes #1280)

### DIFF
--- a/crates/tower-mcp-types/src/error.rs
+++ b/crates/tower-mcp-types/src/error.rs
@@ -609,6 +609,35 @@ impl Error {
     pub fn internal(message: impl Into<String>) -> Self {
         Error::JsonRpc(JsonRpcError::internal_error(message))
     }
+
+    /// Convert into the JSON-RPC error a client will see for this failure.
+    ///
+    /// A structured [`Error::JsonRpc`] is returned as-is, preserving its
+    /// code and message. Every other variant is sanitized to `-32603`
+    /// (Internal Error) using the error's `Display` text, the same policy
+    /// `McpRouter`'s top-level dispatch and `transport::service::CatchError`
+    /// already apply. Callers that sit in front of a `Service` boundary
+    /// (a resource or prompt handler wrapper, for instance) use this to
+    /// convert their own error before it ever reaches a Tower layer, so a
+    /// structured error rides through middleware untouched and only a
+    /// genuine middleware failure needs sanitizing.
+    ///
+    /// ```rust
+    /// # use tower_mcp_types::Error;
+    /// # use tower_mcp_types::error::ErrorCode;
+    /// let structured = Error::invalid_params("bad shape").into_json_rpc_error();
+    /// assert_eq!(structured.code, ErrorCode::InvalidParams.code());
+    ///
+    /// let opaque = Error::Internal("db pool exhausted".to_string()).into_json_rpc_error();
+    /// assert_eq!(opaque.code, ErrorCode::InternalError.code());
+    /// assert!(opaque.message.contains("db pool exhausted"));
+    /// ```
+    pub fn into_json_rpc_error(self) -> JsonRpcError {
+        match self {
+            Error::JsonRpc(err) => err,
+            other => JsonRpcError::internal_error(other.to_string()),
+        }
+    }
 }
 
 /// Extension trait for converting errors into tower-mcp tool errors.
@@ -894,6 +923,29 @@ mod tests {
         assert_eq!(result.tool_err().unwrap(), 42);
         let result: std::result::Result<i32, std::io::Error> = Ok(42);
         assert_eq!(result.tool_context("should not appear").unwrap(), 42);
+    }
+
+    // =========================================================================
+    // #1280: Error::into_json_rpc_error, structured-preserve / opaque-sanitize
+    // =========================================================================
+
+    #[test]
+    fn into_json_rpc_error_preserves_a_structured_error() {
+        let err = Error::JsonRpc(JsonRpcError::invalid_params("bad shape"));
+        let json = err.into_json_rpc_error();
+        assert_eq!(json.code, ErrorCode::InvalidParams.code());
+        assert_eq!(json.message, "bad shape");
+    }
+
+    #[test]
+    fn into_json_rpc_error_sanitizes_an_opaque_error_to_internal_error() {
+        let err = Error::Internal("db pool exhausted".to_string());
+        let json = err.into_json_rpc_error();
+        assert_eq!(json.code, ErrorCode::InternalError.code());
+        // This crate's existing convention (matched by `CatchError` in
+        // `tower-mcp::transport::service`) is to include the `Display` text
+        // in the sanitized message rather than a bare placeholder.
+        assert!(json.message.contains("db pool exhausted"));
     }
 }
 

--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -30,13 +30,16 @@
 //! With the `stateless` feature, `mrtr_handler` accepts a handler that can
 //! suspend and ask the client for more input (SEP-2322).
 //!
-//! # Adding a layer changes what a handler error means
+//! # A layer does not change what a handler error means
 //!
-//! Without middleware, an `Err` from the handler propagates and the router
-//! reports a JSON-RPC error. Add `.layer()` and the handler becomes a Tower
-//! service, whose errors have to be caught for the stack to compose, so the
-//! same `Err` (and any middleware error, such as a timeout) comes back as a
-//! successful `prompts/get` whose assistant message carries the error text:
+//! An `Err` from the handler propagates and the router reports a JSON-RPC
+//! error whether or not `.layer()` was applied. `.layer()` turns the handler
+//! into a Tower service so a middleware stack can compose around it, but the
+//! handler's own error is converted to a structured JSON-RPC error before it
+//! ever reaches a layer, so it rides through untouched. Only a genuine
+//! failure at the Tower level -- a timeout, a rate limit, anything from a
+//! layer rather than from the handler -- is sanitized to a generic `-32603`
+//! Internal Error:
 //!
 //! ```rust
 //! use std::collections::HashMap;
@@ -51,7 +54,8 @@
 //!         Err(Error::internal("template store is offline"))
 //!     })
 //!     .build();
-//! assert!(plain.get(HashMap::new()).await.is_err());
+//! let plain_err = plain.get(HashMap::new()).await.unwrap_err();
+//! assert!(plain_err.to_string().contains("template store is offline"));
 //!
 //! let layered = PromptBuilder::new("layered")
 //!     .handler(|_: HashMap<String, String>| async {
@@ -59,15 +63,14 @@
 //!     })
 //!     .layer(TimeoutLayer::new(Duration::from_secs(5)));
 //!
-//! let result = layered.get(HashMap::new()).await.unwrap();
-//! let text = result.first_message_text().unwrap();
-//! assert!(text.contains("template store is offline"), "{text}");
+//! let layered_err = layered.get(HashMap::new()).await.unwrap_err();
+//! assert!(layered_err.to_string().contains("template store is offline"));
 //! # });
 //! ```
 //!
-//! Per-prompt middleware is the place for a bound that only one prompt needs,
-//! such as a timeout on a prompt that reads from a network template store.
-//! Layering the whole router covers everything else.
+//! Per-prompt middleware is still the place for a bound that only one prompt
+//! needs, such as a timeout on a prompt that reads from a network template
+//! store. Layering the whole router covers everything else.
 
 use std::collections::HashMap;
 use std::convert::Infallible;
@@ -85,7 +88,7 @@ use tower::{Layer, ServiceExt};
 use tower_service::Service;
 
 use crate::context::RequestContext;
-use crate::error::{Error, Result};
+use crate::error::{Error, JsonRpcError, Result};
 use crate::protocol::{
     Content, GetPromptResult, PromptArgument, PromptDefinition, PromptMessage, PromptRole,
     RequestId, RequestOutcome, ToolIcon,
@@ -134,12 +137,21 @@ impl PromptRequest {
 ///
 /// This is the service type used internally after applying middleware layers.
 /// It wraps any `Service<PromptRequest>` implementation so that the prompt
-/// handler can consume it without knowing the concrete middleware stack.
-pub type BoxPromptService = BoxCloneService<PromptRequest, GetPromptResult, Infallible>;
+/// handler can consume it without knowing the concrete middleware stack. The
+/// service itself never fails at the Tower level; whether the prompt
+/// succeeded is carried instead in the success value, `Ok(GetPromptResult)`
+/// or `Err(JsonRpcError)`. A structured `JsonRpcError` here is the handler's
+/// own error, converted before it reached any layer; [`PromptCatchError`]
+/// only ever produces one itself for a genuine middleware failure.
+pub type BoxPromptService =
+    BoxCloneService<PromptRequest, std::result::Result<GetPromptResult, JsonRpcError>, Infallible>;
 
 #[cfg(feature = "stateless")]
-type BoxMrtrPromptService =
-    BoxCloneService<PromptRequest, RequestOutcome<GetPromptResult>, Infallible>;
+type BoxMrtrPromptService = BoxCloneService<
+    PromptRequest,
+    std::result::Result<RequestOutcome<GetPromptResult>, JsonRpcError>,
+    Infallible,
+>;
 
 /// A service wrapper that catches errors from middleware and converts them
 /// into prompt errors, maintaining the `Error = Infallible` contract.
@@ -187,39 +199,40 @@ pin_project! {
 
 impl<F, E> Future for PromptCatchErrorFuture<F>
 where
-    F: Future<Output = std::result::Result<GetPromptResult, E>>,
+    F: Future<Output = std::result::Result<std::result::Result<GetPromptResult, JsonRpcError>, E>>,
     E: fmt::Display,
 {
-    type Output = std::result::Result<GetPromptResult, Infallible>;
+    type Output =
+        std::result::Result<std::result::Result<GetPromptResult, JsonRpcError>, Infallible>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match self.project().inner.poll(cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(response)) => Poll::Ready(Ok(response)),
-            Poll::Ready(Err(err)) => Poll::Ready(Ok(GetPromptResult {
-                description: Some(format!("Prompt error: {}", err)),
-                messages: vec![PromptMessage {
-                    role: PromptRole::Assistant,
-                    content: Content::Text {
-                        text: format!("Error generating prompt: {}", err),
-                        annotations: None,
-                        meta: None,
-                    },
-                    meta: None,
-                }],
-                meta: None,
-            })),
+            // The inner service already decided: either the prompt
+            // succeeded, or the handler's own error was already converted
+            // to a structured JsonRpcError. Either way, pass it through
+            // untouched.
+            Poll::Ready(Ok(inner)) => Poll::Ready(Ok(inner)),
+            // The inner service itself failed at the Tower level: a genuine
+            // middleware failure (timeout, rate limit, ...), not the
+            // handler's own error. Sanitize it to a generic Internal Error.
+            Poll::Ready(Err(err)) => {
+                Poll::Ready(Ok(Err(JsonRpcError::internal_error(err.to_string()))))
+            }
         }
     }
 }
 
 impl<S> Service<PromptRequest> for PromptCatchError<S>
 where
-    S: Service<PromptRequest, Response = GetPromptResult> + Clone + Send + 'static,
+    S: Service<PromptRequest, Response = std::result::Result<GetPromptResult, JsonRpcError>>
+        + Clone
+        + Send
+        + 'static,
     S::Error: fmt::Display + Send,
     S::Future: Send,
 {
-    type Response = GetPromptResult;
+    type Response = std::result::Result<GetPromptResult, JsonRpcError>;
     type Error = Infallible;
     type Future = PromptCatchErrorFuture<S::Future>;
 
@@ -250,11 +263,16 @@ impl<S> MrtrPromptCatchError<S> {
 #[cfg(feature = "stateless")]
 impl<S> Service<PromptRequest> for MrtrPromptCatchError<S>
 where
-    S: Service<PromptRequest, Response = RequestOutcome<GetPromptResult>> + Clone + Send + 'static,
+    S: Service<
+            PromptRequest,
+            Response = std::result::Result<RequestOutcome<GetPromptResult>, JsonRpcError>,
+        > + Clone
+        + Send
+        + 'static,
     S::Error: fmt::Display + Send + 'static,
     S::Future: Send + 'static,
 {
-    type Response = RequestOutcome<GetPromptResult>;
+    type Response = std::result::Result<RequestOutcome<GetPromptResult>, JsonRpcError>;
     type Error = Infallible;
     type Future =
         Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
@@ -270,20 +288,8 @@ where
         let future = self.inner.call(req);
         Box::pin(async move {
             Ok(match future.await {
-                Ok(outcome) => outcome,
-                Err(error) => RequestOutcome::Complete(GetPromptResult {
-                    description: Some(format!("Prompt error: {error}")),
-                    messages: vec![PromptMessage {
-                        role: PromptRole::Assistant,
-                        content: Content::Text {
-                            text: format!("Error generating prompt: {error}"),
-                            annotations: None,
-                            meta: None,
-                        },
-                        meta: None,
-                    }],
-                    meta: None,
-                }),
+                Ok(inner) => inner,
+                Err(error) => Err(JsonRpcError::internal_error(error.to_string())),
             })
         })
     }
@@ -314,9 +320,10 @@ where
     F: Fn(HashMap<String, String>) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<GetPromptResult>> + Send + 'static,
 {
-    type Response = GetPromptResult;
-    type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = std::result::Result<GetPromptResult, Error>> + Send>>;
+    type Response = std::result::Result<GetPromptResult, JsonRpcError>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Infallible>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -324,7 +331,11 @@ where
 
     fn call(&mut self, req: PromptRequest) -> Self::Future {
         let handler = self.handler.clone();
-        Box::pin(async move { handler(req.arguments).await })
+        Box::pin(async move {
+            Ok(handler(req.arguments)
+                .await
+                .map_err(Error::into_json_rpc_error))
+        })
     }
 }
 
@@ -357,10 +368,10 @@ where
     F: Fn(RequestContext, HashMap<String, String>) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<RequestOutcome<GetPromptResult>>> + Send + 'static,
 {
-    type Response = RequestOutcome<GetPromptResult>;
-    type Error = Error;
+    type Response = std::result::Result<RequestOutcome<GetPromptResult>, JsonRpcError>;
+    type Error = Infallible;
     type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Infallible>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -368,7 +379,11 @@ where
 
     fn call(&mut self, req: PromptRequest) -> Self::Future {
         let handler = self.handler.clone();
-        Box::pin(async move { handler(req.context, req.arguments).await })
+        Box::pin(async move {
+            Ok(handler(req.context, req.arguments)
+                .await
+                .map_err(Error::into_json_rpc_error))
+        })
     }
 }
 
@@ -388,9 +403,10 @@ where
     F: Fn(RequestContext, HashMap<String, String>) -> Fut + Clone + Send + Sync + 'static,
     Fut: Future<Output = Result<GetPromptResult>> + Send + 'static,
 {
-    type Response = GetPromptResult;
-    type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = std::result::Result<GetPromptResult, Error>> + Send>>;
+    type Response = std::result::Result<GetPromptResult, JsonRpcError>;
+    type Error = Infallible;
+    type Future =
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Infallible>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -398,7 +414,11 @@ where
 
     fn call(&mut self, req: PromptRequest) -> Self::Future {
         let handler = self.handler.clone();
-        Box::pin(async move { handler(req.context, req.arguments).await })
+        Box::pin(async move {
+            Ok(handler(req.context, req.arguments)
+                .await
+                .map_err(Error::into_json_rpc_error))
+        })
     }
 }
 
@@ -563,9 +583,8 @@ impl Prompt {
     /// and cancellation are inert. The router calls
     /// [`get_with_context`](Self::get_with_context) instead.
     ///
-    /// Whether a handler error arrives as `Err` or as an assistant message
-    /// depends on whether the prompt carries middleware; see the [module
-    /// documentation](crate::prompt).
+    /// A handler error arrives as `Err` whether or not the prompt carries
+    /// middleware; see the [module documentation](crate::prompt).
     pub fn get(
         &self,
         arguments: HashMap<String, String>,
@@ -793,8 +812,8 @@ impl PromptBuilder {
     ///
     /// The handler is called with whatever arguments the client sent, as
     /// strings, with no entry at all for the ones it left out. Finish with
-    /// `.build()`, or apply middleware with `.layer()` first, remembering that
-    /// a layer turns handler errors into prompt content.
+    /// `.build()`, or apply middleware with `.layer()` first; a handler's
+    /// `Err` propagates the same way either way.
     ///
     /// # Sharing State
     ///
@@ -1108,7 +1127,10 @@ where
     pub fn layer<L>(self, layer: L) -> Prompt
     where
         L: Layer<PromptHandlerService<F>> + Send + Sync + 'static,
-        L::Service: Service<PromptRequest, Response = GetPromptResult> + Clone + Send + 'static,
+        L::Service: Service<PromptRequest, Response = std::result::Result<GetPromptResult, JsonRpcError>>
+            + Clone
+            + Send
+            + 'static,
         <L::Service as Service<PromptRequest>>::Error: fmt::Display + Send,
         <L::Service as Service<PromptRequest>>::Future: Send,
     {
@@ -1157,14 +1179,17 @@ where
     /// Apply a Tower layer to every attempt at this MRTR-capable prompt.
     ///
     /// Each retry is an independent request, so the layer runs once per
-    /// round. Middleware failures become complete prompt error results,
-    /// matching non-MRTR prompt middleware.
+    /// round. A genuine middleware failure is sanitized to a `-32603`
+    /// JSON-RPC error, matching non-MRTR prompt middleware; the handler's
+    /// own error, if any, rides through untouched.
     #[allow(private_bounds)]
     pub fn layer<L>(self, layer: L) -> Prompt
     where
         L: Layer<MrtrPromptHandlerService<F>> + Send + Sync + 'static,
-        L::Service: Service<PromptRequest, Response = RequestOutcome<GetPromptResult>>
-            + Clone
+        L::Service: Service<
+                PromptRequest,
+                Response = std::result::Result<RequestOutcome<GetPromptResult>, JsonRpcError>,
+            > + Clone
             + Send
             + 'static,
         <L::Service as Service<PromptRequest>>::Error: fmt::Display + Send + 'static,
@@ -1225,7 +1250,10 @@ where
     pub fn layer<L>(self, layer: L) -> Prompt
     where
         L: Layer<PromptContextHandlerService<F>> + Send + Sync + 'static,
-        L::Service: Service<PromptRequest, Response = GetPromptResult> + Clone + Send + 'static,
+        L::Service: Service<PromptRequest, Response = std::result::Result<GetPromptResult, JsonRpcError>>
+            + Clone
+            + Send
+            + 'static,
         <L::Service as Service<PromptRequest>>::Error: fmt::Display + Send,
         <L::Service as Service<PromptRequest>>::Future: Send,
     {
@@ -1301,7 +1329,7 @@ impl MrtrPromptHandler for ServiceMrtrPromptHandler {
                 .call(request)
                 .await
                 .expect("MRTR prompt service is infallible");
-            Ok(outcome)
+            outcome.map_err(Into::into)
         })
     }
 }
@@ -1359,8 +1387,12 @@ impl PromptHandler for ServiceHandler {
         Box::pin(async move {
             let req = PromptRequest::with_arguments(arguments);
             let mut service = self.service.lock().await.clone();
-            match service.ready().await {
-                Ok(svc) => svc.call(req).await.map_err(|e| match e {}),
+            let outcome = match service.ready().await {
+                Ok(svc) => svc.call(req).await,
+                Err(e) => match e {},
+            };
+            match outcome {
+                Ok(inner) => inner.map_err(Into::into),
                 Err(e) => match e {},
             }
         })
@@ -1374,8 +1406,12 @@ impl PromptHandler for ServiceHandler {
         Box::pin(async move {
             let req = PromptRequest::new(ctx, arguments);
             let mut service = self.service.lock().await.clone();
-            match service.ready().await {
-                Ok(svc) => svc.call(req).await.map_err(|e| match e {}),
+            let outcome = match service.ready().await {
+                Ok(svc) => svc.call(req).await,
+                Err(e) => match e {},
+            };
+            match outcome {
+                Ok(inner) => inner.map_err(Into::into),
                 Err(e) => match e {},
             }
         })
@@ -1401,8 +1437,12 @@ impl PromptHandler for ServiceContextHandler {
         Box::pin(async move {
             let req = PromptRequest::new(ctx, arguments);
             let mut service = self.service.lock().await.clone();
-            match service.ready().await {
-                Ok(svc) => svc.call(req).await.map_err(|e| match e {}),
+            let outcome = match service.ready().await {
+                Ok(svc) => svc.call(req).await,
+                Err(e) => match e {},
+            };
+            match outcome {
+                Ok(inner) => inner.map_err(Into::into),
                 Err(e) => match e {},
             }
         })
@@ -1746,16 +1786,12 @@ mod tests {
             })
             .layer(TimeoutLayer::new(Duration::from_millis(50)));
 
-        let result = prompt.get(HashMap::new()).await.unwrap();
-
-        // Should get an error message due to timeout
-        assert!(result.description.as_ref().unwrap().contains("error"));
-        match &result.messages[0].content {
-            Content::Text { text, .. } => {
-                assert!(text.contains("Error generating prompt"));
-            }
-            _ => panic!("Expected text content"),
-        }
+        // The timeout is a genuine middleware failure (#1280), not the
+        // handler's own error, so it propagates as an Err sanitized to
+        // -32603 rather than becoming a successful prompt whose assistant
+        // message carries the error text.
+        let error = prompt.get(HashMap::new()).await.unwrap_err();
+        assert!(error.to_string().contains("-32603"));
     }
 
     #[tokio::test]
@@ -1969,24 +2005,12 @@ mod tests {
             })
             .layer(TimeoutLayer::new(Duration::from_millis(10)));
 
-        // The prompt goes through ServiceHandler -> PromptCatchError which
-        // converts the timeout error into a GetPromptResult with an error message.
-        // The .get() method delegates through the handler trait.
-        let result = prompt.get(HashMap::new()).await;
-        // PromptCatchError converts middleware errors to Ok(GetPromptResult)
-        // with the error message in the prompt content.
-        match result {
-            Ok(r) => {
-                // Should contain timeout error text in the message
-                assert!(
-                    !r.messages.is_empty(),
-                    "Expected error message in prompt result"
-                );
-            }
-            Err(_) => {
-                // Also acceptable -- error propagated directly
-            }
-        }
+        // The prompt goes through ServiceHandler -> PromptCatchError. The
+        // timeout is a genuine middleware failure (#1280), so it comes back
+        // as a sanitized Err, not a successful GetPromptResult with the
+        // error text folded into the content.
+        let error = prompt.get(HashMap::new()).await.unwrap_err();
+        assert!(error.to_string().contains("-32603"));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -36,15 +36,25 @@
 //! accepts a handler that can suspend and ask the client for more input
 //! (SEP-2322).
 //!
-//! # A failing resource handler is not a failed request
+//! # A failing resource handler is a failed request
 //!
 //! Every [`Resource`] handler is wrapped in an error-catching service, because
-//! a Tower stack composes only when the inner service cannot fail. An `Err`
-//! from the handler, or from middleware such as a timeout, therefore reaches
-//! the client as a successful read whose text is the error message, not as a
-//! JSON-RPC error. [`ResourceTemplate`] handlers are not wrapped: their errors
-//! propagate and the router reports them as JSON-RPC errors. See
-//! [`Resource::read`] for a worked example of the difference.
+//! a Tower stack composes only when the inner service cannot fail at the
+//! Tower level. The wrapper does not discard the handler's error, though: it
+//! converts the handler's own error into a structured JSON-RPC error before
+//! any layer sees it, so that error rides through the middleware stack
+//! untouched and the router reports it exactly the way it would for a
+//! [`ResourceTemplate`] (whose handler is never wrapped at all). Only a
+//! genuine failure at the Tower level -- a timeout, a rate limit, anything
+//! from a layer rather than from the handler -- is sanitized to a generic
+//! `-32603` Internal Error.
+//!
+//! [`Resource::read`] and [`Resource::read_with_context`] are the one
+//! exception: their signatures return [`ReadResourceResult`] rather than a
+//! `Result`, so they have nowhere to put an error and still render one as
+//! content. The router does not use them; it calls
+//! [`Resource::read_outcome_with_context`], which does return a `Result` and
+//! is what a client actually sees.
 //!
 //! # Per-resource middleware
 //!
@@ -118,7 +128,7 @@ use tower_service::Service;
 use tokio::sync::Mutex;
 
 use crate::context::RequestContext;
-use crate::error::{Error, Result};
+use crate::error::{Error, JsonRpcError, Result};
 use crate::protocol::{
     ContentAnnotations, PromptArgument, ReadResourceResult, RequestOutcome, ResourceContent,
     ResourceDefinition, ResourceTemplateDefinition, ToolIcon,
@@ -150,13 +160,25 @@ impl ResourceRequest {
 
 /// A boxed, cloneable resource service with `Error = Infallible`.
 ///
-/// This is the internal service type that resources use. Middleware errors are
-/// caught and converted to error results, so the service never fails at the Tower level.
-pub type BoxResourceService = BoxCloneService<ResourceRequest, ReadResourceResult, Infallible>;
+/// This is the internal service type that resources use. The service itself
+/// never fails at the Tower level (`Error = Infallible`), which is what lets
+/// `.layer()` compose; whether the read succeeded is carried instead in the
+/// success value, `Ok(ReadResourceResult)` or `Err(JsonRpcError)`. A
+/// structured `JsonRpcError` here is the handler's own error, converted
+/// before it reached any layer; [`ResourceCatchError`] only ever produces
+/// one itself for a genuine middleware failure (a timeout, a rate limit).
+pub type BoxResourceService = BoxCloneService<
+    ResourceRequest,
+    std::result::Result<ReadResourceResult, JsonRpcError>,
+    Infallible,
+>;
 
 #[cfg(feature = "stateless")]
-type BoxMrtrResourceService =
-    BoxCloneService<ResourceRequest, RequestOutcome<ReadResourceResult>, Infallible>;
+type BoxMrtrResourceService = BoxCloneService<
+    ResourceRequest,
+    std::result::Result<RequestOutcome<ReadResourceResult>, JsonRpcError>,
+    Infallible,
+>;
 
 /// Catches errors from the inner service and converts them to error results.
 ///
@@ -197,35 +219,32 @@ pin_project! {
     pub struct ResourceCatchErrorFuture<F> {
         #[pin]
         inner: F,
-        uri: Option<String>,
     }
 }
 
 impl<F, E> Future for ResourceCatchErrorFuture<F>
 where
-    F: Future<Output = std::result::Result<ReadResourceResult, E>>,
+    F: Future<
+        Output = std::result::Result<std::result::Result<ReadResourceResult, JsonRpcError>, E>,
+    >,
     E: fmt::Display,
 {
-    type Output = std::result::Result<ReadResourceResult, Infallible>;
+    type Output =
+        std::result::Result<std::result::Result<ReadResourceResult, JsonRpcError>, Infallible>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         match this.inner.poll(cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Ok(result)) => Poll::Ready(Ok(result)),
+            // The inner service already decided: either the read succeeded,
+            // or the handler's own error was already converted to a
+            // structured JsonRpcError. Either way, pass it through untouched.
+            Poll::Ready(Ok(inner)) => Poll::Ready(Ok(inner)),
+            // The inner service itself failed at the Tower level: a genuine
+            // middleware failure (timeout, rate limit, ...), not the
+            // handler's own error. Sanitize it to a generic Internal Error.
             Poll::Ready(Err(err)) => {
-                let uri = this.uri.take().unwrap_or_default();
-                Poll::Ready(Ok(ReadResourceResult {
-                    contents: vec![ResourceContent {
-                        uri,
-                        mime_type: Some("text/plain".to_string()),
-                        text: Some(format!("Error reading resource: {}", err)),
-                        blob: None,
-                        meta: None,
-                    }],
-                    meta: None,
-                    ..Default::default()
-                }))
+                Poll::Ready(Ok(Err(JsonRpcError::internal_error(err.to_string()))))
             }
         }
     }
@@ -233,11 +252,14 @@ where
 
 impl<S> Service<ResourceRequest> for ResourceCatchError<S>
 where
-    S: Service<ResourceRequest, Response = ReadResourceResult> + Clone + Send + 'static,
+    S: Service<ResourceRequest, Response = std::result::Result<ReadResourceResult, JsonRpcError>>
+        + Clone
+        + Send
+        + 'static,
     S::Error: fmt::Display + Send,
     S::Future: Send,
 {
-    type Response = ReadResourceResult;
+    type Response = std::result::Result<ReadResourceResult, JsonRpcError>;
     type Error = Infallible;
     type Future = ResourceCatchErrorFuture<S::Future>;
 
@@ -251,13 +273,9 @@ where
     }
 
     fn call(&mut self, req: ResourceRequest) -> Self::Future {
-        let uri = req.uri.clone();
         let fut = self.inner.call(req);
 
-        ResourceCatchErrorFuture {
-            inner: fut,
-            uri: Some(uri),
-        }
+        ResourceCatchErrorFuture { inner: fut }
     }
 }
 
@@ -277,14 +295,16 @@ impl<S> MrtrResourceCatchError<S> {
 #[cfg(feature = "stateless")]
 impl<S> Service<ResourceRequest> for MrtrResourceCatchError<S>
 where
-    S: Service<ResourceRequest, Response = RequestOutcome<ReadResourceResult>>
-        + Clone
+    S: Service<
+            ResourceRequest,
+            Response = std::result::Result<RequestOutcome<ReadResourceResult>, JsonRpcError>,
+        > + Clone
         + Send
         + 'static,
     S::Error: fmt::Display + Send + 'static,
     S::Future: Send + 'static,
 {
-    type Response = RequestOutcome<ReadResourceResult>;
+    type Response = std::result::Result<RequestOutcome<ReadResourceResult>, JsonRpcError>;
     type Error = Infallible;
     type Future =
         Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
@@ -297,22 +317,11 @@ where
     }
 
     fn call(&mut self, req: ResourceRequest) -> Self::Future {
-        let uri = req.uri.clone();
         let future = self.inner.call(req);
         Box::pin(async move {
             Ok(match future.await {
-                Ok(outcome) => outcome,
-                Err(error) => RequestOutcome::Complete(ReadResourceResult {
-                    contents: vec![ResourceContent {
-                        uri,
-                        mime_type: Some("text/plain".to_string()),
-                        text: Some(format!("Error reading resource: {error}")),
-                        blob: None,
-                        meta: None,
-                    }],
-                    meta: None,
-                    ..Default::default()
-                }),
+                Ok(inner) => inner,
+                Err(error) => Err(JsonRpcError::internal_error(error.to_string())),
             })
         })
     }
@@ -378,10 +387,10 @@ impl<H> Service<ResourceRequest> for MrtrResourceHandlerService<H>
 where
     H: MrtrResourceHandler + 'static,
 {
-    type Response = RequestOutcome<ReadResourceResult>;
-    type Error = Error;
+    type Response = std::result::Result<RequestOutcome<ReadResourceResult>, JsonRpcError>;
+    type Error = Infallible;
     type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Self::Error>> + Send>>;
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Infallible>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -389,7 +398,12 @@ where
 
     fn call(&mut self, req: ResourceRequest) -> Self::Future {
         let handler = self.handler.clone();
-        Box::pin(async move { handler.read(req.ctx).await })
+        Box::pin(async move {
+            Ok(handler
+                .read(req.ctx)
+                .await
+                .map_err(Error::into_json_rpc_error))
+        })
     }
 }
 
@@ -415,7 +429,7 @@ impl MrtrResourceHandler for ServiceMrtrResourceHandler {
                 .call(request)
                 .await
                 .expect("MRTR resource service is infallible");
-            Ok(outcome)
+            outcome.map_err(Into::into)
         })
     }
 }
@@ -455,10 +469,10 @@ impl<H> Service<ResourceRequest> for ResourceHandlerService<H>
 where
     H: ResourceHandler + 'static,
 {
-    type Response = ReadResourceResult;
-    type Error = Error;
+    type Response = std::result::Result<ReadResourceResult, JsonRpcError>;
+    type Error = Infallible;
     type Future =
-        Pin<Box<dyn Future<Output = std::result::Result<ReadResourceResult, Error>> + Send>>;
+        Pin<Box<dyn Future<Output = std::result::Result<Self::Response, Infallible>> + Send>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
@@ -466,7 +480,12 @@ where
 
     fn call(&mut self, req: ResourceRequest) -> Self::Future {
         let handler = self.handler.clone();
-        Box::pin(async move { handler.read_with_context(req.ctx).await })
+        Box::pin(async move {
+            Ok(handler
+                .read_with_context(req.ctx)
+                .await
+                .map_err(Error::into_json_rpc_error))
+        })
     }
 }
 
@@ -605,10 +624,13 @@ impl Resource {
     /// [`ResourceBuilder::handler`], which never see the context anyway. The
     /// transports call [`read_with_context`](Self::read_with_context).
     ///
-    /// There is no `Result` here because a handler error has already been
-    /// turned into the value returned. That is the cost of letting middleware
-    /// compose onto a resource, and it means a failed read still looks like a
-    /// read: the error text arrives as content.
+    /// There is no `Result` here because this method's own signature has no
+    /// room for one: it returns [`ReadResourceResult`] outright, so a handler
+    /// error is rendered as content instead. That is purely a property of
+    /// this convenience method, not of how a resource's error is handled in
+    /// general; the protocol-facing path,
+    /// [`read_outcome_with_context`](Self::read_outcome_with_context), does
+    /// return a `Result` and is what the router and a real client see.
     ///
     /// ```rust
     /// use tower_mcp::error::Error;
@@ -626,8 +648,8 @@ impl Resource {
     /// # });
     /// ```
     ///
-    /// A [`ResourceTemplate`] handler behaves the other way round: its errors
-    /// stay errors, and [`ResourceTemplate::read`] returns a `Result`.
+    /// [`ResourceTemplate::read`] has no such convenience wrapper and always
+    /// returns a `Result`.
     pub fn read(&self) -> BoxFuture<'static, ReadResourceResult> {
         let ctx = RequestContext::new(crate::protocol::RequestId::Number(0));
         self.read_with_context(ctx)
@@ -635,17 +657,18 @@ impl Resource {
 
     /// Read the resource with the request context the transport built.
     ///
-    /// This is the path the router takes. The context carries the request id,
-    /// progress reporting, the cancellation token, and the client requester
-    /// used for sampling and elicitation. Handlers registered through
-    /// [`ResourceBuilder::handler`] ignore it; those registered through
+    /// The context carries the request id, progress reporting, the
+    /// cancellation token, and the client requester used for sampling and
+    /// elicitation. Handlers registered through [`ResourceBuilder::handler`]
+    /// ignore it; those registered through
     /// [`ResourceBuilder::handler_with_context`] receive it.
     ///
-    /// Errors become content rather than a `Result`, as described on
-    /// [`read`](Self::read). A handler that suspends for client input is
-    /// reported the same way, since this signature has nowhere to put a
-    /// continuation; use [`read_outcome_with_context`](Self::read_outcome_with_context)
-    /// for that.
+    /// This signature has no room for an error or for an SEP-2322
+    /// continuation, so both are rendered as content, the same way
+    /// [`read`](Self::read) does. The router does not call this method: it
+    /// calls [`read_outcome_with_context`](Self::read_outcome_with_context),
+    /// which returns a `Result` and preserves a continuation instead of
+    /// flattening it.
     pub fn read_with_context(&self, ctx: RequestContext) -> BoxFuture<'static, ReadResourceResult> {
         let resource = self.clone();
         let uri = self.uri.clone();
@@ -703,7 +726,10 @@ impl Resource {
                 .oneshot(ResourceRequest::new(ctx, uri))
                 .await
                 .unwrap();
-            Ok(RequestOutcome::Complete(result))
+            match result {
+                Ok(read_result) => Ok(RequestOutcome::Complete(read_result)),
+                Err(json_rpc_err) => Err(json_rpc_err.into()),
+            }
         })
     }
 
@@ -1234,8 +1260,9 @@ where
     /// Apply a Tower layer to every attempt at this MRTR-capable resource.
     ///
     /// Each retry is an independent request, so the layer runs once per
-    /// round. Middleware failures become complete resource error results,
-    /// matching non-MRTR resource middleware.
+    /// round. A genuine middleware failure is sanitized to a `-32603`
+    /// JSON-RPC error, matching non-MRTR resource middleware; the handler's
+    /// own error, if any, rides through untouched.
     pub fn layer<L>(self, layer: L) -> ResourceBuilderWithMrtrLayer<F, L> {
         ResourceBuilderWithMrtrLayer {
             uri: self.uri,
@@ -1263,8 +1290,10 @@ where
         + Send
         + Sync
         + 'static,
-    L::Service: Service<ResourceRequest, Response = RequestOutcome<ReadResourceResult>>
-        + Clone
+    L::Service: Service<
+            ResourceRequest,
+            Response = std::result::Result<RequestOutcome<ReadResourceResult>, JsonRpcError>,
+        > + Clone
         + Send
         + 'static,
     <L::Service as Service<ResourceRequest>>::Error: fmt::Display + Send + 'static,
@@ -1413,7 +1442,10 @@ where
     F: Fn() -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
     L: tower::Layer<ResourceHandlerService<FnHandler<F>>> + Clone + Send + Sync + 'static,
-    L::Service: Service<ResourceRequest, Response = ReadResourceResult> + Clone + Send + 'static,
+    L::Service: Service<ResourceRequest, Response = std::result::Result<ReadResourceResult, JsonRpcError>>
+        + Clone
+        + Send
+        + 'static,
     <L::Service as Service<ResourceRequest>>::Error: fmt::Display + Send,
     <L::Service as Service<ResourceRequest>>::Future: Send,
 {
@@ -1544,7 +1576,10 @@ where
     F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<ReadResourceResult>> + Send + 'static,
     L: tower::Layer<ResourceHandlerService<ContextAwareHandler<F>>> + Clone + Send + Sync + 'static,
-    L::Service: Service<ResourceRequest, Response = ReadResourceResult> + Clone + Send + 'static,
+    L::Service: Service<ResourceRequest, Response = std::result::Result<ReadResourceResult, JsonRpcError>>
+        + Clone
+        + Send
+        + 'static,
     <L::Service as Service<ResourceRequest>>::Error: fmt::Display + Send,
     <L::Service as Service<ResourceRequest>>::Future: Send,
 {
@@ -3146,14 +3181,11 @@ mod tests {
             .build();
 
         let result = resource.read().await;
-        // Timeout error should be caught and converted to error content
-        assert!(
-            result.contents[0]
-                .text
-                .as_ref()
-                .unwrap()
-                .contains("Error reading resource")
-        );
+        // read() still renders an error as content, since its signature has
+        // no room for a Result. The timeout is a genuine middleware
+        // failure (#1280), so it is sanitized to -32603 rather than
+        // leaking the raw middleware error.
+        assert!(result.contents[0].text.as_ref().unwrap().contains("-32603"));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -4433,15 +4433,11 @@ impl Service<RouterRequest> for McpRouter {
             let result = router.handle(req.id, req.inner, req.extensions).await;
             Ok(RouterResponse {
                 id: request_id,
-                // Map tower-mcp errors to JSON-RPC errors:
-                // - Error::JsonRpc: forwarded as-is (preserves original code)
-                // - Error::Tool: mapped to -32603 (Internal Error)
-                // - All others: mapped to -32603 (Internal Error)
-                inner: result.map_err(|e| match e {
-                    Error::JsonRpc(err) => err,
-                    Error::Tool(err) => JsonRpcError::internal_error(err.to_string()),
-                    e => JsonRpcError::internal_error(e.to_string()),
-                }),
+                // Map tower-mcp errors to JSON-RPC errors: a structured
+                // Error::JsonRpc is forwarded as-is (preserves the original
+                // code and message); everything else is sanitized to
+                // -32603 (Internal Error). See Error::into_json_rpc_error.
+                inner: result.map_err(Error::into_json_rpc_error),
             })
         })
     }

--- a/crates/tower-mcp/tests/resource_prompt_error_semantics.rs
+++ b/crates/tower-mcp/tests/resource_prompt_error_semantics.rs
@@ -1,0 +1,434 @@
+//! Error semantics do not depend on registration style (#1280).
+//!
+//! Before this fix, a fixed `Resource` handler's `Err` was flattened into
+//! successful resource content, while a `ResourceTemplate` handler's `Err`
+//! propagated as a JSON-RPC error: same request shape, different outcome
+//! depending on which kind of resource matched. A `Prompt` had the same
+//! asymmetry along a different axis: unlayered, an `Err` propagated;
+//! layered, the same `Err` became a successful `prompts/get` whose
+//! assistant message carried the error text.
+//!
+//! Both had one cause: `ResourceCatchError` and `PromptCatchError` had
+//! nowhere to put an `Err` except the response, so it became content. The
+//! fix makes the boxed service's success value a `Result<_, JsonRpcError>`,
+//! converts the handler's own error to a structured `JsonRpcError` before
+//! any layer runs, and sanitizes only a genuine middleware failure to
+//! `-32603`. These tests exercise that through the router, the way a real
+//! client sees it.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use tower::Layer;
+use tower::timeout::TimeoutLayer;
+use tower_service::Service;
+
+use tower_mcp::client::{ChannelTransport, McpClient};
+use tower_mcp::error::{Error, ErrorCode, JsonRpcError};
+use tower_mcp::protocol::ReadResourceResult;
+use tower_mcp::resource::ResourceRequest;
+use tower_mcp::{GetPromptResult, McpRouter, PromptBuilder, ResourceBuilder, ResourceTemplate};
+
+async fn connected_client(router: McpRouter) -> McpClient {
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client
+        .initialize("test-client", "1.0.0")
+        .await
+        .expect("initialize");
+    client
+}
+
+/// Unwrap a `tower_mcp::Result` that is expected to be a structured
+/// JSON-RPC error, and hand back the error itself so a test can assert on
+/// its code and message directly rather than string-matching a rendered
+/// `Display`.
+fn expect_json_rpc_error<T: std::fmt::Debug>(result: tower_mcp::Result<T>) -> JsonRpcError {
+    match result {
+        Ok(value) => panic!("expected a JSON-RPC error, got Ok({value:?})"),
+        Err(Error::JsonRpc(err)) => err,
+        Err(other) => panic!("expected Error::JsonRpc, got {other:?}"),
+    }
+}
+
+// =============================================================================
+// 1. A fixed resource and a template agree on error shape.
+// =============================================================================
+
+#[tokio::test]
+async fn a_fixed_resource_and_a_template_agree_on_error_shape() {
+    let resource = ResourceBuilder::new("boom://fixed")
+        .name("fixed")
+        .handler(|| async { Err(Error::internal("boom")) })
+        .build();
+    let template = ResourceTemplate::builder("boom://template/{id}")
+        .name("template")
+        .handler(|_uri: String, _vars: HashMap<String, String>| async move {
+            Err(Error::internal("boom"))
+        });
+
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource)
+        .resource_template(template);
+    let client = connected_client(router).await;
+
+    let fixed_err = expect_json_rpc_error(client.read_resource("boom://fixed").await);
+    let template_err = expect_json_rpc_error(client.read_resource("boom://template/42").await);
+
+    assert_eq!(fixed_err.code, template_err.code);
+    assert!(fixed_err.message.contains("boom"), "{}", fixed_err.message);
+    assert!(
+        template_err.message.contains("boom"),
+        "{}",
+        template_err.message
+    );
+}
+
+// =============================================================================
+// 2. An unlayered prompt and a layered prompt agree on error shape.
+// =============================================================================
+
+#[tokio::test]
+async fn an_unlayered_and_a_layered_prompt_agree_on_error_shape() {
+    let unlayered = PromptBuilder::new("unlayered")
+        .handler(|_: HashMap<String, String>| async { Err(Error::internal("boom")) })
+        .build();
+    // A generous timeout that never fires: any difference between this and
+    // the unlayered prompt comes from layering itself, not from an
+    // unrelated timeout.
+    let layered = PromptBuilder::new("layered")
+        .handler(|_: HashMap<String, String>| async { Err(Error::internal("boom")) })
+        .layer(TimeoutLayer::new(Duration::from_secs(30)));
+
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .prompt(unlayered)
+        .prompt(layered);
+    let client = connected_client(router).await;
+
+    let unlayered_err = expect_json_rpc_error(client.get_prompt("unlayered", None).await);
+    let layered_err = expect_json_rpc_error(client.get_prompt("layered", None).await);
+
+    assert_eq!(unlayered_err.code, layered_err.code);
+    assert!(
+        unlayered_err.message.contains("boom"),
+        "{}",
+        unlayered_err.message
+    );
+    assert!(
+        layered_err.message.contains("boom"),
+        "{}",
+        layered_err.message
+    );
+}
+
+// =============================================================================
+// 3. A structured error survives a handler intact, resource and prompt.
+// =============================================================================
+
+#[tokio::test]
+async fn a_structured_error_survives_from_a_resource_handler() {
+    let resource = ResourceBuilder::new("structured://resource")
+        .name("structured")
+        .handler(|| async { Err(Error::invalid_params("bad shape")) })
+        .build();
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource);
+    let client = connected_client(router).await;
+
+    let error = expect_json_rpc_error(client.read_resource("structured://resource").await);
+    assert_eq!(error.code, ErrorCode::InvalidParams.code());
+    assert!(error.message.contains("bad shape"), "{}", error.message);
+}
+
+#[tokio::test]
+async fn a_structured_error_survives_from_a_prompt_handler() {
+    let prompt = PromptBuilder::new("structured")
+        .handler(|_: HashMap<String, String>| async { Err(Error::invalid_params("bad shape")) })
+        .build();
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .prompt(prompt);
+    let client = connected_client(router).await;
+
+    let error = expect_json_rpc_error(client.get_prompt("structured", None).await);
+    assert_eq!(error.code, ErrorCode::InvalidParams.code());
+    assert!(error.message.contains("bad shape"), "{}", error.message);
+}
+
+// =============================================================================
+// 4. An opaque middleware failure is sanitized, and its Debug never leaks.
+// =============================================================================
+
+/// An error deliberately shaped so its `Display` (what a sanitized JSON-RPC
+/// message may show) and its `Debug` (what only a log should show) differ.
+/// Only the `Display` text may ever reach a client.
+struct SecretLeakError;
+
+impl std::fmt::Debug for SecretLeakError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "SecretLeakError {{ internal_token: \"sk-supersecret\" }}"
+        )
+    }
+}
+
+impl std::fmt::Display for SecretLeakError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "upstream dependency unavailable")
+    }
+}
+
+impl std::error::Error for SecretLeakError {}
+
+/// A layer that always fails with [`SecretLeakError`], regardless of what
+/// the wrapped resource handler would have done. This is unambiguously a
+/// middleware failure, not a handler failure, since the handler never runs.
+#[derive(Clone)]
+struct AlwaysFailResourceLayer;
+
+impl<S> Layer<S> for AlwaysFailResourceLayer {
+    type Service = AlwaysFailResourceService;
+    fn layer(&self, _inner: S) -> Self::Service {
+        AlwaysFailResourceService
+    }
+}
+
+#[derive(Clone)]
+struct AlwaysFailResourceService;
+
+impl Service<ResourceRequest> for AlwaysFailResourceService {
+    type Response = std::result::Result<ReadResourceResult, JsonRpcError>;
+    type Error = SecretLeakError;
+    type Future = std::future::Ready<std::result::Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: ResourceRequest) -> Self::Future {
+        std::future::ready(Err(SecretLeakError))
+    }
+}
+
+/// The prompt-side equivalent of [`AlwaysFailResourceLayer`].
+#[derive(Clone)]
+struct AlwaysFailPromptLayer;
+
+impl<S> Layer<S> for AlwaysFailPromptLayer {
+    type Service = AlwaysFailPromptService;
+    fn layer(&self, _inner: S) -> Self::Service {
+        AlwaysFailPromptService
+    }
+}
+
+#[derive(Clone)]
+struct AlwaysFailPromptService;
+
+impl Service<tower_mcp::prompt::PromptRequest> for AlwaysFailPromptService {
+    type Response = std::result::Result<GetPromptResult, JsonRpcError>;
+    type Error = SecretLeakError;
+    type Future = std::future::Ready<std::result::Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::result::Result<(), Self::Error>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, _req: tower_mcp::prompt::PromptRequest) -> Self::Future {
+        std::future::ready(Err(SecretLeakError))
+    }
+}
+
+#[tokio::test]
+async fn an_opaque_middleware_failure_on_a_resource_is_sanitized() {
+    let resource = ResourceBuilder::new("opaque://resource")
+        .name("opaque")
+        .handler(|| async { Ok(ReadResourceResult::text("opaque://resource", "unused")) })
+        .layer(AlwaysFailResourceLayer)
+        .build();
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource);
+    let client = connected_client(router).await;
+
+    let error = expect_json_rpc_error(client.read_resource("opaque://resource").await);
+    assert_eq!(error.code, ErrorCode::InternalError.code());
+    assert!(
+        error.message.contains("upstream dependency unavailable"),
+        "{}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("sk-supersecret"),
+        "{}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("internal_token"),
+        "{}",
+        error.message
+    );
+}
+
+#[tokio::test]
+async fn an_opaque_middleware_failure_on_a_prompt_is_sanitized() {
+    let prompt = PromptBuilder::new("opaque")
+        .handler(|_: HashMap<String, String>| async { Ok(GetPromptResult::user_message("unused")) })
+        .layer(AlwaysFailPromptLayer);
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .prompt(prompt);
+    let client = connected_client(router).await;
+
+    let error = expect_json_rpc_error(client.get_prompt("opaque", None).await);
+    assert_eq!(error.code, ErrorCode::InternalError.code());
+    assert!(
+        error.message.contains("upstream dependency unavailable"),
+        "{}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("sk-supersecret"),
+        "{}",
+        error.message
+    );
+    assert!(
+        !error.message.contains("internal_token"),
+        "{}",
+        error.message
+    );
+}
+
+// =============================================================================
+// 5. Ok(...) content that merely mentions "error" is still a success.
+// =============================================================================
+
+#[tokio::test]
+async fn ok_resource_content_mentioning_error_is_still_a_success() {
+    let resource = ResourceBuilder::new("safe://resource")
+        .name("safe")
+        .handler(|| async {
+            Ok(ReadResourceResult::text(
+                "safe://resource",
+                "an error occurred upstream, retry later",
+            ))
+        })
+        .build();
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource);
+    let client = connected_client(router).await;
+
+    let result = client
+        .read_resource("safe://resource")
+        .await
+        .expect("content that merely mentions \"error\" must not become a JSON-RPC error");
+    assert_eq!(
+        result.contents[0].text.as_deref(),
+        Some("an error occurred upstream, retry later")
+    );
+}
+
+#[tokio::test]
+async fn ok_prompt_content_mentioning_error_is_still_a_success() {
+    let prompt = PromptBuilder::new("safe")
+        .handler(|_: HashMap<String, String>| async {
+            Ok(GetPromptResult::user_message(
+                "this describes an error condition",
+            ))
+        })
+        .build();
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .prompt(prompt);
+    let client = connected_client(router).await;
+
+    let result = client
+        .get_prompt("safe", None)
+        .await
+        .expect("content that merely mentions \"error\" must not become a JSON-RPC error");
+    assert_eq!(
+        result.first_message_text(),
+        Some("this describes an error condition")
+    );
+}
+
+// =============================================================================
+// 6. MRTR resource and prompt handlers, plain and layered.
+// =============================================================================
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn mrtr_resource_and_prompt_preserve_handler_errors() {
+    let resource = ResourceBuilder::new("mrtr://resource")
+        .mrtr_handler(|_ctx| async move { Err(Error::internal("mrtr boom")) })
+        .build();
+    let prompt = PromptBuilder::new("mrtr")
+        .mrtr_handler(|_ctx, _args| async move { Err(Error::internal("mrtr boom")) })
+        .build();
+
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource)
+        .prompt(prompt);
+    let client = connected_client(router).await;
+
+    let resource_err = expect_json_rpc_error(client.read_resource("mrtr://resource").await);
+    let prompt_err = expect_json_rpc_error(client.get_prompt("mrtr", None).await);
+
+    assert!(
+        resource_err.message.contains("mrtr boom"),
+        "{}",
+        resource_err.message
+    );
+    assert!(
+        prompt_err.message.contains("mrtr boom"),
+        "{}",
+        prompt_err.message
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn layered_mrtr_resource_and_prompt_preserve_handler_errors() {
+    // A generous timeout that never fires, same reasoning as test 2: any
+    // observed difference from the unlayered MRTR case would come from
+    // layering, not from an unrelated timeout.
+    let resource = ResourceBuilder::new("mrtr-layered://resource")
+        .mrtr_handler(|_ctx| async move { Err(Error::internal("mrtr boom")) })
+        .layer(TimeoutLayer::new(Duration::from_secs(30)))
+        .build();
+    let prompt = PromptBuilder::new("mrtr-layered")
+        .mrtr_handler(|_ctx, _args| async move { Err(Error::internal("mrtr boom")) })
+        .layer(TimeoutLayer::new(Duration::from_secs(30)));
+
+    let router = McpRouter::new()
+        .server_info("error-semantics", "1.0.0")
+        .resource(resource)
+        .prompt(prompt);
+    let client = connected_client(router).await;
+
+    let resource_err = expect_json_rpc_error(client.read_resource("mrtr-layered://resource").await);
+    let prompt_err = expect_json_rpc_error(client.get_prompt("mrtr-layered", None).await);
+
+    assert!(
+        resource_err.message.contains("mrtr boom"),
+        "{}",
+        resource_err.message
+    );
+    assert!(
+        prompt_err.message.contains("mrtr boom"),
+        "{}",
+        prompt_err.message
+    );
+}


### PR DESCRIPTION
Closes #1280.

## Result

Implemented as planned below (approach a: the boxed service's success value became `Result<T, JsonRpcError>`, `Error` stayed `Infallible`). Full validation passed: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`, `cargo test -p tower-mcp` (default features), `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p tower-mcp --all-features`, and the examples build.

**Mutation check.** Stashed the four production-code files (`error.rs`, `resource.rs`, `prompt.rs`, `router.rs`) while keeping the new integration test file, then ran that file against the pre-fix code:

- The two "opaque middleware failure" tests do not even *compile* against the pre-fix API: `ResourceBuilderWithLayer::layer()` and `PromptBuilderWithHandler::layer()` require `Response = ReadResourceResult` / `GetPromptResult` pre-fix, but the test's layer produces `Response = Result<_, JsonRpcError>`. The type change itself is the proof for that axis.
- With those two tests set aside, the remaining six ran against the pre-fix code: 4 failed exactly as expected, with output showing the pre-fix flattening bug directly, e.g. `expected a JSON-RPC error, got Ok(ReadResourceResult { ... text: Some("Error reading resource: JSON-RPC error: boom (code -32603)") ... })`. Failed: `a_fixed_resource_and_a_template_agree_on_error_shape`, `a_structured_error_survives_from_a_resource_handler`, `an_unlayered_and_a_layered_prompt_agree_on_error_shape`, `layered_mrtr_resource_and_prompt_preserve_handler_errors`. Passed (correctly, these paths were never broken): `ok_resource_content_mentioning_error_is_still_a_success`, `ok_prompt_content_mentioning_error_is_still_a_success`, and `mrtr_resource_and_prompt_preserve_handler_errors` (see finding below on why the unlayered MRTR case was already correct).
- Restored the fix (`git stash pop`); full suite green again.

**A finding the issue and the design comment did not anticipate.** The *unlayered* MRTR path (`ResourceBuilder::mrtr_handler(...).build()` / `PromptBuilder::mrtr_handler(...).build()`, no `.layer()`) was already correct before this fix. `Resource::from_mrtr_handler` and its prompt equivalent never wrap the handler in a Tower service at all when unlayered; `read_outcome_with_context` calls the raw `MrtrResourceHandler`/`MrtrPromptHandler` directly, bypassing `MrtrResourceCatchError`/`MrtrPromptCatchError` entirely. Only the *layered* MRTR path (`.mrtr_handler(...).layer(...).build()`) went through the catch-error service and had the flattening bug, mirroring the plain-prompt asymmetry exactly. The mutation check confirms this: `mrtr_resource_and_prompt_preserve_handler_errors` (unlayered) passed even against pre-fix code, while `layered_mrtr_resource_and_prompt_preserve_handler_errors` failed against it.

**Left out of scope, deliberately.** `Resource::read()` and `Resource::read_with_context()` still flatten a handler error into content. Their signatures return `ReadResourceResult`, not a `Result`, so there is no room for an `Err` regardless of anything else; this is not the bug #1280 describes, since the router never calls them, it calls `read_outcome_with_context`, which is fixed. Their doc comments were updated to state this plainly rather than to frame it as "the cost of composing middleware," which was the language that described the actual bug.

**Concurrent change.** `#1325` ("make the handler traits crate-private") landed on `main` between when this branch was cut and when implementation started; the branch was fast-forwarded onto it before any edits. It only touched trait visibility and removed a dead `uses_context` method, no interaction with this fix.

## Plan (written before implementing)

## Issue

Closes #1280: "error semantics change depending on how a resource or prompt is
registered."

Two symptoms, one cause:

1. A fixed `Resource` handler returning `Err` has its error turned into
   resource **content** (a successful `resources/read` whose text is the
   error message). A `ResourceTemplate` handler returning `Err` propagates as
   a JSON-RPC error. Same request shape, different outcome depending on
   registration style.
2. A `Prompt` handler returning `Err` propagates as a JSON-RPC error when
   unlayered. Applying `.layer()` turns the same `Err` (and any middleware
   error) into a **successful** `prompts/get` whose assistant message carries
   the error text.

The repo owner's comment on #1280 records the agreed design (quoted in full,
this is settled, not open for re-litigation):

> The reason both symptoms exist is the same: the error has nowhere to go.
> `ResourceCatchError` and `PromptCatchError` exist so a handler can be
> wrapped as a service and have middleware compose around it, and both are
> `Error = Infallible`, which is what keeps the boxed service types uniform.
> With no error channel, the only place an `Err` can land is the response, so
> it becomes resource content or an assistant message.
>
> That also explains the asymmetries. A `ResourceTemplate` handler is not
> wrapped that way, so its error propagates; a fixed `Resource` is, so its
> error becomes content. A prompt is only wrapped once `.layer()` is applied,
> which is why layering changes its contract.
>
> ## Fix
>
> Make the response carry the failure, which is the pattern the transport
> layer already uses (`RouterResponse.inner` is a `Result`):
>
> 1. The service response becomes `Result<_, JsonRpcError>`, so `Error` can
>    stay `Infallible` and boxing is unaffected.
> 2. The handler wrapper converts its own `crate::Error` into the inner
>    `Err`, so a structured MCP or JSON-RPC error survives intact.
> 3. Genuine middleware failures stay service-level errors and get sanitized
>    to `-32603` by the catch layer.
>
> Point 3 falls out of the design rather than needing a downcast: a
> structured error never becomes an opaque one, because it is converted
> before it reaches any layer. That satisfies preserve-structured and
> sanitize-opaque without inspecting error types at runtime.
>
> Touches `resource.rs`, `prompt.rs`, both MRTR variants, and the router
> dispatch for `resources/read` and `prompts/get`. Resource-not-found stays
> `-32602` per SEP-2164.

This is approach (a): the boxed service response becomes `Result<_,
JsonRpcError>`; the boxed alias `Error` type stays `Infallible`. Do not
consider approach (b) (changing the boxed alias's `Error` type away from
`Infallible`); it was rejected in favor of (a) above.

Non-negotiable acceptance criteria, from the repo owner:

- Fixed resources and templates behave identically.
- Layered and unlayered prompts behave identically.
- Preserve structured MCP/JSON-RPC errors (code and message intact).
- Map opaque internal errors (genuine middleware failures) to sanitized
  `-32603`, and do not leak internal detail (e.g. a middleware error's
  `Debug` output, as opposed to its `Display` output) into the message.
- Never turn an `Err` into successful resource content or an assistant
  prompt message, **at the protocol / router level**.
- An application can still deliberately return error-looking content as
  `Ok(...)` and that must stay a success.
- Resource-not-found stays `-32602` per SEP-2164 (this is untouched by this
  fix; it is produced directly by the router before any handler runs).
- This is an acceptable 0.22 breaking change. Do not preserve the old
  flattening behavior for compatibility.

## A recent concurrent change to be aware of

`c9d34e5` "refactor(resource,prompt)!: make the handler traits crate-private
(#1325)" landed on `main` immediately before this branch was cut and is
already included in this branch. It made `ResourceHandler`, `PromptHandler`,
`MrtrResourceHandler`, `MrtrPromptHandler`, `ResourceTemplateHandler`, and
`MrtrResourceTemplateHandler` `pub(crate)` (were `pub`), removed the now-dead
`ResourceHandler::uses_context` method, and dropped the now-invalid `pub use`
re-exports of those traits from `lib.rs`. This is unrelated to #1280's fix
but touches the same two files. It does not change the plan below.

## Root cause, verified by reading the code

`ResourceCatchError<S>` (`crates/tower-mcp/src/resource.rs`) and
`PromptCatchError<S>` (`crates/tower-mcp/src/prompt.rs`) both have
`Error = Infallible`. That is what lets `BoxResourceService` /
`BoxPromptService` (and their MRTR equivalents) stay uniform so `.layer()`
can compose. With no error channel in the `Service` trait, the only place an
`Err` can land today is the success value: `ResourceCatchErrorFuture` and
`PromptCatchErrorFuture` (and their Mrtr equivalents) both currently turn any
`Err` -- whether it came from the handler itself or from a genuine middleware
failure -- into a synthesized success value with the error text embedded as
content.

`Resource::from_handler` (the *unlayered* path) wraps the handler in
`ResourceCatchError` unconditionally, which is why a fixed resource always
flattens, layered or not. `PromptBuilderWithHandler::build()` (unlayered)
does **not** wrap in `PromptCatchError`; only `PromptBuilderWithHandler::layer()`
does, which is why layering is what flips a prompt's behavior.
`ResourceTemplate` never wraps its handler in a wrapping service at all; its
handler is a bare `Arc<dyn ResourceTemplateHandler>` returning
`Result<ReadResourceResult>` directly, which is why its errors already
propagate correctly today.

Router call sites (`crates/tower-mcp/src/router.rs`): `McpRequest::ReadResource`
calls `resource.read_outcome_with_context(ctx).await?` and
`template.read_outcome_with_context(ctx, ...).await?`; `McpRequest::GetPrompt`
calls `prompt.get_outcome_with_context(ctx, ...).await?`. These are the
methods that decide what the client actually sees. `Resource::read_outcome_with_context`
today does `service.oneshot(...).await.unwrap()` (safe because the boxed
service is `Infallible`) and then **unconditionally** wraps the result in
`Ok(RequestOutcome::Complete(result))` -- there is no way for it to produce
an `Err`, because the error was already eaten by `ResourceCatchError`
upstream. That is the bug.

## The fix, precisely

Change what a resource/prompt's boxed internal service carries in its
**success** value from the bare result type to
`std::result::Result<T, JsonRpcError>`. The service's own `Service::Error`
stays `Infallible` throughout (this is exactly the same pattern
`RouterResponse.inner: Result<McpResponse, JsonRpcError>` already uses at the
transport level, and the same pattern `transport::service::CatchError`
already uses to sanitize genuine middleware failures to `-32603` via
`JsonRpcError::internal_error(err.to_string())`).

The key discipline: the **handler wrapper** service (the adapter that calls
into the user's closure/trait impl, i.e. `ResourceHandlerService`,
`MrtrResourceHandlerService`, `PromptHandlerService`,
`PromptContextHandlerService`, `MrtrPromptHandlerService`) converts the
handler's own `crate::Error` into a `JsonRpcError` **immediately**, before
returning from `Service::call`, and embeds it in `Ok(Err(json_rpc_error))`.
Because this conversion happens at the innermost point, before any `.layer()`
sees the value, a structured error rides through every middleware layer
completely untouched -- no layer can rewrite, replace, or discard it, because
it is not a Tower-level failure at all from the layer's point of view, it's
just data in the success value. A layer can still genuinely fail (a timeout
elapsing, a rate limiter rejecting) -- that failure surfaces as a real
`Service::Error` from the layered stack, and that is the *only* thing the
outer `ResourceCatchError` / `PromptCatchError` (or their Mrtr equivalents)
still need to catch and sanitize to `-32603`. This is why no downcasting of
`BoxError` is needed anywhere: structured vs. opaque is decided by *where the
error entered the pipeline* (handler wrapper vs. genuine service failure),
not by inspecting the error's type at runtime.

Add one small shared helper rather than duplicating the
structured-vs-sanitize decision in five places. In
`crates/tower-mcp-types/src/error.rs`, on `impl Error`:

```rust
pub fn into_json_rpc_error(self) -> JsonRpcError {
    match self {
        Error::JsonRpc(err) => err,
        other => JsonRpcError::internal_error(other.to_string()),
    }
}
```

Then use it in `router.rs`'s top-level `Service<RouterRequest> for
McpRouter::call`, replacing the inline match with `result.map_err(Error::into_json_rpc_error)`
(same behavior, one definition).

## Touches

`crates/tower-mcp-types/src/error.rs`, `crates/tower-mcp/src/resource.rs`,
`crates/tower-mcp/src/prompt.rs`, `crates/tower-mcp/src/router.rs` (one call
site), plus existing tests in both `mod tests` blocks that assert the old
(buggy) behavior and a new integration test file,
`crates/tower-mcp/tests/resource_prompt_error_semantics.rs`, covering: fixed
resource vs. template error shape, layered vs. unlayered prompt error shape,
a structured `Error::JsonRpc` surviving intact, an opaque middleware failure
sanitized to `-32603` without leaking `Debug`-only detail, `Ok(...)` content
that merely mentions "error" staying a success, and the MRTR resource/prompt
variants (both plain and layered) under `#[cfg(feature = "stateless")]`.

Full symbol-by-symbol change list, the mutation-verification discipline, and
the validation command sequence are in the dispatch prompt this PR's commits
are implementing against; the PR description will be updated with the
mutation-check results and any findings once the implementation lands.

Breaking change: a handler `Err` for a fixed `Resource` or a `Prompt` now
reaches the client as a JSON-RPC error instead of successful content
(matching `ResourceTemplate`'s existing behavior); `BoxResourceService` /
`BoxPromptService` and their MRTR equivalents now carry `Result<_,
JsonRpcError>` in their Response type. Targeted for 0.22.

