### PR TITLE
fix(http): loopback validation compares scheme and host by exact bytes (closes #1341)

### DIFF
--- a/crates/tower-mcp/src/transport/http/handlers.rs
+++ b/crates/tower-mcp/src/transport/http/handlers.rs
@@ -16,19 +16,28 @@
 //!
 //! Split out of `http.rs` in #1256 (phase 3).
 
+use std::net::IpAddr;
+
 use super::*;
 
 type AssociatedCall = Pin<Box<dyn Future<Output = Result<JsonRpcResponse>> + Send + 'static>>;
 
 pub(super) fn is_localhost_origin(origin: &str) -> bool {
-    // Parse the origin to extract the host
-    if let Some(rest) = origin
-        .strip_prefix("http://")
-        .or_else(|| origin.strip_prefix("https://"))
-    {
-        is_localhost_host(rest)
+    // Parse the origin to extract the host. RFC 3986 makes the URI scheme
+    // case-insensitive, so the prefix match must be too.
+    strip_scheme_ci(origin, "http://")
+        .or_else(|| strip_scheme_ci(origin, "https://"))
+        .is_some_and(is_localhost_host)
+}
+
+/// Case-insensitively strip an ASCII scheme prefix (e.g. `"http://"`) from
+/// `s`, returning the remainder if `s` starts with it.
+fn strip_scheme_ci<'a>(s: &'a str, scheme: &str) -> Option<&'a str> {
+    let prefix = scheme.as_bytes();
+    if s.len() >= prefix.len() && s.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        Some(&s[prefix.len()..])
     } else {
-        false
+        None
     }
 }
 
