### PR TITLE
feat(tasks): let one tool serve a live task plus a synchronous/MRTR fallback (closes #1246)

### DIFF
--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -1507,31 +1507,45 @@ impl Tool {
     where
         G: Fn(&ToolRequest) -> std::result::Result<(), String> + Clone + Send + Sync + 'static,
     {
-        if let Some(inner) = self.live_handler.clone() {
-            return Tool {
-                live_handler: Some(Arc::new(GuardedLiveToolHandler { guard, inner })),
-                ..self
-            };
-        }
+        // A tool can now have a live handler and a fallback at the same time
+        // (#1246), so every path that is actually present gets wrapped,
+        // rather than returning after whichever one this found first and
+        // leaving a coexisting fallback unguarded.
+        let live_handler = self.live_handler.clone().map(|inner| {
+            Arc::new(GuardedLiveToolHandler {
+                guard: guard.clone(),
+                inner,
+            }) as Arc<dyn LiveToolHandler>
+        });
 
         #[cfg(feature = "stateless")]
         if let Some(inner) = self.mrtr_handler.clone() {
             return Tool {
+                live_handler,
                 mrtr_handler: Some(Arc::new(GuardedMrtrToolHandler { guard, inner })),
                 ..self
             };
         }
 
-        let guarded = GuardService {
-            guard,
-            inner: self
-                .service
-                .expect("tool must have a complete or MRTR handler"),
-        };
-        let caught = ToolCatchError::new(guarded);
-        Tool {
-            service: Some(BoxCloneService::new(caught)),
-            ..self
+        match self.service.clone() {
+            Some(service) => {
+                let guarded = GuardService {
+                    guard,
+                    inner: service,
+                };
+                let caught = ToolCatchError::new(guarded);
+                Tool {
+                    live_handler,
+                    service: Some(BoxCloneService::new(caught)),
+                    ..self
+                }
+            }
+            // Live-only: there is no synchronous or MRTR path to guard.
+            None if live_handler.is_some() => Tool {
+                live_handler,
+                ..self
+            },
+            None => panic!("tool must have a complete, MRTR, or live handler"),
         }
     }
 
@@ -2463,6 +2477,300 @@ impl ToolBuilderWithLiveHandler {
             #[cfg(feature = "stateless")]
             mrtr_handler: None,
             live_handler: Some(self.handler),
+            input_schema: ensure_object_schema(self.input_schema),
+        }
+    }
+
+    /// Add a synchronous fallback for calls that do not negotiate Tasks.
+    ///
+    /// [`live_task_handler`](ToolBuilder::live_task_handler) alone forces
+    /// [`TaskSupportMode::Required`]: a live handler has nothing to run for a
+    /// call that never becomes a task, so the tool is invisible to a client
+    /// that has not negotiated Tasks. Adding a fallback here changes that:
+    /// the tool is registered as [`TaskSupportMode::Optional`] instead
+    /// (still overridable with
+    /// [`task_support`](ToolBuilderWithLiveAndFallback::task_support)), the
+    /// live handler runs for a task-backed call, and this fallback runs for
+    /// an ordinary one -- same schema, same name, whichever path the caller
+    /// actually used (#1246).
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{CallToolResult, TaskContext, TaskOutcome, ToolBuilder};
+    /// use serde::Deserialize;
+    /// use tower_mcp::schemars::JsonSchema;
+    ///
+    /// #[derive(Deserialize, JsonSchema)]
+    /// struct Run { prompt: String }
+    ///
+    /// let tool = ToolBuilder::new("run")
+    ///     .description("Live when Tasks are negotiated, synchronous otherwise")
+    ///     .live_task_handler(|task: TaskContext, input: Run| async move {
+    ///         let _ = (task, input);
+    ///         Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+    ///     })
+    ///     .fallback_handler(|input: Run| async move {
+    ///         Ok(CallToolResult::text(format!("synchronous: {}", input.prompt)))
+    ///     })
+    ///     .build();
+    /// ```
+    ///
+    /// # No shared handler logic
+    ///
+    /// The two closures are independent rather than one shape reused twice.
+    /// A live handler owns a future that stays alive across input rounds; a
+    /// fallback returns once. Unifying them would mean either allocating
+    /// task machinery a synchronous call never uses, or running a task to
+    /// completion inside a single request -- so this asks for both instead of
+    /// forcing a false unification.
+    pub fn fallback_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveAndFallback
+    where
+        I: DeserializeOwned + Send + Sync + 'static,
+        F: Fn(I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<CallToolResult>> + Send + 'static,
+    {
+        let service = ToolHandlerService::new(LiveFallbackHandler {
+            handler,
+            _phantom: std::marker::PhantomData::<fn() -> I>,
+        });
+        let caught = ToolCatchError::new(service);
+        ToolBuilderWithLiveAndFallback {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema: self.input_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: TaskSupportMode::Optional,
+            live_handler: self.handler,
+            fallback: BoxCloneService::new(caught),
+        }
+    }
+
+    /// Add an SEP-2322 MRTR fallback for calls that do not negotiate Tasks.
+    ///
+    /// Same routing as [`fallback_handler`](Self::fallback_handler): this
+    /// runs when a call is not task-backed, the live handler runs when it is.
+    /// Unlike the plain fallback, this one can ask for input itself and
+    /// resume from [`RequestContext::input_responses`] on the client's
+    /// retry, which matters when the non-task caller also needs a
+    /// multi-round interaction rather than a single synchronous result.
+    ///
+    /// A [`RequestOutcome::InputRequired`] result from this fallback is only
+    /// accepted by the router from a 2026-07-28 caller (a pre-existing rule,
+    /// not new here -- see `validate_input_required_result` in `router.rs`).
+    /// A legacy 2025-11-25 caller can still reach this fallback, but only the
+    /// [`RequestOutcome::Complete`] branch is usable for it.
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{
+    ///     CallToolResult, RequestContext, RequestOutcome, TaskContext, TaskOutcome, ToolBuilder,
+    /// };
+    /// use serde::Deserialize;
+    /// use tower_mcp::schemars::JsonSchema;
+    ///
+    /// #[derive(Deserialize, JsonSchema)]
+    /// struct Run { prompt: String }
+    ///
+    /// let tool = ToolBuilder::new("run")
+    ///     .description("Live when Tasks are negotiated, MRTR otherwise")
+    ///     .live_task_handler(|task: TaskContext, input: Run| async move {
+    ///         let _ = (task, input);
+    ///         Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+    ///     })
+    ///     .fallback_mrtr_handler(|ctx: RequestContext, input: Run| async move {
+    ///         let _ = input;
+    ///         if ctx.input_responses().is_some() {
+    ///             return Ok(RequestOutcome::Complete(CallToolResult::text("resumed")));
+    ///         }
+    ///         Ok(RequestOutcome::Complete(CallToolResult::text("done")))
+    ///     })
+    ///     .build();
+    /// ```
+    #[cfg(feature = "stateless")]
+    pub fn fallback_mrtr_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveAndMrtrFallback
+    where
+        I: DeserializeOwned + Send + Sync + 'static,
+        F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+    {
+        ToolBuilderWithLiveAndMrtrFallback {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            input_schema: self.input_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            task_support: TaskSupportMode::Optional,
+            live_handler: self.handler,
+            fallback: Arc::new(LiveFallbackMrtrHandler {
+                handler,
+                _phantom: std::marker::PhantomData::<fn() -> I>,
+            }),
+        }
+    }
+}
+
+/// A synchronous fallback for a tool that also has a live handler.
+///
+/// Unlike [`TypedHandler`], the input type does not need [`JsonSchema`]: the
+/// schema is already fixed by the live handler this fallback is attached to,
+/// so there is nothing left for this adapter to derive it from (#1246).
+struct LiveFallbackHandler<I, F> {
+    handler: F,
+    _phantom: std::marker::PhantomData<fn() -> I>,
+}
+
+impl<I, F, Fut> ToolHandler for LiveFallbackHandler<I, F>
+where
+    I: DeserializeOwned + Send + Sync + 'static,
+    F: Fn(I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<CallToolResult>> + Send + 'static,
+{
+    fn call(&self, args: Value) -> BoxFuture<'_, Result<CallToolResult>> {
+        Box::pin(async move {
+            let input: I = match serde_json::from_value(args) {
+                Ok(input) => input,
+                Err(e) => return Ok(CallToolResult::error(format!("Invalid input: {e}"))),
+            };
+            (self.handler)(input).await
+        })
+    }
+
+    fn input_schema(&self) -> Value {
+        // Never consulted: `ToolBuilderWithLiveAndFallback::build` uses the
+        // schema already fixed by the live handler rather than asking this
+        // adapter to derive one.
+        serde_json::json!({ "type": "object" })
+    }
+}
+
+/// An MRTR fallback for a tool that also has a live handler. Same relaxed
+/// bound as [`LiveFallbackHandler`], for the same reason.
+#[cfg(feature = "stateless")]
+struct LiveFallbackMrtrHandler<I, F> {
+    handler: F,
+    _phantom: std::marker::PhantomData<fn() -> I>,
+}
+
+#[cfg(feature = "stateless")]
+impl<I, F, Fut> MrtrToolHandler for LiveFallbackMrtrHandler<I, F>
+where
+    I: DeserializeOwned + Send + Sync + 'static,
+    F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static,
+{
+    fn call(
+        &self,
+        ctx: RequestContext,
+        args: Value,
+    ) -> BoxFuture<'_, Result<RequestOutcome<CallToolResult>>> {
+        Box::pin(async move {
+            let input: I = serde_json::from_value(args)
+                .map_err(|error| Error::invalid_params(format!("Invalid input: {error}")))?;
+            (self.handler)(ctx, input).await
+        })
+    }
+
+    fn input_schema(&self) -> Value {
+        serde_json::json!({ "type": "object" })
+    }
+}
+
+/// Builder state after a live handler and a synchronous fallback have both
+/// been set.
+///
+/// Created by [`ToolBuilderWithLiveHandler::fallback_handler`]. `task_support`
+/// defaults to [`TaskSupportMode::Optional`] because a fallback now exists;
+/// override with [`task_support`](Self::task_support) if the tool should
+/// stay [`TaskSupportMode::Required`] anyway (#1246).
+pub struct ToolBuilderWithLiveAndFallback {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    output_schema: Option<Value>,
+    input_schema: Value,
+    icons: Option<Vec<ToolIcon>>,
+    annotations: Option<ToolAnnotations>,
+    task_support: TaskSupportMode,
+    live_handler: Arc<dyn LiveToolHandler>,
+    fallback: BoxToolService,
+}
+
+impl ToolBuilderWithLiveAndFallback {
+    /// Override the default [`TaskSupportMode::Optional`].
+    pub fn task_support(mut self, mode: TaskSupportMode) -> Self {
+        self.task_support = mode;
+        self
+    }
+
+    /// Finish the tool.
+    pub fn build(self) -> Tool {
+        Tool {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            meta: None,
+            task_support: self.task_support,
+            required_client_capabilities: None,
+            task_preparer: None,
+            service: Some(self.fallback),
+            #[cfg(feature = "stateless")]
+            mrtr_handler: None,
+            live_handler: Some(self.live_handler),
+            input_schema: ensure_object_schema(self.input_schema),
+        }
+    }
+}
+
+/// Builder state after a live handler and an MRTR fallback have both been
+/// set.
+///
+/// Created by [`ToolBuilderWithLiveHandler::fallback_mrtr_handler`]. Same
+/// `task_support` default and override as
+/// [`ToolBuilderWithLiveAndFallback`].
+#[cfg(feature = "stateless")]
+pub struct ToolBuilderWithLiveAndMrtrFallback {
+    name: String,
+    title: Option<String>,
+    description: Option<String>,
+    output_schema: Option<Value>,
+    input_schema: Value,
+    icons: Option<Vec<ToolIcon>>,
+    annotations: Option<ToolAnnotations>,
+    task_support: TaskSupportMode,
+    live_handler: Arc<dyn LiveToolHandler>,
+    fallback: Arc<dyn MrtrToolHandler>,
+}
+
+#[cfg(feature = "stateless")]
+impl ToolBuilderWithLiveAndMrtrFallback {
+    /// Override the default [`TaskSupportMode::Optional`].
+    pub fn task_support(mut self, mode: TaskSupportMode) -> Self {
+        self.task_support = mode;
+        self
+    }
+
+    /// Finish the tool.
+    pub fn build(self) -> Tool {
+        Tool {
+            name: self.name,
+            title: self.title,
+            description: self.description,
+            output_schema: self.output_schema,
+            icons: self.icons,
+            annotations: self.annotations,
+            meta: None,
+            task_support: self.task_support,
+            required_client_capabilities: None,
+            task_preparer: None,
+            service: None,
+            mrtr_handler: Some(self.fallback),
+            live_handler: Some(self.live_handler),
             input_schema: ensure_object_schema(self.input_schema),
         }
     }

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -17,11 +17,12 @@ use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
 use tower_mcp::client::{ChannelTransport, McpClient};
 use tower_mcp::protocol::{
     ElicitAction, ElicitFormParams, ElicitFormSchema, ElicitRequestParams, ElicitResult,
-    InputRequest, InputRequests, InputResponse, TaskStatus,
+    InputRequest, InputRequests, InputRequiredResult, InputResponse, RequestOutcome, TaskStatus,
 };
 use tower_mcp::schemars::JsonSchema;
 use tower_mcp::{
-    CallToolResult, McpRouter, PanicPolicy, RequestContext, TaskContext, TaskOutcome, ToolBuilder,
+    CallToolResult, McpRouter, PanicPolicy, ProtocolSupport, RequestContext, TaskContext,
+    TaskOutcome, Tool, ToolBuilder,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -949,4 +950,357 @@ async fn require_input_still_parks_and_waits_in_one_call() {
     let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
     let text = serde_json::to_value(result.unwrap()).unwrap()["content"][0]["text"].clone();
     assert_eq!(text, "one");
+}
+
+// ============================================================================
+// Live plus fallback (#1246)
+// ============================================================================
+//
+// A `Tool` can now carry a live handler and a synchronous/MRTR fallback at
+// the same time: the live handler runs when a call is task-backed, the
+// fallback runs when it is not. One tool, one schema, one name -- the router
+// already picked between the two by how the call arrived (see `router.rs`);
+// what was missing was the ability to build a `Tool` that carries both.
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct MultiInput {
+    value: String,
+    #[serde(default)]
+    ask: bool,
+}
+
+/// Bounds an awaited client call so a routing regression that panics a
+/// connection task -- rather than returning a clean error -- fails this test
+/// instead of hanging the run. Found empirically while mutation-testing
+/// `Tool::clone`: dropping the fallback there does not surface as a client
+/// error, because the panic happens inside `ChannelTransport`'s background
+/// task and the client is left waiting on a response that will never come.
+async fn timed<F, T>(fut: F) -> T
+where
+    F: std::future::Future<Output = T>,
+{
+    tokio::time::timeout(std::time::Duration::from_secs(5), fut)
+        .await
+        .expect("call timed out; the connection likely panicked without responding")
+}
+
+/// One tool, a live handler and an MRTR fallback, both counted so a test can
+/// assert which side actually ran rather than only checking the result text.
+fn multi_tool(live_calls: Arc<AtomicUsize>, fallback_calls: Arc<AtomicUsize>) -> Tool {
+    ToolBuilder::new("multi")
+        .description("Live when Tasks are negotiated, MRTR/synchronous otherwise")
+        .live_task_handler(move |_task: TaskContext, input: MultiInput| {
+            let live_calls = live_calls.clone();
+            async move {
+                live_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(TaskOutcome::Completed(CallToolResult::text(format!(
+                    "live:{}",
+                    input.value
+                ))))
+            }
+        })
+        .fallback_mrtr_handler(move |ctx: RequestContext, input: MultiInput| {
+            let fallback_calls = fallback_calls.clone();
+            async move {
+                fallback_calls.fetch_add(1, Ordering::SeqCst);
+                // A non-empty request_state means this is the client's retry
+                // after answering the question below.
+                if ctx.request_state().is_some() {
+                    return Ok(RequestOutcome::Complete(CallToolResult::text(format!(
+                        "resumed:{}",
+                        input.value
+                    ))));
+                }
+                if input.ask {
+                    return Ok(RequestOutcome::input_required(
+                        InputRequiredResult::new().with_request_state("confirm"),
+                    ));
+                }
+                Ok(RequestOutcome::Complete(CallToolResult::text(format!(
+                    "sync:{}",
+                    input.value
+                ))))
+            }
+        })
+        .build()
+}
+
+/// A plain, non-task-backed `tools/call` (legacy protocol, no `task` param)
+/// must reach the fallback. The live handler has nothing to run for a call
+/// that never became a task, so it must not run at all.
+#[tokio::test]
+async fn a_live_plus_fallback_tool_serves_a_plain_call_through_the_fallback() {
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = Arc::new(AtomicUsize::new(0));
+    let tool = multi_tool(live_calls.clone(), fallback_calls.clone());
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let result = timed(client.call_tool("multi", json!({"value": "a"})))
+        .await
+        .expect("call");
+    assert!(!result.is_error);
+    assert_eq!(result.all_text(), "sync:a");
+    assert_eq!(fallback_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        live_calls.load(Ordering::SeqCst),
+        0,
+        "the live handler must not run for a plain call"
+    );
+}
+
+/// The same tool, task-requested, must reach the live handler and never the
+/// fallback -- distinguishing this from "any handler ran" is the point.
+#[tokio::test]
+async fn a_live_plus_fallback_tool_serves_a_task_backed_call_through_the_live_handler() {
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = Arc::new(AtomicUsize::new(0));
+    let tool = multi_tool(live_calls.clone(), fallback_calls.clone());
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = timed(client.call_tool_as_task("multi", json!({"value": "b"}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(result.unwrap().all_text(), "live:b");
+    assert_eq!(live_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        fallback_calls.load(Ordering::SeqCst),
+        0,
+        "the fallback must not run for a task-backed call"
+    );
+}
+
+/// The same tool again, this time driving the fallback through an SEP-2322
+/// MRTR round trip. `InputRequiredResult` from a synchronous `tools/call` is
+/// only accepted by the router from a 2026-07-28 caller, so this is the one
+/// case in the file that needs the final protocol rather than legacy.
+#[tokio::test]
+async fn a_live_plus_fallback_tool_serves_an_mrtr_round_trip_through_the_fallback() {
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = Arc::new(AtomicUsize::new(0));
+    let tool = multi_tool(live_calls.clone(), fallback_calls.clone());
+
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(Arc::new(MemoryTaskStore::new()))
+        .tool(tool)
+        .with_tasks();
+
+    // Final protocol, but this client never declares Tasks, so the router
+    // never elects a task for it: every call reaches the fallback.
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .connect_simple(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.discover("t", "1.0.0").await.expect("discover");
+
+    let outcome =
+        timed(client.call_tool_once("multi", json!({"value": "c", "ask": true}), None, None))
+            .await
+            .expect("tools/call");
+    let required = outcome
+        .as_input_required()
+        .expect("the fallback asked for input");
+    assert_eq!(required.request_state.as_deref(), Some("confirm"));
+    assert_eq!(fallback_calls.load(Ordering::SeqCst), 1);
+
+    let outcome = timed(client.call_tool_once(
+        "multi",
+        json!({"value": "c", "ask": true}),
+        None,
+        required.request_state.clone(),
+    ))
+    .await
+    .expect("tools/call retry");
+    let result = outcome.as_complete().expect("the retry completes");
+    assert_eq!(result.all_text(), "resumed:c");
+    assert_eq!(
+        fallback_calls.load(Ordering::SeqCst),
+        2,
+        "both rounds go through the fallback"
+    );
+    assert_eq!(
+        live_calls.load(Ordering::SeqCst),
+        0,
+        "the live handler must not run for a non-task call"
+    );
+}
+
+/// Regression: a live-only tool (no fallback registered) keeps its existing
+/// `TaskSupportMode::Required` contract. A plain call must still be rejected
+/// with a clear protocol error before any handler runs, not panic reaching
+/// for a synchronous or MRTR path that was never registered.
+#[tokio::test]
+async fn a_live_only_tool_still_rejects_a_plain_call_without_panicking() {
+    let tool = ToolBuilder::new("live_only")
+        .description("No fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(
+                "should not run",
+            )))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live-only", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let error = timed(client.call_tool("live_only", json!({})))
+        .await
+        .expect_err("a live-only tool has nothing to run for a plain call");
+    assert!(
+        error.to_string().contains("requires async task execution"),
+        "got: {error}"
+    );
+}
+
+/// `Tool::clone` and `Tool::with_name_prefix` must carry a live handler and a
+/// fallback together, not just whichever one #1295 already covered alone.
+/// Asserted by actually running both paths post-clone/prefix, the same
+/// discipline the #1295 tests above use: checking that a field is non-`None`
+/// would pass even if the clone were otherwise broken.
+#[tokio::test]
+async fn clone_and_prefix_carry_both_the_live_handler_and_the_fallback() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus fallback")
+        .live_task_handler(|_task: TaskContext, input: MultiInput| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(format!(
+                "live:{}",
+                input.value
+            ))))
+        })
+        .fallback_handler(|input: MultiInput| async move {
+            Ok(CallToolResult::text(format!("sync:{}", input.value)))
+        })
+        .build();
+
+    let cloned = tool.clone();
+    let prefixed = tool.with_name_prefix("ns");
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(cloned)
+        .tool(prefixed)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    for name in ["multi", "ns.multi"] {
+        let result = timed(client.call_tool(name, json!({"value": "x"})))
+            .await
+            .unwrap_or_else(|e| panic!("plain call to {name} failed: {e}"));
+        assert_eq!(
+            result.all_text(),
+            "sync:x",
+            "fallback must survive for {name}"
+        );
+
+        let task_id = timed(client.call_tool_as_task(name, json!({"value": "x"}), None))
+            .await
+            .unwrap_or_else(|e| panic!("task call to {name} failed: {e}"))
+            .task
+            .task_id;
+        await_status(&store, &task_id, TaskStatus::Completed).await;
+        let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+        assert_eq!(
+            result.unwrap().all_text(),
+            "live:x",
+            "live handler must survive for {name}"
+        );
+    }
+}
+
+/// `Tool::with_guard` on a live-plus-fallback tool must reject both paths.
+/// Before this PR's fix, `with_guard` returned after guarding whichever of
+/// `live_handler`/`service`/`mrtr_handler` it found first, which was
+/// harmless while those fields were mutually exclusive but silently left a
+/// coexisting fallback unguarded once they no longer were.
+#[tokio::test]
+async fn a_guard_on_a_live_plus_fallback_tool_rejects_both_paths() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(
+                "should not run (live)",
+            )))
+        })
+        .fallback_handler(|_input: NoArgs| async move {
+            Ok(CallToolResult::text("should not run (fallback)"))
+        })
+        .build()
+        .with_guard(|_req: &tower_mcp::ToolRequest| Err("nope".to_string()));
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    // The fallback path is rejected.
+    let result = timed(client.call_tool("multi", json!({})))
+        .await
+        .expect("call");
+    assert!(
+        result.is_error,
+        "the guard must reject the fallback path too"
+    );
+    assert!(result.all_text().contains("nope"));
+
+    // The live path is rejected too.
+    let task_id = timed(client.call_tool_as_task("multi", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let result = result.expect("a rejected call still produces a result");
+    assert!(result.is_error);
+    assert!(result.all_text().contains("nope"));
 }


### PR DESCRIPTION
## What this is

The remaining piece of #1246. Everything else in that issue landed already
(live task execution, two-phase input parking via `park_input`/`PendingInput`,
owner-aware presence). What's left, per the repo owner's comment on the
issue:

> the same tool still needs live Task execution plus ordinary/MRTR fallback

Today `ToolBuilder::live_task_handler(...)` forces `TaskSupportMode::Required`
and the built `Tool` has no `service`/`mrtr_handler`. A tool built that way is
invisible to any client that hasn't negotiated Tasks -- there is no way to
register one tool that runs live when Tasks are negotiated and falls back to
an ordinary or MRTR response otherwise, short of registering the same logic
twice under two different names.

## Proposed API shape

Two new terminal methods on `ToolBuilderWithLiveHandler` (the state after
`.live_task_handler(...)`/`.live_task_handler_with_context(...)`):

```rust
impl ToolBuilderWithLiveHandler {
    pub fn fallback_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveAndFallback
    where
        I: DeserializeOwned + Send + Sync + 'static,
        F: Fn(I) -> Fut + Send + Sync + 'static,
        Fut: Future<Output = Result<CallToolResult>> + Send + 'static;

    #[cfg(feature = "stateless")]
    pub fn fallback_mrtr_handler<I, F, Fut>(self, handler: F) -> ToolBuilderWithLiveAndMrtrFallback
    where
        I: DeserializeOwned + Send + Sync + 'static,
        F: Fn(RequestContext, I) -> Fut + Send + Sync + 'static,
        Fut: Future<Output = Result<RequestOutcome<CallToolResult>>> + Send + 'static;
}
```

Each returns a small terminal builder (`ToolBuilderWithLiveAndFallback` /
`ToolBuilderWithLiveAndMrtrFallback`) that carries both handlers, defaults
`task_support` to `TaskSupportMode::Optional` (overridable via
`.task_support(mode)` before `.build()`), and produces a `Tool` with
`live_handler: Some(..)` and `service: Some(..)` or `mrtr_handler: Some(..)`
populated simultaneously -- something no `Tool` could be constructed as
before this PR.

Usage:

```rust
let tool = ToolBuilder::new("run")
    .live_task_handler(|task: TaskContext, input: Run| async move {
        let answers = task.require_input(approval()).await?;
        Ok(TaskOutcome::Completed(CallToolResult::text("done")))
    })
    .fallback_handler(|input: Run| async move {
        Ok(CallToolResult::text("synchronous result"))
    })
    .build();
```

`.build()` still exists directly on `ToolBuilderWithLiveHandler` and still
forces `TaskSupportMode::Required` with no fallback -- unchanged, so every
tool built the way tools are built today keeps working unchanged.

### How the router picks a path

This is the load-bearing finding of this PR: **the router does not need to
change.** Re-reading `McpRequest::CallTool` in `router.rs` end to end:

- Task creation already special-cases `tool.live_handler.is_some()` to skip
  persisting arguments, independent of whether a fallback also exists.
- The spawned execution already branches `if let Some(live_handler) =
  tool.live_handler.clone() { <live path> } else { <invoke_tool, the
  ordinary/MRTR replay path> }` -- this already **is** "task-backed calls run
  the live handler."
- The non-task synchronous branch already calls `invoke_tool` ->
  `Tool::call_outcome_with_context`, which already prefers `mrtr_handler`
  then falls back to `service` -- this already **is** "non-task calls run the
  fallback."
- `tools/list` visibility and `Tool::definition()` already treat
  `TaskSupportMode::Optional` as "always visible, `execution.task_support`
  reported honestly," on both protocols.
- `tasks/update`'s live-vs-replay dispatch (`wake_live_task` before
  `resume_task`) is keyed by a **task-id runtime registry**
  (`self.inner.live_tasks`), populated only for tasks actually created
  through the live branch -- not by re-inspecting the tool's handler slots --
  so it cannot confuse a live task with a fallback-served one even once a
  single `Tool` can produce both kinds of task.
