### PR TITLE
fix(transport): route transport error responses through the disclosure policy (closes #1354)

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -273,6 +273,10 @@ impl PanicPolicy {
     ///
     /// The tool-name switches are deliberately not consulted. They select how
     /// to name a tool, and there is no tool here to name.
+    ///
+    /// Gated with its caller. Widen the gate when a second transport adopts
+    /// [`McpRouter::transport_internal_error`].
+    #[cfg(feature = "websocket")]
     fn internal_error_message(&self, error: &dyn std::fmt::Display) -> String {
         match &self.client_message {
             ClientPanicMessage::Detailed => error.to_string(),
@@ -3025,6 +3029,11 @@ impl McpRouter {
     /// is both the behaviour these paths already had and the stance the crate
     /// takes elsewhere: a panic is not caught at all until `catch_panics` asks
     /// for it.
+    ///
+    /// Gated on `websocket` because that is where the two sites are. Widen the
+    /// gate rather than duplicating the decision when another transport needs
+    /// it, which is the whole point of it being one helper.
+    #[cfg(feature = "websocket")]
     pub(crate) fn transport_internal_error(&self, error: &dyn std::fmt::Display) -> JsonRpcError {
         match &self.inner.panic_policy {
             Some(policy) => JsonRpcError::internal_error(policy.internal_error_message(error)),

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -261,6 +261,24 @@ impl PanicPolicy {
     fn needs_payload(&self) -> bool {
         matches!(self.client_message, ClientPanicMessage::Detailed) || self.include_payload_in_logs
     }
+
+    /// The client-visible text for an internal failure that is not a caught
+    /// tool panic.
+    ///
+    /// A transport that builds its own error response has no tool to name and
+    /// no panic payload to redact, so it cannot use `client_message`. The
+    /// operator's disclosure choice still applies: a policy installed to keep
+    /// internal text away from clients should not be bypassed because the
+    /// failure happened while framing a response rather than inside a handler.
+    ///
+    /// The tool-name switches are deliberately not consulted. They select how
+    /// to name a tool, and there is no tool here to name.
+    fn internal_error_message(&self, error: &dyn std::fmt::Display) -> String {
+        match &self.client_message {
+            ClientPanicMessage::Detailed => error.to_string(),
+            ClientPanicMessage::Fixed(message) => message.to_string(),
+        }
+    }
 }
 
 /// The Task operation whose failure is being exposed to a client.
@@ -2990,6 +3008,28 @@ impl McpRouter {
 
         Self::log_caught_panic(logged_tool, logged_payload, task_id);
         policy.client_message(tool_name, payload.as_deref())
+    }
+
+    /// Build the JSON-RPC error a transport sends for an internal failure of
+    /// its own, honouring the configured disclosure policy.
+    ///
+    /// A transport that hand-builds an error response is outside every path
+    /// that consults [`PanicPolicy`], so before this existed it sent the
+    /// error's `Display` text whatever the operator had configured (#1354).
+    /// Routing the two websocket sites through one helper rather than
+    /// widening the panic path is what keeps the next transport from
+    /// reintroducing the gap: the previous round of this, #1335, fixed one of
+    /// a pair of near-identical sites and left the other to drift.
+    ///
+    /// With no policy installed the error's text is returned unchanged, which
+    /// is both the behaviour these paths already had and the stance the crate
+    /// takes elsewhere: a panic is not caught at all until `catch_panics` asks
+    /// for it.
+    pub(crate) fn transport_internal_error(&self, error: &dyn std::fmt::Display) -> JsonRpcError {
+        match &self.inner.panic_policy {
+            Some(policy) => JsonRpcError::internal_error(policy.internal_error_message(error)),
+            None => JsonRpcError::internal_error(error.to_string()),
+        }
     }
 
     fn log_caught_panic(tool_name: Option<&str>, payload: Option<&str>, task_id: Option<&str>) {

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -1874,6 +1874,7 @@ fn panic_policy_debug_does_not_disclose_its_fixed_client_message() {
 /// #1354: a transport that hand-builds an error response used to send the
 /// error's `Display` text whatever the operator had configured, because the
 /// disclosure policy was reachable only from the caught-panic path.
+#[cfg(feature = "websocket")]
 #[test]
 fn a_redacted_policy_covers_transport_errors_too() {
     let leaky = Error::internal("connection to db-primary.internal:5432 refused");
@@ -1887,6 +1888,7 @@ fn a_redacted_policy_covers_transport_errors_too() {
 /// Without a policy the text passes through, which is both what these paths
 /// already did and the stance taken for panics: nothing is caught until
 /// `catch_panics` asks for it.
+#[cfg(feature = "websocket")]
 #[test]
 fn transport_errors_are_unchanged_without_a_policy() {
     let failure = Error::internal("serialization failed");
@@ -1908,6 +1910,7 @@ fn transport_errors_are_unchanged_without_a_policy() {
 /// The tool-name switches select how to name a tool. A transport-level
 /// failure has none, so a policy that would have prefixed `tool 'x':` onto a
 /// panic must not invent one here.
+#[cfg(feature = "websocket")]
 #[test]
 fn a_transport_error_is_not_attributed_to_a_tool() {
     let router = McpRouter::new().catch_panics_with(

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -1871,6 +1871,55 @@ fn panic_policy_debug_does_not_disclose_its_fixed_client_message() {
     assert!(!debug.contains("private incident text"), "{debug}");
 }
 
+/// #1354: a transport that hand-builds an error response used to send the
+/// error's `Display` text whatever the operator had configured, because the
+/// disclosure policy was reachable only from the caught-panic path.
+#[test]
+fn a_redacted_policy_covers_transport_errors_too() {
+    let leaky = Error::internal("connection to db-primary.internal:5432 refused");
+
+    let router = McpRouter::new().catch_panics_with(PanicPolicy::redacted("internal error"));
+    let error = router.transport_internal_error(&leaky);
+    assert_eq!(error.message, "internal error");
+    assert!(!error.message.contains("db-primary.internal"));
+}
+
+/// Without a policy the text passes through, which is both what these paths
+/// already did and the stance taken for panics: nothing is caught until
+/// `catch_panics` asks for it.
+#[test]
+fn transport_errors_are_unchanged_without_a_policy() {
+    let failure = Error::internal("serialization failed");
+
+    let router = McpRouter::new();
+    assert_eq!(
+        router.transport_internal_error(&failure).message,
+        failure.to_string()
+    );
+
+    // `catch_panics` is the detailed policy, so it discloses too.
+    let detailed = McpRouter::new().catch_panics();
+    assert_eq!(
+        detailed.transport_internal_error(&failure).message,
+        failure.to_string()
+    );
+}
+
+/// The tool-name switches select how to name a tool. A transport-level
+/// failure has none, so a policy that would have prefixed `tool 'x':` onto a
+/// panic must not invent one here.
+#[test]
+fn a_transport_error_is_not_attributed_to_a_tool() {
+    let router = McpRouter::new().catch_panics_with(
+        PanicPolicy::redacted("internal error")
+            .include_tool_name_in_client_message(true)
+            .client_tool_name("provider tool"),
+    );
+    let error = router.transport_internal_error(&Error::internal("boom"));
+    assert_eq!(error.message, "internal error");
+    assert!(!error.message.contains("provider tool"));
+}
+
 /// #1208: the full task input round trip. The handler asks, the task
 /// parks in `input_required` carrying the requests, the client answers
 /// with `tasks/update`, the router re-invokes the handler with the

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -87,7 +87,7 @@ use crate::context::{
     ChannelClientRequester, ClientRequesterHandle, OutgoingRequest, OutgoingRequestReceiver,
     OutgoingRequestSender, outgoing_request_channel,
 };
-use crate::error::{Error, JsonRpcError, Result};
+use crate::error::{Error, Result};
 use crate::jsonrpc::JsonRpcService;
 use crate::protocol::{
     JsonRpcMessage, JsonRpcNotification, JsonRpcRequest, JsonRpcResponse, McpNotification,
@@ -794,7 +794,7 @@ async fn handle_socket_simple(
                         tracing::error!(error = %e, "Error processing message");
                         let error_response = JsonRpcResponse::error(
                             None,
-                            JsonRpcError::internal_error(e.to_string()),
+                            session.router.transport_internal_error(&e),
                         );
                         if let Ok(json) = serde_json::to_string(&error_response) {
                             let _ = sender.send(Message::Text(json.into())).await;
@@ -1052,13 +1052,13 @@ where
         Ok(response) => send_response(&sender, &response).await?,
         Err(e) => {
             tracing::error!(error = %e, "Error processing message");
-            // `e` here is a transport/serialization failure, not a caught
-            // tool panic, so the disclosure policy in `router.rs` (#1309)
-            // does not apply to it and its methods are private to that
-            // module regardless. `e.to_string()` is left as-is rather than
-            // inventing a second disclosure rule for this path.
+            // `e` here is a transport or serialization failure rather than a
+            // caught tool panic, so it carries no tool name and no panic
+            // payload. The operator's disclosure choice still governs what
+            // reaches the client, which is what the router helper applies
+            // (#1354).
             let error_response =
-                JsonRpcResponse::error(request_id, JsonRpcError::internal_error(e.to_string()));
+                JsonRpcResponse::error(request_id, router.transport_internal_error(&e));
             let _ = send_response(&sender, &error_response).await;
         }
     }


### PR DESCRIPTION
## Summary

Give transports one helper for building an internal-error response, and make it consult the configured `PanicPolicy`. Apply it to both websocket sites at once.

## Why

#1309 added `PanicPolicy` so internal failure text is not returned to a client by default, but the two methods that decide what a client sees are private to `router.rs` and reachable only from `handle_caught_panic`. A transport that builds an error response by hand cannot consult the policy, and two do:

- `transport/websocket.rs`, the `handle_socket_simple` loop
- `transport/websocket.rs`, the `handle_socket_bidirectional` loop

Both send `JsonRpcError::internal_error(e.to_string())` regardless of what the operator configured.

## Approach

Of the three options in the issue, this is the third: a shared helper. It is the only one that stops the next transport from reintroducing the gap, which is how #1335 happened. Both sites already hold an `&McpRouter`, so the helper hangs off the router and every transport can reach it.

The panic path is left alone. `client_message` keeps its tool-shaped signature, because a caught panic genuinely has a tool and a transport serialization failure genuinely does not; the shared disclosure decision is factored out rather than the panic formatting widened.

## Reachability

As the issue states, neither site is realistically reachable today. This closes a policy that did not cover what it appeared to cover, rather than a live leak.

Closes #1354.