### PR TITLE
test(tasks): cross Tool/Resource/Prompt construction methods against every handler kind (closes #1340)

### DIFF
--- a/crates/tower-mcp/src/prompt.rs
+++ b/crates/tower-mcp/src/prompt.rs
@@ -2028,4 +2028,34 @@ mod tests {
         let result = cloned.get(HashMap::new()).await.unwrap();
         assert_eq!(result.messages.len(), 1);
     }
+
+    /// #1340: `test_prompt_clone` above only exercises the plain-handler
+    /// field. Unlike `Resource::read`, `Prompt::get`/`get_with_context` do
+    /// not clone `self` internally, so nothing incidentally covered
+    /// `Prompt::clone` for an MRTR handler either.
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn test_prompt_clone_mrtr() {
+        let prompt = PromptBuilder::new("cloneable_continue")
+            .mrtr_handler(|_ctx, _args| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("cloned-state"),
+                ))
+            })
+            .build();
+
+        let cloned = prompt.clone();
+        let outcome = cloned
+            .get_outcome_with_context(RequestContext::new(RequestId::Number(1)), HashMap::new())
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("cloned-state"),
+            "a dropped mrtr_handler after clone would fall through to the \
+             absent plain `handler` and error instead of returning this"
+        );
+    }
 }

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -3043,6 +3043,70 @@ mod tests {
         );
     }
 