- The task-election match arms (both the final-protocol capability
  negotiation and the legacy `params.task` client-directed one) already
  route `TaskSupportMode::Optional` to the live path when a task is
  negotiated/requested and to the sync path otherwise -- see the doc comment
  on `TaskSupportMode::Optional` itself, which already describes this exact
  policy.

So the entire "one tool, up to three execution paths, chosen by how the call
arrives" mechanism was already implemented in the router; the only missing
piece was the inability to construct a `Tool` that carries a live handler and
a fallback at once. This PR's router.rs diff is therefore expected to be
**zero** -- confirmed during implementation, not assumed up front.

One real bug found while auditing the surrounding code for this change:
`Tool::with_guard` currently returns early after guarding whichever of
`live_handler`/`mrtr_handler`/`service` it finds *first*, which was
harmless while those fields were mutually exclusive but silently leaves a
newly-possible coexisting fallback unguarded. Fixed as part of this PR (guard
wraps every path that is actually present).

### Combinations the server did not supply

- **Live-only (no fallback), plain `tools/call`:** unchanged from today.
  `task_support` stays `Required`, so the router rejects the call before any
  handler runs (`missing_required_client_capability` / `method_not_found` on
  the final protocol, `"requires async task execution"` on legacy) rather
  than reaching a handler that doesn't exist.
