### PR TITLE
fix(tasks): harden task error boundaries

### DIFF
--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -664,7 +664,8 @@ pub use resource::{
 };
 pub use router::{
     McpRouter, MergeConflict, MergeConflictKind, MergeConflicts, PanicPolicy, RouterRequest,
-    RouterResponse, ToolAnnotationsMap,
+    RouterResponse, TaskErrorContext, TaskErrorPolicy, TaskFailure, TaskOperation,
+    ToolAnnotationsMap,
 };
 pub use session::{SessionPhase, SessionState};
 #[cfg(feature = "stateless")]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -58,7 +58,6 @@ fn encode_cursor(offset: usize) -> String {
     BASE64.encode(offset.to_string())
 }
 
-/// Map a [`TaskStoreError`] to a JSON-RPC internal error.
 /// Releases a live task's registry entry however its handler leaves.
 ///
 /// The handler can return, panic, or be dropped. Unregistering only on the
@@ -261,6 +260,227 @@ impl PanicPolicy {
 
     fn needs_payload(&self) -> bool {
         matches!(self.client_message, ClientPanicMessage::Detailed) || self.include_payload_in_logs
+    }
+}
+
+/// The Task operation whose failure is being exposed to a client.
+///
+/// A [`TaskErrorPolicy`] receives this alongside the typed failure so an
+/// application can attach stable operation-specific data without parsing an
+/// error message.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum TaskOperation {
+    /// Creating and preparing a Task from a task-augmented request.
+    Create,
+    /// Reading a Task through `tasks/get`.
+    Get,
+    /// Applying client input through `tasks/update`.
+    Update,
+    /// Requesting cancellation through `tasks/cancel`.
+    Cancel,
+    /// Persisting an input-required transition requested by a Task handler.
+    ParkInput,
+    /// Task-store work performed inside a live Task handler after creation.
+    Execute,
+    /// Reading durable state needed to resume a replayed Task handler.
+    Resume,
+    /// Persisting a terminal Task outcome after handler execution.
+    Finalize,
+}
+
+/// The typed reason a Task operation failed.
+///
+/// Store errors retain their original typed value for an explicitly installed
+/// [`TaskErrorPolicy`]. Their display text may contain backend paths, queries,
+/// or codec details and must not be copied into a client response without an
+/// application-specific disclosure review. Tower's default policy never does
+/// so.
+#[non_exhaustive]
+pub enum TaskFailure {
+    /// The Task ID is unknown or its retained tombstone was removed.
+    NotFound,
+    /// The Task is known to have expired and the caller owns it.
+    Expired,
+    /// The Task store returned an error.
+    Store(TaskStoreError),
+    /// Tower detected a safe, static Task-lifecycle invariant failure.
+    Internal(&'static str),
+    /// Client-supplied Task arguments were malformed.
+    InvalidArguments(&'static str),
+    /// A live Task handler returned an unclassified execution error.
+    ///
+    /// The underlying error is deliberately neither logged nor exposed to the
+    /// policy: its display text is application-owned and can contain provider
+    /// details.
+    Handler,
+}
+
+impl std::fmt::Debug for TaskFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => f.write_str("NotFound"),
+            Self::Expired => f.write_str("Expired"),
+            Self::Store(error) => {
+                let kind = match error {
+                    TaskStoreError::Encode(_) => "Encode",
+                    TaskStoreError::Decode(_) => "Decode",
+                    TaskStoreError::Backend(_) => "Backend",
+                    TaskStoreError::InvalidTransition(_) => "InvalidTransition",
+                };
+                write!(f, "Store({kind})")
+            }
+            Self::Internal(message) => f.debug_tuple("Internal").field(message).finish(),
+            Self::InvalidArguments(message) => {
+                f.debug_tuple("InvalidArguments").field(message).finish()
+            }
+            Self::Handler => f.write_str("Handler"),
+        }
+    }
+}
+
+/// Typed input to a [`TaskErrorPolicy`].
+///
+/// The fields are intentionally private so Tower can add context without
+/// breaking policy implementations. Inspect them through the accessors.
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct TaskErrorContext {
+    operation: TaskOperation,
+    task_id: Option<String>,
+    failure: TaskFailure,
+}
+
+impl TaskErrorContext {
+    fn new(operation: TaskOperation, task_id: Option<&str>, failure: TaskFailure) -> Self {
+        Self {
+            operation,
+            task_id: task_id.map(str::to_owned),
+            failure,
+        }
+    }
+
+    /// The Task operation that failed.
+    pub const fn operation(&self) -> TaskOperation {
+        self.operation
+    }
+
+    /// The Task ID, when one had been allocated or supplied.
+    pub fn task_id(&self) -> Option<&str> {
+        self.task_id.as_deref()
+    }
+
+    /// The typed failure.
+    pub const fn failure(&self) -> &TaskFailure {
+        &self.failure
+    }
+}
+
+type TaskErrorMapper = dyn Fn(&TaskErrorContext) -> JsonRpcError + Send + Sync + 'static;
+
+/// Maps Task lifecycle failures to client-visible JSON-RPC errors.
+///
+/// The default preserves Tower's established `-32602` shapes for unknown and
+/// expired Tasks. Store failures use `-32603` with fixed text, deliberately
+/// omitting the store error's display string because it may disclose backend
+/// details.
+///
+/// A custom policy can attach an application's structured error envelope. It
+/// receives the original [`TaskStoreError`] by reference, so it must make its
+/// own explicit disclosure decision rather than forwarding `Display` text.
+#[derive(Clone)]
+pub struct TaskErrorPolicy {
+    mapper: Arc<TaskErrorMapper>,
+}
+
+impl std::fmt::Debug for TaskErrorPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TaskErrorPolicy").finish_non_exhaustive()
+    }
+}
+
+impl Default for TaskErrorPolicy {
+    fn default() -> Self {
+        Self::new(default_task_error)
+    }
+}
+
+impl TaskErrorPolicy {
+    /// Construct a Task error policy from a synchronous mapper.
+    ///
+    /// The mapper runs only after Tower has authorized any distinction between
+    /// an expired Task and a missing one. An unauthorized Task is passed to the
+    /// mapper as [`TaskFailure::NotFound`], exactly like a never-issued ID. It
+    /// runs synchronously on the request or handler path, so it should be fast.
+    /// Tower catches a panic and substitutes a fixed redacted internal error.
+    /// Rust's process-global panic hook still runs before the unwind is caught.
+    pub fn new<F>(mapper: F) -> Self
+    where
+        F: Fn(&TaskErrorContext) -> JsonRpcError + Send + Sync + 'static,
+    {
+        Self {
+            mapper: Arc::new(mapper),
+        }
+    }
+
+    fn map(&self, context: &TaskErrorContext) -> JsonRpcError {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| (self.mapper)(context))) {
+            Ok(error) => error,
+            Err(_) => {
+                // The policy itself is application code. Record that it broke,
+                // but do not attach the Task ID, failure, or panic payload:
+                // this is the final redaction boundary.
+                tracing::error!(
+                    target: "mcp::tasks",
+                    "task error policy panicked; using the redacted fallback"
+                );
+                JsonRpcError::internal_error("Task error policy failed")
+            }
+        }
+    }
+
+    pub(crate) fn map_store_error(
+        &self,
+        operation: TaskOperation,
+        task_id: &str,
+        error: TaskStoreError,
+    ) -> JsonRpcError {
+        self.map(&TaskErrorContext::new(
+            operation,
+            Some(task_id),
+            TaskFailure::Store(error),
+        ))
+    }
+
+    pub(crate) fn map_internal_error(
+        &self,
+        operation: TaskOperation,
+        task_id: &str,
+        message: &'static str,
+    ) -> JsonRpcError {
+        self.map(&TaskErrorContext::new(
+            operation,
+            Some(task_id),
+            TaskFailure::Internal(message),
+        ))
+    }
+}
+
+fn default_task_error(context: &TaskErrorContext) -> JsonRpcError {
+    match context.failure() {
+        TaskFailure::NotFound => JsonRpcError::invalid_params(format!(
+            "Task not found: {}",
+            context.task_id().unwrap_or("<unknown>")
+        )),
+        TaskFailure::Expired => JsonRpcError::invalid_params(format!(
+            "Task expired: {}",
+            context.task_id().unwrap_or("<unknown>")
+        ))
+        .with_data(serde_json::json!({ "reason": "task_expired" })),
+        TaskFailure::Store(_) => JsonRpcError::internal_error("Task store operation failed"),
+        TaskFailure::Internal(message) => JsonRpcError::internal_error(*message),
+        TaskFailure::InvalidArguments(message) => JsonRpcError::invalid_params(*message),
+        TaskFailure::Handler => JsonRpcError::internal_error("Task handler failed"),
     }
 }
 