+    // =========================================================================
+    // Clone vs. handler kind (#1340)
+    // =========================================================================
+    //
+    // `Resource::clone` (see the hand-written `impl Clone for Resource` above)
+    // is exercised incidentally by `read()`/`read_with_context()`, which clone
+    // `self` before dispatching -- so a plain-handler resource's clone was
+    // already covered by every test that calls `.read()`. `read_outcome_with_context`,
+    // which the router actually calls, does not clone `self`, only the handler
+    // behind it, so nothing here had exercised `Resource::clone` for an MRTR
+    // handler at all. `Tool::clone` dropping a field (#1298) is the reason
+    // this gets a dedicated, named test rather than staying implicit.
+
+    #[tokio::test]
+    async fn resource_clone_carries_the_plain_handler() {
+        let resource = ResourceBuilder::new("memory://cloneable")
+            .name("Cloneable")
+            .handler(|| async {
+                Ok(ReadResourceResult {
+                    contents: vec![ResourceContent {
+                        uri: "memory://cloneable".to_string(),
+                        mime_type: Some("text/plain".to_string()),
+                        text: Some("original".to_string()),
+                        blob: None,
+                        meta: None,
+                    }],
+                    meta: None,
+                    ..Default::default()
+                })
+            })
+            .build();
+
+        let cloned = resource.clone();
+        let result = cloned.read().await;
+        assert_eq!(result.contents[0].text.as_deref(), Some("original"));
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn resource_clone_carries_the_mrtr_handler() {
+        let resource = ResourceBuilder::new("test://cloneable-continue")
+            .mrtr_handler(|_ctx| async move {
+                Ok(RequestOutcome::input_required(
+                    crate::protocol::InputRequiredResult::new().with_request_state("cloned-state"),
+                ))
+            })
+            .build();
+
+        let cloned = resource.clone();
+        let outcome = cloned
+            .read_outcome_with_context(RequestContext::new(crate::protocol::RequestId::Number(1)))
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome
+                .as_input_required()
+                .and_then(|result| result.request_state.as_deref()),
+            Some("cloned-state"),
+            "a dropped mrtr_handler after clone would fall through to the \
+             absent `service` and panic on `.expect(...)` instead of \
+             returning this"
+        );
+    }
+
     #[cfg(feature = "stateless")]
     #[tokio::test]
     async fn mrtr_resource_composes_middleware() {

--- a/crates/tower-mcp/src/tool/tests.rs
+++ b/crates/tower-mcp/src/tool/tests.rs
@@ -1398,3 +1398,277 @@ async fn test_input_schema_override_adds_type_object_if_missing() {
     assert_eq!(schema["type"], "object");
     assert!(schema["properties"]["x"].is_object());
 }
+
+// =============================================================================
+// Clone / prefix / guard vs. handler kind (#1340)
+// =============================================================================
+//
+// #1298 found that `Tool::clone` dropped `live_handler`, and that
+// `Tool::with_guard` panicked reaching for an absent service on a live-only
+// tool. Both are fixed, but nothing had crossed every construction and
+// transformation method against every handler kind systematically. These pin
+// that matrix at the unit level, calling the handler after the
+// transformation rather than checking that a field is non-`None` -- a field
+// check would have passed even while #1298's bug was live, since the field
+// itself was untouched; only the wrong one was cloned. The combinations that
+// need a live task to actually run end-to-end through a router (clone and
+// prefix together on a live-plus-fallback tool, a guard rejecting both of a
+// tool's paths) live in `tests/live_tasks.rs`, where the router and task
+// store are already wired up; this module covers the handler kinds that
+// don't need that machinery, plus the live handler kinds invoked directly
+// through the crate-private `LiveToolHandler` trait so a test here does not
+// have to stand up a task store just to prove a field survived.
+
+#[tokio::test]
+async fn plain_tool_clone_still_runs() {
+    let tool = ToolBuilder::new("greet")
+        .description("Greet someone")
+        .handler(|input: GreetInput| async move {
+            Ok(CallToolResult::text(format!("Hello, {}!", input.name)))
+        })
+        .build();
+
+    let cloned = tool.clone();
+    let result = cloned.call(serde_json::json!({"name": "World"})).await;
+    assert!(!result.is_error);
+    assert_eq!(result.first_text().unwrap(), "Hello, World!");
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn mrtr_tool_clone_still_runs() {
+    let tool = ToolBuilder::new("continue")
+        .mrtr_handler::<NoParams, _, _>(|_ctx, _input| async move {
+            Ok(RequestOutcome::input_required(
+                crate::protocol::InputRequiredResult::new().with_request_state("signed-state"),
+            ))
+        })
+        .build();
+
+    let cloned = tool.clone();
+    let outcome = cloned.call_outcome(serde_json::json!({})).await.unwrap();
+    assert_eq!(
+        outcome
+            .as_input_required()
+            .and_then(|result| result.request_state.as_deref()),
+        Some("signed-state"),
+        "a dropped mrtr_handler would fall through to the absent `service` \
+         and panic on `.expect(...)` in `call_outcome_with_context` instead"
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn mrtr_tool_with_name_prefix_still_runs() {
+    let tool = ToolBuilder::new("continue")
+        .mrtr_handler::<NoParams, _, _>(|_ctx, _input| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text("done")))
+        })
+        .build();
+
+    let prefixed = tool.with_name_prefix("ns");
+    assert_eq!(prefixed.name, "ns.continue");
+
+    let outcome = prefixed.call_outcome(serde_json::json!({})).await.unwrap();
+    let result = outcome
+        .as_complete()
+        .expect("mrtr_handler must survive the prefix");
+    assert_eq!(result.first_text().unwrap(), "done");
+}
+
+/// A live handler has nothing reachable through `Tool::call`/`call_outcome`
+/// (#1329 tracks `call_outcome_with_context` panicking for a live-only tool
+/// called that way), so these invoke `LiveToolHandler::call` directly. Both
+/// the trait and the field it lives behind are crate-private, and this
+/// module is a sibling of `tool.rs` rather than an integration test
+/// specifically so it can reach them (see the module doc comment).
+fn live_ctx() -> RequestContext {
+    RequestContext::new(crate::protocol::RequestId::Number(0))
+}
+
+#[tokio::test]
+async fn live_only_tool_clone_carries_the_live_handler() {
+    let tool = ToolBuilder::new("run")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: NoParams| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ran")))
+        })
+        .build();
+
+    let cloned = tool.clone();
+    let handler = cloned
+        .live_handler
+        .as_ref()
+        .expect("clone must carry the live handler");
+    let outcome = handler
+        .call(
+            live_ctx(),
+            TaskContext::new("t1".to_string()),
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+    match outcome {
+        TaskOutcome::Completed(result) => assert_eq!(result.first_text().unwrap(), "ran"),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn live_only_tool_with_name_prefix_carries_the_live_handler() {
+    let tool = ToolBuilder::new("run")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: NoParams| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("ran")))
+        })
+        .build();
+
+    let prefixed = tool.with_name_prefix("ns");
+    assert_eq!(prefixed.name, "ns.run");
+
+    let handler = prefixed
+        .live_handler
+        .as_ref()
+        .expect("with_name_prefix must carry the live handler");
+    let outcome = handler
+        .call(
+            live_ctx(),
+            TaskContext::new("t1".to_string()),
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+    match outcome {
+        TaskOutcome::Completed(result) => assert_eq!(result.first_text().unwrap(), "ran"),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// #1328 landed a `Tool` that carries a live handler and an MRTR fallback at
+/// the same time, the day before this matrix was written. Its clone,
+/// prefix, and guard paths had no dedicated coverage yet beyond the routing
+/// behavior in `tests/live_tasks.rs::multi_tool`.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn live_plus_mrtr_fallback_clone_carries_both_handlers() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus MRTR fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoParams| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("live")))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoParams| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text("fallback")))
+        })
+        .build();
+
+    let cloned = tool.clone();
+
+    let outcome = cloned.call_outcome(serde_json::json!({})).await.unwrap();
+    let result = outcome
+        .as_complete()
+        .expect("mrtr fallback must survive the clone");
+    assert_eq!(result.first_text().unwrap(), "fallback");
+
+    let handler = cloned
+        .live_handler
+        .as_ref()
+        .expect("clone must carry the live handler alongside the fallback");
+    let outcome = handler
+        .call(
+            live_ctx(),
+            TaskContext::new("t1".to_string()),
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+    match outcome {
+        TaskOutcome::Completed(result) => assert_eq!(result.first_text().unwrap(), "live"),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn live_plus_mrtr_fallback_with_name_prefix_carries_both_handlers() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus MRTR fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoParams| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("live")))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoParams| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text("fallback")))
+        })
+        .build();
+
+    let prefixed = tool.with_name_prefix("ns");
+    assert_eq!(prefixed.name, "ns.multi");
+
+    let outcome = prefixed.call_outcome(serde_json::json!({})).await.unwrap();
+    let result = outcome
+        .as_complete()
+        .expect("mrtr fallback must survive the prefix");
+    assert_eq!(result.first_text().unwrap(), "fallback");
+
+    let handler = prefixed
+        .live_handler
+        .as_ref()
+        .expect("with_name_prefix must carry the live handler alongside the fallback");
+    let outcome = handler
+        .call(
+            live_ctx(),
+            TaskContext::new("t1".to_string()),
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+    match outcome {
+        TaskOutcome::Completed(result) => assert_eq!(result.first_text().unwrap(), "live"),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn live_plus_mrtr_fallback_with_guard_rejects_both_paths() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus MRTR fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoParams| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(
+                "should not run (live)",
+            )))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoParams| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text(
+                "should not run (fallback)",
+            )))
+        })
+        .build()
+        .with_guard(|_req: &ToolRequest| Err("nope".to_string()));
+
+    let outcome = tool.call_outcome(serde_json::json!({})).await.unwrap();
+    let result = outcome
+        .as_complete()
+        .expect("guard rejection is a complete tool error");
+    assert!(result.is_error);
+    assert_eq!(result.first_text().unwrap(), "nope");
+
+    let handler = tool
+        .live_handler
+        .as_ref()
+        .expect("with_guard must not drop the live handler");
+    let outcome = handler
+        .call(
+            live_ctx(),
+            TaskContext::new("t1".to_string()),
+            serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+    match outcome {
+        TaskOutcome::Completed(result) => {
+            assert!(result.is_error);
+            assert_eq!(result.first_text().unwrap(), "nope");
+        }
+        other => panic!("expected a rejected-but-terminal Completed, got {other:?}"),
+    }
+}

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -1140,4 +1140,59 @@ mod panics {
         assert!(!result.is_error);
         assert_eq!(result.all_text(), "ok");
     }