- **Live + fallback, task not negotiated/requested:** the fallback runs.
- **Live + fallback, task negotiated/requested:** the live handler runs, the
  fallback never runs.
- **Live + MRTR fallback, fallback wants to ask for input:** works, but only
  for a caller on the final (2026-07-28) protocol -- `InputRequiredResult` is
  already rejected by the router for a legacy-protocol caller regardless of
  whether the tool has a live sibling (pre-existing `validate_input_required_result`
  behavior, not something this PR changes). Called out explicitly in the
  fallback_mrtr_handler doc comment so it isn't a surprise.

## Alternative considered and rejected

**Attach the live handler on top of the ordinary/MRTR builder instead**
(`.handler(...).live_fallback(...)` rather than
`.live_task_handler(...).fallback_handler(...)`). Arguably reads more
naturally if "ordinary" is the primary path and "live" is the enhancement.
Rejected because it is the more committal shape: it would require threading
a new method through every existing terminal/layered builder state
(`ToolBuilderWithHandler`, `ToolBuilderWithLayer`, `ToolBuilderWithMrtrHandler`,
`ToolBuilderWithMrtrLayer`, `ToolBuilderWithNoParamsHandler(Layer)`, and the
extractor-pattern builders in `extract.rs`) -- seven-plus types instead of
two, combinatorial with the `.layer()`/`.guard()` already on those types.

