### PR TITLE
feat(router): per-capability advertisement builders (closes #1338)

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -765,6 +765,22 @@ struct McpRouterInner {
     /// Whether to advertise `resources.subscribe`. Defaults to true, which
     /// is what this router has always advertised when resources exist (#1261).
     advertise_resource_subscriptions: bool,
+    /// Explicit override for whether to advertise `tools.listChanged`.
+    /// `None` derives from whether a notification channel is attached, which
+    /// is what this router has always advertised (#1338).
+    advertise_tools_list_changed: Option<bool>,
+    /// Explicit override for whether to advertise `prompts.listChanged`.
+    /// `None` derives from whether a notification channel is attached, which
+    /// is what this router has always advertised (#1338).
+    advertise_prompts_list_changed: Option<bool>,
+    /// Explicit override for whether to advertise `resources.listChanged`.
+    /// `None` derives from whether a notification channel is attached, which
+    /// is what this router has always advertised (#1338).
+    advertise_resources_list_changed: Option<bool>,
+    /// Explicit override for whether to advertise the `logging` capability.
+    /// `None` derives from whether a notification channel is attached, which
+    /// is what this router has always advertised (#1338).
+    advertise_mcp_logging: Option<bool>,
     /// Live tasks currently running, keyed by task id (#1246).
     ///
     /// A live handler parks inside its own future rather than returning, so
@@ -956,6 +972,10 @@ impl McpRouter {
                 resource_templates: Vec::new(),
                 prompts: HashMap::new(),
                 advertise_resource_subscriptions: true,
+                advertise_tools_list_changed: None,
+                advertise_prompts_list_changed: None,
+                advertise_resources_list_changed: None,
+                advertise_mcp_logging: None,
                 live_tasks: Arc::new(Mutex::new(HashMap::new())),
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 next_dispatch: Arc::new(AtomicU64::new(0)),
@@ -1597,6 +1617,137 @@ impl McpRouter {
     /// ```
     pub fn resource_subscriptions(mut self, advertise: bool) -> Self {
         Arc::make_mut(&mut self.inner).advertise_resource_subscriptions = advertise;
+        self
+    }
+
+    /// Whether to advertise `tools.listChanged`.
+    ///
+    /// Defaults to whether a notification channel is attached to this
+    /// router, which is what it has always advertised: choosing a transport
+    /// that installs the channel (for example `StdioTransport::new`)
+    /// promised `tools/list_changed` traffic even for a server that never
+    /// sends it. Pass `true` or `false` to declare the flag independently of
+    /// that channel (#1338).
+    ///
+    /// This affects advertisement only. Notifications are still routed
+    /// through the channel exactly as before; this only changes what
+    /// `initialize` reports.
+    ///
+    /// An explicit call here always wins over the notification-channel
+    /// default, including under `StdioTransport::without_server_notifications`
+    /// (#1257), which leaves the channel unattached. That method is the
+    /// all-or-nothing switch; this builder is the per-flag refinement
+    /// underneath it, so setting `tools_list_changed(true)` still advertises
+    /// the flag even though the transport will never emit it.
+    ///
+    /// ```rust
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .tools_list_changed(true);
+    /// ```
+    pub fn tools_list_changed(mut self, advertise: bool) -> Self {
+        Arc::make_mut(&mut self.inner).advertise_tools_list_changed = Some(advertise);
+        self
+    }
+
+    /// Whether to advertise `prompts.listChanged`.
+    ///
+    /// Defaults to whether a notification channel is attached to this
+    /// router, which is what it has always advertised: choosing a transport
+    /// that installs the channel (for example `StdioTransport::new`)
+    /// promised `prompts/list_changed` traffic even for a server that never
+    /// sends it. Pass `true` or `false` to declare the flag independently of
+    /// that channel (#1338).
+    ///
+    /// This affects advertisement only. Notifications are still routed
+    /// through the channel exactly as before; this only changes what
+    /// `initialize` reports.
+    ///
+    /// An explicit call here always wins over the notification-channel
+    /// default, including under `StdioTransport::without_server_notifications`
+    /// (#1257), which leaves the channel unattached. That method is the
+    /// all-or-nothing switch; this builder is the per-flag refinement
+    /// underneath it, so setting `prompts_list_changed(true)` still
+    /// advertises the flag even though the transport will never emit it.
+    ///
+    /// ```rust
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .prompts_list_changed(false);
+    /// ```
+    pub fn prompts_list_changed(mut self, advertise: bool) -> Self {
+        Arc::make_mut(&mut self.inner).advertise_prompts_list_changed = Some(advertise);
+        self
+    }
+
+    /// Whether to advertise `resources.listChanged`.
+    ///
+    /// Defaults to whether a notification channel is attached to this
+    /// router, which is what it has always advertised: choosing a transport
+    /// that installs the channel (for example `StdioTransport::new`)
+    /// promised `resources/list_changed` traffic even for a server that
+    /// never sends it. Pass `true` or `false` to declare the flag
+    /// independently of that channel (#1338).
+    ///
+    /// This affects advertisement only. Notifications are still routed
+    /// through the channel exactly as before; this only changes what
+    /// `initialize` reports. It is independent of
+    /// [`Self::resource_subscriptions`], which governs `resources.subscribe`
+    /// rather than `resources.listChanged`.
+    ///
+    /// An explicit call here always wins over the notification-channel
+    /// default, including under `StdioTransport::without_server_notifications`
+    /// (#1257), which leaves the channel unattached. That method is the
+    /// all-or-nothing switch; this builder is the per-flag refinement
+    /// underneath it, so setting `resources_list_changed(true)` still
+    /// advertises the flag even though the transport will never emit it.
+    ///
+    /// ```rust
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .resources_list_changed(false);
+    /// ```
+    pub fn resources_list_changed(mut self, advertise: bool) -> Self {
+        Arc::make_mut(&mut self.inner).advertise_resources_list_changed = Some(advertise);
+        self
+    }
+
+    /// Whether to advertise the `logging` capability (MCP logging, i.e.
+    /// `notifications/message`).
+    ///
+    /// Defaults to whether a notification channel is attached to this
+    /// router, which is what it has always advertised: choosing a transport
+    /// that installs the channel (for example `StdioTransport::new`)
+    /// promised MCP logging even for a server that logs elsewhere, such as
+    /// stderr or OTLP. Pass `true` or `false` to declare the flag
+    /// independently of that channel (#1338).
+    ///
+    /// This affects advertisement only. [`McpRouter::log`] and its
+    /// convenience methods still route through the channel exactly as
+    /// before; this only changes what `initialize` reports.
+    ///
+    /// An explicit call here always wins over the notification-channel
+    /// default, including under `StdioTransport::without_server_notifications`
+    /// (#1257), which leaves the channel unattached. That method is the
+    /// all-or-nothing switch; this builder is the per-flag refinement
+    /// underneath it, so setting `mcp_logging(true)` still advertises the
+    /// flag even though the transport will never emit it.
+    ///
+    /// ```rust
+    /// use tower_mcp::McpRouter;
+    ///
+    /// let router = McpRouter::new()
+    ///     .server_info("my-server", "1.0.0")
+    ///     .mcp_logging(false);
+    /// ```
+    pub fn mcp_logging(mut self, advertise: bool) -> Self {
+        Arc::make_mut(&mut self.inner).advertise_mcp_logging = Some(advertise);
         self
     }
 
@@ -2617,6 +2768,29 @@ impl McpRouter {
             !self.inner.resources.is_empty() || !self.inner.resource_templates.is_empty();
         let has_notifications = self.inner.notification_tx.is_some();
 
+        // Each of these defaults to `has_notifications`, which is what this
+        // router has always advertised as soon as a transport attached a
+        // notification channel. An explicit builder call
+        // (`tools_list_changed`, `prompts_list_changed`,
+        // `resources_list_changed`, `mcp_logging`) overrides that default in
+        // either direction, independently of the channel (#1338).
+        let tools_list_changed = self
+            .inner
+            .advertise_tools_list_changed
+            .unwrap_or(has_notifications);
+        let prompts_list_changed = self
+            .inner
+            .advertise_prompts_list_changed
+            .unwrap_or(has_notifications);
+        let resources_list_changed = self
+            .inner
+            .advertise_resources_list_changed
+            .unwrap_or(has_notifications);
+        let mcp_logging = self
+            .inner
+            .advertise_mcp_logging
+            .unwrap_or(has_notifications);
+
         #[cfg(feature = "dynamic-tools")]
         let has_dynamic_tools = self.inner.dynamic_tools.is_some();
         #[cfg(not(feature = "dynamic-tools"))]
@@ -2638,13 +2812,13 @@ impl McpRouter {
                 None
             } else {
                 Some(ToolsCapability {
-                    list_changed: has_notifications,
+                    list_changed: tools_list_changed,
                 })
             },
             resources: if has_resources || has_dynamic_resources {
                 Some(ResourcesCapability {
                     subscribe: self.inner.advertise_resource_subscriptions,
-                    list_changed: has_notifications,
+                    list_changed: resources_list_changed,
                 })
             } else {
                 None
@@ -2653,11 +2827,12 @@ impl McpRouter {
                 None
             } else {
                 Some(PromptsCapability {
-                    list_changed: has_notifications,
+                    list_changed: prompts_list_changed,
                 })
             },
-            // Always advertise logging capability when notification channel is configured
-            logging: if self.inner.notification_tx.is_some() {
+            // Advertised when a notification channel is configured, unless
+            // overridden by `mcp_logging` (#1338).
+            logging: if mcp_logging {
                 Some(LoggingCapability {
                     deprecated: self.inner.logging_deprecated.clone(),
                 })

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -3572,6 +3572,90 @@ fn declining_subscriptions_does_not_invent_a_resources_capability() {
     assert!(router.capabilities().resources.is_none());
 }
 
+/// Build a router with a tool, a resource, and a prompt registered, and
+/// optionally a notification channel attached. Used to pin the pre-#1338
+/// capability advertisement across every configuration that exists today.
+fn router_with_all_capabilities(with_notifications: bool) -> McpRouter {
+    let tool = ToolBuilder::new("test")
+        .description("test")
+        .handler(|_input: AddInput| async { Ok(CallToolResult::text("ok")) })
+        .build();
+
+    let mut router = McpRouter::new()
+        .server_info("defaults", "1.0")
+        .tool(tool)
+        .resource(
+            crate::resource::ResourceBuilder::new("mem://one")
+                .name("one")
+                .text("hi"),
+        )
+        .prompt(crate::prompt::PromptBuilder::new("greeting").user_message("hi"));
+
+    if with_notifications {
+        let (tx, _rx) = crate::context::notification_channel(16);
+        router = router.with_notification_sender(tx);
+    }
+
+    router
+}
+
+/// Regression test for #1338: before per-capability builders existed, all of
+/// `tools.listChanged`, `prompts.listChanged`, `resources.listChanged`, and
+/// `logging` were derived solely from whether a notification channel was
+/// attached. This pins that exact behavior, in every configuration that
+/// exists today, as a guard against the new builders' defaults drifting from
+/// it.
+#[test]
+fn capability_defaults_are_unchanged_by_per_capability_builders() {
+    // No notifications, nothing registered: no capability advertised at all.
+    let empty_router = McpRouter::new().server_info("empty", "1.0");
+    let empty_caps = empty_router.capabilities();
+    assert!(empty_caps.tools.is_none());
+    assert!(empty_caps.resources.is_none());
+    assert!(empty_caps.prompts.is_none());
+    assert!(empty_caps.logging.is_none());
+
+    // Notifications attached, nothing registered: only logging is advertised,
+    // since tools/resources/prompts capabilities are only present when the
+    // corresponding items are registered.
+    let (tx, _rx) = crate::context::notification_channel(16);
+    let empty_with_notifications = McpRouter::new()
+        .server_info("empty-notified", "1.0")
+        .with_notification_sender(tx);
+    let empty_notified_caps = empty_with_notifications.capabilities();
+    assert!(empty_notified_caps.tools.is_none());
+    assert!(empty_notified_caps.resources.is_none());
+    assert!(empty_notified_caps.prompts.is_none());
+    assert!(empty_notified_caps.logging.is_some());
+
+    // Everything registered, no notification channel: every capability is
+    // advertised, but every `list_changed` flag is false, and there is no
+    // logging capability.
+    let no_notifications = router_with_all_capabilities(false);
+    let no_notif_caps = no_notifications.capabilities();
+    let tools_cap = no_notif_caps.tools.expect("tool registered");
+    assert!(!tools_cap.list_changed);
+    let resources_cap = no_notif_caps.resources.expect("resource registered");
+    assert!(!resources_cap.list_changed);
+    assert!(resources_cap.subscribe, "subscribe still defaults to true");
+    let prompts_cap = no_notif_caps.prompts.expect("prompt registered");
+    assert!(!prompts_cap.list_changed);
+    assert!(no_notif_caps.logging.is_none());
+
+    // Everything registered, notification channel attached: every capability
+    // is advertised and every `list_changed` flag, plus logging, is true.
+    let with_notifications = router_with_all_capabilities(true);
+    let notif_caps = with_notifications.capabilities();
+    let tools_cap = notif_caps.tools.expect("tool registered");
+    assert!(tools_cap.list_changed);
+    let resources_cap = notif_caps.resources.expect("resource registered");
+    assert!(resources_cap.list_changed);
+    assert!(resources_cap.subscribe);
+    let prompts_cap = notif_caps.prompts.expect("prompt registered");
+    assert!(prompts_cap.list_changed);
+    assert!(notif_caps.logging.is_some());
+}
+
 #[tokio::test]
 async fn test_completion_handler() {
     let router = McpRouter::new()

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -3656,6 +3656,116 @@ fn capability_defaults_are_unchanged_by_per_capability_builders() {
     assert!(notif_caps.logging.is_some());
 }
 
+/// #1338: `tools_list_changed` overrides the notification-channel default in
+/// either direction, whether or not a channel is attached.
+#[test]
+fn tools_list_changed_overrides_the_notification_channel_default() {
+    for with_channel in [false, true] {
+        for advertise in [true, false] {
+            let router = router_with_all_capabilities(with_channel).tools_list_changed(advertise);
+            let tools_cap = router.capabilities().tools.expect("tool registered");
+            assert_eq!(
+                tools_cap.list_changed, advertise,
+                "with_channel={with_channel} advertise={advertise}"
+            );
+        }
+    }
+}
+
+/// #1338: `prompts_list_changed` overrides the notification-channel default
+/// in either direction, whether or not a channel is attached.
+#[test]
+fn prompts_list_changed_overrides_the_notification_channel_default() {
+    for with_channel in [false, true] {
+        for advertise in [true, false] {
+            let router = router_with_all_capabilities(with_channel).prompts_list_changed(advertise);
+            let prompts_cap = router.capabilities().prompts.expect("prompt registered");
+            assert_eq!(
+                prompts_cap.list_changed, advertise,
+                "with_channel={with_channel} advertise={advertise}"
+            );
+        }
+    }
+}
+
+/// #1338: `resources_list_changed` overrides the notification-channel
+/// default in either direction, whether or not a channel is attached, and is
+/// independent of `resource_subscriptions`.
+#[test]
+fn resources_list_changed_overrides_the_notification_channel_default() {
+    for with_channel in [false, true] {
+        for advertise in [true, false] {
+            let router =
+                router_with_all_capabilities(with_channel).resources_list_changed(advertise);
+            let resources_cap = router
+                .capabilities()
+                .resources
+                .expect("resource registered");
+            assert_eq!(
+                resources_cap.list_changed, advertise,
+                "with_channel={with_channel} advertise={advertise}"
+            );
+            // Independent of resources.listChanged: subscribe keeps its own
+            // default regardless of this setting.
+            assert!(resources_cap.subscribe);
+        }
+    }
+}
+
+/// #1338: `mcp_logging` overrides the notification-channel default in either
+/// direction, whether or not a channel is attached.
+#[test]
+fn mcp_logging_overrides_the_notification_channel_default() {
+    for with_channel in [false, true] {
+        for advertise in [true, false] {
+            let router = router_with_all_capabilities(with_channel).mcp_logging(advertise);
+            assert_eq!(
+                router.capabilities().logging.is_some(),
+                advertise,
+                "with_channel={with_channel} advertise={advertise}"
+            );
+        }
+    }
+}
+
+/// #1338: the four per-capability builders and
+/// `StdioTransport::without_server_notifications` (#1257) compose sensibly.
+///
+/// `without_server_notifications` never attaches a notification channel to
+/// the router, so on the router side its effect is identical to simply not
+/// calling `with_notification_sender`. A server built on top of it still
+/// gets the same all-or-nothing default (nothing advertised), but an
+/// explicit per-capability override still wins, exactly as it does with a
+/// channel attached. The all-or-nothing switch is the default; the builders
+/// are the refinement underneath it, not something it disables.
+#[test]
+fn without_server_notifications_composes_with_explicit_overrides() {
+    // No notification channel attached (what `without_server_notifications`
+    // produces on the router): every flag defaults to false, matching the
+    // "nothing advertised" behavior of the all-or-nothing switch.
+    let router = router_with_all_capabilities(false);
+    let caps = router.capabilities();
+    assert!(!caps.tools.expect("tool registered").list_changed);
+    assert!(!caps.prompts.expect("prompt registered").list_changed);
+    assert!(!caps.resources.expect("resource registered").list_changed);
+    assert!(caps.logging.is_none());
+
+    // An explicit override still wins even though no channel is attached:
+    // the flag is advertised, even though nothing will ever be sent over a
+    // channel that does not exist. That is the caller's responsibility once
+    // they have opted in explicitly.
+    let router = router_with_all_capabilities(false)
+        .tools_list_changed(true)
+        .prompts_list_changed(true)
+        .resources_list_changed(true)
+        .mcp_logging(true);
+    let caps = router.capabilities();
+    assert!(caps.tools.expect("tool registered").list_changed);
+    assert!(caps.prompts.expect("prompt registered").list_changed);
+    assert!(caps.resources.expect("resource registered").list_changed);
+    assert!(caps.logging.is_some());
+}
+
 #[tokio::test]
 async fn test_completion_handler() {
     let router = McpRouter::new()


### PR DESCRIPTION
Implements #1338. Draft opened before work starts; the commit stream is the implementation. See the issue for the authoritative spec.