### PR TITLE
refactor(framing): extract the JSON-RPC inbound frame classification predicate

### DIFF
--- a/crates/tower-mcp/src/client/channel.rs
+++ b/crates/tower-mcp/src/client/channel.rs
@@ -354,10 +354,7 @@ impl ChannelTransport {
                 // and a result or error but no method. This must be checked
                 // before the request parse below, which such a frame cannot
                 // satisfy (JsonRpcRequest requires `method`).
-                if parsed.get("method").is_none()
-                    && parsed.get("id").is_some()
-                    && (parsed.get("result").is_some() || parsed.get("error").is_some())
-                {
+                if parsed.get("id").is_some() && crate::framing::is_response_frame(&parsed) {
                     if let Ok(id) = serde_json::from_value::<RequestId>(parsed["id"].clone()) {
                         let responder = pending.lock().ok().and_then(|mut p| p.remove(&id));
                         if let Some(responder) = responder {

--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -2851,9 +2851,7 @@ async fn handle_incoming<T: ClientTransport, H: ClientHandler>(
     };
 
     // Case 1: Response to one of our pending requests (has result or error, no method)
-    if parsed.get("method").is_none()
-        && (parsed.get("result").is_some() || parsed.get("error").is_some())
-    {
+    if crate::framing::is_response_frame(&parsed) {
         // Check for session-level errors (id: null with -32005) that affect
         // all pending requests, not just a specific one.
         if let Some(error) = parsed.get("error") {

--- a/crates/tower-mcp/src/framing.rs
+++ b/crates/tower-mcp/src/framing.rs
@@ -119,6 +119,69 @@ pub(crate) fn clean_input_line(line: &str) -> &str {
     line.strip_prefix('\u{feff}').unwrap_or(line).trim()
 }
 
+/// Which of the three JSON-RPC frame shapes a decoded value is.
+///
+/// A batch (JSON array) is always [`FrameClass::Request`] -- neither a
+/// notification nor a response can be a top-level array, so an array skips
+/// straight to "otherwise".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FrameClass {
+    /// No `id` field: nothing to answer, so nothing is sent back.
+    Notification,
+    /// An `id`, no `method`, and a `result` or `error`: a reply arriving on
+    /// a channel that never sent the matching request.
+    Response,
+    /// Everything else, single or batched. Includes the malformed case of an
+    /// `id` with no `method` and neither `result` nor `error` -- that is not
+    /// a valid request, but classifying it as one is what gets it a `-32700`
+    /// reply instead of being silently dropped as if it were a response.
+    Request,
+}
+
+/// Classify a decoded JSON-RPC value by shape alone, before any schema
+/// validation runs.
+///
+/// Order is pinned and matters: notification, then response, then request.
+/// Classifying before validating means a malformed notification cannot come
+/// back as an error the client has no id to correlate (#1272). Checking
+/// response before falling through to request means a reply frame is
+/// ignored rather than answered with a parse error naming an internal type.
+///
+/// This is the extraction of the test `process_line` in `transport::stdio`
+/// used to hand-write, now shared by every receive path that needs the full
+/// three-way split. A path that only needs the response test in isolation
+/// (for example one that establishes "has an id" some other way) should
+/// call [`is_response_frame`] directly instead -- `classify_frame` folds the
+/// id check into the ordering, so its [`FrameClass::Response`] arm is only
+/// reachable once an id is already known to be present.
+pub(crate) fn classify_frame(value: &serde_json::Value) -> FrameClass {
+    if !value.is_array() && value.get("id").is_none() {
+        return FrameClass::Notification;
+    }
+    if is_response_frame(value) {
+        return FrameClass::Response;
+    }
+    FrameClass::Request
+}
+
+/// The response half of [`classify_frame`]'s test, callable on its own.
+///
+/// A response carries no `method` and one of `result` or `error`. All three
+/// conditions here matter together: dropping the `result`/`error` check
+/// would misclassify any method-less frame as a response and silently
+/// discard it, when a method-less frame with neither is actually an invalid
+/// request that must still be refused with an error, not dropped.
+///
+/// This test alone says nothing about `id` -- callers that need "has an id
+/// AND looks like a response" (as opposed to "would be classified `Response`
+/// by [`classify_frame`]'s pinned ordering") check `id` themselves alongside
+/// this.
+pub(crate) fn is_response_frame(value: &serde_json::Value) -> bool {
+    !value.is_array()
+        && value.get("method").is_none()
+        && (value.get("result").is_some() || value.get("error").is_some())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,5 +304,107 @@ mod tests {
         assert_eq!(clean_input_line(""), "");
         assert_eq!(clean_input_line("\u{feff}"), "");
         assert_eq!(clean_input_line("   \n\t"), "");
+    }
+
+    // =========================================================================
+    // classify_frame / is_response_frame tests
+    // =========================================================================
+
+    #[test]
+    fn classify_frame_notification_has_no_id() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "method": "notifications/initialized"});
+        assert_eq!(classify_frame(&value), FrameClass::Notification);
+    }
+
+    #[test]
+    fn classify_frame_response_has_id_no_method_and_result() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": {}});
+        assert_eq!(classify_frame(&value), FrameClass::Response);
+    }
+
+    #[test]
+    fn classify_frame_response_has_id_no_method_and_error() {
+        let value =
+            serde_json::json!({"jsonrpc": "2.0", "id": 1, "error": {"code": -1, "message": "x"}});
+        assert_eq!(classify_frame(&value), FrameClass::Response);
+    }
+
+    #[test]
+    fn classify_frame_request_has_id_and_method() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert_eq!(classify_frame(&value), FrameClass::Request);
+    }
+
+    /// A batch is always `Request`, whatever shape its members are -- a
+    /// top-level array can never be a notification or a response.
+    #[test]
+    fn classify_frame_batch_array_is_always_request() {
+        let value = serde_json::json!([
+            {"jsonrpc": "2.0", "id": 1, "method": "a"},
+            {"jsonrpc": "2.0", "method": "b"},
+        ]);
+        assert_eq!(classify_frame(&value), FrameClass::Request);
+    }
+
+    /// The key must be *absent* to count as no id. `"id": null` still has
+    /// the key, so `get("id")` returns `Some(Null)`, not `None`.
+    #[test]
+    fn classify_frame_id_present_but_null_is_not_a_notification() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "id": null, "method": "tools/list"});
+        assert_eq!(classify_frame(&value), FrameClass::Request);
+    }
+
+    /// An id-bearing, null-id response is still a response: the id key is
+    /// present, there is no method, and `result` is present.
+    #[test]
+    fn classify_frame_id_present_but_null_can_still_be_a_response() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "id": null, "result": {}});
+        assert_eq!(classify_frame(&value), FrameClass::Response);
+    }
+
+    /// An id with no method and neither `result` nor `error` is not a valid
+    /// request, but it must still classify as `Request` so it gets refused
+    /// with a `-32700` reply rather than being silently dropped as if it
+    /// were a response.
+    #[test]
+    fn classify_frame_id_no_method_no_result_or_error_is_a_request_not_a_response() {
+        let value = serde_json::json!({"jsonrpc": "2.0", "id": 1});
+        assert_eq!(classify_frame(&value), FrameClass::Request);
+    }
+
+    #[test]
+    fn is_response_frame_matches_the_response_shape() {
+        assert!(is_response_frame(
+            &serde_json::json!({"jsonrpc": "2.0", "id": 1, "result": {}})
+        ));
+        assert!(is_response_frame(
+            &serde_json::json!({"jsonrpc": "2.0", "id": 1, "error": {"code": -1}})
+        ));
+    }
+
+    #[test]
+    fn is_response_frame_rejects_a_request_shape() {
+        assert!(!is_response_frame(
+            &serde_json::json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+        ));
+        assert!(!is_response_frame(
+            &serde_json::json!({"jsonrpc": "2.0", "id": 1})
+        ));
+    }
+
+    /// `is_response_frame` alone does not consider `id`: it is meant to be
+    /// combined with whatever id check a caller already has, or called
+    /// after a caller has already established (as `classify_frame` does)
+    /// that the frame is not a notification.
+    #[test]
+    fn is_response_frame_does_not_itself_require_an_id() {
+        assert!(is_response_frame(&serde_json::json!({"result": {}})));
+    }
+
+    #[test]
+    fn is_response_frame_rejects_a_batch_array() {
+        assert!(!is_response_frame(&serde_json::json!([
+            {"result": {}},
+        ])));
     }
 }