The chosen shape touches exactly one existing type
(`ToolBuilderWithLiveHandler`) and adds two new leaf types. Both shapes
converge on the same `Tool` fields (`live_handler` + `service`/`mrtr_handler`),
so the rejected alternative remains addable later without conflicting with
what lands here -- which is the point of picking the less committal option.

## Deliberately left out

- `.layer()`/`.guard()` chainable *before* `.build()` on the two new builder
  types. Post-build `Tool::with_guard(...)` already exists and (after the fix
  above) already covers both paths, so guards remain available; per-tool
  `.layer()` middleware specifically on the fallback is left out because
  nothing in the issue asks for it and it would need its own adapter
  plumbing symmetric to `ToolBuilderWithLayer`/`ToolBuilderWithMrtrLayer`.
- A context-carrying flavor of `.fallback_handler` (i.e. one that also
  receives `RequestContext`). The plain `.handler()` on the base `ToolBuilder`
  doesn't have one either; context access for that shape goes through the
  extractor pattern. `.fallback_mrtr_handler` already takes `RequestContext`,
  matching `.mrtr_handler()`.
- `Tool::call_outcome_with_context`'s existing
  `.expect("tool must have a complete or MRTR handler")` panic for a
  live-only tool (no fallback) called *directly*, bypassing the router. This
  predates this PR -- `ToolBuilderWithLiveHandler::build()` already produces
  exactly that shape today -- and the router never reaches it because
  `task_support` stays `Required` and rejects a non-task call earlier with a
  proper JSON-RPC error. My new fallback-carrying tools never hit this branch
  (they always populate `service` or `mrtr_handler`). Not fixed here to keep
  the diff scoped to the one remaining piece of #1246; flagged in case it's
  worth its own follow-up issue.