@@ -534,6 +754,8 @@ struct McpRouterInner {
     /// How to convert a panicking tool handler into an error result rather
     /// than letting it unwind out of the service (#1230, #1306).
     panic_policy: Option<PanicPolicy>,
+    /// Root-owned mapping for client-visible Task lifecycle failures.
+    task_error_policy: TaskErrorPolicy,
     auto_instructions: Option<AutoInstructionsConfig>,
     tools: HashMap<String, Arc<Tool>>,
     resources: HashMap<String, Arc<Resource>>,
@@ -727,6 +949,7 @@ impl McpRouter {
                 server_website_url: None,
                 instructions: None,
                 panic_policy: None,
+                task_error_policy: TaskErrorPolicy::default(),
                 auto_instructions: None,
                 tools: HashMap::new(),
                 resources: HashMap::new(),
@@ -844,6 +1067,23 @@ impl McpRouter {
     /// ```
     pub fn task_store(mut self, store: Arc<dyn TaskStore>) -> Self {
         Arc::make_mut(&mut self.inner).task_store = store;
+        self
+    }
+
+    /// Set the root router's client-visible Task error policy.
+    ///
+    /// The policy applies to task creation, `tasks/get`, `tasks/update`,
+    /// `tasks/cancel`, and failures while parking, executing, resuming, or
+    /// finalizing a handler. Like [`McpRouter::catch_panics_with`], it is root
+    /// configuration: merging or nesting another router imports that router's
+    /// capabilities but not its policy, so the receiving router governs the
+    /// combined catalog.
+    ///
+    /// Tower's default preserves the established missing/expired response
+    /// shapes and redacts every [`TaskStoreError`] to a fixed internal error.
+    #[must_use]
+    pub fn task_error_policy(mut self, policy: TaskErrorPolicy) -> Self {
+        Arc::make_mut(&mut self.inner).task_error_policy = policy;
         self
     }
 
@@ -2980,7 +3220,9 @@ impl McpRouter {
                             request_principal(&extensions),
                         )
                         .await
-                        .map_err(task_store_error)?;
+                        .map_err(|error| {
+                            self.task_store_error(TaskOperation::Create, None, error)
+                        })?;
 
                     tracing::info!(task_id = %task_id, tool = %params.name, "Created async task");
 
@@ -3018,14 +3260,22 @@ impl McpRouter {
                             Ok(persisted) => persisted,
                             Err(error) => {
                                 discard_unprepared_task(&task_store, &task_id).await;
-                                return Err(task_store_error(error));
+                                return Err(self.task_store_error(
+                                    TaskOperation::Create,
+                                    Some(&task_id),
+                                    error,
+                                ));
                             }
                         };
                         if !persisted {
                             discard_unprepared_task(&task_store, &task_id).await;
-                            return Err(Error::JsonRpc(JsonRpcError::internal_error(
-                                "Task store could not persist preparation metadata",
-                            )));
+                            return Err(self.task_error(
+                                TaskOperation::Create,
+                                Some(&task_id),
+                                TaskFailure::Internal(
+                                    "Task store could not persist preparation metadata",
+                                ),
+                            ));
                         }
                     }
                     ctx.extensions_mut().merge(&preparation.extensions);
@@ -3045,6 +3295,7 @@ impl McpRouter {
                         if let Some(live_handler) = tool.live_handler.clone() {
                             let handle = std::sync::Arc::new(crate::tool::LiveTask {
                                 store: task_store.clone(),
+                                error_policy: notifier.inner.task_error_policy.clone(),
                                 input_ready: tokio::sync::Notify::new(),
                                 cancelled: crate::context::CancellationToken::new(),
                             });
@@ -3110,37 +3361,49 @@ impl McpRouter {
                             let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
 
                             let applied = match outcome {
-                                Ok(crate::tool::TaskOutcome::Completed(result)) => task_store
-                                    .complete_task(&task_id_clone, result)
+                                Ok(crate::tool::TaskOutcome::Completed(result)) => notifier
+                                    .complete_task_or_fail(&task_id_clone, result)
                                     .await
-                                    .map(|_| "completed"),
-                                Ok(crate::tool::TaskOutcome::Failed(error)) => task_store
-                                    .fail_task(&task_id_clone, error)
+                                    .then_some("completed"),
+                                Ok(crate::tool::TaskOutcome::Failed(error)) => notifier
+                                    .record_task_failure(&task_id_clone, error)
                                     .await
-                                    .map(|_| "failed"),
-                                Ok(crate::tool::TaskOutcome::Cancelled { message }) => task_store
-                                    .cancel_task(&task_id_clone, message.as_deref())
+                                    .then_some("failed"),
+                                Ok(crate::tool::TaskOutcome::Cancelled { message }) => notifier
+                                    .record_task_cancellation(&task_id_clone, message.as_deref())
                                     .await
-                                    .map(|_| "cancelled"),
+                                    .then_some("cancelled"),
                                 // Propagating the cancellation error is the
                                 // ordinary way a live handler unwinds, so it
                                 // ends the task cancelled rather than failed.
-                                Err(crate::error::Error::TaskCancelled) => task_store
-                                    .cancel_task(
+                                Err(crate::error::Error::TaskCancelled) => notifier
+                                    .record_task_cancellation(
                                         &task_id_clone,
                                         Some("handler observed cancellation"),
                                     )
                                     .await
-                                    .map(|_| "cancelled"),
+                                    .then_some("cancelled"),
                                 // An unclassified error is an execution
                                 // failure the handler declined to describe.
-                                Err(error) => task_store
-                                    .fail_task(
-                                        &task_id_clone,
-                                        JsonRpcError::internal_error(error.to_string()),
-                                    )
+                                Err(Error::JsonRpc(error)) => notifier
+                                    .record_task_failure(&task_id_clone, error)
                                     .await
-                                    .map(|_| "failed"),
+                                    .then_some("failed"),
+                                Err(_error) => {
+                                    tracing::warn!(
+                                        task_id = %task_id_clone,
+                                        "live task handler returned an unclassified error"
+                                    );
+                                    let error = notifier.task_json_rpc_error(
+                                        TaskOperation::Execute,
+                                        Some(&task_id_clone),
+                                        TaskFailure::Handler,
+                                    );
+                                    notifier
+                                        .record_task_failure(&task_id_clone, error)
+                                        .await
+                                        .then_some("failed")
+                                }
                             };
                             // The terminal write must win before unregistering
                             // (#1294), but the dead handle must not remain
@@ -3151,7 +3414,7 @@ impl McpRouter {
                             drop(registration);
 
                             match applied {
-                                Ok(status) => tracing::info!(
+                                Some(status) => tracing::info!(
                                     target: "mcp::tools",
                                     tool = %tool_name,
                                     task_id = %task_id_clone,
@@ -3159,9 +3422,8 @@ impl McpRouter {
                                     status,
                                     "live task finished"
                                 ),
-                                Err(e) => tracing::warn!(
+                                None => tracing::warn!(
                                     task_id = %task_id_clone,
-                                    error = %e,
                                     "failed to record live task outcome"
                                 ),
                             }
@@ -3215,18 +3477,17 @@ impl McpRouter {
                                 .is_error
                                 .then(|| result.first_text().unwrap_or("Tool execution failed"))
                                 .map(str::to_string);
-                            if let Err(e) = task_store.complete_task(&task_id_clone, result).await {
-                                tracing::warn!(task_id = %task_id_clone, error = %e, "failed to record task completion");
+                            if notifier.complete_task_or_fail(&task_id_clone, result).await {
+                                tracing::info!(
+                                    target: "mcp::tools",
+                                    tool = %tool_name,
+                                    task_id = %task_id_clone,
+                                    duration_ms,
+                                    status,
+                                    error = error_msg.as_deref().unwrap_or_default(),
+                                    "tool call completed"
+                                );
                             }
-                            tracing::info!(
-                                target: "mcp::tools",
-                                tool = %tool_name,
-                                task_id = %task_id_clone,
-                                duration_ms,
-                                status,
-                                error = error_msg.as_deref().unwrap_or_default(),
-                                "tool call completed"
-                            );
                             notifier.notify_task_state(&task_id_clone).await;
                         }
                     });
@@ -3236,11 +3497,15 @@ impl McpRouter {
                         .task_store
                         .get_task(&task_id)
                         .await
-                        .map_err(task_store_error)?
+                        .map_err(|error| {
+                            self.task_store_error(TaskOperation::Create, Some(&task_id), error)
+                        })?
                         .ok_or_else(|| {
-                            Error::JsonRpc(JsonRpcError::internal_error(
-                                "Failed to retrieve created task",
-                            ))
+                            self.task_error(
+                                TaskOperation::Create,
+                                Some(&task_id),
+                                TaskFailure::Internal("Failed to retrieve created task"),
+                            )
                         })?;
 
                     // The final wire is flat with `resultType: "task"`; the
@@ -3776,10 +4041,12 @@ impl McpRouter {
             McpRequest::GetTaskInfo(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/get")?;
-                    self.authorize_task(&params.task_id, &extensions).await?;
-                    return self.final_get_task(&params.task_id).await;
+                    self.authorize_task(TaskOperation::Get, &params.task_id, &extensions)
+                        .await?;
+                    return self.final_get_task(&params.task_id, &extensions).await;
                 }
-                self.authorize_task(&params.task_id, &extensions).await?;
+                self.authorize_task(TaskOperation::Get, &params.task_id, &extensions)
+                    .await?;
 
                 // SEP-2663 DetailedTask: `tasks/get` carries the
                 // status-discriminated payload inline. `completed` includes
@@ -3792,12 +4059,14 @@ impl McpRouter {
                     .task_store
                     .get_task_result(&params.task_id)
                     .await
-                    .map_err(task_store_error)?
+                    .map_err(|error| {
+                        self.task_store_error(TaskOperation::Get, Some(&params.task_id), error)
+                    })?
                 else {
                     // Present when it was authorized, absent now, so it
                     // expired in between (#1249).
                     return Err(self
-                        .classify_absent_task(&params.task_id, &extensions)
+                        .classify_absent_task(TaskOperation::Get, &params.task_id, &extensions)
                         .await);
                 };
 
@@ -3820,7 +4089,8 @@ impl McpRouter {
             McpRequest::UpdateTask(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/update")?;
-                    self.authorize_task(&params.task_id, &extensions).await?;
+                    self.authorize_task(TaskOperation::Update, &params.task_id, &extensions)
+                        .await?;
                     // Partial responses are the normal case: the store
                     // consumes what matches an outstanding request and ignores
                     // unknown, already-answered, and superseded keys.
@@ -3829,28 +4099,34 @@ impl McpRouter {
                         .task_store
                         .apply_input_responses(
                             &params.task_id,
-                            decode_input_responses(&params.input_responses),
+                            decode_input_responses(self, &params.task_id, &params.input_responses)?,
                         )
                         .await
-                        .map_err(task_store_error)?
+                        .map_err(|error| {
+                            self.task_store_error(
+                                TaskOperation::Update,
+                                Some(&params.task_id),
+                                error,
+                            )
+                        })?
                     else {
                         // Nothing left to apply. A task the store still knows
                         // and has not expired is a late or duplicate update,
                         // so it gets the ordinary empty acknowledgement, which
                         // makes a client retry idempotent (#1249).
-                        return match self
-                            .inner
-                            .task_store
-                            .task_presence(&params.task_id)
-                            .await
-                            .map_err(task_store_error)?
-                        {
+                        let presence = self
+                            .task_presence(TaskOperation::Update, &params.task_id)
+                            .await?;
+                        return match presence {
                             crate::async_task::TaskPresence::Present { .. } => Ok(
                                 McpResponse::FinalTaskAck(crate::tasks::TaskAcknowledgement::new()),
                             ),
-                            _ => Err(self
-                                .classify_absent_task(&params.task_id, &extensions)
-                                .await),
+                            absent => Err(self.classify_absent_presence(
+                                TaskOperation::Update,
+                                &params.task_id,
+                                &extensions,
+                                absent,
+                            )),
                         };
                     };
                     // Answering the last outstanding request resumes the task,
@@ -3883,7 +4159,8 @@ impl McpRouter {
                     ));
                 }
 
-                self.authorize_task(&params.task_id, &extensions).await?;
+                self.authorize_task(TaskOperation::Update, &params.task_id, &extensions)
+                    .await?;
 
                 // Input responses reach the store on this path exactly as they
                 // do on the final path above. The spec allowance for ignoring
@@ -3896,28 +4173,30 @@ impl McpRouter {
                     .task_store
                     .apply_input_responses(
                         &params.task_id,
-                        decode_input_responses(&params.input_responses),
+                        decode_input_responses(self, &params.task_id, &params.input_responses)?,
                     )
                     .await
-                    .map_err(task_store_error)?
+                    .map_err(|error| {
+                        self.task_store_error(TaskOperation::Update, Some(&params.task_id), error)
+                    })?
                 else {
                     // Nothing left to apply. A task the store still knows and
                     // has not expired is a late or duplicate update, so it
                     // gets the ordinary empty acknowledgement, which makes a
                     // client retry idempotent rather than a not-found (#1249).
-                    return match self
-                        .inner
-                        .task_store
-                        .task_presence(&params.task_id)
-                        .await
-                        .map_err(task_store_error)?
-                    {
+                    let presence = self
+                        .task_presence(TaskOperation::Update, &params.task_id)
+                        .await?;
+                    return match presence {
                         crate::async_task::TaskPresence::Present { .. } => {
                             Ok(McpResponse::UpdateTask(EmptyResult {}))
                         }
-                        _ => Err(self
-                            .classify_absent_task(&params.task_id, &extensions)
-                            .await),
+                        absent => Err(self.classify_absent_presence(
+                            TaskOperation::Update,
+                            &params.task_id,
+                            &extensions,
+                            absent,
+                        )),
                     };
                 };
                 // A final-protocol subscriber watching this task should see it
@@ -3938,7 +4217,8 @@ impl McpRouter {
             McpRequest::CancelTask(params) => {
                 if is_final_protocol_request(&extensions) {
                     self.require_negotiated_tasks(&extensions, "tasks/cancel")?;
-                    self.authorize_task(&params.task_id, &extensions).await?;
+                    self.authorize_task(TaskOperation::Cancel, &params.task_id, &extensions)
+                        .await?;
                     // A live task is signalled and left non-terminal: its
                     // handler owns the teardown and reports when it actually
                     // stopped, so completion can still legitimately win the
@@ -3958,10 +4238,20 @@ impl McpRouter {
                         .task_store
                         .cancel_task(&params.task_id, params.reason.as_deref())
                         .await
-                        .map_err(task_store_error)?;
+                        .map_err(|error| {
+                            self.task_store_error(
+                                TaskOperation::Cancel,
+                                Some(&params.task_id),
+                                error,
+                            )
+                        })?;
                     if cancelled.is_none() {
                         return Err(self
-                            .classify_absent_task(&params.task_id, &extensions)
+                            .classify_absent_task(
+                                TaskOperation::Cancel,
+                                &params.task_id,
+                                &extensions,
+                            )
                             .await);
                     }
                     self.notify_task_state(&params.task_id).await;
@@ -3970,7 +4260,8 @@ impl McpRouter {
                     ));
                 }
 
-                self.authorize_task(&params.task_id, &extensions).await?;
+                self.authorize_task(TaskOperation::Cancel, &params.task_id, &extensions)
+                    .await?;
 
                 // Same reasoning as the final path: a live task owns its own
                 // teardown, so it is signalled and left non-terminal (#1246).
@@ -3985,10 +4276,12 @@ impl McpRouter {
                     .task_store
                     .get_task(&params.task_id)
                     .await
-                    .map_err(task_store_error)?
+                    .map_err(|error| {
+                        self.task_store_error(TaskOperation::Cancel, Some(&params.task_id), error)
+                    })?
                 else {
                     return Err(self
-                        .classify_absent_task(&params.task_id, &extensions)
+                        .classify_absent_task(TaskOperation::Cancel, &params.task_id, &extensions)
                         .await);
                 };
 
@@ -4004,10 +4297,12 @@ impl McpRouter {
                     .task_store
                     .cancel_task(&params.task_id, params.reason.as_deref())
                     .await
-                    .map_err(task_store_error)?;
+                    .map_err(|error| {
+                        self.task_store_error(TaskOperation::Cancel, Some(&params.task_id), error)
+                    })?;
                 if cancelled.is_none() {
                     return Err(self
-                        .classify_absent_task(&params.task_id, &extensions)
+                        .classify_absent_task(TaskOperation::Cancel, &params.task_id, &extensions)
                         .await);
                 }
 
@@ -4447,7 +4742,7 @@ mod notify;
 mod task_ops;
 
 use task_ops::{
-    client_declares_tasks, decode_input_responses, discard_unprepared_task, task_store_error,
+    client_declares_tasks, decode_input_responses, discard_unprepared_task,
     tasks_client_capabilities,
 };
 // Gated in `task_ops` too, so importing it unconditionally breaks the default
@@ -4457,6 +4752,9 @@ use task_ops::validate_input_required_result;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, feature = "stateless"))]
+mod task_error_tests;
 
 #[cfg(test)]
 mod cursor_property_tests;

--- a/crates/tower-mcp/src/router/task_error_tests.rs
+++ b/crates/tower-mcp/src/router/task_error_tests.rs
@@ -1,0 +1,722 @@
+//! Focused tests for Task error mapping and multi-read races.
+
+use super::*;
+use crate::tool::ToolBuilder;
+
+fn tasks_client_extensions() -> Extensions {
+    let mut extensions = Extensions::new();
+    extensions.insert(crate::stateless::StatelessRequestMeta {
+        protocol_version: Some(PROTOCOL_VERSION_2026_07_28.to_string()),
+        client_capabilities: Some(ClientCapabilities {
+            extensions: Some(
+                [(TASKS_EXTENSION_ID.to_string(), serde_json::json!({}))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    extensions
+}
+
+// A deterministic store for Task error-policy and multi-read race tests. Each
+// method consumes the next scripted answer, so a changed call order fails the
+// test instead of relying on timing.
+#[cfg(feature = "stateless")]
+#[derive(Default)]
+struct ScriptedTaskStore {
+    creates: std::sync::Mutex<
+        std::collections::VecDeque<
+            crate::async_task::Result<(String, crate::async_task::CancellationToken)>,
+        >,
+    >,
+    presences: std::sync::Mutex<
+        std::collections::VecDeque<crate::async_task::Result<crate::async_task::TaskPresence>>,
+    >,
+    snapshots: std::sync::Mutex<
+        std::collections::VecDeque<
+            crate::async_task::Result<Option<crate::async_task::TaskSnapshot>>,
+        >,
+    >,
+    outstanding: std::sync::Mutex<
+        std::collections::VecDeque<
+            crate::async_task::Result<Option<crate::protocol::InputRequests>>,
+        >,
+    >,
+    cancellations:
+        std::sync::Mutex<std::collections::VecDeque<crate::async_task::Result<Option<TaskObject>>>>,
+    resumes: std::sync::Mutex<
+        std::collections::VecDeque<
+            crate::async_task::Result<Option<crate::async_task::TaskResumeContext>>,
+        >,
+    >,
+    completions: std::sync::Mutex<std::collections::VecDeque<crate::async_task::Result<bool>>>,
+    failure_results: std::sync::Mutex<std::collections::VecDeque<crate::async_task::Result<bool>>>,
+    recorded_failures: std::sync::Mutex<Vec<JsonRpcError>>,
+}
+
+#[cfg(feature = "stateless")]
+impl ScriptedTaskStore {
+    fn with_creates(
+        self,
+        steps: impl IntoIterator<
+            Item = crate::async_task::Result<(String, crate::async_task::CancellationToken)>,
+        >,
+    ) -> Self {
+        *self.creates.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_presences(
+        self,
+        steps: impl IntoIterator<Item = crate::async_task::Result<crate::async_task::TaskPresence>>,
+    ) -> Self {
+        *self.presences.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_snapshots(
+        self,
+        steps: impl IntoIterator<
+            Item = crate::async_task::Result<Option<crate::async_task::TaskSnapshot>>,
+        >,
+    ) -> Self {
+        *self.snapshots.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_outstanding(
+        self,
+        steps: impl IntoIterator<
+            Item = crate::async_task::Result<Option<crate::protocol::InputRequests>>,
+        >,
+    ) -> Self {
+        *self.outstanding.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_cancellations(
+        self,
+        steps: impl IntoIterator<Item = crate::async_task::Result<Option<TaskObject>>>,
+    ) -> Self {
+        *self.cancellations.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_resumes(
+        self,
+        steps: impl IntoIterator<
+            Item = crate::async_task::Result<Option<crate::async_task::TaskResumeContext>>,
+        >,
+    ) -> Self {
+        *self.resumes.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_completions(
+        self,
+        steps: impl IntoIterator<Item = crate::async_task::Result<bool>>,
+    ) -> Self {
+        *self.completions.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn with_failure_results(
+        self,
+        steps: impl IntoIterator<Item = crate::async_task::Result<bool>>,
+    ) -> Self {
+        *self.failure_results.lock().unwrap() = steps.into_iter().collect();
+        self
+    }
+
+    fn pop<T>(queue: &std::sync::Mutex<std::collections::VecDeque<T>>, method: &str) -> T {
+        queue
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| panic!("unexpected {method} call"))
+    }
+}
+
+#[cfg(feature = "stateless")]
+#[async_trait::async_trait]
+impl crate::async_task::TaskStore for ScriptedTaskStore {
+    async fn create_task(
+        &self,
+        _tool_name: &str,
+        _arguments: serde_json::Value,
+        _ttl: Option<u64>,
+        _owner: crate::async_task::TaskOwner,
+    ) -> crate::async_task::Result<(String, crate::async_task::CancellationToken)> {
+        Self::pop(&self.creates, "create_task")
+    }
+
+    async fn task_owner(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskOwner>> {
+        panic!("task_presence is overridden")
+    }
+
+    async fn task_presence(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<crate::async_task::TaskPresence> {
+        Self::pop(&self.presences, "task_presence")
+    }
+
+    async fn get_task(&self, _task_id: &str) -> crate::async_task::Result<Option<TaskObject>> {
+        panic!("unexpected get_task call")
+    }
+
+    async fn get_task_result(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+        Self::pop(&self.snapshots, "get_task_result")
+    }
+
+    async fn wait_for_completion(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+        panic!("unexpected wait_for_completion call")
+    }
+
+    async fn list_tasks(
+        &self,
+        _status_filter: Option<TaskStatus>,
+    ) -> crate::async_task::Result<Vec<TaskObject>> {
+        panic!("unexpected list_tasks call")
+    }
+
+    async fn require_input(
+        &self,
+        _task_id: &str,
+        _requests: crate::protocol::InputRequests,
+        _message: Option<&str>,
+    ) -> crate::async_task::Result<bool> {
+        panic!("unexpected require_input call")
+    }
+
+    async fn outstanding_input_requests(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::protocol::InputRequests>> {
+        Self::pop(&self.outstanding, "outstanding_input_requests")
+    }
+
+    async fn apply_input_responses(
+        &self,
+        _task_id: &str,
+        _responses: crate::protocol::InputResponses,
+    ) -> crate::async_task::Result<Option<crate::async_task::AppliedInputResponses>> {
+        panic!("unexpected apply_input_responses call")
+    }
+
+    async fn set_ttl(&self, _task_id: &str, _ttl_ms: u64) -> crate::async_task::Result<bool> {
+        panic!("unexpected set_ttl call")
+    }
+
+    async fn complete_task(
+        &self,
+        _task_id: &str,
+        _result: CallToolResult,
+    ) -> crate::async_task::Result<bool> {
+        Self::pop(&self.completions, "complete_task")
+    }
+
+    async fn fail_task(
+        &self,
+        _task_id: &str,
+        error: JsonRpcError,
+    ) -> crate::async_task::Result<bool> {
+        self.recorded_failures.lock().unwrap().push(error);
+        Self::pop(&self.failure_results, "fail_task")
+    }
+
+    async fn cancel_task(
+        &self,
+        _task_id: &str,
+        _reason: Option<&str>,
+    ) -> crate::async_task::Result<Option<TaskObject>> {
+        Self::pop(&self.cancellations, "cancel_task")
+    }
+
+    async fn resume_context(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskResumeContext>> {
+        Self::pop(&self.resumes, "resume_context")
+    }
+}
+
+#[cfg(feature = "stateless")]
+fn scripted_task(status: TaskStatus) -> TaskObject {
+    TaskObject {
+        task_id: "task_scripted".to_string(),
+        status,
+        status_message: None,
+        created_at: "2026-08-12T00:00:00Z".to_string(),
+        last_updated_at: "2026-08-12T00:00:01Z".to_string(),
+        ttl: Some(60_000),
+        poll_interval: Some(100),
+        result: None,
+        error: None,
+        meta: None,
+    }
+}
+
+#[cfg(feature = "stateless")]
+fn final_get_request() -> McpRequest {
+    McpRequest::GetTaskInfo(GetTaskInfoParams {
+        task_id: "task_scripted".to_string(),
+        meta: None,
+    })
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn the_default_task_policy_redacts_backend_errors() {
+    const SECRET: &str = "/private/db/tasks.sqlite: password=hunter2";
+    let store = Arc::new(ScriptedTaskStore::default().with_presences([Err(
+        crate::async_task::TaskStoreError::Backend(SECRET.to_string()),
+    )]));
+    let router = McpRouter::new().task_store(store).with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            final_get_request(),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("a backend failure must reject tasks/get")
+    };
+    assert_eq!(error.code, -32603);
+    assert_eq!(error.message, "Task store operation failed");
+    assert!(error.data.is_none());
+    assert!(!format!("{error:?}").contains(SECRET));
+}
+
+#[tokio::test]
+async fn merge_and_nest_keep_the_receiving_routers_task_policy() {
+    let store = Arc::new(ScriptedTaskStore::default().with_presences([
+        Ok(crate::async_task::TaskPresence::Missing),
+        Ok(crate::async_task::TaskPresence::Missing),
+    ]));
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let recorded = calls.clone();
+    let root = McpRouter::new()
+        .task_store(store)
+        .task_error_policy(TaskErrorPolicy::new(move |context| {
+            recorded.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(context.operation(), TaskOperation::Get);
+            assert!(matches!(context.failure(), TaskFailure::NotFound));
+            JsonRpcError::invalid_params("root policy")
+        }))
+        .with_tasks();
+    let child = || {
+        McpRouter::new().task_error_policy(TaskErrorPolicy::new(|_| {
+            JsonRpcError::invalid_params("child policy")
+        }))
+    };
+
+    for router in [root.clone().merge(child()), root.nest("child", child())] {
+        let Err(Error::JsonRpc(error)) = router
+            .handle(
+                RequestId::Number(1),
+                final_get_request(),
+                tasks_client_extensions(),
+            )
+            .await
+        else {
+            panic!("an unknown task must be mapped")
+        };
+        assert_eq!(error.message, "root policy");
+    }
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn cancel_does_not_mask_a_backend_failure_during_absence_classification() {
+    use crate::async_task::{TaskPresence, TaskStoreError};
+
+    const SECRET: &str = "redis://admin:secret@private-host";
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_presences([
+                Ok(TaskPresence::Present { owner: None }),
+                Err(TaskStoreError::Backend(SECRET.to_string())),
+            ])
+            .with_cancellations([Ok(None)]),
+    );
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let recorded = calls.clone();
+    let router = McpRouter::new()
+        .task_store(store)
+        .task_error_policy(TaskErrorPolicy::new(move |context| {
+            recorded.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(context.operation(), TaskOperation::Cancel);
+            assert_eq!(context.task_id(), Some("task_scripted"));
+            assert!(matches!(
+                context.failure(),
+                TaskFailure::Store(TaskStoreError::Backend(message)) if message == SECRET
+            ));
+            JsonRpcError::internal_error("mapped task failure")
+                .with_data(serde_json::json!({"kind": "task_store", "operation": "cancel"}))
+        }))
+        .with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::CancelTask(CancelTaskParams {
+                task_id: "task_scripted".to_string(),
+                reason: None,
+                meta: None,
+            }),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("the classification lookup failure must be returned")
+    };
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert_eq!(error.message, "mapped task failure");
+    assert!(!format!("{error:?}").contains(SECRET));
+    assert_eq!(error.data.unwrap()["operation"], "cancel");
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_get_reclassifies_a_disappeared_snapshot_as_expired() {
+    use crate::async_task::TaskPresence;
+
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_presences([
+                Ok(TaskPresence::Present { owner: None }),
+                Ok(TaskPresence::Expired { owner: None }),
+            ])
+            .with_snapshots([Ok(None)]),
+    );
+    let router = McpRouter::new().task_store(store).with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            final_get_request(),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("the owner must see that the task expired between reads")
+    };
+    assert_eq!(error.message, "Task expired: task_scripted");
+    assert_eq!(
+        error.data,
+        Some(serde_json::json!({"reason": "task_expired"}))
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_get_reclassifies_disappeared_outstanding_inputs_as_expired() {
+    use crate::async_task::TaskPresence;
+
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_presences([
+                Ok(TaskPresence::Present { owner: None }),
+                Ok(TaskPresence::Expired { owner: None }),
+            ])
+            .with_snapshots([Ok(Some((
+                scripted_task(TaskStatus::InputRequired),
+                None,
+                None,
+            )))])
+            .with_outstanding([Ok(None)]),
+    );
+    let router = McpRouter::new().task_store(store).with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            final_get_request(),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("the owner must see expiry rather than an empty input-required task")
+    };
+    assert_eq!(error.message, "Task expired: task_scripted");
+    assert_eq!(
+        error.data,
+        Some(serde_json::json!({"reason": "task_expired"}))
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_get_rereads_after_an_empty_outstanding_input_race() {
+    use crate::async_task::TaskPresence;
+
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_presences([Ok(TaskPresence::Present { owner: None })])
+            .with_snapshots([
+                Ok(Some((scripted_task(TaskStatus::InputRequired), None, None))),
+                Ok(Some((scripted_task(TaskStatus::Working), None, None))),
+            ])
+            .with_outstanding([Ok(Some(Default::default()))]),
+    );
+    let router = McpRouter::new().task_store(store).with_tasks();
+
+    let response = router
+        .handle(
+            RequestId::Number(1),
+            final_get_request(),
+            tasks_client_extensions(),
+        )
+        .await
+        .expect("the stabilized snapshot is valid");
+    let McpResponse::FinalGetTask(result) = response else {
+        panic!("expected a final tasks/get result")
+    };
+    assert_eq!(result.task.status(), TaskStatus::Working);
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn malformed_input_responses_flow_through_the_custom_task_policy() {
+    use crate::async_task::TaskStore;
+
+    let store = Arc::new(crate::async_task::MemoryTaskStore::new());
+    let (task_id, _) = store
+        .create_task("tool", serde_json::json!({}), None, None)
+        .await
+        .unwrap();
+    let router = McpRouter::new()
+        .task_store(store)
+        .task_error_policy(TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), TaskOperation::Update);
+            assert!(matches!(
+                context.failure(),
+                TaskFailure::InvalidArguments(message)
+                    if *message == "inputResponses contains a malformed value"
+            ));
+            JsonRpcError::invalid_params("mapped invalid arguments")
+                .with_data(serde_json::json!({"kind": "invalid_arguments"}))
+        }))
+        .with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::UpdateTask(UpdateTaskParams {
+                task_id,
+                input_responses: [("approval".to_string(), serde_json::json!({"bogus": true}))]
+                    .into_iter()
+                    .collect(),
+                meta: None,
+            }),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("a malformed response must be rejected")
+    };
+    assert_eq!(error.code, -32602);
+    assert_eq!(error.message, "mapped invalid arguments");
+    assert_eq!(error.data.unwrap()["kind"], "invalid_arguments");
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn a_panicking_task_policy_uses_a_fixed_redacted_fallback() {
+    let store = Arc::new(
+        ScriptedTaskStore::default().with_presences([Ok(crate::async_task::TaskPresence::Missing)]),
+    );
+    let router = McpRouter::new()
+        .task_store(store)
+        .task_error_policy(TaskErrorPolicy::new(|_| {
+            panic!("secret policy panic payload")
+        }))
+        .with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            final_get_request(),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("the policy panic must become a JSON-RPC error")
+    };
+    assert_eq!(error.code, -32603);
+    assert_eq!(error.message, "Task error policy failed");
+    assert!(error.data.is_none());
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn create_store_failures_include_the_create_operation() {
+    let store = Arc::new(ScriptedTaskStore::default().with_creates([Err(
+        crate::async_task::TaskStoreError::Backend("private create detail".to_string()),
+    )]));
+    let router = McpRouter::new()
+        .task_store(store)
+        .task_error_policy(TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), TaskOperation::Create);
+            assert_eq!(context.task_id(), None);
+            assert!(matches!(context.failure(), TaskFailure::Store(_)));
+            JsonRpcError::internal_error("mapped create failure")
+        }))
+        .tool(
+            ToolBuilder::new("task_tool")
+                .task_support(TaskSupportMode::Optional)
+                .handler(|_: serde_json::Value| async { Ok(CallToolResult::text("unused")) })
+                .build(),
+        )
+        .with_tasks();
+
+    let Err(Error::JsonRpc(error)) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::CallTool(CallToolParams {
+                name: "task_tool".to_string(),
+                arguments: serde_json::json!({}),
+                input_responses: None,
+                request_state: None,
+                meta: None,
+                task: None,
+            }),
+            tasks_client_extensions(),
+        )
+        .await
+    else {
+        panic!("create_task must surface its mapped store failure")
+    };
+    assert_eq!(error.message, "mapped create failure");
+}
+
+#[tokio::test]
+async fn resume_store_failures_are_mapped_and_persisted_without_backend_details() {
+    use crate::async_task::TaskStoreError;
+
+    const SECRET: &str = "postgres://private-user:secret@database/tasks";
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_resumes([Err(TaskStoreError::Backend(SECRET.to_string()))])
+            .with_failure_results([Ok(true)]),
+    );
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .task_error_policy(TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), TaskOperation::Resume);
+            assert_eq!(context.task_id(), Some("task_scripted"));
+            assert!(matches!(
+                context.failure(),
+                TaskFailure::Store(TaskStoreError::Backend(message)) if message == SECRET
+            ));
+            JsonRpcError::internal_error("mapped resume failure")
+                .with_data(serde_json::json!({"phase": "resume"}))
+        }));
+
+    router.resume_task("task_scripted").await;
+
+    let failures = store.recorded_failures.lock().unwrap();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].message, "mapped resume failure");
+    assert_eq!(failures[0].data.as_ref().unwrap()["phase"], "resume");
+    assert!(!format!("{:?}", failures[0]).contains(SECRET));
+}
+
+#[tokio::test]
+async fn absent_resume_state_and_missing_tools_use_typed_safe_failures() {
+    const SECRET_TOOL: &str = "private.provider.secret-tool";
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_resumes([
+                Ok(None),
+                Ok(Some(crate::async_task::TaskResumeContext {
+                    tool_name: SECRET_TOOL.to_string(),
+                    arguments: serde_json::json!({}),
+                    input_responses: Default::default(),
+                })),
+            ])
+            .with_failure_results([Ok(true), Ok(true)]),
+    );
+    let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let recorded = calls.clone();
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .task_error_policy(TaskErrorPolicy::new(move |context| {
+            recorded.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            assert_eq!(context.operation(), TaskOperation::Resume);
+            assert!(matches!(context.failure(), TaskFailure::Internal(_)));
+            JsonRpcError::internal_error("mapped safe resume failure")
+        }));
+
+    router.resume_task("task_scripted").await;
+    router.resume_task("task_scripted").await;
+
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    let failures = store.recorded_failures.lock().unwrap();
+    assert_eq!(failures.len(), 2);
+    assert!(
+        failures
+            .iter()
+            .all(|error| error.message == "mapped safe resume failure")
+    );
+    assert!(!format!("{failures:?}").contains(SECRET_TOOL));
+}
+
+#[tokio::test]
+async fn completion_write_failures_become_one_policy_mapped_task_failure() {
+    use crate::async_task::TaskStoreError;
+
+    const SECRET: &str = "sqlite write failed at /private/tasks.sqlite";
+    let store = Arc::new(
+        ScriptedTaskStore::default()
+            .with_completions([Err(TaskStoreError::Backend(SECRET.to_string())), Ok(false)])
+            .with_failure_results([Ok(true)]),
+    );
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .task_error_policy(TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), TaskOperation::Finalize);
+            assert!(matches!(
+                context.failure(),
+                TaskFailure::Store(TaskStoreError::Backend(message)) if message == SECRET
+            ));
+            JsonRpcError::internal_error("mapped finalization failure")
+                .with_data(serde_json::json!({"phase": "finalize"}))
+        }));
+
+    assert!(
+        !router
+            .complete_task_or_fail("task_scripted", CallToolResult::text("done"))
+            .await
+    );
+    let failures_after_error = store.recorded_failures.lock().unwrap().len();
+    assert_eq!(failures_after_error, 1);
+
+    // `Ok(false)` means a terminal outcome won the race. It must not be
+    // rewritten with a synthetic failure or reported as an applied success.
+    assert!(
+        !router
+            .complete_task_or_fail("task_scripted", CallToolResult::text("late"))
+            .await
+    );
+    let failures = store.recorded_failures.lock().unwrap();
+    assert_eq!(failures.len(), 1);
+    assert_eq!(failures[0].message, "mapped finalization failure");
+    assert_eq!(failures[0].data.as_ref().unwrap()["phase"], "finalize");
+    assert!(!format!("{:?}", failures[0]).contains(SECRET));
+}

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -11,7 +11,70 @@
 
 use super::*;
 
+type DetailedTaskSnapshot = (
+    crate::tasks::DetailedTask,
+    Option<serde_json::Map<String, serde_json::Value>>,
+);
+
 impl McpRouter {
+    pub(super) fn task_json_rpc_error(
+        &self,
+        operation: TaskOperation,
+        task_id: Option<&str>,
+        failure: TaskFailure,
+    ) -> JsonRpcError {
+        let context = TaskErrorContext::new(operation, task_id, failure);
+        self.inner.task_error_policy.map(&context)
+    }
+
+    pub(super) fn task_error(
+        &self,
+        operation: TaskOperation,
+        task_id: Option<&str>,
+        failure: TaskFailure,
+    ) -> Error {
+        Error::JsonRpc(self.task_json_rpc_error(operation, task_id, failure))
+    }
+
+    pub(super) fn task_store_error(
+        &self,
+        operation: TaskOperation,
+        task_id: Option<&str>,
+        error: TaskStoreError,
+    ) -> Error {
+        self.task_error(operation, task_id, TaskFailure::Store(error))
+    }
+
+    pub(super) async fn task_presence(
+        &self,
+        operation: TaskOperation,
+        task_id: &str,
+    ) -> Result<crate::async_task::TaskPresence> {
+        self.inner
+            .task_store
+            .task_presence(task_id)
+            .await
+            .map_err(|error| self.task_store_error(operation, Some(task_id), error))
+    }
+
+    pub(super) fn classify_absent_presence(
+        &self,
+        operation: TaskOperation,
+        task_id: &str,
+        extensions: &crate::context::Extensions,
+        presence: crate::async_task::TaskPresence,
+    ) -> Error {
+        let owns = presence.owner().is_some_and(|owner| {
+            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
+        });
+        match presence {
+            crate::async_task::TaskPresence::Expired { .. } if owns => {
+                self.task_error(operation, Some(task_id), TaskFailure::Expired)
+            }
+            _ => self.task_error(operation, Some(task_id), TaskFailure::NotFound),
+        }
+    }
+
     /// Classify an operation that found nothing, after authorization passed.
     ///
     /// The task was present when it was authorized, so an operation that then
@@ -25,21 +88,15 @@ impl McpRouter {
     /// whether a store could return a differently-owned record here.
     pub(super) async fn classify_absent_task(
         &self,
+        operation: TaskOperation,
         task_id: &str,
         extensions: &crate::context::Extensions,
     ) -> Error {
-        let Ok(presence) = self.inner.task_store.task_presence(task_id).await else {
-            return Error::JsonRpc(unknown_task_error(task_id));
+        let presence = match self.task_presence(operation, task_id).await {
+            Ok(presence) => presence,
+            Err(error) => return error,
         };
-        let owns = presence.owner().is_some_and(|owner| {
-            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
-        });
-        match presence {
-            crate::async_task::TaskPresence::Expired { .. } if owns => {
-                Error::JsonRpc(expired_task_error(task_id))
-            }
-            _ => Error::JsonRpc(unknown_task_error(task_id)),
-        }
+        self.classify_absent_presence(operation, task_id, extensions, presence)
     }
 
     /// Reject a final task method that was not negotiated by both peers.
@@ -69,6 +126,7 @@ impl McpRouter {
     /// thing unguessable IDs exist to prevent.
     pub(super) async fn authorize_task(
         &self,
+        operation: TaskOperation,
         task_id: &str,
         extensions: &crate::context::Extensions,
     ) -> Result<()> {
@@ -76,21 +134,16 @@ impl McpRouter {
         // such to its owner. Everyone else must still see exactly what they
         // see for an id that was never issued, so the owner check happens
         // before any of that distinction escapes (#1249).
-        let presence = self
-            .inner
-            .task_store
-            .task_presence(task_id)
-            .await
-            .map_err(task_store_error)?;
+        let presence = self.task_presence(operation, task_id).await?;
         let Some(owner) = presence.owner() else {
-            return Err(Error::JsonRpc(unknown_task_error(task_id)));
+            return Err(self.task_error(operation, Some(task_id), TaskFailure::NotFound));
         };
 
         if crate::async_task::owner_matches(owner, request_principal(extensions).as_deref()) {
             match presence {
                 // The owner is told the difference; nobody else reaches here.
                 crate::async_task::TaskPresence::Expired { .. } => {
-                    Err(Error::JsonRpc(expired_task_error(task_id)))
+                    Err(self.task_error(operation, Some(task_id), TaskFailure::Expired))
                 }
                 _ => Ok(()),
             }
@@ -100,13 +153,21 @@ impl McpRouter {
                 task_id = %task_id,
                 "task operation refused: principal does not own the task"
             );
-            Err(Error::JsonRpc(unknown_task_error(task_id)))
+            Err(self.task_error(operation, Some(task_id), TaskFailure::NotFound))
         }
     }
 
     /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
-    pub(super) async fn final_get_task(&self, task_id: &str) -> Result<McpResponse> {
-        let (detailed, meta) = self.detailed_task(task_id).await?;
+    pub(super) async fn final_get_task(
+        &self,
+        task_id: &str,
+        extensions: &crate::context::Extensions,
+    ) -> Result<McpResponse> {
+        let Some((detailed, meta)) = self.detailed_task(task_id).await? else {
+            return Err(self
+                .classify_absent_task(TaskOperation::Get, task_id, extensions)
+                .await);
+        };
         let mut result = crate::tasks::GetTaskResult::new(detailed);
         result.meta = meta;
         Ok(McpResponse::FinalGetTask(result))
@@ -120,74 +181,99 @@ impl McpRouter {
     pub(super) async fn detailed_task(
         &self,
         task_id: &str,
-    ) -> Result<(
-        crate::tasks::DetailedTask,
-        Option<serde_json::Map<String, serde_json::Value>>,
-    )> {
-        let (task, result, error) = self
-            .inner
-            .task_store
-            .get_task_result(task_id)
-            .await
-            .map_err(task_store_error)?
-            .ok_or_else(|| Error::JsonRpc(unknown_task_error(task_id)))?;
+    ) -> Result<Option<DetailedTaskSnapshot>> {
+        // A final Task view takes two store reads while input is outstanding:
+        // the status/result snapshot, then the requests map. `tasks/update`
+        // can move the Task back to `working` between them. Re-read once when
+        // that race produces an empty map rather than emitting the impossible
+        // wire shape `input_required` with no requests.
+        for attempt in 0..2 {
+            let Some((task, result, error)) = self
+                .inner
+                .task_store
+                .get_task_result(task_id)
+                .await
+                .map_err(|error| self.task_store_error(TaskOperation::Get, Some(task_id), error))?
+            else {
+                return Ok(None);
+            };
 
-        let mut metadata = crate::tasks::TaskMetadata::new(
-            task.task_id.clone(),
-            task.created_at.clone(),
-            task.last_updated_at.clone(),
-            task.ttl,
-        );
-        metadata.status_message = task.status_message.clone();
-        metadata.poll_interval_ms = task.poll_interval;
+            let mut metadata = crate::tasks::TaskMetadata::new(
+                task.task_id.clone(),
+                task.created_at.clone(),
+                task.last_updated_at.clone(),
+                task.ttl,
+            );
+            metadata.status_message = task.status_message.clone();
+            metadata.poll_interval_ms = task.poll_interval;
 
-        let meta = task.meta.and_then(|value| value.as_object().cloned());
-        let detailed = match task.status {
-            TaskStatus::Working => crate::tasks::DetailedTask::working(metadata),
-            TaskStatus::InputRequired => {
-                // Every request still awaiting a response, not just the most
-                // recent one.
-                let outstanding = self
-                    .inner
-                    .task_store
-                    .outstanding_input_requests(task_id)
-                    .await
-                    .map_err(task_store_error)?
-                    .unwrap_or_default();
-                crate::tasks::DetailedTask::input_required(metadata, outstanding)
-            }
-            TaskStatus::Completed => {
-                // The exact object the synchronous call would have returned,
-                // including `isError: true` results.
-                let mut object = result
-                    .map(serde_json::to_value)
-                    .transpose()
-                    .map_err(|e| {
-                        Error::JsonRpc(JsonRpcError::internal_error(format!(
-                            "failed to encode task result: {e}"
-                        )))
-                    })?
-                    .and_then(|value| value.as_object().cloned())
-                    .unwrap_or_default();
-                // This object is nested inside tasks/get, so it does not pass
-                // through the JSON-RPC response stamper that adds the final
-                // protocol's required complete discriminator.
-                object.insert(
-                    "resultType".to_string(),
-                    serde_json::Value::String("complete".to_string()),
-                );
-                crate::tasks::DetailedTask::completed(metadata, object)
-            }
-            TaskStatus::Failed => crate::tasks::DetailedTask::failed(
-                metadata,
-                error.unwrap_or_else(|| JsonRpcError::internal_error("Task failed")),
-            ),
-            TaskStatus::Cancelled => crate::tasks::DetailedTask::cancelled(metadata),
-            // `TaskStatus` is non_exhaustive. Report an unrecognized status as
-            // working rather than inventing a terminal state.
-            _ => crate::tasks::DetailedTask::working(metadata),
-        };
-        Ok((detailed, meta))
+            let meta = task.meta.and_then(|value| value.as_object().cloned());
+            let detailed = match task.status {
+                TaskStatus::Working => crate::tasks::DetailedTask::working(metadata),
+                TaskStatus::InputRequired => {
+                    // Every request still awaiting a response, not just the
+                    // most recent one.
+                    let outstanding = self
+                        .inner
+                        .task_store
+                        .outstanding_input_requests(task_id)
+                        .await
+                        .map_err(|error| {
+                            self.task_store_error(TaskOperation::Get, Some(task_id), error)
+                        })?;
+                    let Some(outstanding) = outstanding else {
+                        return Ok(None);
+                    };
+                    if outstanding.is_empty() {
+                        if attempt == 0 {
+                            continue;
+                        }
+                        return Err(self.task_error(
+                            TaskOperation::Get,
+                            Some(task_id),
+                            TaskFailure::Internal(
+                                "task store returned input_required without outstanding requests",
+                            ),
+                        ));
+                    }
+                    crate::tasks::DetailedTask::input_required(metadata, outstanding)
+                }
+                TaskStatus::Completed => {
+                    // The exact object the synchronous call would have returned,
+                    // including `isError: true` results.
+                    let mut object = result
+                        .map(serde_json::to_value)
+                        .transpose()
+                        .map_err(|_| {
+                            self.task_error(
+                                TaskOperation::Get,
+                                Some(task_id),
+                                TaskFailure::Internal("failed to encode task result"),
+                            )
+                        })?
+                        .and_then(|value| value.as_object().cloned())
+                        .unwrap_or_default();
+                    // This object is nested inside tasks/get, so it does not
+                    // pass through the JSON-RPC response stamper that adds the
+                    // final protocol's required complete discriminator.
+                    object.insert(
+                        "resultType".to_string(),
+                        serde_json::Value::String("complete".to_string()),
+                    );
+                    crate::tasks::DetailedTask::completed(metadata, object)
+                }
+                TaskStatus::Failed => crate::tasks::DetailedTask::failed(
+                    metadata,
+                    error.unwrap_or_else(|| JsonRpcError::internal_error("Task failed")),
+                ),
+                TaskStatus::Cancelled => crate::tasks::DetailedTask::cancelled(metadata),
+                // `TaskStatus` is non_exhaustive. Report an unrecognized status
+                // as working rather than inventing a terminal state.
+                _ => crate::tasks::DetailedTask::working(metadata),
+            };
+            return Ok(Some((detailed, meta)));
+        }
+        unreachable!("bounded Task snapshot retry always returns")
     }
 
     /// Park a task on the input its handler asked for.
@@ -204,9 +290,13 @@ impl McpRouter {
         if requests.is_empty() {
             // Parking here would strand the task: no `tasks/update` can ever
             // complete an empty request set.
-            let error = JsonRpcError::internal_error(
-                "handler asked for input without naming any requests, so the task has \
-                 nothing to wait for",
+            let error = self.task_json_rpc_error(
+                TaskOperation::ParkInput,
+                Some(task_id),
+                TaskFailure::Internal(
+                    "handler asked for input without naming any requests, so the task has \
+                     nothing to wait for",
+                ),
             );
             if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
                 tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
@@ -238,16 +328,13 @@ impl McpRouter {
                 // though: an invalid transition is the handler asking for
                 // something the protocol forbids, which no retry fixes,
                 // while a backend failure is infrastructure (#1246).
-                let error = match &e {
+                match &e {
                     crate::async_task::TaskStoreError::InvalidTransition(message) => {
                         tracing::error!(
                             task_id = %task_id,
                             error = %message,
                             "handler asked for input the protocol does not allow"
                         );
-                        JsonRpcError::internal_error(format!(
-                            "handler asked for input the protocol does not allow: {message}"
-                        ))
                     }
                     other => {
                         tracing::warn!(
@@ -255,11 +342,13 @@ impl McpRouter {
                             error = %other,
                             "task store could not park the task for input"
                         );
-                        JsonRpcError::internal_error(format!(
-                            "could not park the task for input: {other}"
-                        ))
                     }
-                };
+                }
+                let error = self.task_json_rpc_error(
+                    TaskOperation::ParkInput,
+                    Some(task_id),
+                    TaskFailure::Store(e),
+                );
                 if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
                     tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
                 }
@@ -318,6 +407,88 @@ impl McpRouter {
         }
     }
 
+    /// Persist a structured failure without exposing a store error if that
+    /// terminal write itself fails.
+    pub(super) async fn record_task_failure(&self, task_id: &str, error: JsonRpcError) -> bool {
+        match self.inner.task_store.fail_task(task_id, error).await {
+            Ok(true) => true,
+            Ok(false) => {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "task failure was not applied because the task is absent or terminal"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    "failed to record task failure"
+                );
+                false
+            }
+        }
+    }
+
+    /// Persist cancellation without claiming success for an absent or
+    /// already-terminal Task and without displaying a backend error.
+    pub(super) async fn record_task_cancellation(
+        &self,
+        task_id: &str,
+        reason: Option<&str>,
+    ) -> bool {
+        match self.inner.task_store.cancel_task(task_id, reason).await {
+            Ok(Some(_)) => true,
+            Ok(None) => {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "task cancellation was not applied because the task is absent"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    "failed to record task cancellation"
+                );
+                false
+            }
+        }
+    }
+
+    /// Commit a completed result, converting a backend write failure into one
+    /// bounded attempt to persist a structured, policy-mapped Task failure.
+    pub(super) async fn complete_task_or_fail(
+        &self,
+        task_id: &str,
+        result: CallToolResult,
+    ) -> bool {
+        match self.inner.task_store.complete_task(task_id, result).await {
+            Ok(true) => true,
+            Ok(false) => {
+                // A terminal outcome may have won concurrently. Never rewrite
+                // it, and do not claim this completion was applied.
+                tracing::debug!(
+                    task_id = %task_id,
+                    "task completion was not applied because the task is absent or terminal"
+                );
+                false
+            }
+            Err(error) => {
+                tracing::warn!(
+                    task_id = %task_id,
+                    "failed to record task completion; recording a task failure"
+                );
+                let error = self.task_json_rpc_error(
+                    TaskOperation::Finalize,
+                    Some(task_id),
+                    TaskFailure::Store(error),
+                );
+                self.record_task_failure(task_id, error).await;
+                false
+            }
+        }
+    }
+
     /// Re-invoke a task's handler after its input requests were answered.
     ///
     /// A task's client answers through `tasks/update` rather than by retrying
@@ -332,19 +503,28 @@ impl McpRouter {
                 // Either the task vanished, or the store predates resumption
                 // and cannot supply what a re-invocation needs. Fail loudly
                 // rather than leave the task working forever.
-                let error = JsonRpcError::internal_error(
-                    "this task store cannot resume a task after input was provided; \
+                let error = self.task_json_rpc_error(
+                    TaskOperation::Resume,
+                    Some(task_id),
+                    TaskFailure::Internal(
+                        "this task store cannot resume a task after input was provided; \
                      implement TaskStore::resume_context to support handlers that ask \
                      for input",
+                    ),
                 );
-                if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
-                    tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
-                }
+                self.record_task_failure(task_id, error).await;
                 self.notify_task_state(task_id).await;
                 return;
             }
-            Err(e) => {
-                tracing::warn!(task_id = %task_id, error = %e, "failed to read resume context");
+            Err(error) => {
+                tracing::warn!(task_id = %task_id, "failed to read resume context");
+                let error = self.task_json_rpc_error(
+                    TaskOperation::Resume,
+                    Some(task_id),
+                    TaskFailure::Store(error),
+                );
+                self.record_task_failure(task_id, error).await;
+                self.notify_task_state(task_id).await;
                 return;
             }
         };
@@ -359,13 +539,19 @@ impl McpRouter {
                 .and_then(|d| d.get(&resume.tool_name))
         });
         let Some(tool) = tool else {
-            let error = JsonRpcError::internal_error(format!(
-                "tool '{}' is no longer registered, so the task cannot resume",
-                resume.tool_name
-            ));
-            if let Err(e) = self.inner.task_store.fail_task(task_id, error).await {
-                tracing::warn!(task_id = %task_id, error = %e, "failed to record task failure");
-            }
+            tracing::warn!(
+                task_id = %task_id,
+                tool = %resume.tool_name,
+                "task cannot resume because its tool is no longer registered"
+            );
+            let error = self.task_json_rpc_error(
+                TaskOperation::Resume,
+                Some(task_id),
+                TaskFailure::Internal(
+                    "the task cannot resume because its tool is no longer registered",
+                ),
+            );
+            self.record_task_failure(task_id, error).await;
             self.notify_task_state(task_id).await;
             return;
         };
@@ -386,7 +572,6 @@ impl McpRouter {
 
         let task_id = task_id.to_string();
         let notifier = self.clone();
-        let task_store = self.inner.task_store.clone();
         tokio::spawn(async move {
             let outcome = notifier
                 .invoke_tool(&tool, ctx, resume.arguments, &resume.tool_name)
@@ -402,9 +587,7 @@ impl McpRouter {
                 Err(error) => CallToolResult::error(error.to_string()),
             };
 
-            if let Err(e) = task_store.complete_task(&task_id, result).await {
-                tracing::warn!(task_id = %task_id, error = %e, "failed to record task completion");
-            }
+            notifier.complete_task_or_fail(&task_id, result).await;
             notifier.notify_task_state(&task_id).await;
         });
     }
@@ -423,7 +606,15 @@ impl McpRouter {
         }
 
         let (detailed, meta) = match self.detailed_task(task_id).await {
-            Ok(detailed) => detailed,
+            Ok(Some(detailed)) => detailed,
+            Ok(None) => {
+                tracing::debug!(
+                    target: "mcp::tasks",
+                    task_id = %task_id,
+                    "skipping task notification: task state no longer exists"
+                );
+                return;
+            }
             Err(error) => {
                 tracing::debug!(
                     target: "mcp::tasks",
@@ -468,13 +659,6 @@ impl McpRouter {
 // of `router.rs`, above the type they serve, rather than beside the group that
 // uses them (#1256).
 
-pub(super) fn task_store_error(e: TaskStoreError) -> Error {
-    Error::JsonRpc(JsonRpcError::internal_error(format!(
-        "Task store error: {}",
-        e
-    )))
-}
-
 pub(super) async fn discard_unprepared_task(store: &Arc<dyn TaskStore>, task_id: &str) {
     if !matches!(store.discard_task(task_id).await, Ok(true)) {
         let _ = store
@@ -503,43 +687,29 @@ pub(super) fn client_declares_tasks(_extensions: &crate::context::Extensions) ->
 
 /// Decode the wire `inputResponses` map into typed responses.
 ///
-/// A key whose value does not match any known response shape is dropped here
-/// rather than failing the request: the store treats an unmatched key as
-/// ignorable, and SEP-2663 requires ignoring responses that do not correspond
-/// to an outstanding request.
+/// Unknown, already-answered, and superseded keys remain the store's
+/// idempotency concern. A value that is not any valid protocol response shape
+/// is malformed input, however, and rejects the complete request instead of
+/// being silently reclassified as an unknown key.
 pub(super) fn decode_input_responses(
+    router: &McpRouter,
+    task_id: &str,
     responses: &std::collections::HashMap<String, serde_json::Value>,
-) -> crate::protocol::InputResponses {
+) -> Result<crate::protocol::InputResponses> {
     responses
         .iter()
-        .filter_map(|(key, value)| {
+        .map(|(key, value)| {
             serde_json::from_value(value.clone())
-                .ok()
                 .map(|response| (key.clone(), response))
+                .map_err(|_| {
+                    router.task_error(
+                        TaskOperation::Update,
+                        Some(task_id),
+                        TaskFailure::InvalidArguments("inputResponses contains a malformed value"),
+                    )
+                })
         })
         .collect()
-}
-
-/// Error for a task the server cannot serve.
-///
-/// Unknown and expired tasks are deliberately indistinguishable, so a caller
-/// cannot probe for the existence of a task whose retention window closed.
-/// The error an owner gets for a task the store still holds but whose TTL
-/// elapsed.
-///
-/// Deliberately distinct from [`unknown_task_error`] in its `data`, and
-/// deliberately only ever produced after the caller has been shown to own the
-/// task. A caller who does not own it gets `unknown_task_error`, which is
-/// also what a genuinely unknown id gets, so the two cannot be told apart
-/// from outside (#1249).
-fn expired_task_error(task_id: &str) -> JsonRpcError {
-    let mut error = JsonRpcError::invalid_params(format!("Task expired: {task_id}"));
-    error.data = Some(serde_json::json!({ "reason": "task_expired" }));
-    error
-}
-
-fn unknown_task_error(task_id: &str) -> JsonRpcError {
-    JsonRpcError::invalid_params(format!("Task not found: {task_id}"))
 }
 
 /// The client capability shape a server names in a `-32021` when it cannot

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -2295,9 +2295,10 @@ async fn reusing_a_spent_input_key_fails_the_task_instead_of_stranding_it() {
         }
     }
     let error = failed.expect("the task must fail rather than strand");
+    assert_eq!(error.message, "Task store operation failed");
     assert!(
-        error.message.contains("decision"),
-        "the failure must name the offending key: {}",
+        !error.message.contains("decision"),
+        "store transition details must be redacted: {}",
         error.message
     );
 }
@@ -2604,6 +2605,45 @@ async fn stable_task_update_ignores_unmatched_keys() {
     match unknown.inner {
         Err(error) => assert_eq!(error.code, -32602),
         other => panic!("expected -32602 for an unknown task, got {other:?}"),
+    }
+}
+
+/// Unknown keys are idempotently ignored only when their values are valid
+/// protocol responses. A malformed value is Invalid Params even when the key
+/// does not match an outstanding request.
+#[tokio::test]
+async fn task_update_rejects_malformed_response_values() {
+    use crate::async_task::{MemoryTaskStore, TaskStore};
+
+    let store = std::sync::Arc::new(MemoryTaskStore::new());
+    let mut router = McpRouter::new().task_store(store.clone());
+    init_router(&mut router).await;
+
+    let (task_id, _cancel) = store
+        .create_task("noop", serde_json::json!({}), None, None)
+        .await
+        .expect("create task");
+    let response = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::UpdateTask(UpdateTaskParams {
+                task_id,
+                input_responses: [("never-issued".to_string(), serde_json::json!(42))]
+                    .into_iter()
+                    .collect(),
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        })
+        .await
+        .unwrap();
+
+    match response.inner {
+        Err(error) => assert_eq!(error.code, -32602),
+        other => panic!("expected -32602 for malformed inputResponses, got {other:?}"),
     }
 }
 

--- a/crates/tower-mcp/src/tool.rs
+++ b/crates/tower-mcp/src/tool.rs
@@ -595,6 +595,7 @@ impl Eq for TaskContext {}
 /// router, which signals it once `tasks/update` has committed.
 pub(crate) struct LiveTask {
     pub(crate) store: Arc<dyn crate::async_task::TaskStore>,
+    pub(crate) error_policy: crate::router::TaskErrorPolicy,
     /// Signalled after responses are durably recorded, never before.
     pub(crate) input_ready: tokio::sync::Notify,
     pub(crate) cancelled: crate::context::CancellationToken,
@@ -762,9 +763,13 @@ impl TaskContext {
             ))
         })?;
         if requests.is_empty() {
-            return Err(crate::error::Error::Tool(crate::error::ToolError::new(
-                "require_input needs at least one request, or the task would wait for something that can never arrive",
-            )));
+            return Err(crate::error::Error::JsonRpc(
+                live.error_policy.map_internal_error(
+                    crate::router::TaskOperation::ParkInput,
+                    &self.task_id,
+                    "require_input needs at least one request, or the task would wait for something that can never arrive",
+                ),
+            ));
         }
         let asked: Vec<String> = requests.keys().cloned().collect();
 
@@ -776,15 +781,21 @@ impl TaskContext {
             .store
             .require_input(&self.task_id, requests, message.as_deref())
             .await
-            .map_err(|e| {
-                crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                    "could not park the task for input: {e}"
-                )))
+            .map_err(|error| {
+                crate::error::Error::JsonRpc(live.error_policy.map_store_error(
+                    crate::router::TaskOperation::ParkInput,
+                    &self.task_id,
+                    error,
+                ))
             })?;
         if !accepted {
-            return Err(crate::error::Error::Tool(crate::error::ToolError::new(
-                "the task is already terminal, so it cannot ask for input",
-            )));
+            return Err(crate::error::Error::JsonRpc(
+                live.error_policy.map_internal_error(
+                    crate::router::TaskOperation::ParkInput,
+                    &self.task_id,
+                    "the task is already terminal, so it cannot ask for input",
+                ),
+            ));
         }
 
         Ok(PendingInput {
@@ -801,14 +812,26 @@ impl TaskContext {
                 "working needs a live task handler",
             ))
         })?;
-        live.store
+        let updated = live
+            .store
             .set_status(&self.task_id, TaskStatus::Working, Some(&message.into()))
             .await
-            .map_err(|e| {
-                crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                    "could not update task status: {e}"
-                )))
+            .map_err(|error| {
+                crate::error::Error::JsonRpc(live.error_policy.map_store_error(
+                    crate::router::TaskOperation::Execute,
+                    &self.task_id,
+                    error,
+                ))
             })?;
+        if !updated {
+            return Err(crate::error::Error::JsonRpc(
+                live.error_policy.map_internal_error(
+                    crate::router::TaskOperation::Execute,
+                    &self.task_id,
+                    "the task is already terminal, so its status cannot be updated",
+                ),
+            ));
+        }
         Ok(())
     }
 
@@ -932,12 +955,25 @@ impl PendingInput {
                 .store
                 .outstanding_input_requests(&self.task_id)
                 .await
-                .map_err(|e| {
-                    crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                        "could not read outstanding requests: {e}"
-                    )))
-                })?
-                .unwrap_or_default();
+                .map_err(|error| {
+                    crate::error::Error::JsonRpc(live.error_policy.map_store_error(
+                        crate::router::TaskOperation::Execute,
+                        &self.task_id,
+                        error,
+                    ))
+                })?;
+            let Some(outstanding) = outstanding else {
+                if live.cancelled.is_cancelled() {
+                    return Err(crate::error::Error::TaskCancelled);
+                }
+                return Err(crate::error::Error::JsonRpc(
+                    live.error_policy.map_internal_error(
+                        crate::router::TaskOperation::Execute,
+                        &self.task_id,
+                        "the task disappeared while waiting for input",
+                    ),
+                ));
+            };
             if !outstanding.keys().any(|key| self.asked.contains(key)) {
                 break;
             }
@@ -954,12 +990,25 @@ impl PendingInput {
             .store
             .input_responses(&self.task_id)
             .await
-            .map_err(|e| {
-                crate::error::Error::Tool(crate::error::ToolError::new(format!(
-                    "could not read input responses: {e}"
-                )))
-            })?
-            .unwrap_or_default();
+            .map_err(|error| {
+                crate::error::Error::JsonRpc(live.error_policy.map_store_error(
+                    crate::router::TaskOperation::Execute,
+                    &self.task_id,
+                    error,
+                ))
+            })?;
+        let Some(all) = all else {
+            if live.cancelled.is_cancelled() {
+                return Err(crate::error::Error::TaskCancelled);
+            }
+            return Err(crate::error::Error::JsonRpc(
+                live.error_policy.map_internal_error(
+                    crate::router::TaskOperation::Execute,
+                    &self.task_id,
+                    "the task disappeared before its input responses could be read",
+                ),
+            ));
+        };
         Ok(all
             .into_iter()
             .filter(|(key, _)| self.asked.contains(key))

--- a/crates/tower-mcp/src/tool/tests.rs
+++ b/crates/tower-mcp/src/tool/tests.rs
@@ -9,6 +9,201 @@ use crate::protocol::Content;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
+#[derive(Default)]
+struct TerminalStatusStore {
+    outstanding: Option<InputRequests>,
+}
+
+#[async_trait::async_trait]
+impl crate::async_task::TaskStore for TerminalStatusStore {
+    async fn create_task(
+        &self,
+        _tool_name: &str,
+        _arguments: serde_json::Value,
+        _ttl: Option<u64>,
+        _owner: crate::async_task::TaskOwner,
+    ) -> crate::async_task::Result<(String, crate::async_task::CancellationToken)> {
+        unimplemented!("not used by this focused status test")
+    }
+
+    async fn task_owner(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskOwner>> {
+        Ok(Some(None))
+    }
+
+    async fn get_task(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::protocol::TaskObject>> {
+        Ok(None)
+    }
+
+    async fn get_task_result(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+        Ok(None)
+    }
+
+    async fn wait_for_completion(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<crate::async_task::TaskSnapshot>> {
+        Ok(None)
+    }
+
+    async fn list_tasks(
+        &self,
+        _status_filter: Option<TaskStatus>,
+    ) -> crate::async_task::Result<Vec<crate::protocol::TaskObject>> {
+        Ok(Vec::new())
+    }
+
+    async fn require_input(
+        &self,
+        _task_id: &str,
+        _requests: InputRequests,
+        _message: Option<&str>,
+    ) -> crate::async_task::Result<bool> {
+        Ok(false)
+    }
+
+    async fn outstanding_input_requests(
+        &self,
+        _task_id: &str,
+    ) -> crate::async_task::Result<Option<InputRequests>> {
+        Ok(self.outstanding.clone())
+    }
+
+    async fn apply_input_responses(
+        &self,
+        _task_id: &str,
+        _responses: InputResponses,
+    ) -> crate::async_task::Result<Option<crate::async_task::AppliedInputResponses>> {
+        Ok(None)
+    }
+
+    async fn set_ttl(&self, _task_id: &str, _ttl_ms: u64) -> crate::async_task::Result<bool> {
+        Ok(false)
+    }
+
+    async fn set_status(
+        &self,
+        _task_id: &str,
+        _status: TaskStatus,
+        _message: Option<&str>,
+    ) -> crate::async_task::Result<bool> {
+        Ok(false)
+    }
+
+    async fn complete_task(
+        &self,
+        _task_id: &str,
+        _result: CallToolResult,
+    ) -> crate::async_task::Result<bool> {
+        Ok(false)
+    }
+
+    async fn fail_task(
+        &self,
+        _task_id: &str,
+        _error: crate::error::JsonRpcError,
+    ) -> crate::async_task::Result<bool> {
+        Ok(false)
+    }
+
+    async fn cancel_task(
+        &self,
+        _task_id: &str,
+        _reason: Option<&str>,
+    ) -> crate::async_task::Result<Option<crate::protocol::TaskObject>> {
+        Ok(None)
+    }
+}
+
+#[tokio::test]
+async fn live_working_reports_a_terminal_race_through_the_task_policy() {
+    let live = Arc::new(LiveTask {
+        store: Arc::new(TerminalStatusStore::default()),
+        error_policy: crate::router::TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), crate::router::TaskOperation::Execute);
+            assert!(matches!(
+                context.failure(),
+                crate::router::TaskFailure::Internal(_)
+            ));
+            crate::error::JsonRpcError::internal_error("mapped terminal race")
+        }),
+        input_ready: tokio::sync::Notify::new(),
+        cancelled: crate::context::CancellationToken::new(),
+    });
+    let context = TaskContext::with_live("task_terminal".into(), live);
+
+    let error = context
+        .working("resumed")
+        .await
+        .expect_err("a terminal Task cannot accept a progress update");
+    assert!(matches!(
+        error,
+        crate::error::Error::JsonRpc(error) if error.message == "mapped terminal race"
+    ));
+}
+
+fn mapped_live(store: TerminalStatusStore) -> Arc<LiveTask> {
+    Arc::new(LiveTask {
+        store: Arc::new(store),
+        error_policy: crate::router::TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), crate::router::TaskOperation::Execute);
+            assert!(matches!(
+                context.failure(),
+                crate::router::TaskFailure::Internal(_)
+            ));
+            crate::error::JsonRpcError::internal_error("mapped missing input state")
+        }),
+        input_ready: tokio::sync::Notify::new(),
+        cancelled: crate::context::CancellationToken::new(),
+    })
+}
+
+#[tokio::test]
+async fn pending_input_reports_a_disappeared_task_instead_of_empty_answers() {
+    let pending = PendingInput {
+        live: mapped_live(TerminalStatusStore::default()),
+        task_id: "task_missing".into(),
+        asked: vec!["approval".into()],
+    };
+
+    let error = pending
+        .wait()
+        .await
+        .expect_err("a missing outstanding-input snapshot must not resume the handler");
+    assert!(matches!(
+        error,
+        crate::error::Error::JsonRpc(error) if error.message == "mapped missing input state"
+    ));
+}
+
+#[tokio::test]
+async fn pending_input_reports_missing_responses_instead_of_empty_answers() {
+    let pending = PendingInput {
+        live: mapped_live(TerminalStatusStore {
+            outstanding: Some(InputRequests::default()),
+        }),
+        task_id: "task_missing".into(),
+        asked: vec!["approval".into()],
+    };
+
+    let error = pending
+        .wait()
+        .await
+        .expect_err("a missing response snapshot must not resume the handler");
+    assert!(matches!(
+        error,
+        crate::error::Error::JsonRpc(error) if error.message == "mapped missing input state"
+    ));
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 struct GreetInput {
     name: String,

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -21,8 +21,8 @@ use tower_mcp::protocol::{
 };
 use tower_mcp::schemars::JsonSchema;
 use tower_mcp::{
-    CallToolResult, McpRouter, PanicPolicy, ProtocolSupport, RequestContext, TaskContext,
-    TaskOutcome, Tool, ToolBuilder,
+    CallToolResult, Error, JsonRpcError, McpRouter, PanicPolicy, ProtocolSupport, RequestContext,
+    TaskContext, TaskErrorPolicy, TaskFailure, TaskOperation, TaskOutcome, Tool, ToolBuilder,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -594,6 +594,47 @@ async fn a_panicking_live_handler_uses_the_redacted_policy() {
         .task
         .task_id;
     await_status(&store, &next, TaskStatus::Completed).await;
+}
+
+/// Unclassified handler errors can contain provider details in their Display
+/// text. They reach the Task policy by kind, without exposing that text.
+#[tokio::test]
+async fn a_live_handler_error_flows_through_the_task_policy() {
+    const SECRET: &str = "provider stderr: token=private";
+    let broken = ToolBuilder::new("broken")
+        .description("Returns an unclassified error")
+        .live_task_handler(|_task: TaskContext, _input: NoArgs| async move {
+            Err::<TaskOutcome, _>(Error::tool(SECRET))
+        })
+        .build();
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(broken)
+        .with_tasks()
+        .task_error_policy(TaskErrorPolicy::new(|context| {
+            assert_eq!(context.operation(), TaskOperation::Execute);
+            assert!(matches!(context.failure(), TaskFailure::Handler));
+            JsonRpcError::internal_error("mapped handler failure")
+                .with_data(json!({"kind": "internal", "phase": "provider_execution"}))
+        }));
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("broken", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Failed).await;
+    let (_, _, error) = store.get_task_result(&task_id).await.unwrap().unwrap();
+    let error = error.expect("a failed task carries a structured error");
+    assert_eq!(error.message, "mapped handler failure");
+    assert!(!format!("{error:?}").contains(SECRET));
+    assert_eq!(error.data.as_ref().unwrap()["phase"], "provider_execution");
 }
 
 /// The registry entry must be released however the handler leaves, so a later


### PR DESCRIPTION
Closes #1347.
Closes #1353.

## Summary

- reject malformed final `tasks/update` response values instead of silently dropping them;
- add a root-owned `TaskErrorPolicy` with typed create/get/update/cancel/park/execute/resume/finalize context;
- preserve the existing missing/expired wire shapes while redacting Task-store and unclassified handler details by default;
- keep unauthorized live or expired Tasks indistinguishable from never-issued IDs;
- fix final-get and outstanding-input races without fabricating an empty `input_required` state;
- route live status/input and handler failures through the same typed boundary;
- fail safely when resume state cannot be reconstructed;
- make one bounded, policy-shaped failure attempt when a background completion write fails, without overwriting a terminal outcome that won the race;
- keep the receiving router's policy across merge/nest, matching the existing root-owned panic-policy model.

The policy callback is synchronous, panic-isolated, and opaque by default. It receives typed store errors for an explicit application disclosure decision, but Tower's default no longer copies backend `Display` text into client responses or persisted Task failures.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-targets --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`
- `cargo test --workspace --doc --all-features --locked`

The full workspace test run passed after rerunning outside the filesystem sandbox so the OAuth and Unix-socket fixtures could bind local listeners.
