### PR TITLE
ci: teach the version-drift scanner to fix what it finds (closes #1339)

### DIFF
--- a/crates/tower-mcp/tests/version_drift.rs
+++ b/crates/tower-mcp/tests/version_drift.rs
@@ -19,7 +19,22 @@
 //! That last one is deliberate. If a migration guide ever needs to show an old
 //! snippet, write it as prose rather than as a copyable dependency line,
 //! because a code block a reader can paste should never carry a stale version.
+//!
+//! # Fixing the drift
+//!
+//! ```text
+//! TOWER_MCP_FIX_VERSION_DRIFT=1 cargo test -p tower-mcp --test version_drift
+//! ```
+//!
+//! rewrites every site instead of reporting it. The list this produces cannot
+//! be acted on ahead of time, which is why it is worth automating: the check
+//! compares each declaration against the current `[workspace.package] version`,
+//! so moving the snippets forward on `main` fails the same assertion that
+//! leaving them behind fails. They are only correct inside the release commit
+//! itself, and that commit has been written by hand three releases running
+//! (#1339).
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 /// Crates published from this workspace.
@@ -27,6 +42,22 @@ use std::path::{Path, PathBuf};
 /// A declaration of any of them has to track the workspace version, because
 /// they are all released together off one `[workspace.package] version`.
 const OWN_CRATES: &[&str] = &["tower-mcp", "tower-mcp-types", "tower-mcp-macros"];
+
+/// Rust constants that carry the release line.
+///
+/// codegen-mcp interpolates `TOWER_MCP_RELEASE_LINE` into the manifest of every
+/// project it generates, which makes it a dependency declaration in everything
+/// but syntax. It is the one site the scan above cannot see, because it is a
+/// Rust constant rather than TOML, and it used to be caught only by its own
+/// guard test next to the definition. That guard reports the drift a release
+/// has already hit; carrying the constant here instead means one failure lists
+/// every edit and one command makes them.
+const RELEASE_LINE_CONSTANTS: &[&str] = &["TOWER_MCP_RELEASE_LINE"];
+
+/// Whether this run rewrites what it finds instead of reporting it.
+fn fixing() -> bool {
+    std::env::var_os("TOWER_MCP_FIX_VERSION_DRIFT").is_some_and(|value| value != "0")
+}
 
 /// Extensions worth reading.
 ///
@@ -67,52 +98,171 @@ fn dependency_declarations_name_the_current_release_line() {
     let expected = release_line(&workspace_version)
         .unwrap_or_else(|| panic!("workspace version {workspace_version} is not major.minor"));
 
-    let mut checked = Vec::new();
-    let mut offenders = Vec::new();
-    for file in scannable_files(&root) {
-        let Ok(source) = std::fs::read_to_string(&file) else {
-            continue;
-        };
-        let relative = file
-            .strip_prefix(&root)
-            .unwrap_or(&file)
-            .display()
-            .to_string();
-        for found in declarations(&source) {
-            let at = format!("{relative}:{}", found.line);
-            match release_line(&found.requirement) {
-                Some(line) if line == expected => checked.push(at),
-                _ => offenders.push(format!(
-                    "  {at}: {} names {}, expected {expected}",
-                    found.name, found.requirement
-                )),
-            }
-        }
-    }
+    let found = scan(&root, &expected);
 
     // A scan that silently matches nothing would pass forever. The README
     // install snippet is the reference this exists to protect, so its absence
     // means the parser broke rather than that the drift is gone.
     assert!(
-        checked
-            .iter()
-            .chain(&offenders)
-            .any(|at| at.contains("README.md")),
+        found.saw_readme(),
         "no dependency declaration found in README.md, so the scan is broken \
          rather than clean. Check declarations() against the install snippet."
     );
 
+    if fixing() {
+        let rewritten = rewrite(&found.drifted, &expected);
+
+        // Rewriting from stale offsets would corrupt a file rather than fix
+        // it, so the result is re-derived from the tree rather than assumed.
+        let after = scan(&root, &expected);
+        assert!(
+            after.drifted.is_empty(),
+            "the rewrite left {} declaration(s) drifted, so it is wrong rather \
+             than the tree clean:\n{}",
+            after.drifted.len(),
+            report(&after.drifted, &expected),
+        );
+
+        // Only visible under `-- --nocapture`, because a passing test captures
+        // its output. `git diff` is the authoritative report either way.
+        println!("{rewritten}");
+        return;
+    }
+
     assert!(
-        offenders.is_empty(),
+        found.drifted.is_empty(),
         "dependency declarations drifted from the {expected} release line:\n{}\n\n\
          The expected line is the major.minor of `[workspace.package] version` \
          in the root Cargo.toml ({workspace_version}). Every declaration above \
          is a snippet a reader can copy, so each one has to name {expected}. \
-         Update them, and the codegen-mcp TOWER_MCP_RELEASE_LINE constant with \
-         them. {} other declarations already match.",
-        offenders.join("\n"),
-        checked.len(),
+         {} other declarations already match.\n\n\
+         Rewrite them with:\n\
+         \x20 TOWER_MCP_FIX_VERSION_DRIFT=1 cargo test -p tower-mcp --test version_drift",
+        report(&found.drifted, &expected),
+        found.matching.len(),
     );
+}
+
+/// One version literal, and where it was found.
+struct Site {
+    file: PathBuf,
+    /// Path as a reader would cite it, relative to the repository root.
+    relative: String,
+    found: Declaration,
+}
+
+/// What a pass over the repository found.
+#[derive(Default)]
+struct Scan {
+    /// `file:line` of every declaration that already names the current line.
+    matching: Vec<String>,
+    drifted: Vec<Site>,
+}
+
+impl Scan {
+    /// Whether the README install snippet was seen at all, drifted or not.
+    fn saw_readme(&self) -> bool {
+        self.matching.iter().any(|at| at.contains("README.md"))
+            || self
+                .drifted
+                .iter()
+                .any(|site| site.relative.contains("README.md"))
+    }
+}
+
+/// Every version literal in the repository, split by whether it names
+/// `expected`.
+fn scan(root: &Path, expected: &str) -> Scan {
+    let mut scan = Scan::default();
+    for file in scannable_files(root) {
+        let Ok(source) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        let relative = file
+            .strip_prefix(root)
+            .unwrap_or(&file)
+            .display()
+            .to_string();
+        for found in sites(&source) {
+            match release_line(&found.requirement) {
+                Some(line) if line == expected => {
+                    scan.matching.push(format!("{relative}:{}", found.line));
+                }
+                _ => scan.drifted.push(Site {
+                    file: file.clone(),
+                    relative: relative.clone(),
+                    found,
+                }),
+            }
+        }
+    }
+    scan
+}
+
+/// The drifted sites as an edit list.
+fn report(drifted: &[Site], expected: &str) -> String {
+    drifted
+        .iter()
+        .map(|site| {
+            format!(
+                "  {}:{}: {} names {}, expected {expected}",
+                site.relative, site.found.line, site.found.name, site.found.requirement
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Rewrite every drifted literal to `expected`, and describe what changed.
+///
+/// A rewrite keeps any leading comparator and drops any patch component, so
+/// `^0.21.1` becomes `^0.22`. That is the spelling this repository uses
+/// everywhere, and it is the only one a rewrite can produce safely: the patch
+/// releases of a line that is just opening do not exist yet.
+fn rewrite(drifted: &[Site], expected: &str) -> String {
+    let mut by_file: BTreeMap<&Path, Vec<&Site>> = BTreeMap::new();
+    for site in drifted {
+        by_file.entry(&site.file).or_default().push(site);
+    }
+
+    let mut described = Vec::new();
+    for (file, mut sites) in by_file {
+        let mut source = std::fs::read_to_string(file).expect("re-read a scanned file");
+
+        // Back to front, so replacing one literal cannot move the offset of
+        // another still to be replaced.
+        sites.sort_by_key(|site| std::cmp::Reverse(site.found.start));
+        for site in &sites {
+            let found = &site.found;
+            let end = found.start + found.requirement.len();
+            assert_eq!(
+                source.get(found.start..end),
+                Some(found.requirement.as_str()),
+                "{}:{} moved between the scan and the rewrite",
+                site.relative,
+                found.line,
+            );
+            let replacement = format!("{}{expected}", comparator(&found.requirement));
+            described.push(format!(
+                "  {}:{}: {} -> {replacement}",
+                site.relative, found.line, found.requirement
+            ));
+            source.replace_range(found.start..end, &replacement);
+        }
+        std::fs::write(file, source).expect("write a rewritten file");
+    }
+
+    described.sort();
+    format!(
+        "rewrote {} declaration(s) to the {expected} release line:\n{}",
+        described.len(),
+        described.join("\n"),
+    )
+}
+
+/// The leading semver comparator of `requirement`, which a rewrite keeps.
+fn comparator(requirement: &str) -> &str {
+    &requirement[..requirement.len() - strip_comparator(requirement).len()]
 }
 
 /// Repository root, if this checkout has one.
@@ -219,9 +369,73 @@ fn walk_files(root: &Path) -> Vec<PathBuf> {
 struct Declaration {
     /// One-based line of the version literal, which is the line to edit.
     line: usize,
+    /// Byte offset of the literal's first character, which is where a rewrite
+    /// starts. The line alone is enough to report a site but not to change one:
+    /// several declarations can share a line, and the version is rarely the
+    /// only thing on it.
+    start: usize,
     name: String,
     /// The literal as written, comparator and all: `0.21`, `^0.21.1`.
     requirement: String,
+}
+
+/// Every version literal in `source`, from either syntax.
+fn sites(source: &str) -> Vec<Declaration> {
+    let mut found = declarations(source);
+    found.extend(constant_declarations(source));
+    found.sort_by_key(|found| found.start);
+    found
+}
+
+/// Every release-line constant defined in `source`.
+///
+/// Only the definition counts. The constant's other appearances (interpolated
+/// into a template, asserted against in its own guard, named in a doc comment)
+/// carry no literal to compare or rewrite, and are told apart by exactly that:
+/// a definition assigns a quoted string on the name's own line.
+fn constant_declarations(source: &str) -> Vec<Declaration> {
+    let mut found = Vec::new();
+    for name in RELEASE_LINE_CONSTANTS {
+        let mut cursor = 0;
+        while let Some(offset) = source[cursor..].find(name) {
+            let start = cursor + offset;
+            cursor = start + name.len();
+
+            if source[..start]
+                .chars()
+                .next_back()
+                .is_some_and(is_name_char)
+            {
+                continue;
+            }
+            let rest = &source[cursor..];
+            if rest.starts_with(is_name_char) {
+                continue;
+            }
+
+            // The type annotation sits between the name and the `=`, so this
+            // looks along the line rather than at what immediately follows.
+            let line = &rest[..rest.find('\n').unwrap_or(rest.len())];
+            let Some(equals) = line.find('=') else {
+                continue;
+            };
+            let value = &line[equals + 1..];
+            let padding = value.len() - value.trim_start_matches([' ', '\t']).len();
+            let Some(literal) = quoted(&value[padding..]) else {
+                continue;
+            };
+
+            // +1 for the opening quote.
+            let start = cursor + equals + 1 + padding + 1;
+            found.push(Declaration {
+                line: line_of(source, start),
+                start,
+                name: (*name).to_string(),
+                requirement: literal.to_string(),
+            });
+        }
+    }
+    found
 }
 
 /// Every dependency declaration in `source` that names one of our crates with
@@ -259,8 +473,11 @@ fn declarations(source: &str) -> Vec<Declaration> {
             if !strip_comparator(requirement).starts_with(|c: char| c.is_ascii_digit()) {
                 continue;
             }
+            // `requirement_at` points at the opening quote; +1 is the literal.
+            let start = cursor + offset + 1;
             found.push(Declaration {
-                line: line_of(source, cursor + offset),
+                line: line_of(source, start),
+                start,
                 name: (*name).to_string(),
                 requirement: requirement.to_string(),
             });
@@ -512,6 +729,57 @@ mod parsing {
         assert_eq!(release_line("0.21.1").as_deref(), Some("0.21"));
         assert_eq!(release_line("=1.0.0").as_deref(), Some("1.0"));
         assert_eq!(release_line("1"), None);
+    }
+
+    /// Every site is rewritten by byte offset, so an offset that points
+    /// anywhere but at the literal would corrupt the file it meant to fix.
+    #[test]
+    fn the_offset_points_at_the_literal() {
+        for source in [
+            r#"tower-mcp = "0.21""#,
+            r#"tower-mcp = { version = "0.21", features = ["http"] }"#,
+            "//! tower-mcp = \"0.21\"\n",
+            "tower-mcp = {\n  version = \"0.21\",\n}",
+            r#"const TOWER_MCP_RELEASE_LINE: &str = "0.21";"#,
+        ] {
+            let found = sites(source);
+            assert_eq!(found.len(), 1, "expected one site in {source:?}");
+            let found = &found[0];
+            assert_eq!(
+                &source[found.start..found.start + found.requirement.len()],
+                found.requirement,
+                "offset {} does not land on the literal in {source:?}",
+                found.start,
+            );
+        }
+    }
+
+    #[test]
+    fn a_release_line_constant_is_a_declaration() {
+        let found = sites(r#"const TOWER_MCP_RELEASE_LINE: &str = "0.21";"#);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "TOWER_MCP_RELEASE_LINE");
+        assert_eq!(found[0].requirement, "0.21");
+    }
+
+    /// The constant is named several more times in the same file it is defined
+    /// in. None of those carry a literal, and rewriting one would produce code
+    /// that does not compile.
+    #[test]
+    fn other_appearances_of_the_constant_declare_none() {
+        assert!(sites("        tower_mcp_release_line = TOWER_MCP_RELEASE_LINE,\n").is_empty());
+        assert!(sites("assert_eq!(TOWER_MCP_RELEASE_LINE, workspace_release_line());").is_empty());
+        assert!(sites(r#"format!("tower-mcp = \"{TOWER_MCP_RELEASE_LINE}\"")"#).is_empty());
+        assert!(sites("/// `TOWER_MCP_RELEASE_LINE` is the one version reference\n").is_empty());
+    }
+
+    /// A rewrite normalizes to a plain `major.minor`, because the patch
+    /// releases of a line that is just opening do not exist yet.
+    #[test]
+    fn a_rewrite_keeps_the_comparator_and_drops_the_patch() {
+        assert_eq!(comparator("0.21"), "");
+        assert_eq!(comparator("^0.21.1"), "^");
+        assert_eq!(comparator(">=0.21"), ">=");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Give `version_drift` a write mode, so the release-line pass becomes one command instead of a hand edit across every copyable snippet in the repository.

## Why

The scanner already locates every site precisely and its failure output is effectively the edit list, but acting on that list is manual. The edits cannot be made ahead of time: the guard compares every declaration against the current `[workspace.package] version`, so moving the snippets forward on main fails the same test that leaving them behind fails. Every release therefore repeats the same pass, and it has been missed three releases running (`cd4b7b7`, `20bdf42`, `01ea78b`). For 0.22 it was 11 edits across 6 files.

## Plan

- record the byte offset of each version literal, not just its line, so a rewrite can be precise
- add `TOWER_MCP_FIX_VERSION_DRIFT=1`, which rewrites every drifted declaration to the current line and re-scans to prove the rewrite landed
- bring codegen-mcp's `TOWER_MCP_RELEASE_LINE` constant into the same scan, since it is a dependency declaration in everything but syntax and is the one site the workspace scan could not see
- name the fix command in the failure message

Closes #1339.