## Testing (implemented)

`tests/live_tasks.rs`, one tool (`multi_tool`) built with
`.live_task_handler(...).fallback_mrtr_handler(...)`, plus two more tools for
the regression/clone/guard cases:

1. `a_live_plus_fallback_tool_serves_a_plain_call_through_the_fallback` -- a
   plain `tools/call` (legacy protocol, no task requested) completes via the
   fallback; the live handler never runs.
2. `a_live_plus_fallback_tool_serves_a_task_backed_call_through_the_live_handler`
   -- the same tool, task-requested (`call_tool_as_task`), completes via the
   live handler; the fallback never runs.
3. `a_live_plus_fallback_tool_serves_an_mrtr_round_trip_through_the_fallback`
   -- the same tool, plain `tools/call` on the final protocol asking for
   input, then a second call carrying `request_state` completes it (MRTR
   round trip through the same fallback). Both rounds counted to confirm the
   fallback ran twice and the live handler never ran.
4. `a_live_only_tool_still_rejects_a_plain_call_without_panicking` --
   regression: a live-only tool (no fallback) receiving a plain `tools/call`
   still gets the existing clear, non-panicking rejection.
5. `clone_and_prefix_carry_both_the_live_handler_and_the_fallback` --
   `Tool::clone` and `Tool::with_name_prefix` carry both handlers intact,
   asserted through actually running both paths post-clone/prefix.