@@ -37,6 +46,17 @@ pub(super) fn is_localhost_origin(origin: &str) -> bool {
 /// Used by both Origin validation (after stripping the `http(s)://` scheme)
 /// and Host validation (where there's no scheme to begin with).
 pub(super) fn is_localhost_host(host: &str) -> bool {
+    // A bare (unbracketed, port-less) IPv6 literal like `::1` parses whole
+    // as an IpAddr. Check this first: the port-splitting logic below would
+    // otherwise misread one of its internal colons as a port separator.
+    // A bare IPv6 literal with a trailing segment (e.g. `::1:3000`) parses
+    // whole as a distinct, non-loopback address rather than `::1` plus a
+    // port -- RFC 3986 requires brackets around an IPv6 host whenever a
+    // port follows it, so that's the correct outcome, not a special case.
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return ip.is_loopback();
+    }
+
     let host_only = if host.starts_with('[') {
         // Bracketed IPv6: [::1]:3000 -> ::1
         host.split(']')
@@ -47,7 +67,19 @@ pub(super) fn is_localhost_host(host: &str) -> bool {
         // Strip port if present
         host.split(':').next().unwrap_or(host)
     };
-    matches!(host_only, "localhost" | "127.0.0.1" | "::1")
+
+    // `localhost`, and its RFC 3986 trailing-dot FQDN form, is
+    // case-insensitive like any DNS name.
+    if host_only.eq_ignore_ascii_case("localhost") || host_only.eq_ignore_ascii_case("localhost.") {
+        return true;
+    }
+
+    // Covers the entire 127.0.0.0/8 range and ::1 (the only IPv6 loopback
+    // address) in one shot. Rust's std parser requires canonical
+    // dotted-decimal IPv4 (rejecting shorthand and hex/octal/decimal
+    // obfuscation forms), so this doesn't widen the guard beyond the
+    // canonical numeric forms a conforming URL host parser would produce.
+    host_only.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 /// Resolve the effective host for validation.

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -2625,6 +2625,16 @@ fn test_is_not_localhost_origin() {
     assert!(!is_localhost_origin(""));
 }
 
+#[test]
+fn test_is_not_localhost_origin_embedded_loopback_strings() {
+    // These embed a loopback string without being loopback themselves.
+    // Pinned before widening the guard (#1341) so a fix cannot
+    // accidentally admit them.
+    assert!(!is_localhost_origin("http://127.0.0.1.evil.com"));
+    assert!(!is_localhost_origin("http://notlocalhost"));
+    assert!(!is_localhost_origin("http://evil.com#localhost"));
+}
+
 #[tokio::test]
 async fn test_origin_validation_rejects_cross_origin() {
     let transport = HttpTransport::new(create_test_router());
@@ -2840,6 +2850,42 @@ fn test_is_localhost_host_variants() {
     assert!(!is_localhost_host("evil.com"));
     assert!(!is_localhost_host("api.example.com:8443"));
     assert!(!is_localhost_host("10.0.0.1"));
+}
+
+#[test]
+fn test_is_not_localhost_host_embedded_loopback_strings() {
+    // Pinned before widening is_localhost_host (#1341): none of these are
+    // loopback even though each embeds a loopback string.
+    assert!(!is_localhost_host("localhost.evil.com"));
+    assert!(!is_localhost_host("127.0.0.1.evil.com"));
+    assert!(!is_localhost_host("notlocalhost"));
+    assert!(!is_localhost_host("evil.com#localhost"));
+}
+
+#[test]
+fn test_is_not_localhost_host_non_canonical_ipv4_forms() {
+    // Classic SSRF-style numeric encodings of 127.0.0.1. Rust's
+    // std::net::IpAddr parser requires canonical 4-octet dotted-decimal
+    // form and rejects all of these, so the loopback guard does not need
+    // to (and deliberately does not) special-case them.
+    assert!(!is_localhost_host("0x7f.0.0.1"));
+    assert!(!is_localhost_host("017700000001"));
+    assert!(!is_localhost_host("2130706433"));
+    // Non-canonical shorthand (2-part) IPv4 for 127.0.0.1. A conforming
+    // URL host parser would already have canonicalized this to
+    // "127.0.0.1" before it reached the wire; left deliberately rejected
+    // here rather than adding custom shorthand-IPv4 parsing.
+    assert!(!is_localhost_host("127.1"));
+}
+
+#[test]
+fn test_is_not_localhost_host_bare_ipv6_with_trailing_segment() {
+    // A bare (unbracketed) IPv6 literal has no notion of an appended
+    // port: "::1:3000" parses whole as the distinct, non-loopback
+    // address 0:0:0:0:0:0:1:3000, not as "::1" plus port 3000.
+    // Deliberately rejected: RFC 3986 requires brackets around an IPv6
+    // host whenever a port follows it.
+    assert!(!is_localhost_host("::1:3000"));
 }
 
 #[tokio::test]

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -2616,6 +2616,20 @@ fn test_is_localhost_origin_https() {
 }
 
 #[test]
+fn test_is_localhost_origin_case_insensitive_scheme() {
+    // RFC 3986: the URI scheme is case-insensitive.
+    assert!(is_localhost_origin("HTTP://localhost"));
+    assert!(is_localhost_origin("Https://127.0.0.1"));
+    assert!(is_localhost_origin("http://LOCALHOST"));
+}
+
+#[test]
+fn test_is_localhost_origin_trailing_dot_fqdn() {
+    assert!(is_localhost_origin("http://localhost."));
+    assert!(is_localhost_origin("http://localhost.:3000"));
+}
+
+#[test]
 fn test_is_not_localhost_origin() {
     assert!(!is_localhost_origin("http://example.com"));
     assert!(!is_localhost_origin("http://evil-localhost.com"));
@@ -2850,6 +2864,36 @@ fn test_is_localhost_host_variants() {
     assert!(!is_localhost_host("evil.com"));
     assert!(!is_localhost_host("api.example.com:8443"));
     assert!(!is_localhost_host("10.0.0.1"));
+}
+
+#[test]
+fn test_is_localhost_host_case_insensitive() {
+    assert!(is_localhost_host("LOCALHOST"));
+    assert!(is_localhost_host("LOCALHOST:3000"));
+    assert!(is_localhost_host("Localhost"));
+}
+
+#[test]
+fn test_is_localhost_host_full_loopback_range() {
+    // RFC 5735: the entire 127.0.0.0/8 range is loopback, not just
+    // 127.0.0.1.
+    assert!(is_localhost_host("127.0.0.2"));
+    assert!(is_localhost_host("127.1.2.3"));
+    assert!(is_localhost_host("127.255.255.255"));
+    assert!(is_localhost_host("127.0.0.2:8080"));
+}
+
+#[test]
+fn test_is_localhost_host_trailing_dot_fqdn() {
+    assert!(is_localhost_host("localhost."));
+    assert!(is_localhost_host("localhost.:3000"));
+}
+
+#[test]
+fn test_is_localhost_host_bare_ipv6() {
+    // A bare (unbracketed, port-less) IPv6 literal is loopback too, not
+    // just the bracketed `[::1]` form.
+    assert!(is_localhost_host("::1"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #1341.

## Bug

`is_localhost_origin` and `is_localhost_host` in
`crates/tower-mcp/src/transport/http/handlers.rs` compare the URI scheme
and the host by exact bytes, so:

- `HTTP://localhost` / `http://LOCALHOST` are rejected (scheme and host
  are both case-insensitive per RFC 3986).
- `127.0.0.2`, `127.1.2.3`, etc. are rejected -- only the literal string
  `127.0.0.1` is recognized, not the rest of `127.0.0.0/8`.
- `localhost.` (the trailing-dot fully-qualified form) is rejected.
- A bare, unbracketed `::1` is rejected (only `[::1]` is recognized).

Every one of these is a false-rejection (fails closed), not a rebinding
bypass, per the issue's severity note.

## Approach

Table-driven tests over `is_localhost_origin` / `is_localhost_host`,
negative cases pinned first, then the widening.

For the host check: parse the extracted host as `std::net::IpAddr` and use
`is_loopback()` instead of the literal match list. This covers the full
`127.0.0.0/8` range and `::1` in one shot, and -- as a side benefit --
Rust's std parser rejects non-canonical numeric IPv4 forms (`127.1`,
`0x7f.0.0.1`, octal/decimal encodings), so the guard doesn't grow a new
surface for the classic SSRF numeric-obfuscation trick. `IpAddr::parse`
does not cover the `localhost` name itself, so a case-insensitive name
check (`localhost` and `localhost.`) stays alongside it.

For a bare (unbracketed, port-less) IPv6 literal like `::1`, the whole
host string is tried as an `IpAddr` first, before the port-splitting
logic runs -- otherwise the port-splitter misreads one of `::1`'s
internal colons as a port separator. This also makes the "bare IPv6 in a
Host header" question the issue raises deliberate: a bare `::1` matches;
a bare `::1:3000` parses whole as a distinct (non-loopback) IPv6 address
per RFC syntax, not as `::1` + a port, and stays rejected -- both
covered by tests either way.

For the scheme: case-insensitive ASCII prefix comparison instead of
`strip_prefix`.

## Scope

Confined to `is_localhost_origin`, `is_localhost_host`, and their tests
in `crates/tower-mcp/src/transport/http/handlers.rs` and
`crates/tower-mcp/src/transport/http/tests.rs`. Not touching the
body-decode path or the request-dispatch error paths in the same file
(reserved for #1336).

## Severity

Confirmed independently: for the gaps this issue describes (scheme case,
host case, `127.0.0.0/8`, trailing-dot `localhost.`), the current
implementation fails closed -- every one rejects a legitimate loopback
request rather than admitting a non-loopback one. This is an interop /
false-rejection defect, not a rebinding bypass.