+
+    /// #1340: the panic boundary above (`a_panicking_tool_does_not_take_down_the_server`)
+    /// only exercises a plain, extractor-based handler. `Tool::call_outcome_with_context`
+    /// picks `mrtr_handler` over `service` when both could apply, so an MRTR
+    /// handler reaches `invoke_tool`'s boundary through a different branch,
+    /// and nothing had put a panic through it.
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn a_panicking_mrtr_tool_is_caught_on_a_plain_call() {
+        use tower_mcp::RequestContext;
+        use tower_mcp::protocol::RequestOutcome;
+
+        let boom = ToolBuilder::new("mrtr_boom")
+            .description("Panics before ever asking for input")
+            .mrtr_handler::<serde_json::Value, _, _>(|_ctx: RequestContext, _input| async move {
+                panic!("mrtr handler exploded");
+                #[allow(unreachable_code)]
+                Ok(RequestOutcome::Complete(CallToolResult::text(
+                    "unreachable",
+                )))
+            })
+            .build();
+        let fine = ToolBuilder::new("fine")
+            .description("Works")
+            .extractor_handler((), |_ctx: Context, RawArgs(_): RawArgs| async move {
+                Ok(CallToolResult::text("ok"))
+            })
+            .build();
+
+        let router = McpRouter::new()
+            .server_info("panic-mrtr", "1.0.0")
+            .tool(boom)
+            .tool(fine)
+            .catch_panics();
+        let client = McpClient::connect(ChannelTransport::new(router))
+            .await
+            .expect("connect");
+        client
+            .initialize("test", "1.0.0")
+            .await
+            .expect("initialize");
+
+        let result = client
+            .call_tool("mrtr_boom", serde_json::json!({}))
+            .await
+            .expect("the call must return, not kill the connection");
+        assert!(result.is_error, "a caught panic is an error result");
+        assert!(result.all_text().contains("panicked"));
+
+        let after = client
+            .call_tool("fine", serde_json::json!({}))
+            .await
+            .expect("the server must still be serving");
+        assert_eq!(after.all_text(), "ok");
+    }
 }

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -1304,3 +1304,396 @@ async fn a_guard_on_a_live_plus_fallback_tool_rejects_both_paths() {
     assert!(result.is_error);
     assert!(result.all_text().contains("nope"));
 }