6. `a_guard_on_a_live_plus_fallback_tool_rejects_both_paths` --
   `Tool::with_guard` on a live+fallback tool rejects both paths, not just
   the live one (the bug fixed above).

All 22 tests in the file pass (`cargo test -p tower-mcp --test live_tasks
--all-features`), the 16 pre-existing ones unchanged.

### Router confirmed untouched

The diff is exactly two files: `crates/tower-mcp/src/tool.rs` and
`crates/tower-mcp/tests/live_tasks.rs`. `router.rs` / `router/task_ops.rs`
needed zero changes, confirming the "How the router picks a path" analysis
above rather than just assuming it.

### Mutation testing

Each mutation was installed, the targeted test(s) confirmed to fail, then
reverted and the suite re-confirmed green. `MUTATION TEST` markers do not
appear anywhere in the final diff.

**A -- default `task_support` to `Required` instead of `Optional`** in both
new builders. Broke exactly the 4 tests that depend on the fallback being
reachable without a task (1, 3, 5, 6); test 2 (task-backed) still passed, as
expected since `Required` doesn't block the task path itself:

```
failures:
    a_guard_on_a_live_plus_fallback_tool_rejects_both_paths
    a_live_plus_fallback_tool_serves_a_plain_call_through_the_fallback
    a_live_plus_fallback_tool_serves_an_mrtr_round_trip_through_the_fallback
    clone_and_prefix_carry_both_the_live_handler_and_the_fallback
test result: FAILED. 18 passed; 4 failed
```

