### PR TITLE
fix(childproc): correlate responses by id, frame over bytes, strip BOM (closes #1334)

### DIFF
--- a/crates/tower-mcp/src/transport/childproc.rs
+++ b/crates/tower-mcp/src/transport/childproc.rs
@@ -36,14 +36,16 @@
 //! }
 //! ```
 
+use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::AsyncWriteExt;
 use tokio::process::{Child, Command};
 
 use crate::error::{Error, Result};
-use crate::protocol::{JsonRpcRequest, JsonRpcResponse};
+use crate::framing::{FrameReader, InputFrame, clean_input_line};
+use crate::protocol::{JsonRpcRequest, JsonRpcResponse, RequestId};
 
 /// Builder for child process transport
 pub struct ChildProcessTransport {
@@ -107,11 +109,28 @@ impl ChildProcessTransport {
 }
 
 /// Active connection to a child MCP server process
+///
+/// # Response correlation and notifications
+///
+/// `send_request` reads frames from the child's stdout until it finds the
+/// response whose id matches the request it just sent, rather than assuming
+/// the next line is the answer. A spec-compliant child may write
+/// notifications (progress, log messages, list-changed) before it answers a
+/// request; those are logged and dropped, since this connection has no
+/// channel to publish them on -- there is no background reader task or
+/// subscriber here, unlike [`crate::client::McpClient`]. A response whose id
+/// does not match the one currently being awaited is not dropped: it is set
+/// aside in a small pending map, so a later call waiting on that id can pick
+/// it up immediately instead of losing a response that arrived out of order
+/// (#1334).
 pub struct ChildProcessConnection {
     child: Child,
     stdin: tokio::process::ChildStdin,
-    stdout: BufReader<tokio::process::ChildStdout>,
+    stdout: FrameReader<tokio::process::ChildStdout>,
     request_id: AtomicI64,
+    /// Responses read ahead of the request they answer, keyed by id, waiting
+    /// for the `send_request` call that is watching for that id.
+    pending: HashMap<RequestId, JsonRpcResponse>,
 }
 
 impl ChildProcessConnection {
@@ -128,8 +147,9 @@ impl ChildProcessConnection {
         Ok(Self {
             child,
             stdin,
-            stdout: BufReader::new(stdout),
+            stdout: FrameReader::new(stdout),
             request_id: AtomicI64::new(1),
+            pending: HashMap::new(),
         })
     }
 
@@ -139,14 +159,14 @@ impl ChildProcessConnection {
         method: &str,
         params: serde_json::Value,
     ) -> Result<serde_json::Value> {
-        let id = self.request_id.fetch_add(1, Ordering::Relaxed);
-        let request = JsonRpcRequest::new(id, method).with_params(params);
+        let id = RequestId::Number(self.request_id.fetch_add(1, Ordering::Relaxed));
+        let request = JsonRpcRequest::new(id.clone(), method).with_params(params);
 
         // Send request
         let request_json = serde_json::to_string(&request)
             .map_err(|e| Error::Transport(format!("Failed to serialize request: {}", e)))?;
 
-        tracing::debug!(method = %method, id = %id, "Sending request to child");
+        tracing::debug!(method = %method, id = ?id, "Sending request to child");
 
         self.stdin
             .write_all(request_json.as_bytes())
@@ -161,22 +181,94 @@ impl ChildProcessConnection {
             .await
             .map_err(|e| Error::Transport(format!("Failed to flush stdin: {}", e)))?;
 
-        // Read response
-        let mut line = String::new();
-        self.stdout
-            .read_line(&mut line)
-            .await
-            .map_err(|e| Error::Transport(format!("Failed to read from child stdout: {}", e)))?;
+        self.response_for(&id).await
+    }
 
-        if line.is_empty() {
-            return Err(Error::Transport("Child process closed stdout".to_string()));
+    /// Read frames until the response for `id` arrives.
+    ///
+    /// Notifications are logged and discarded. A response for some other id
+    /// is held in `pending` rather than discarded, since it answers a request
+    /// this connection already sent and a future call will be watching for
+    /// it. A frame that is not valid UTF-8, per [`FrameReader`], costs only
+    /// itself; the loop reads on.
+    async fn response_for(&mut self, id: &RequestId) -> Result<serde_json::Value> {
+        if let Some(response) = self.pending.remove(id) {
+            return Self::into_result(response);
         }
 
-        tracing::debug!(response = %line.trim(), "Received response from child");
+        loop {
+            let frame = self
+                .stdout
+                .next_frame()
+                .await?
+                .ok_or_else(|| Error::Transport("Child process closed stdout".to_string()))?;
 
-        let response: JsonRpcResponse = serde_json::from_str(line.trim())
-            .map_err(|e| Error::Transport(format!("Failed to parse response: {}", e)))?;
+            let line = match frame {
+                InputFrame::Line(line) => line,
+                InputFrame::Undecodable => {
+                    tracing::warn!(
+                        "invalid UTF-8 in a frame from the child, discarding it; \
+                         a response carried in it will not arrive"
+                    );
+                    continue;
+                }
+            };
 
+            let line = clean_input_line(&line);
+            if line.is_empty() {
+                continue;
+            }
+
+            tracing::debug!(response = %line, "Received frame from child");
+
+            let value: serde_json::Value = match serde_json::from_str(line) {
+                Ok(value) => value,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to parse frame from child, discarding it");
+                    continue;
+                }
+            };
+
+            // A response carries "result" or "error"; a notification (or a
+            // request, which this connection does not expect from a child)
+            // carries neither and is dropped.
+            if value.get("result").is_none() && value.get("error").is_none() {
+                tracing::debug!(
+                    method = ?value.get("method").and_then(|m| m.as_str()),
+                    "dropping a notification from the child"
+                );
+                continue;
+            }
+
+            let response: JsonRpcResponse = match serde_json::from_value(value) {
+                Ok(response) => response,
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to parse response from child, discarding it");
+                    continue;
+                }
+            };
+
+            let response_id = match &response {
+                JsonRpcResponse::Result(r) => Some(r.id.clone()),
+                JsonRpcResponse::Error(e) => e.id.clone(),
+                _ => None,
+            };
+
+            match response_id {
+                Some(response_id) if &response_id == id => {
+                    return Self::into_result(response);
+                }
+                Some(response_id) => {
+                    self.pending.insert(response_id, response);
+                }
+                None => {
+                    tracing::warn!("child sent a response with no id, discarding it");
+                }
+            }
+        }
+    }
+
+    fn into_result(response: JsonRpcResponse) -> Result<serde_json::Value> {
         match response {
             JsonRpcResponse::Result(r) => Ok(r.result),
             JsonRpcResponse::Error(e) => Err(Error::JsonRpc(e.error)),
@@ -352,20 +444,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_spawn_and_communicate() {
-        // Use `cat` as a simple echo server
-        let mut conn = ChildProcessTransport::new("cat").spawn().await.unwrap();
+        // A minimal scripted server: read the request line, ignore it, and
+        // answer with a response matching the id `send_request` sent. `cat`
+        // used to stand in here, but its echoed request has no
+        // "result"/"error" field, so under the fix (#1334) it reads as a
+        // notification and is correctly dropped rather than surfaced as an
+        // error -- there is nothing left to assert without a real answer.
+        let mut conn = ChildProcessTransport::new("sh")
+            .arg("-c")
+            .arg(r#"read -r _line; printf '{"jsonrpc":"2.0","id":1,"result":{"echoed":true}}\n'"#)
+            .spawn()
+            .await
+            .unwrap();
 
         assert!(conn.is_running());
 
-        // Send a JSON-RPC request
         let response = conn
             .send_request("echo", serde_json::json!({"msg": "hello"}))
-            .await;
+            .await
+            .unwrap();
 
-        // cat will echo our request back, but it won't be a valid JSON-RPC response.
-        // That's OK - we're testing that I/O works, not protocol correctness.
-        // The response will be a parse error since cat echoes the request verbatim.
-        assert!(response.is_err());
+        assert_eq!(response, serde_json::json!({"echoed": true}));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/childproc.rs
+++ b/crates/tower-mcp/tests/childproc.rs
@@ -23,8 +23,6 @@ use tower_mcp::transport::childproc::ChildProcessTransport;
 /// not be mistaken for the response. `send_request` has to keep reading past
 /// it and return the frame whose id matches the request it sent.
 #[tokio::test]
-#[ignore = "#1334 defect 1: send_request takes the next line unconditionally \
-            and fails to parse the notification as a response"]
 async fn response_correlates_by_id_past_a_leading_notification() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
@@ -51,8 +49,6 @@ async fn response_correlates_by_id_past_a_leading_notification() {
 /// sequential calls, answered out of order, must each get their own result --
 /// the id decides which is which, not arrival order.
 #[tokio::test]
-#[ignore = "#1334 defect 1: send_request has no id correlation at all, so it \
-            returns whichever response arrives first regardless of id"]
 async fn out_of_order_responses_are_matched_by_id_not_by_arrival_order() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
@@ -88,8 +84,6 @@ async fn out_of_order_responses_are_matched_by_id_not_by_arrival_order() {
 /// only the frame it landed in. `crate::framing::FrameReader` frames over
 /// bytes precisely so this can be discarded and the connection can read on.
 #[tokio::test]
-#[ignore = "#1334 defect 2: read_line decodes before framing, so invalid \
-            UTF-8 is a fatal Error::Transport instead of a discarded frame"]
 async fn invalid_utf8_frame_is_discarded_and_the_response_still_arrives() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
@@ -112,7 +106,6 @@ async fn invalid_utf8_frame_is_discarded_and_the_response_still_arrives() {
 /// stripped, the same as every other receive path in this crate
 /// (`crate::framing::clean_input_line`, #1303).
 #[tokio::test]
-#[ignore = "#1334 defect 3: no BOM strip on the childproc receive path"]
 async fn a_leading_bom_on_the_response_is_stripped() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")

--- a/crates/tower-mcp/tests/childproc.rs
+++ b/crates/tower-mcp/tests/childproc.rs
@@ -14,6 +14,19 @@
 //! `#[ignore]`d reproductions and have since been fixed, so each one now
 //! guards a regression rather than describing a bug; the issue number stays
 //! in the doc comment so what it guards stays legible.
+//!
+//! # Every script reads before it writes
+//!
+//! A child that never reads stdin at all is a race, not a fixture: `sh -c`
+//! with nothing but `printf` runs to completion (and exits, closing its end
+//! of the stdin pipe) as fast as the shell can fork, which can beat the
+//! client's first `write_all` to the same pipe. That write then fails with
+//! `Broken pipe` -- observed on Linux CI, not on macOS, because the two
+//! platforms schedule the race differently; it is not a `childproc.rs`
+//! defect and reproducing it locally on one platform proves nothing about
+//! the other. Every script below starts with a blocking `read` so the child
+//! cannot exit before the client's write lands, which makes the test's own
+//! control flow decide the child's lifetime instead of the OS scheduler.
 
 #![cfg(feature = "childproc")]
 
@@ -27,6 +40,7 @@ async fn response_correlates_by_id_past_a_leading_notification() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
         .arg(concat!(
+            r#"read -r _line; "#,
             r#"printf '{"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n'; "#,
             r#"printf '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#
         ))
@@ -48,13 +62,24 @@ async fn response_correlates_by_id_past_a_leading_notification() {
 /// being waited on must not be discarded or mistaken for the answer. Two
 /// sequential calls, answered out of order, must each get their own result --
 /// the id decides which is which, not arrival order.
+///
+/// The child answers both ids from a single read: it cannot legitimately
+/// have id 2's request yet (the client only sends it after id 1's call
+/// returns), so both responses are canned output written in reply to
+/// reading id 1's request, deliberately out of order. `send_request`
+/// unconditionally writes the request before consulting anything it already
+/// has buffered, so the second call still needs somewhere for its write to
+/// land; `cat` drains and discards it (and anything further) until the
+/// client closes stdin at `shutdown`.
 #[tokio::test]
 async fn out_of_order_responses_are_matched_by_id_not_by_arrival_order() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
         .arg(concat!(
+            r#"read -r _line; "#,
             r#"printf '{"jsonrpc":"2.0","id":2,"result":{"which":2}}\n'; "#,
-            r#"printf '{"jsonrpc":"2.0","id":1,"result":{"which":1}}\n'"#
+            r#"printf '{"jsonrpc":"2.0","id":1,"result":{"which":1}}\n'; "#,
+            r#"cat >/dev/null"#
         ))
         .spawn()
         .await
@@ -87,7 +112,11 @@ async fn out_of_order_responses_are_matched_by_id_not_by_arrival_order() {
 async fn invalid_utf8_frame_is_discarded_and_the_response_still_arrives() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
-        .arg(r#"printf '\377\376\n'; printf '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#)
+        .arg(concat!(
+            r#"read -r _line; "#,
+            r#"printf '\377\376\n'; "#,
+            r#"printf '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#
+        ))
         .spawn()
         .await
         .unwrap();
@@ -109,7 +138,10 @@ async fn invalid_utf8_frame_is_discarded_and_the_response_still_arrives() {
 async fn a_leading_bom_on_the_response_is_stripped() {
     let mut conn = ChildProcessTransport::new("sh")
         .arg("-c")
-        .arg(r#"printf '\357\273\277{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#)
+        .arg(concat!(
+            r#"read -r _line; "#,
+            r#"printf '\357\273\277{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#
+        ))
         .spawn()
         .await
         .unwrap();

--- a/crates/tower-mcp/tests/childproc.rs
+++ b/crates/tower-mcp/tests/childproc.rs
@@ -1,0 +1,132 @@
+//! Integration tests for [`ChildProcessConnection`] (#1334).
+//!
+//! `send_request` used to take the next line off the child's stdout
+//! unconditionally and treat it as the answer, so a spec-compliant child that
+//! writes a notification before its response desynchronized the connection
+//! permanently: the notification failed to parse as a response, and the next
+//! `send_request` got the *previous* call's answer. `read_line` also decoded
+//! before framing, so one invalid UTF-8 byte on the child's stdout was fatal
+//! instead of costing a single frame, and there was no BOM strip on the
+//! receive path, unlike every other stdio transport in this crate.
+//!
+//! Every test here drives a real child process via `sh -c`, the same way
+//! `client/stdio.rs`'s own tests do. The findings below landed as
+//! `#[ignore]`d reproductions and have since been fixed, so each one now
+//! guards a regression rather than describing a bug; the issue number stays
+//! in the doc comment so what it guards stays legible.
+
+#![cfg(feature = "childproc")]
+
+use tower_mcp::transport::childproc::ChildProcessTransport;
+
+/// #1334, defect 1: a notification the child writes before its response must
+/// not be mistaken for the response. `send_request` has to keep reading past
+/// it and return the frame whose id matches the request it sent.
+#[tokio::test]
+#[ignore = "#1334 defect 1: send_request takes the next line unconditionally \
+            and fails to parse the notification as a response"]
+async fn response_correlates_by_id_past_a_leading_notification() {
+    let mut conn = ChildProcessTransport::new("sh")
+        .arg("-c")
+        .arg(concat!(
+            r#"printf '{"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n'; "#,
+            r#"printf '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#
+        ))
+        .spawn()
+        .await
+        .unwrap();
+
+    let result = conn
+        .send_request("ping", serde_json::json!({}))
+        .await
+        .expect("the response after the notification must still be delivered");
+
+    assert_eq!(result, serde_json::json!({"ok": true}));
+
+    conn.shutdown().await.unwrap();
+}
+
+/// #1334, defect 1: a response for a request other than the one currently
+/// being waited on must not be discarded or mistaken for the answer. Two
+/// sequential calls, answered out of order, must each get their own result --
+/// the id decides which is which, not arrival order.
+#[tokio::test]
+#[ignore = "#1334 defect 1: send_request has no id correlation at all, so it \
+            returns whichever response arrives first regardless of id"]
+async fn out_of_order_responses_are_matched_by_id_not_by_arrival_order() {
+    let mut conn = ChildProcessTransport::new("sh")
+        .arg("-c")
+        .arg(concat!(
+            r#"printf '{"jsonrpc":"2.0","id":2,"result":{"which":2}}\n'; "#,
+            r#"printf '{"jsonrpc":"2.0","id":1,"result":{"which":1}}\n'"#
+        ))
+        .spawn()
+        .await
+        .unwrap();
+
+    // First call sends id 1 but the child answers id 2 first; the id-2 frame
+    // must be set aside, not returned as if it were id 1's answer.
+    let first = conn
+        .send_request("a", serde_json::json!({}))
+        .await
+        .expect("id 1's own response must be returned, not id 2's");
+    assert_eq!(first, serde_json::json!({"which": 1}));
+
+    // Second call sends id 2; its answer already arrived and must have been
+    // held rather than lost.
+    let second = conn
+        .send_request("b", serde_json::json!({}))
+        .await
+        .expect("the response set aside for id 2 must be delivered");
+    assert_eq!(second, serde_json::json!({"which": 2}));
+
+    conn.shutdown().await.unwrap();
+}
+
+/// #1334, defect 2: `read_line` decoded before framing, so one byte that is
+/// not valid UTF-8 turned into a fatal `Error::Transport` instead of costing
+/// only the frame it landed in. `crate::framing::FrameReader` frames over
+/// bytes precisely so this can be discarded and the connection can read on.
+#[tokio::test]
+#[ignore = "#1334 defect 2: read_line decodes before framing, so invalid \
+            UTF-8 is a fatal Error::Transport instead of a discarded frame"]
+async fn invalid_utf8_frame_is_discarded_and_the_response_still_arrives() {
+    let mut conn = ChildProcessTransport::new("sh")
+        .arg("-c")
+        .arg(r#"printf '\377\376\n'; printf '{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#)
+        .spawn()
+        .await
+        .unwrap();
+
+    let result = conn
+        .send_request("ping", serde_json::json!({}))
+        .await
+        .expect("a bad frame must cost only itself, not the connection");
+
+    assert_eq!(result, serde_json::json!({"ok": true}));
+
+    conn.shutdown().await.unwrap();
+}
+
+/// #1334, defect 3: a leading UTF-8 BOM on the response frame must be
+/// stripped, the same as every other receive path in this crate
+/// (`crate::framing::clean_input_line`, #1303).
+#[tokio::test]
+#[ignore = "#1334 defect 3: no BOM strip on the childproc receive path"]
+async fn a_leading_bom_on_the_response_is_stripped() {
+    let mut conn = ChildProcessTransport::new("sh")
+        .arg("-c")
+        .arg(r#"printf '\357\273\277{"jsonrpc":"2.0","id":1,"result":{"ok":true}}\n'"#)
+        .spawn()
+        .await
+        .unwrap();
+
+    let result = conn
+        .send_request("ping", serde_json::json!({}))
+        .await
+        .expect("a BOM-prefixed response must still parse");
+
+    assert_eq!(result, serde_json::json!({"ok": true}));
+
+    conn.shutdown().await.unwrap();
+}


### PR DESCRIPTION
Closes #1334.

## Plan

`crates/tower-mcp/tests/childproc.rs` does not exist. The harness has to be
built before any of the three defects can be pinned, so this lands test-first:

1. Add `crates/tower-mcp/tests/childproc.rs`, gated `#![cfg(feature = "childproc")]`,
   with one test per defect, each driving a real child process via `sh -c`
   scripts (same pattern as `client/stdio.rs`'s `spawn_writer` tests). Each new
   test is marked `#[ignore = "..."]` referencing the defect it reproduces, so
   the commit that adds them keeps CI green (precedent: #1271).
2. Confirm each ignored test actually fails against current
   `src/transport/childproc.rs` (`cargo test --features childproc -- --ignored`).
3. Fix `ChildProcessConnection`:
   - Read via `crate::framing::FrameReader` / `InputFrame` instead of
     `BufReader::read_line`, so a frame that is not valid UTF-8 costs one
     frame instead of the connection.
   - Strip a leading BOM with `crate::framing::clean_input_line`.
   - Correlate responses by request id instead of taking the next line
     unconditionally.
4. Remove `#[ignore]` from the now-passing tests.
5. `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`,
   `cargo test` (workspace, plus `--features childproc` explicitly).

## Design decision (defect 1)

The issue asks for one of two choices: a pending-response map keyed by id
(what the client message loop in `client/mod.rs` does for `McpClient`), or a
documented strictly-request/response contract where child notifications are
dropped.

Picking a small version of the first, scoped to what `ChildProcessConnection`
actually needs: `send_request` reads frames in a loop until it finds the
response whose id matches the request it just sent. A notification (no
`result`/`error` field) is logged and dropped, since this connection has no
channel to publish it on -- there's no background reader task or subscriber
here, unlike `McpClient`. A response whose id does *not* match is not dropped;
it goes into a small `HashMap<RequestId, JsonRpcResponse>` so a later call
waiting on that id can pick it up immediately, rather than the connection
losing a response that arrived out of order.

`StdioClientTransport` itself (`crates/tower-mcp/src/client/stdio.rs`) does
not do id correlation -- it only frames and discards bad bytes; correlation by
id lives one layer up, in the `McpClient` message loop
(`crates/tower-mcp/src/client/mod.rs`), which uses channels and a background
task because it's fully async/multiplexed. `ChildProcessConnection` is a
simpler, synchronous, single-flight API (`send_request` takes `&mut self` and
returns the answer directly), so the map here doesn't need channels or a
background task -- it's populated and drained entirely within the same
read loop that already exists.

## CI feature coverage

`childproc` is exercised by CI, confirmed by observing it actually run and
fail there (see "Test harness fix" below), not just by reading the workflow:

- `Test (ubuntu-latest, stable)` / `Test (ubuntu-latest, beta)` /
  `Test (macos-latest, stable)` / `Test (macos-latest, beta)` /
  `Test (windows-latest, stable)`: `cargo test --all-targets --all-features`
  (`.github/workflows/ci.yml` line 126).
- `Coverage`: `cargo llvm-cov --workspace --all-features --no-report`
  (line 184).
- `Feature combinations`: `cargo check -p tower-mcp --all-targets --features childproc`
  explicitly, alongside every other public feature in isolation (line 44).
- `Check`, `Clippy`, `MSRV (1.90)`: `--all-features` variants of `cargo check`
  / `cargo clippy`.

No CI changes needed -- the matrix already covers this feature; the gap was in
the test fixtures, not the workflow.

## Test harness fix

The first CI run on this PR failed `Test (ubuntu-latest, stable)`,
`Test (ubuntu-latest, beta)`, and `Coverage` with `Broken pipe` write errors
in two of the four new tests, while passing locally on macOS every time. Root
cause: the `sh -c` fixtures didn't read stdin at all, so a fixture could run
to completion and close its end of the pipe before the client's first write
landed -- a real race, resolved differently by the two platforms' schedulers,
not a bug in the fix. Every fixture now opens with a blocking `read` so the
child cannot exit before the client's write to it lands, and the one
multi-write test drains further input with `cat` so its second request has
somewhere to land too. Verified with 20 consecutive local runs after the fix,
and by watching the actual CI run to completion (not just re-running locally).
