### PR TITLE
fix(oauth): match Bearer scheme case-insensitively in resource-server middleware (closes #1337)

### DIFF
--- a/crates/tower-mcp/src/auth.rs
+++ b/crates/tower-mcp/src/auth.rs
@@ -327,7 +327,10 @@ impl Validate for StaticBearerValidator {
 /// `Bearer`, and `BEARER` are the same scheme. Comparing bytes directly keeps
 /// this allocation-free, and the token after the space is returned untouched
 /// because only the scheme is case-insensitive, never the credential (#1276).
-fn strip_scheme<'a>(header: &'a str, scheme: &str) -> Option<&'a str> {
+///
+/// `pub(crate)` so [`crate::oauth::middleware`] can share this implementation
+/// rather than growing a second, divergent copy (#1337).
+pub(crate) fn strip_scheme<'a>(header: &'a str, scheme: &str) -> Option<&'a str> {
     let rest = header.get(..scheme.len())?;
     if !rest.eq_ignore_ascii_case(scheme) {
         return None;

--- a/crates/tower-mcp/src/oauth/middleware.rs
+++ b/crates/tower-mcp/src/oauth/middleware.rs
@@ -139,12 +139,14 @@ where
                 return inner.oneshot(req).await;
             }
 
-            // Extract bearer token
+            // Extract bearer token. The scheme is matched case-insensitively
+            // per RFC 7235 via the shared `strip_scheme` helper; the
+            // credential itself stays case-sensitive.
             let token = req
                 .headers()
                 .get(header::AUTHORIZATION)
                 .and_then(|v| v.to_str().ok())
-                .and_then(|s| s.strip_prefix("Bearer "))
+                .and_then(|s| crate::auth::strip_scheme(s, "Bearer"))
                 .map(|t| t.trim().to_string());
 
             let resource_metadata_url = metadata.well_known_url().ok();
@@ -300,6 +302,63 @@ mod tests {
         let resp = service.ready().await.unwrap().call(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert!(resp.headers().contains_key("WWW-Authenticate"));
+    }
+
+    #[tokio::test]
+    async fn test_bearer_scheme_is_case_insensitive() {
+        let layer = OAuthLayer::new(test_validator(), test_metadata());
+        let mut service = layer.layer(OkService);
+
+        let token = make_token(&serde_json::json!({"sub": "user123"}));
+
+        for scheme in ["Bearer", "bearer", "BEARER", "BeArEr"] {
+            let req = Request::builder()
+                .uri("/mcp")
+                .header("Authorization", format!("{scheme} {token}"))
+                .body(Body::empty())
+                .unwrap();
+
+            let resp = service.ready().await.unwrap().call(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "scheme: {scheme}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bearer_like_scheme_is_rejected() {
+        let layer = OAuthLayer::new(test_validator(), test_metadata());
+        let mut service = layer.layer(OkService);
+
+        let token = make_token(&serde_json::json!({"sub": "user123"}));
+
+        // `Bearerish` must not match `Bearer`: the scheme is case-insensitive
+        // but it must still be exactly `Bearer`, followed by whitespace.
+        let req = Request::builder()
+            .uri("/mcp")
+            .header("Authorization", format!("Bearerish {token}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = service.ready().await.unwrap().call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_bearer_credential_stays_case_sensitive() {
+        let layer = OAuthLayer::new(test_validator(), test_metadata());
+        let mut service = layer.layer(OkService);
+
+        let token = make_token(&serde_json::json!({"sub": "user123"}));
+        let uppercased_token = token.to_uppercase();
+        assert_ne!(token, uppercased_token, "test token must contain letters");
+
+        let req = Request::builder()
+            .uri("/mcp")
+            .header("Authorization", format!("bearer {uppercased_token}"))
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = service.ready().await.unwrap().call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`OAuthService::call` in `crates/tower-mcp/src/oauth/middleware.rs` extracts
the bearer token with `s.strip_prefix("Bearer ")`, an exact-byte comparison.
RFC 7235 defines the auth scheme token as case-insensitive; only the
credential that follows the scheme is case-sensitive. A client that sends
`Authorization: bearer <token>` (or `BEARER <token>`) is rejected with a 401
(`OAuthError::MissingToken`) even though the token itself is valid.

#1289 fixed the equivalent problem in `crates/tower-mcp/src/auth.rs` by
adding a `strip_scheme` helper that compares the scheme with
`eq_ignore_ascii_case` and requires the following whitespace (so `Bearerish`
does not match `Bearer`), leaving the credential untouched. That fix did not
reach `oauth/middleware.rs`, which is the more security-relevant of the two
paths since it gates a protected resource.

This fails closed: a lowercase scheme currently yields no token and a 401,
not an authentication bypass. It is an interop defect, not a security
vulnerability -- a spec-compliant client that normalizes its scheme to
lowercase simply cannot authenticate.

## Plan

- Make `strip_scheme` in `auth.rs` `pub(crate)` so both modules share one
  implementation, instead of the middleware growing a second copy.
- Route `oauth/middleware.rs`'s bearer-token extraction through it.
- Test-first: add a middleware test asserting `Authorization: bearer <token>`
  is accepted, alongside `Bearer` and `BEARER`, before changing the
  extraction line.
- Add the negative case: `Bearerish token` must not match `Bearer`, mirroring
  the doctests #1289 added to `auth.rs`.
- Scan the crate for other exact-byte scheme/token comparisons. One other
  site is already filed separately as #1341 (`is_localhost_origin`'s scheme
  check) and is out of scope here.

## Constraints

- Single shared helper; no duplicate implementation.
- No behavior change to the credential comparison (still case-sensitive).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
  and `cargo test` (with the `oauth` feature compiled in) must pass before
  push.