**B -- reinstated `Tool::with_guard`'s pre-fix early return** (guard whichever
of live/mrtr/service is found first, return immediately). Broke exactly test
6 and nothing else:

```
---- a_guard_on_a_live_plus_fallback_tool_rejects_both_paths stdout ----
panicked: the guard must reject the fallback path too
test result: FAILED. 21 passed; 1 failed
```

**C -- dropped `live_handler` in `ToolBuilderWithLiveAndMrtrFallback::build()`**
(set to `None`). Broke exactly test 2, and the failure output shows the
task-backed call silently fell through to the fallback's synchronous branch
instead of erroring:

```
---- a_live_plus_fallback_tool_serves_a_task_backed_call_through_the_live_handler stdout ----
assertion `left == right` failed
  left: "sync:b"
 right: "live:b"
test result: FAILED. 21 passed; 1 failed
```

**D -- dropped `service` in `Tool::clone()`** (the #1295 bug class, now
exercised for the first time by the coexistence this PR adds). This one
surfaced something worth recording: the mutated clone doesn't return a client
error, it *hangs*. `Tool::call_outcome_with_context`'s pre-existing
`.expect("tool must have a complete or MRTR handler")` panics inside
`ChannelTransport`'s background connection task, and the client is left
waiting on a response that will never arrive. The full run sat past 60s on
one test before I killed it and confirmed it was the clone test specifically.

