### PR TITLE
docs: enforce missing_docs on the published crates (closes #1365)

### DIFF
--- a/crates/tower-mcp-macros/src/lib.rs
+++ b/crates/tower-mcp-macros/src/lib.rs
@@ -83,6 +83,11 @@
 //! // Generates `read_file_resource_template() -> tower_mcp::resource::ResourceTemplate`
 //! ```
 
+// Every public item here is documented, and this is what keeps it that way.
+// CI runs clippy with `-D warnings`, so this is a failure there; `warn`
+// rather than `deny` leaves a local build usable mid-edit.
+#![warn(missing_docs)]
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{ItemFn, LitStr, Token, parse_macro_input};

--- a/crates/tower-mcp-types/src/lib.rs
+++ b/crates/tower-mcp-types/src/lib.rs
@@ -111,6 +111,11 @@
 //! [tower-mcp issue #777](https://github.com/joshrotenberg/tower-mcp/issues/777)
 //! for progress on client-side WASM support in the full crate.
 
+// Every public item here is documented, and this is what keeps it that way.
+// CI runs clippy with `-D warnings`, so this is a failure there; `warn`
+// rather than `deny` leaves a local build usable mid-edit.
+#![warn(missing_docs)]
+
 pub mod error;
 pub mod inspection;
 pub mod protocol;

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -492,6 +492,11 @@
 //! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) --
 //!   strict HTTP headers (`Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`)
 
+// Every public item here is documented, and this is what keeps it that way.
+// CI runs clippy with `-D warnings`, so this is a failure there; `warn`
+// rather than `deny` leaves a local build usable mid-edit.
+#![warn(missing_docs)]
+
 #[cfg(feature = "mcp-apps")]
 pub mod apps;
 mod ascii;


### PR DESCRIPTION
## Summary

Add `#![warn(missing_docs)]` to `tower-mcp`, `tower-mcp-types`, and `tower-mcp-macros`.

## Why

All three already document every public item. Nothing enforced it, so the next undocumented `pub` item would have shipped to docs.rs unnoticed. This is a guard around documentation that already exists, not new documentation: the diff is three lines.

`warn` rather than `deny`, because CI runs clippy with `-D warnings` and turns it into a failure there anyway, while a local build stays usable mid-edit.

Scoped to the published crates. A `[workspace.lints]` entry would also cover the examples and tools, which are binaries held to a different bar.

Closes #1365.