+
+// ============================================================================
+// Live plus MRTR fallback: clone, prefix, and guard (#1340)
+// ============================================================================
+//
+// The tests above pin `clone`/`with_name_prefix`/`with_guard` for a live
+// handler paired with a *synchronous* fallback. `ToolBuilderWithLiveHandler::fallback_mrtr_handler`
+// (#1246, shipped alongside `fallback_handler` in the same PR that landed
+// `multi_tool` below) is a materially different branch of `Tool::with_guard`:
+// finding an MRTR handler returns early, rather than falling through to the
+// `match self.service.clone()` the synchronous fallback goes through. Nothing
+// exercised clone/prefix/guard on that branch before.
+
+/// The same discipline as `clone_and_prefix_carry_both_the_live_handler_and_the_fallback`
+/// above, for the MRTR fallback rather than the synchronous one.
+#[tokio::test]
+async fn clone_and_prefix_carry_both_the_live_handler_and_the_mrtr_fallback() {
+    let live_calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = Arc::new(AtomicUsize::new(0));
+    let tool = multi_tool(live_calls.clone(), fallback_calls.clone());
+
+    let cloned = tool.clone();
+    let prefixed = tool.with_name_prefix("ns");
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(cloned)
+        .tool(prefixed)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    for name in ["multi", "ns.multi"] {
+        let result = timed(client.call_tool(name, json!({"value": "x"})))
+            .await
+            .unwrap_or_else(|e| panic!("plain call to {name} failed: {e}"));
+        assert_eq!(
+            result.all_text(),
+            "sync:x",
+            "mrtr fallback must survive for {name}"
+        );
+
+        let task_id = timed(client.call_tool_as_task(name, json!({"value": "x"}), None))
+            .await
+            .unwrap_or_else(|e| panic!("task call to {name} failed: {e}"))
+            .task
+            .task_id;
+        await_status(&store, &task_id, TaskStatus::Completed).await;
+        let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+        assert_eq!(
+            result.unwrap().all_text(),
+            "live:x",
+            "live handler must survive for {name}"
+        );
+    }
+}
+
+/// The same discipline as `a_guard_on_a_live_plus_fallback_tool_rejects_both_paths`
+/// above, for the MRTR fallback rather than the synchronous one.
+#[tokio::test]
+async fn a_guard_on_a_live_plus_mrtr_fallback_tool_rejects_both_paths() {
+    let tool = ToolBuilder::new("multi")
+        .description("Live plus MRTR fallback")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text(
+                "should not run (live)",
+            )))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoArgs| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text(
+                "should not run (fallback)",
+            )))
+        })
+        .build()
+        .with_guard(|_req: &tower_mcp::ToolRequest| Err("nope".to_string()));
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    // The fallback path is rejected.
+    let result = timed(client.call_tool("multi", json!({})))
+        .await
+        .expect("call");
+    assert!(
+        result.is_error,
+        "the guard must reject the mrtr fallback path too"
+    );
+    assert!(result.all_text().contains("nope"));
+
+    // The live path is rejected too.
+    let task_id = timed(client.call_tool_as_task("multi", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let result = result.expect("a rejected call still produces a result");
+    assert!(result.is_error);
+    assert!(result.all_text().contains("nope"));
+}
+
+// ============================================================================
+// Panic isolation across combined handlers (#1340)
+// ============================================================================
+//
+// #1307 established panic containment for a live-only tool: the live branch
+// gets its own `catch_unwind` boundary, independent of the one `invoke_tool`
+// gives ordinary and replayed handlers. Neither boundary had been exercised
+// on a tool that carries a live handler *and* a fallback, where a bug could
+// plausibly wire the live branch's boundary to depend on the fallback being
+// absent, or vice versa.
+
+/// A panic in the live handler must not disturb the synchronous fallback on
+/// the same tool, and a panic in the fallback must not disturb the live
+/// handler on the same tool. Two tools, each panicking on one path and fine
+/// on the other, so a failure to isolate the two shows up as the working
+/// path also failing.
+#[tokio::test]
+async fn a_panicking_live_plus_fallback_tool_isolates_each_path() {
+    let live_boom = ToolBuilder::new("live_boom")
+        .description("Live handler panics, fallback is fine")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            panic!("live handler exploded");
+            #[allow(unreachable_code)]
+            Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+        })
+        .fallback_handler(|_input: NoArgs| async move { Ok(CallToolResult::text("fallback fine")) })
+        .build();
+    let fallback_boom = ToolBuilder::new("fallback_boom")
+        .description("Fallback panics, live handler is fine")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("live fine")))
+        })
+        .fallback_handler(|_input: NoArgs| async move {
+            panic!("fallback exploded");
+            #[allow(unreachable_code)]
+            Ok(CallToolResult::text("unreachable"))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("panic-multi", "1.0.0")
+        .task_store(store.clone())
+        .tool(live_boom)
+        .tool(fallback_boom)
+        .with_tasks()
+        .catch_panics();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = timed(client.call_tool_as_task("live_boom", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Failed).await;
+
+    // The fallback on the same tool is unaffected by the live panic.
+    let result = timed(client.call_tool("live_boom", json!({})))
+        .await
+        .expect("call");
+    assert_eq!(result.all_text(), "fallback fine");
+
+    // The fallback panics on the other tool; its live path is unaffected.
+    let result = timed(client.call_tool("fallback_boom", json!({})))
+        .await
+        .expect("call");
+    assert!(
+        result.is_error,
+        "the caught fallback panic is an error result"
+    );
+    assert!(result.all_text().contains("panicked"));
+
+    let task_id = timed(client.call_tool_as_task("fallback_boom", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(result.unwrap().all_text(), "live fine");
+}
+
+/// The same isolation, for an MRTR fallback rather than a synchronous one.
+#[tokio::test]
+async fn a_panicking_live_plus_mrtr_fallback_tool_isolates_each_path() {
+    let live_boom = ToolBuilder::new("live_boom_mrtr")
+        .description("Live handler panics, MRTR fallback is fine")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            panic!("live handler exploded");
+            #[allow(unreachable_code)]
+            Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoArgs| async move {
+            Ok(RequestOutcome::Complete(CallToolResult::text(
+                "fallback fine",
+            )))
+        })
+        .build();
+    let fallback_boom = ToolBuilder::new("fallback_boom_mrtr")
+        .description("MRTR fallback panics, live handler is fine")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("live fine")))
+        })
+        .fallback_mrtr_handler(|_ctx: RequestContext, _input: NoArgs| async move {
+            panic!("fallback exploded");
+            #[allow(unreachable_code)]
+            Ok(RequestOutcome::Complete(CallToolResult::text(
+                "unreachable",
+            )))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("panic-multi-mrtr", "1.0.0")
+        .task_store(store.clone())
+        .tool(live_boom)
+        .tool(fallback_boom)
+        .with_tasks()
+        .catch_panics();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = timed(client.call_tool_as_task("live_boom_mrtr", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Failed).await;
+
+    let result = timed(client.call_tool("live_boom_mrtr", json!({})))
+        .await
+        .expect("call");
+    assert_eq!(result.all_text(), "fallback fine");
+
+    let result = timed(client.call_tool("fallback_boom_mrtr", json!({})))
+        .await
+        .expect("call");
+    assert!(result.is_error);
+    assert!(result.all_text().contains("panicked"));
+
+    let task_id = timed(client.call_tool_as_task("fallback_boom_mrtr", json!({}), None))
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(result.unwrap().all_text(), "live fine");
+}
+
+// ============================================================================
+// Cancellation: outcome path and registration ordering, hardened (#1340)
+// ============================================================================
+
+/// #1304 fixed a race between the completion write and a late cancellation;
+/// `a_completion_is_not_overwritten_by_a_late_cancellation` above repeats the
+/// race many times for confidence under scheduling variance. This is the
+/// deterministic complement: with no interleaving at all, a cancellation
+/// attempted strictly after the handler has already completed and the task
+/// has reached its terminal state must never move that state.
+#[tokio::test]
+async fn cancelling_an_already_completed_task_does_not_change_its_terminal_state() {
+    let tool = ToolBuilder::new("live")
+        .description("Completes immediately")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    // No race: wait for the task to fully complete (which also releases the
+    // live registration, #1305) before even attempting a cancellation.
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+
+    let cancellation = client.task_cancel(&task_id, None).await;
+    assert!(
+        cancellation.is_err(),
+        "a completed task must refuse a cancellation, not silently accept one"
+    );
+
+    let task = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        task.status,
+        TaskStatus::Completed,
+        "the terminal state must not move once the outcome path has already \
+         written it"
+    );
+    let (_, result, _) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        result.unwrap().all_text(),
+        "done",
+        "the original result must survive a post-terminal cancellation attempt"
+    );
+}
+
+/// #1304, startup window, hardened: `cancelling_before_the_handler_starts_is_still_observed`
+/// above documents that a single attempt passes even against the old
+/// ordering, since it does not reliably land in the gap between registering
+/// the live handle and checking the store's cancellation token. Repeating
+/// the same immediate-cancel sequence many times, each with a fresh router so
+/// the runs cannot interfere with each other, raises the odds that at least
+/// one round lands in that window without introducing a sleep that would
+/// guarantee missing it.
+#[tokio::test]
+async fn cancelling_immediately_after_creation_is_observed_across_many_rounds() {
+    for round in 0..30 {
+        let tore_down = Arc::new(AtomicUsize::new(0));
+        let counter = tore_down.clone();
+        let tool = ToolBuilder::new("live")
+            .description("Waits forever unless cancelled")
+            .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+                let counter = counter.clone();
+                async move {
+                    let result = task.require_input(ask("never")).await;
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    result?;
+                    Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+                }
+            })
+            .build();
+
+        let store = Arc::new(MemoryTaskStore::new());
+        let router = McpRouter::new()
+            .server_info("live", "1.0.0")
+            .task_store(store.clone())
+            .tool(tool)
+            .with_tasks();
+
+        let client = McpClient::connect(ChannelTransport::new(router))
+            .await
+            .expect("connect");
+        client.initialize("t", "1.0.0").await.expect("init");
+
+        let task_id = client
+            .call_tool_as_task("live", json!({}), None)
+            .await
+            .expect("task created")
+            .task
+            .task_id;
+
+        // No sleep: cancel as soon as the handle exists.
+        client.task_cancel(&task_id, None).await.expect("cancel");
+
+        await_status(&store, &task_id, TaskStatus::Cancelled).await;
+        assert_eq!(
+            tore_down.load(Ordering::SeqCst),
+            1,
+            "round {round}: a cancel landing before registration must still \
+             be observed once the handler starts, not lost in the gap #1304 closed"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Pure test work for #1340. Live task execution (#1288) shipped in the 0.21.1
to 0.22.0 window and took six fixes in two days against the same surface
(#1247, #1248, #1298, #1302, #1304, #1307), with #1329 still open. Three of
the six were not races: a hand-written `Clone` that dropped a field
(#1298), a type that could not be constructed (#1302), and a wrapper that
was not applied (#1307) -- the kind of gap a systematic pass over the
surface finds in one sitting.

This builds that pass: `Tool`'s construction/transformation methods
(`clone`, `with_name_prefix`, `with_guard`) crossed against every handler
kind (plain, MRTR-only, live-only, live+sync-fallback, live+MRTR-fallback),
plus `Resource::clone` and `Prompt::clone` (plain and MRTR), panic
containment across handler kinds, and cancellation registration ordering.

## Plan

1. Read `crates/tower-mcp/tests/live_tasks.rs` (already ~1300 lines) and the
   `Tool`/`Resource`/`Prompt` source to find which matrix cells it does not
   cross.
2. Add unit-level tests to `crates/tower-mcp/src/tool/tests.rs` for handler
   kinds that don't need a live router (plain clone, MRTR clone/prefix,
   live-only clone/prefix invoked directly through the crate-private
   `LiveToolHandler` trait, live+MRTR-fallback clone/prefix/guard).
3. Add router-integration tests to `crates/tower-mcp/tests/live_tasks.rs`
   for the live+MRTR-fallback combination end to end (mirroring the
   existing live+sync-fallback tests), panic isolation across combined
   handlers, and cancellation-outcome/registration-ordering tests that
   don't rely purely on race timing.
4. Add one MRTR-panic test to `crates/tower-mcp/tests/channel_transport.rs`
   (the existing panic tests there only exercise a plain handler).
5. Add `Resource::clone`/`Prompt::clone` tests for the MRTR handler kind to
   `resource.rs`/`prompt.rs`, which had no direct coverage (only incidental,
   for `Resource`, through `.read()`'s internal `self.clone()`).
6. Run `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`,
   and `cargo test --all-features` before every push.

## Constraints

- No `src/` changes. If a test fails, it means a real bug -- mark it
  `#[ignore]` with the defect noted, don't fix it here, and report it for
  its own issue.
- Test-only; conventional commit prefix `test:`.

## Result

Every new test passes. No behavior gaps found; every matrix cell already
holds correctly.