### PR TITLE
fix(oauth): match cache-control directives case-insensitively (closes #1358)

### DIFF
--- a/crates/tower-mcp/src/ascii.rs
+++ b/crates/tower-mcp/src/ascii.rs
@@ -1,0 +1,78 @@
+//! ASCII case-insensitive matching for wire tokens.
+//!
+//! HTTP defines a number of tokens as case-insensitive: authentication scheme
+//! names (RFC 9110 section 11.1) and cache directive names (RFC 9111 section
+//! 5.2) among them. A peer is free to send `BEARER` or `Max-Age`, and a server
+//! that compares by exact bytes silently fails to recognize either.
+//!
+//! This module exists because that comparison was written by hand three
+//! separate times before anyone shared it: `auth.rs` (#1276, fixed in #1289),
+//! `oauth/middleware.rs` (#1337, fixed in #1342), and `oauth/token.rs`
+//! (#1358). Each was found on its own, after the previous one had been fixed.
+
+/// `s` with `prefix` removed, comparing ASCII case-insensitively.
+///
+/// `None` when `s` does not start with `prefix`. Only ASCII case is folded,
+/// which is what the specifications above call for; a token is ASCII by
+/// definition, and folding Unicode case here would accept input the grammar
+/// does not.
+///
+/// This is a prefix match and nothing more. A caller that needs the token to
+/// end at a delimiter, the way an auth scheme has to be followed by a space so
+/// that `Bearerish` does not match `Bearer`, has to check the remainder
+/// itself; [`crate::auth::strip_scheme`] is that check on top of this.
+pub(crate) fn strip_prefix_ignore_ascii_case<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    // `get` rather than slicing: `prefix.len()` can land inside a multi-byte
+    // character, and a header is arbitrary peer input.
+    let head = s.get(..prefix.len())?;
+    head.eq_ignore_ascii_case(prefix)
+        .then(|| &s[prefix.len()..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_prefix_matches_in_any_ascii_case() {
+        for prefix in ["max-age=", "MAX-AGE=", "Max-Age=", "mAx-AgE="] {
+            assert_eq!(
+                strip_prefix_ignore_ascii_case(&format!("{prefix}300"), "max-age="),
+                Some("300"),
+                "{prefix} should match"
+            );
+        }
+    }
+
+    #[test]
+    fn a_different_prefix_does_not_match() {
+        assert_eq!(strip_prefix_ignore_ascii_case("no-cache", "max-age="), None);
+        assert_eq!(strip_prefix_ignore_ascii_case("", "Bearer"), None);
+    }
+
+    /// The match is a prefix match, so the caller is the one that decides
+    /// whether the token ended where it should have.
+    #[test]
+    fn the_remainder_is_returned_unexamined() {
+        assert_eq!(
+            strip_prefix_ignore_ascii_case("Bearerish", "Bearer"),
+            Some("ish")
+        );
+        assert_eq!(strip_prefix_ignore_ascii_case("Bearer", "Bearer"), Some(""));
+    }
+
+    /// A header is arbitrary peer input, so the prefix length can fall inside
+    /// a multi-byte character. That is a non-match, not a panic.
+    #[test]
+    fn a_prefix_ending_inside_a_character_does_not_match() {
+        assert_eq!(strip_prefix_ignore_ascii_case("é", "ma"), None);
+        assert_eq!(strip_prefix_ignore_ascii_case("mé", "max"), None);
+    }
+
+    /// Only ASCII case folds. `İ` lowercases to `i` under Unicode rules, and
+    /// accepting it would take input the token grammar does not allow.
+    #[test]
+    fn non_ascii_case_does_not_fold() {
+        assert_eq!(strip_prefix_ignore_ascii_case("İd=1", "id="), None);
+    }
+}

--- a/crates/tower-mcp/src/auth.rs
+++ b/crates/tower-mcp/src/auth.rs
@@ -331,13 +331,11 @@ impl Validate for StaticBearerValidator {
 /// `pub(crate)` so [`crate::oauth::middleware`] can share this implementation
 /// rather than growing a second, divergent copy (#1337).
 pub(crate) fn strip_scheme<'a>(header: &'a str, scheme: &str) -> Option<&'a str> {
-    let rest = header.get(..scheme.len())?;
-    if !rest.eq_ignore_ascii_case(scheme) {
-        return None;
-    }
-    let after = header.get(scheme.len()..)?;
+    let after = crate::ascii::strip_prefix_ignore_ascii_case(header, scheme)?;
     // The scheme must be followed by whitespace, or `Bearerish` would match
-    // `Bearer`.
+    // `Bearer`. That requirement is why the prefix match itself is the shared
+    // helper and this is not: a cache directive is `name=value` and has no
+    // such delimiter (#1358).
     if !after.starts_with(' ') {
         return None;
     }

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -494,6 +494,7 @@
 
 #[cfg(feature = "mcp-apps")]
 pub mod apps;
+mod ascii;
 pub mod async_task;
 pub mod auth;
 pub mod client;

--- a/crates/tower-mcp/src/oauth/token.rs
+++ b/crates/tower-mcp/src/oauth/token.rs
@@ -712,7 +712,9 @@ fn parse_cache_control_max_age(header: Option<&str>) -> Option<std::time::Durati
     let header = header?;
     for directive in header.split(',') {
         let directive = directive.trim();
-        if let Some(value) = directive.strip_prefix("max-age=")
+        // RFC 9111 section 5.2: directive names are case-insensitive tokens,
+        // so `MAX-AGE=300` asks for the same TTL as `max-age=300` (#1358).
+        if let Some(value) = crate::ascii::strip_prefix_ignore_ascii_case(directive, "max-age=")
             && let Ok(seconds) = value.trim().parse::<u64>()
         {
             return Some(std::time::Duration::from_secs(seconds));
@@ -1126,6 +1128,26 @@ mod tests {
             parse_cache_control_max_age(Some("max-age=0")),
             Some(std::time::Duration::from_secs(0))
         );
+    }
+
+    /// #1358: RFC 9111 section 5.2 makes directive names case-insensitive
+    /// tokens. Matching them by exact bytes dropped the server's TTL and fell
+    /// back to the default, silently.
+    #[cfg(feature = "jwks")]
+    #[test]
+    fn cache_control_directives_are_matched_case_insensitively() {
+        for header in [
+            "MAX-AGE=300",
+            "Max-Age=300",
+            "mAx-AgE=300",
+            "public, MAX-AGE=300, must-revalidate",
+        ] {
+            assert_eq!(
+                parse_cache_control_max_age(Some(header)),
+                Some(std::time::Duration::from_secs(300)),
+                "{header} should be honoured"
+            );
+        }
     }
 
     #[cfg(feature = "jwks")]


### PR DESCRIPTION
## Summary

Extract the case-insensitive prefix match that `strip_scheme` already performs into `src/ascii.rs`, rebuild `strip_scheme` on it, and use it for `max-age` in the JWKS cache-control parser.

## Why

RFC 9111 section 5.2 defines cache directive names as case-insensitive tokens. `parse_cache_control_max_age` compared them by exact bytes, so `MAX-AGE=300` and `Max-Age=300` were not recognized and the key cache silently fell back to its default TTL.

This is the third site in the class #1276 opened. The other two are fixed (#1289, #1342). `strip_scheme` could not be reused directly: it requires the whitespace in `Bearer <token>` so that `Bearerish` does not match `Bearer`, and a cache directive is `name=value` with no whitespace. The shared primitive underneath both is the case-insensitive prefix strip, so that is what gets extracted, rather than writing the comparison by hand a third time.

## Scope

- new `src/ascii.rs` with `strip_prefix_ignore_ascii_case`
- `auth.rs`: `strip_scheme` becomes that helper plus its whitespace requirement, with no behavior change
- `oauth/token.rs`: `parse_cache_control_max_age` uses the helper

`jwks` is in the CI feature matrix, so the fix is covered by existing jobs.

Closes #1358.