--- a/crates/tower-mcp/src/transport/http/handlers.rs
+++ b/crates/tower-mcp/src/transport/http/handlers.rs
@@ -191,8 +191,7 @@ fn is_initialize_request(body: &serde_json::Value) -> bool {
 
 /// Check if this is a response to one of our outgoing requests
 fn is_response(parsed: &serde_json::Value) -> bool {
-    parsed.get("method").is_none()
-        && (parsed.get("result").is_some() || parsed.get("error").is_some())
+    crate::framing::is_response_frame(parsed)
 }
 
 /// Resolve the selected tool's input schema when the transport owns an

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -69,7 +69,10 @@ use crate::context::{
 use tower_service::Service;
 
 use crate::error::{Error, Result};
-use crate::framing::{FrameReader, InputFrame, clean_input_line, read_frame_blocking};
+use crate::framing::{
+    FrameClass, FrameReader, InputFrame, classify_frame, clean_input_line, is_response_frame,
+    read_frame_blocking,
+};
 use crate::jsonrpc::JsonRpcService;
 #[cfg(feature = "stateless")]
 use crate::protocol::{Implementation, SubscriptionFilter};
@@ -644,23 +647,8 @@ async fn process_line(
     // response, so answering one is a JSON-RPC violation whatever validation
     // would have said about it. Validating first meant a malformed
     // notification came back as an error the client could not correlate
-    // (#1272).
-    if !parsed.is_array() && parsed.get("id").is_none() {
-        let method = parsed.get("method").and_then(|m| m.as_str());
-        if let Err(error) =
-            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
-        {
-            // Still worth surfacing, just not to the client.
-            tracing::debug!(method, %error, "rejected an invalid notification");
-            return Ok(None);
-        }
-        match serde_json::from_str::<JsonRpcNotification>(line) {
-            Ok(notification) => handle_notification(router, notification)?,
-            Err(_) => tracing::debug!(method, "unparseable notification"),
-        }
-        return Ok(None);
-    }
-
+    // (#1272). See `classify_frame` for the pinned ordering this depends on.
+    //
     // A response carries an id, no method, and one of `result` or `error`.
     // All three matter: an id with no method and neither of those is an
     // invalid *request* and must still be refused. `BidirectionalStdioTransport`
@@ -669,12 +657,27 @@ async fn process_line(
     // This transport never sends requests, so a response arriving is the
     // peer's mistake. Ignoring it beats answering, which previously produced
     // a parse error naming an internal type (#1272).
-    if !parsed.is_array()
-        && parsed.get("method").is_none()
-        && (parsed.get("result").is_some() || parsed.get("error").is_some())
-    {
-        tracing::debug!("ignoring an unexpected JSON-RPC response frame");
-        return Ok(None);
+    match classify_frame(&parsed) {
+        FrameClass::Notification => {
+            let method = parsed.get("method").and_then(|m| m.as_str());
+            if let Err(error) = service
+                .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+            {
+                // Still worth surfacing, just not to the client.
+                tracing::debug!(method, %error, "rejected an invalid notification");
+                return Ok(None);
+            }
+            match serde_json::from_str::<JsonRpcNotification>(line) {
+                Ok(notification) => handle_notification(router, notification)?,
+                Err(_) => tracing::debug!(method, "unparseable notification"),
+            }
+            return Ok(None);
+        }
+        FrameClass::Response => {
+            tracing::debug!("ignoring an unexpected JSON-RPC response frame");
+            return Ok(None);
+        }
+        FrameClass::Request => {}
     }
 
     if let Err(error) =
@@ -2158,9 +2161,7 @@ impl BidirectionalStdioTransport {
         }
 
         // Check if this is a response to one of our pending requests
-        if parsed.get("method").is_none()
-            && (parsed.get("result").is_some() || parsed.get("error").is_some())
-        {
+        if is_response_frame(&parsed) {
             return self.handle_response(&parsed).await;
         }
 

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -985,9 +985,7 @@ where
     }
 
     // Check if this is a response to one of our pending requests
-    if parsed.get("method").is_none()
-        && (parsed.get("result").is_some() || parsed.get("error").is_some())
-    {
+    if crate::framing::is_response_frame(&parsed) {
         return handle_response(&parsed, pending_requests).await;
     }
 
@@ -1156,6 +1154,12 @@ async fn process_message(
         }
         return Ok(None);
     }
+
+    // #1335: this path is missing the response-frame branch that
+    // `handle_incoming_message` (above) and the stdio transport both have --
+    // a response arriving here falls through to the request parse below and
+    // gets answered with a parse error instead of being ignored. Not fixed
+    // here; this extraction is a no-behavior-change base for that fix.
 
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)


### PR DESCRIPTION
## What this is

A pure, no-behavior-change extraction of the JSON-RPC inbound frame
classification predicate into `crate::framing`, per the spec in the
[comment on #1335](https://github.com/joshrotenberg/tower-mcp/issues/1335#issuecomment)
titled "A fourth divergence, and a spec for the shared helper."

**This PR is the base of a stacked-PR set.** #1335 and #1336 (the actual
bug fixes) build on top of this branch. This PR itself changes no
observable behavior anywhere it touches.

## The shared helper

`crate::framing` now exposes:

- `FrameClass` (`Notification` / `Response` / `Request`) and
  `classify_frame(&Value) -> FrameClass`, the full three-way, pinned-order
  classification that `process_line` in `transport/stdio.rs` used to
  hand-write: notification first (no `id`), then response (`method`
  absent, `result` or `error` present), else request.
- `is_response_frame(&Value) -> bool`, the response half of that test on
  its own, for callers that only need it in isolation (several call sites
  already establish "has an id" some other way before or alongside this
  check, and folding it into `classify_frame`'s ordering would change what
  they classify id-absent frames as).

Both carry the original reasoning comments, including why branch 2 needs
all three of its conditions: an id with no method and neither `result`
nor `error` is an invalid request that must still be refused with a
`-32700`, not silently dropped as if it were a response.

## Sites routed (6 of 7)

- `transport/stdio.rs` `process_line` -- now the canonical site, driven by
  `classify_frame` (a `match` on `FrameClass`, same order, same behavior
  per branch).
- `transport/stdio.rs` `BidirectionalStdioTransport::handle_incoming_message`
  -- routed to `is_response_frame`.
- `transport/websocket.rs` `handle_incoming_message` -- routed to
  `is_response_frame`.
- `transport/http/handlers.rs` `is_response` -- body now delegates to
  `is_response_frame`. Nothing else in that file touched (it's also the
  target of #1336 and #1341).
- `client/channel.rs` -- routed to `is_response_frame`, keeping its
  existing local `id.is_some()` check alongside (its original test already
  required an id; `is_response_frame` alone does not, so the id check
  stays inline at the call site).
- `client/mod.rs` `handle_incoming` Case 1 -- routed to `is_response_frame`.

## Site skipped (1 of 7)

- `client/http.rs:1330` (`is_terminal` in the SSE POST response loop) --
  **not routed.** This is a request/response id-correlation check against
  a specific pending request (`value.get("id").zip(req_id.as_ref())...`),
  not a generic frame classification. It also has no `method`-absence
  guard, unlike the shared predicate. Substituting the shared helper here
  would either add a constraint that was not there before (if the method
  guard is included) or require inventing a two-value id-correlation
  helper outside the pure single-value classification the issue scopes.
  Left alone.

## Known gap, not fixed here

`transport/websocket.rs` `process_message` (the unidirectional loop) is
missing the response-frame branch entirely -- a response arriving there
falls through to the request parse and gets a spurious `-32700` instead
of being ignored. That's the `#1335` bug. Marked with a `// #1335` comment
at the gap; not fixed in this PR by design, so the fix PR can build the
correction on top of the shared helper this PR introduces.

## Testing

New unit tests in `crate::framing` cover all three `FrameClass` variants
plus the edge cases called out in the spec: batch arrays (always
`Request`), an id key present but `null` (still counts as "has an id"),
and an id with no method and no `result`/`error` (classifies `Request`,
not silently dropped as `Response`).

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D
warnings`, and `cargo test` (full workspace) all pass clean.