### PR TITLE
fix(websocket): apply the full frame classification to the bidirectional path (closes #1335)

### DIFF
--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -767,7 +767,12 @@ async fn handle_socket_simple(
 
         match msg {
             Message::Text(text) => {
-                match process_message(&mut service, &session.router, &text).await {
+                // A peer whose runtime prefixes its output with a UTF-8 BOM
+                // writes one into its text frames too; the crate's own
+                // websocket client already strips one on receive (#1303,
+                // `client/websocket.rs`), so the server side must too (#1335).
+                let text = crate::framing::clean_input_line(&text);
+                match process_message(&mut service, &session.router, text).await {
                     Ok(Some(response)) => {
                         let response_json = match serde_json::to_string(&response) {
                             Ok(json) => json,
@@ -875,8 +880,12 @@ async fn handle_socket_bidirectional(
 
                 match msg {
                     Message::Text(text) => {
+                        // See the matching comment in `handle_socket_simple`
+                        // (#1303, #1335): both server loops must strip a
+                        // leading BOM the way the crate's own client does.
+                        let text = crate::framing::clean_input_line(&text);
                         let result = handle_incoming_message(
-                            &text,
+                            text,
                             &mut service,
                             &router,
                             pending_requests.clone(),
@@ -940,6 +949,36 @@ async fn handle_socket_bidirectional(
     }
 }
 
+/// Serialize `value` and send it as one text frame.
+///
+/// Every reply `handle_incoming_message` sends goes through here so the
+/// serialize-then-send pattern (and its error mapping) is written once.
+async fn send_response<S>(sender: &Mutex<S>, value: &impl serde::Serialize) -> Result<()>
+where
+    S: futures::Sink<Message> + Unpin,
+    S::Error: std::fmt::Display,
+{
+    let text = serde_json::to_string(value)
+        .map_err(|error| Error::Transport(format!("Failed to serialize response: {error}")))?;
+    sender
+        .lock()
+        .await
+        .send(Message::Text(text.into()))
+        .await
+        .map_err(|error| Error::Transport(format!("Failed to send response: {error}")))
+}
+
+/// The id to answer with if `call_message` fails after `message` already
+/// parsed successfully. A batch has no single id to correlate against,
+/// matching what `call_message` itself does for its own within-batch errors
+/// (see the `Err(Error::JsonRpc(error))` arm in `JsonRpcService::call_message`).
+fn correlating_id(message: &JsonRpcMessage) -> Option<RequestId> {
+    match message {
+        JsonRpcMessage::Single(req) => Some(req.id.clone()),
+        _ => None,
+    }
+}
+
 /// Handle an incoming WebSocket message (bidirectional mode)
 async fn handle_incoming_message<S>(
     text: &str,
@@ -954,70 +993,73 @@ where
 {
     let parsed: serde_json::Value = serde_json::from_str(text)?;
 
-    // A notification cannot be answered, so a validation failure on one is
-    // logged rather than sent back (#1272). Requests fall through.
-    if !parsed.is_array()
-        && parsed.get("id").is_none()
-        && let Err(error) =
-            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
-    {
-        tracing::debug!(
-            method = parsed.get("method").and_then(|m| m.as_str()),
-            %error,
-            "rejected an invalid notification"
-        );
-        return Ok(());
+    // Classify before validating, then response before request: the same
+    // order `process_line` (stdio) and `process_message` (below) use
+    // (#1272, #1335). A malformed notification cannot be answered (there is
+    // nowhere to put the reply), and a response frame is always the peer's
+    // mistake on a binding that never sends requests of its own -- both get
+    // no reply rather than one derived from validation that was never meant
+    // to apply to them.
+    match crate::framing::classify_frame(&parsed) {
+        crate::framing::FrameClass::Notification => {
+            if let Err(error) = service
+                .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+            {
+                tracing::debug!(
+                    method = parsed.get("method").and_then(|m| m.as_str()),
+                    %error,
+                    "rejected an invalid notification"
+                );
+                return Ok(());
+            }
+            if let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text) {
+                let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
+                router.handle_notification(mcp_notification);
+            }
+            return Ok(());
+        }
+        crate::framing::FrameClass::Response => {
+            return handle_response(&parsed, pending_requests).await;
+        }
+        crate::framing::FrameClass::Request => {}
     }
 
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
-        let response = JsonRpcResponse::error(None, error);
-        let response = serde_json::to_string(&response)
-            .map_err(|error| Error::Transport(format!("Failed to serialize response: {error}")))?;
-        sender
-            .lock()
-            .await
-            .send(Message::Text(response.into()))
-            .await
-            .map_err(|error| Error::Transport(format!("Failed to send response: {error}")))?;
-        return Ok(());
+        return send_response(&sender, &JsonRpcResponse::error(None, error)).await;
     }
 
-    // Check if this is a response to one of our pending requests
-    if crate::framing::is_response_frame(&parsed) {
-        return handle_response(&parsed, pending_requests).await;
-    }
+    // Parse and process as a request (single or batch). The serde error is
+    // deliberately not surfaced: for an untagged enum it names the Rust
+    // type, which has no business on the wire (#1272). Guarding this parse
+    // rather than propagating it with `?` matters here specifically: the
+    // caller of this function only logs a returned `Err`, so an unguarded
+    // parse failure left the client with no reply at all (#1335).
+    let Ok(message) = serde_json::from_str::<JsonRpcMessage>(text) else {
+        return send_response(
+            &sender,
+            &crate::transport::stdio::parse_error_response("not a valid JSON-RPC request"),
+        )
+        .await;
+    };
 
-    // Check if it's a notification (no id field)
-    if !parsed.is_array() && parsed.get("id").is_none() {
-        if let Ok(notification) = serde_json::from_str::<JsonRpcNotification>(text) {
-            let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
-            router.handle_notification(mcp_notification);
-        }
-        return Ok(());
-    }
+    // Captured before `message` moves into `call_message`, so a failure
+    // there can still answer with the id the client is waiting on (#1335).
+    let request_id = correlating_id(&message);
 
-    // Process as a request
-    let message: JsonRpcMessage = serde_json::from_str(text)?;
     match service.call_message(message).await {
-        Ok(response) => {
-            let response_json = serde_json::to_string(&response)
-                .map_err(|e| Error::Transport(format!("Failed to serialize response: {}", e)))?;
-            let mut sender = sender.lock().await;
-            sender
-                .send(Message::Text(response_json.into()))
-                .await
-                .map_err(|e| Error::Transport(format!("Failed to send response: {}", e)))?;
-        }
+        Ok(response) => send_response(&sender, &response).await?,
         Err(e) => {
             tracing::error!(error = %e, "Error processing message");
+            // `e` here is a transport/serialization failure, not a caught
+            // tool panic, so the disclosure policy in `router.rs` (#1309)
+            // does not apply to it and its methods are private to that
+            // module regardless. `e.to_string()` is left as-is rather than
+            // inventing a second disclosure rule for this path.
             let error_response =
-                JsonRpcResponse::error(None, JsonRpcError::internal_error(e.to_string()));
-            if let Ok(json) = serde_json::to_string(&error_response) {
-                let mut sender = sender.lock().await;
-                let _ = sender.send(Message::Text(json.into())).await;
-            }
+                JsonRpcResponse::error(request_id, JsonRpcError::internal_error(e.to_string()));
+            let _ = send_response(&sender, &error_response).await;
         }
     }
 
@@ -1134,32 +1176,35 @@ async fn process_message(
 ) -> Result<Option<crate::protocol::JsonRpcResponseMessage>> {
     let parsed: serde_json::Value = serde_json::from_str(text)?;
 
-    // Classify before validating: a frame with no id has nowhere to put a
-    // response, so answering one is a JSON-RPC violation regardless of what
-    // validation says. Same fix as the stdio transport (#1272).
-    if !parsed.is_array() && parsed.get("id").is_none() {
-        let method = parsed.get("method").and_then(|m| m.as_str());
-        if let Err(error) =
-            service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
-        {
-            tracing::debug!(method, %error, "rejected an invalid notification");
+    // Classify before validating, then response before request: same order
+    // as `process_line` (stdio) and `handle_incoming_message` above (#1272,
+    // #1335). This transport never sends requests, so a response arriving
+    // here is the peer's mistake; ignoring it beats answering with a parse
+    // error that names an internal type.
+    match crate::framing::classify_frame(&parsed) {
+        crate::framing::FrameClass::Notification => {
+            let method = parsed.get("method").and_then(|m| m.as_str());
+            if let Err(error) = service
+                .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+            {
+                tracing::debug!(method, %error, "rejected an invalid notification");
+                return Ok(None);
+            }
+            match serde_json::from_str::<JsonRpcNotification>(text) {
+                Ok(notification) => {
+                    let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
+                    router.handle_notification(mcp_notification);
+                }
+                Err(_) => tracing::debug!(method, "unparseable notification"),
+            }
             return Ok(None);
         }
-        match serde_json::from_str::<JsonRpcNotification>(text) {
-            Ok(notification) => {
-                let mcp_notification = McpNotification::from_jsonrpc(&notification)?;
-                router.handle_notification(mcp_notification);
-            }
-            Err(_) => tracing::debug!(method, "unparseable notification"),
+        crate::framing::FrameClass::Response => {
+            tracing::debug!("ignoring an unexpected JSON-RPC response frame");
+            return Ok(None);
         }
-        return Ok(None);
+        crate::framing::FrameClass::Request => {}
     }
-
-    // #1335: this path is missing the response-frame branch that
-    // `handle_incoming_message` (above) and the stdio transport both have --
-    // a response arriving here falls through to the request parse below and
-    // gets answered with a parse error instead of being ignored. Not fixed
-    // here; this extraction is a no-behavior-change base for that fix.
 
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
@@ -1431,6 +1476,32 @@ mod tests {
                 .unwrap()
                 .contains("does not permit top-level JSON-RPC batches")
         );
+    }
+
+    // ========================================================================
+    // #1335: the id `handle_incoming_message` answers with if `call_message`
+    // fails after `message` already parsed.
+    //
+    // `call_message` only returns `Err` for conditions outside the ordinary
+    // request/response surface (`Error::Serialization`, the router's inner
+    // service is `Infallible`), so a live socket cannot currently drive that
+    // branch. `correlating_id` is tested directly instead of end to end.
+    // ========================================================================
+
+    #[test]
+    fn correlating_id_uses_the_single_requests_own_id() {
+        let request = JsonRpcRequest::new(7, "ping");
+        let message = JsonRpcMessage::Single(request);
+        assert_eq!(correlating_id(&message), Some(RequestId::Number(7)));
+    }
+
+    #[test]
+    fn correlating_id_has_nothing_to_correlate_for_a_batch() {
+        let message = JsonRpcMessage::Batch(vec![
+            JsonRpcRequest::new(1, "ping"),
+            JsonRpcRequest::new(2, "ping"),
+        ]);
+        assert_eq!(correlating_id(&message), None);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/tests/adversarial_input_websocket.rs
+++ b/crates/tower-mcp/tests/adversarial_input_websocket.rs
@@ -1,0 +1,300 @@
+//! WebSocket equivalents of the malformed/stray-frame coverage in
+//! `adversarial_input.rs` (#1335).
+//!
+//! `websocket.rs` has two receive loops -- `process_message` (no sampling)
+//! and `handle_incoming_message` (`.with_sampling()`) -- and only one of them
+//! got the #1272 conformance fix. Every test here drives a real
+//! [`WebSocketTransport`] over an actual socket via a raw `tokio-tungstenite`
+//! client, so it is not fooled by any validation the crate's own
+//! [`tower_mcp::client::WebSocketClientTransport`] might add on the way out.
+//! Each test says which loop it targets.
+
+#![cfg(feature = "websocket")]
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpListener;
+use tokio_tungstenite::MaybeTlsStream;
+use tokio_tungstenite::tungstenite::protocol::Message;
+use tower_mcp::{McpRouter, WebSocketTransport};
+
+// ============================================================================
+// Harness
+// ============================================================================
+
+type RawWs = tokio_tungstenite::WebSocketStream<MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// A running [`WebSocketTransport`] plus a raw client socket, bypassing this
+/// crate's own client transport so nothing sanitizes a frame before it hits
+/// the wire.
+struct Server {
+    ws: RawWs,
+}
+
+impl Server {
+    /// Start a server in simple (no-sampling) mode, driving `process_message`.
+    async fn simple(router: McpRouter) -> Self {
+        Self::start(router, false).await
+    }
+
+    /// Start a server with sampling enabled, driving `handle_incoming_message`.
+    async fn bidirectional(router: McpRouter) -> Self {
+        Self::start(router, true).await
+    }
+
+    async fn start(router: McpRouter, sampling: bool) -> Self {
+        let mut transport = WebSocketTransport::new(router);
+        if sampling {
+            transport = transport.with_sampling();
+        }
+        let app = transport.into_router();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        // Let the listener come up before the first dial.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let (ws, _response) = tokio_tungstenite::connect_async(format!("ws://{addr}/"))
+            .await
+            .expect("connect");
+        Self { ws }
+    }
+
+    /// Send one raw text frame, exactly as given.
+    async fn send_raw(&mut self, text: &str) {
+        self.ws
+            .send(Message::Text(text.to_string().into()))
+            .await
+            .unwrap();
+    }
+
+    async fn send(&mut self, frame: serde_json::Value) {
+        self.send_raw(&frame.to_string()).await;
+    }
+
+    /// Read the next text frame, failing the test rather than hanging.
+    async fn next_frame(&mut self) -> serde_json::Value {
+        self.next_frame_within(Duration::from_secs(5))
+            .await
+            .expect("no frame arrived before the deadline")
+    }
+
+    async fn next_frame_within(&mut self, budget: Duration) -> Option<serde_json::Value> {
+        let read =
+            async {
+                loop {
+                    match self.ws.next().await {
+                        Some(Ok(Message::Text(text))) => {
+                            return Some(serde_json::from_str(&text).unwrap_or_else(|e| {
+                                panic!("server wrote invalid JSON: {e}: {text}")
+                            }));
+                        }
+                        Some(Ok(Message::Close(_))) => return None,
+                        Some(Ok(_)) => continue,
+                        Some(Err(e)) => panic!("websocket error: {e}"),
+                        None => return None,
+                    }
+                }
+            };
+        tokio::time::timeout(budget, read).await.ok().flatten()
+    }
+
+    /// Assert nothing more arrives within `budget`.
+    async fn expect_silence(&mut self, budget: Duration) {
+        if let Some(frame) = self.next_frame_within(budget).await {
+            panic!("expected no further frames, got: {frame}");
+        }
+    }
+
+    async fn initialize(&mut self) {
+        self.initialize_with_version("2025-11-25").await;
+    }
+
+    /// Negotiate a specific protocol revision, needed for the batch tests: a
+    /// top-level JSON-RPC batch is only accepted by MCP 2025-03-26.
+    async fn initialize_with_version(&mut self, version: &str) {
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0", "id": "init", "method": "initialize",
+            "params": {
+                "protocolVersion": version,
+                "capabilities": {},
+                "clientInfo": {"name": "adversary", "version": "1.0.0"}
+            }
+        }))
+        .await;
+        let init = self.next_frame().await;
+        assert_eq!(init["id"], "init", "unexpected initialize reply: {init}");
+        self.send(serde_json::json!({
+            "jsonrpc": "2.0", "method": "notifications/initialized"
+        }))
+        .await;
+    }
+}
+
+fn ping(id: i64) -> serde_json::Value {
+    serde_json::json!({"jsonrpc": "2.0", "id": id, "method": "ping"})
+}
+
+fn base_router() -> McpRouter {
+    McpRouter::new().server_info("adversarial-ws", "1.0.0")
+}
+
+// ============================================================================
+// 1. `handle_incoming_message` (bidirectional / `.with_sampling()`)
+// ============================================================================
+
+/// Control: general MCP validation already refuses a request whose `method`
+/// is the wrong JSON type, before the untagged `JsonRpcMessage` parse is ever
+/// reached. Kept as a guard so the rewrite in #1335 does not regress it.
+#[tokio::test]
+async fn a_request_with_a_wrong_typed_method_is_refused() {
+    let mut server = Server::bidirectional(base_router()).await;
+    server.initialize().await;
+
+    server
+        .send_raw(r#"{"jsonrpc":"2.0","id":1,"method":42}"#)
+        .await;
+    let frame = server.next_frame_within(Duration::from_secs(2)).await;
+    let frame =
+        frame.unwrap_or_else(|| panic!("a request with a wrong-typed method must be answered"));
+    assert!(
+        frame.get("error").is_some(),
+        "a malformed request must be refused, not accepted: {frame}"
+    );
+
+    // The connection must keep serving afterward.
+    server.send(ping(2)).await;
+    let pong = server.next_frame().await;
+    assert_eq!(pong["id"], 2);
+    assert!(pong.get("result").is_some(), "ping must work: {pong}");
+}
+
+/// A batch may mix requests and notifications (general MCP validation allows
+/// this), but `JsonRpcMessage::Batch` requires every member to deserialize as
+/// a full `JsonRpcRequest`, which a notification-shaped member (no `id`)
+/// cannot. That failure reaches the untagged parse in `handle_incoming_message`
+/// after validation has already passed it, and before #1335 the `?` on that
+/// parse propagates to a caller that only logs -- the client hangs forever
+/// instead of getting a `-32700`.
+#[tokio::test]
+async fn a_batch_that_fails_the_untagged_parse_after_validation_still_answers() {
+    let mut server = Server::bidirectional(base_router()).await;
+    server.initialize_with_version("2025-03-26").await;
+
+    server
+        .send_raw(
+            r#"[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","method":"notifications/bogus"}]"#,
+        )
+        .await;
+    let frame = server.next_frame_within(Duration::from_secs(2)).await;
+    let frame = frame.unwrap_or_else(|| {
+        panic!(
+            "a batch that fails the untagged parse after validation must still be answered, not ignored"
+        )
+    });
+    assert!(
+        frame.get("error").is_some(),
+        "must be refused, not silently accepted: {frame}"
+    );
+
+    // The connection must keep serving afterward.
+    server.send(ping(2)).await;
+    let pong = server.next_frame().await;
+    assert_eq!(pong["id"], 2);
+    assert!(pong.get("result").is_some(), "ping must work: {pong}");
+}
+
+/// The classification order must match stdio: classify before validating. A
+/// response frame whose id does not fit `i64` fails general MCP validation,
+/// but it is still shaped like a response (an id, no method, a `result`) and
+/// must be silently ignored rather than answered with a validation error
+/// that leaks internal detail about a frame the client never asked about.
+#[tokio::test]
+async fn a_response_shaped_frame_that_fails_validation_is_still_ignored() {
+    let mut server = Server::bidirectional(base_router()).await;
+    server.initialize().await;
+
+    server
+        .send_raw(r#"{"jsonrpc":"2.0","id":99999999999999999999,"result":{}}"#)
+        .await;
+    server.expect_silence(Duration::from_millis(300)).await;
+
+    // The connection must keep serving afterward.
+    server.send(ping(2)).await;
+    let pong = server.next_frame().await;
+    assert_eq!(pong["id"], 2);
+}
+
+/// Control: a genuine stray response frame over the bidirectional loop
+/// (already handled correctly before #1335, but worth pinning since the
+/// fix rewrites the surrounding function).
+#[tokio::test]
+async fn a_stray_response_frame_is_not_answered_bidirectional() {
+    let mut server = Server::bidirectional(base_router()).await;
+    server.initialize().await;
+
+    server
+        .send_raw(r#"{"jsonrpc":"2.0","id":4242,"result":{}}"#)
+        .await;
+    server.expect_silence(Duration::from_millis(300)).await;
+
+    server.send(ping(2)).await;
+    assert_eq!(server.next_frame().await["id"], 2);
+}
+
+/// A BOM-prefixed frame is accepted over the bidirectional loop, the way the
+/// crate's own websocket client already strips one on receive (#1303,
+/// `client/websocket.rs`), and the way stdio does on the server side.
+#[tokio::test]
+async fn a_bom_prefixed_frame_is_accepted_bidirectional() {
+    let mut server = Server::bidirectional(base_router()).await;
+    server.initialize().await;
+
+    server.send_raw(&format!("\u{feff}{}", ping(1))).await;
+    let frame = server.next_frame().await;
+    assert_eq!(frame["id"], 1);
+    assert!(
+        frame.get("result").is_some(),
+        "BOM must be stripped: {frame}"
+    );
+}
+
+// ============================================================================
+// 2. `process_message` (simple / unidirectional)
+// ============================================================================
+
+/// A stray response frame arriving on the unidirectional loop must be
+/// ignored, not answered with a `-32700` that names an internal Rust type.
+/// This transport never sends requests, so a response is always the peer's
+/// mistake -- the same reasoning stdio's `process_line` documents.
+#[tokio::test]
+async fn a_stray_response_frame_is_not_answered_simple() {
+    let mut server = Server::simple(base_router()).await;
+    server.initialize().await;
+
+    server
+        .send_raw(r#"{"jsonrpc":"2.0","id":4242,"result":{}}"#)
+        .await;
+    server.expect_silence(Duration::from_millis(300)).await;
+
+    server.send(ping(2)).await;
+    assert_eq!(server.next_frame().await["id"], 2);
+}
+
+/// A BOM-prefixed frame is accepted over the unidirectional loop too.
+#[tokio::test]
+async fn a_bom_prefixed_frame_is_accepted_simple() {
+    let mut server = Server::simple(base_router()).await;
+    server.initialize().await;
+
+    server.send_raw(&format!("\u{feff}{}", ping(1))).await;
+    let frame = server.next_frame().await;
+    assert_eq!(frame["id"], 1);
+    assert!(
+        frame.get("result").is_some(),
+        "BOM must be stripped: {frame}"
+    );
+}


### PR DESCRIPTION
Implements #1335. Draft opened before work starts; the commit stream is the implementation.

See the issue for the authoritative spec, including the comment on #1335 titled "A fourth divergence, and a spec for the shared helper".

Uses the `classify_frame` / `is_response_frame` helpers added to `crate::framing` by #1346.