In response, I added a `timed()` helper (`tokio::time::timeout`, 5s) around
every client call added in this PR's new tests, matching the pattern
`client_tasks.rs` already uses for exactly this reason. Re-running the same
mutation afterward now fails in 5.01s with a clear diagnostic instead of
hanging:

```
thread '...' panicked at crates/tower-mcp/src/tool.rs:1417:14:
tool must have a complete or MRTR handler
thread '...' panicked at crates/tower-mcp/tests/live_tasks.rs:984:10:
call timed out; the connection likely panicked without responding: Elapsed(())
test result: FAILED. 0 passed; 1 failed; ... finished in 5.01s
```

I left `call_outcome_with_context`'s `.expect(...)` itself unchanged (see
"Deliberately left out" -- it's pre-existing and unreachable through this
PR's own construction paths), but the timeout hardening this uncovered is a
real, permanent improvement to the six new tests, not just mutation-testing
scaffolding.

## Files touched

- `crates/tower-mcp/src/tool.rs` -- the two new builder methods/types, the
  `with_guard` fix.
- `crates/tower-mcp/tests/live_tasks.rs` -- the six tests above plus the
  `timed()` helper.
- `crates/tower-mcp/src/router.rs` / `router/task_ops.rs` -- untouched, as
  predicted.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (1029+ lib/integration tests, 225
  doctests, all passing)
- `cargo test -p tower-mcp` (default features -- the `#[cfg(feature =
  "stateless")]` hazard this area has hit twice before; 497+ tests passing)
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p tower-mcp --all-features`
