### PR TITLE
fix(tool): return an error for direct live-only calls

### DIFF
--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -1410,10 +1410,12 @@ impl Tool {
         if let Some(handler) = self.mrtr_handler.clone() {
             return Box::pin(async move { handler.call(ctx, args).await });
         }
-        let service = self
-            .service
-            .clone()
-            .expect("tool must have a complete or MRTR handler");
+        let Some(service) = self.service.clone() else {
+            let error = Error::tool(
+                "tool has no synchronous or MRTR handler; it can only be invoked as a task",
+            );
+            return Box::pin(async move { Err(error) });
+        };
         Box::pin(async move {
             let result = service.oneshot(ToolRequest::new(ctx, args)).await.unwrap();
             Ok(RequestOutcome::Complete(result))

--- a/crates/tower-mcp/src/tool/tests.rs
+++ b/crates/tower-mcp/src/tool/tests.rs
@@ -31,6 +31,42 @@ async fn test_builder_tool() {
     assert!(!result.is_error);
 }
 
+#[tokio::test]
+async fn direct_call_to_live_only_tool_returns_an_error_without_running_it() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let observed = calls.clone();
+    let tool = ToolBuilder::new("live_only")
+        .live_task_handler(move |_task: TaskContext, _input: NoParams| {
+            observed.fetch_add(1, Ordering::SeqCst);
+            async move { Ok(TaskOutcome::Completed(CallToolResult::text("unreachable"))) }
+        })
+        .build();
+
+    let error = tool
+        .call_outcome(serde_json::json!({}))
+        .await
+        .expect_err("a direct call cannot run a live-only handler");
+    let Error::Tool(error) = error else {
+        panic!("expected a tool error");
+    };
+    assert_eq!(
+        error.message,
+        "tool has no synchronous or MRTR handler; it can only be invoked as a task"
+    );
+
+    let result = tool.call(serde_json::json!({})).await;
+    assert!(result.is_error);
+    assert_eq!(
+        result.first_text(),
+        Some(
+            "Tool error: tool has no synchronous or MRTR handler; it can only be invoked as a task"
+        )
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
 #[cfg(feature = "stateless")]
 #[tokio::test]
 async fn test_mrtr_builder_preserves_input_required_outcome() {


### PR DESCRIPTION
## Summary

- return a structured `Error::Tool` when a live-only `Tool` is invoked directly
- keep `Tool::call` behavior non-panicking by converting that error to `CallToolResult::error`
- prove neither direct entry point executes the live handler

## Why

A live-only tool has no complete or MRTR service. `Tool::call_outcome_with_context` previously reached an `expect` for that absent service, so direct calls could panic (or strand a caller when request handling ran in a spawned task). Router dispatch already rejects this shape correctly; the direct public API should fail safely too.

Closes #1329.

## Validation

- `cargo fmt --all -- --check`
- focused regression under default and all features
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-Dwarnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`