### PR TITLE
fix(transport): keep the request id on inspection error responses (closes #1372)

### DIFF
--- a/crates/tower-mcp/src/framing.rs
+++ b/crates/tower-mcp/src/framing.rs
@@ -182,6 +182,151 @@ pub(crate) fn is_response_frame(value: &serde_json::Value) -> bool {
         && (value.get("result").is_some() || value.get("error").is_some())
 }
 
+/// The id an error response should carry back, read straight off the frame.
+///
+/// A receive loop that rejects a frame before typing it still has the id
+/// sitting in front of it, and JSON-RPC 2.0 section 5 requires an error
+/// response to echo the request's id. Answering `null` anyway leaves a client
+/// with more than one request in flight unable to tell which one failed
+/// (#1372).
+///
+/// `None` for the cases where there genuinely is no single id to answer with:
+/// a batch, a notification, and an `id` that is neither of the two JSON-RPC
+/// id types. A batch is deliberately not resolved to its first element's id,
+/// because answering one member's id for a whole-batch rejection would be a
+/// worse lie than answering none.
+pub(crate) fn correlating_id(value: &serde_json::Value) -> Option<crate::protocol::RequestId> {
+    match value.get("id")? {
+        serde_json::Value::String(id) => Some(crate::protocol::RequestId::String(id.clone())),
+        serde_json::Value::Number(id) => id.as_i64().map(crate::protocol::RequestId::Number),
+        _ => None,
+    }
+}
+
+/// The id to answer `error` with, for a frame rejected before it was typed.
+///
+/// Section 5 permits a null id when "there was an error in detecting the id
+/// in the Request object (e.g. Parse error/Invalid Request)". The two halves
+/// of that sentence pull in different directions here, and the split falls on
+/// whether the envelope itself is well formed:
+///
+/// * `-32600 Invalid Request` says the envelope is not a request at all. It is
+///   named in the specification's own parenthetical, and this crate answers
+///   every malformed envelope shape uniformly with a null id whether or not an
+///   `id` happens to be readable out of it. Nothing is correlated to a frame
+///   that was never a valid request.
+/// * Anything else means the envelope parsed as a request and then failed
+///   semantic validation, `-32602` invalid params and `-32022` unsupported
+///   protocol version among them. The id was detected perfectly well, so
+///   section 5's first sentence applies and it has to be echoed (#1372).
+pub(crate) fn error_response_id(
+    value: &serde_json::Value,
+    error: &crate::error::JsonRpcError,
+) -> Option<crate::protocol::RequestId> {
+    const INVALID_REQUEST: i32 = -32600;
+    if error.code == INVALID_REQUEST {
+        return None;
+    }
+    correlating_id(value)
+}
+
+#[cfg(test)]
+mod correlating_id_tests {
+    use super::*;
+    use crate::protocol::RequestId;
+
+    #[test]
+    fn both_json_rpc_id_types_are_read_off_the_frame() {
+        assert_eq!(
+            correlating_id(&serde_json::json!({"id": 42, "method": "tools/list"})),
+            Some(RequestId::Number(42))
+        );
+        assert_eq!(
+            correlating_id(&serde_json::json!({"id": "req-1", "method": "tools/list"})),
+            Some(RequestId::String("req-1".into()))
+        );
+    }
+
+    /// A batch rejection covers every member, so borrowing the first one's id
+    /// would answer a request that may well have been fine.
+    #[test]
+    fn a_batch_has_no_single_id_to_answer_with() {
+        assert_eq!(
+            correlating_id(&serde_json::json!([{"id": 1, "method": "tools/list"}])),
+            None
+        );
+    }
+
+    #[test]
+    fn a_notification_has_no_id() {
+        assert_eq!(
+            correlating_id(&serde_json::json!({"method": "notifications/initialized"})),
+            None
+        );
+    }
+
+    /// An `id` the JSON-RPC grammar does not allow is not an id. Answering
+    /// with `null` is then correct rather than a lost correlation.
+    #[test]
+    fn an_id_of_the_wrong_type_is_not_an_id() {
+        for id in [
+            serde_json::json!(null),
+            serde_json::json!({"nested": 1}),
+            serde_json::json!([1]),
+            serde_json::json!(true),
+        ] {
+            assert_eq!(
+                correlating_id(&serde_json::json!({"id": id, "method": "tools/list"})),
+                None,
+                "{id} is not a JSON-RPC id"
+            );
+        }
+    }
+
+    /// Fractional numbers are not JSON-RPC ids either, and must not silently
+    /// truncate to a different id than the client sent.
+    #[test]
+    fn a_fractional_id_does_not_truncate() {
+        assert_eq!(
+            correlating_id(&serde_json::json!({"id": 1.5, "method": "tools/list"})),
+            None
+        );
+    }
+
+    /// The split the specification's section 5 parenthetical draws. An
+    /// envelope that was never a valid request correlates to nothing, even
+    /// with a perfectly readable id on it.
+    #[test]
+    fn an_invalid_request_answers_with_a_null_id() {
+        let frame = serde_json::json!({"jsonrpc": "2.0", "id": 6});
+        assert_eq!(
+            error_response_id(
+                &frame,
+                &crate::error::JsonRpcError::invalid_request("no method")
+            ),
+            None
+        );
+    }
+
+    /// A valid envelope that failed semantic validation is the other side of
+    /// it: the id was detected, so it has to come back.
+    #[test]
+    fn a_semantic_failure_answers_with_the_id() {
+        let frame = serde_json::json!({"jsonrpc": "2.0", "id": 6, "method": "tools/list"});
+        for error in [
+            crate::error::JsonRpcError::invalid_params("bad _meta"),
+            crate::error::JsonRpcError::internal_error("boom"),
+        ] {
+            assert_eq!(
+                error_response_id(&frame, &error),
+                Some(RequestId::Number(6)),
+                "code {} should correlate",
+                error.code
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tower-mcp/src/jsonrpc.rs
+++ b/crates/tower-mcp/src/jsonrpc.rs
@@ -880,6 +880,9 @@ mod tests {
         };
         assert_eq!(response.error.code, -32602);
         assert!(response.error.message.contains("clientCapabilities"));
+        // As above: unasserted here, and dropped by the transport loops
+        // (#1372).
+        assert_eq!(response.id, Some(crate::protocol::RequestId::Number(1)));
     }
 
     #[cfg(feature = "stateless")]
@@ -904,6 +907,9 @@ mod tests {
             response.error.data.unwrap()["supported"],
             serde_json::json!([crate::protocol::PROTOCOL_VERSION_2026_07_28])
         );
+        // The id was asserted nowhere here, so this path could drop it
+        // silently, and the transport loops did (#1372).
+        assert_eq!(response.id, Some(crate::protocol::RequestId::Number(1)));
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -684,7 +684,7 @@ async fn process_line(
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
         return Ok(Some(JsonRpcResponseMessage::Single(
-            JsonRpcResponse::error(None, error),
+            JsonRpcResponse::error(crate::framing::error_response_id(&parsed, &error), error),
         )));
     }
 
@@ -1656,7 +1656,8 @@ where
         if let Err(error) =
             service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
         {
-            let response = JsonRpcResponse::error(None, error);
+            let response =
+                JsonRpcResponse::error(crate::framing::error_response_id(&parsed, &error), error);
             let _ = out_tx.send(serde_json::to_string(&response)?);
             return Ok(());
         }
@@ -2154,7 +2155,8 @@ impl BidirectionalStdioTransport {
             .service
             .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
         {
-            let response = JsonRpcResponse::error(None, error);
+            let response =
+                JsonRpcResponse::error(crate::framing::error_response_id(&parsed, &error), error);
             return self
                 .write_line(&serde_json::to_string(&response)?, writer)
                 .await;

--- a/crates/tower-mcp/src/transport/websocket.rs
+++ b/crates/tower-mcp/src/transport/websocket.rs
@@ -972,6 +972,11 @@ where
 /// parsed successfully. A batch has no single id to correlate against,
 /// matching what `call_message` itself does for its own within-batch errors
 /// (see the `Err(Error::JsonRpc(error))` arm in `JsonRpcService::call_message`).
+///
+/// This is the typed half of the same question
+/// [`crate::framing::correlating_id`] answers for a frame that has not been
+/// typed yet, which is where a rejection before parsing has to read the id
+/// from (#1372). The two agree, including that a batch resolves to `None`.
 fn correlating_id(message: &JsonRpcMessage) -> Option<RequestId> {
     match message {
         JsonRpcMessage::Single(req) => Some(req.id.clone()),
@@ -1027,7 +1032,11 @@ where
     if let Err(error) =
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
-        return send_response(&sender, &JsonRpcResponse::error(None, error)).await;
+        return send_response(
+            &sender,
+            &JsonRpcResponse::error(crate::framing::error_response_id(&parsed, &error), error),
+        )
+        .await;
     }
 
     // Parse and process as a request (single or batch). The serde error is
@@ -1210,7 +1219,7 @@ async fn process_message(
         service.inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
     {
         return Ok(Some(crate::protocol::JsonRpcResponseMessage::Single(
-            JsonRpcResponse::error(None, error),
+            JsonRpcResponse::error(crate::framing::error_response_id(&parsed, &error), error),
         )));
     }
 

--- a/crates/tower-mcp/tests/error_response_correlation.rs
+++ b/crates/tower-mcp/tests/error_response_correlation.rs
@@ -1,0 +1,176 @@
+//! An error response has to carry the id of the request that caused it.
+//!
+//! JSON-RPC 2.0 section 5 permits a null response id only when the id could
+//! not be detected, "e.g. Parse error/Invalid Request". A frame that parsed
+//! cleanly and then failed semantic validation does not qualify: the id is
+//! sitting right there, and a client with more than one request in flight
+//! needs it to know which request failed.
+//!
+//! The stdio and websocket receive loops inspect the raw frame before typing
+//! it, and answered those failures with `null` (#1372). The same request sent
+//! through `call_single` kept its id, which is why no library-level test saw
+//! this. These drive the real loops.
+
+#![cfg(all(feature = "stateless", feature = "http"))]
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28;
+use tower_mcp::{CallToolResult, McpRouter, ProtocolSupport, StdioTransport, ToolBuilder};
+
+fn router() -> McpRouter {
+    McpRouter::new()
+        .server_info("correlation-test", "1.0.0")
+        .tool(
+            ToolBuilder::new("echo")
+                .description("Echo a value")
+                .read_only()
+                .handler(
+                    |v: serde_json::Value| async move { Ok(CallToolResult::text(v.to_string())) },
+                )
+                .build(),
+        )
+}
+
+/// Drive one frame through the real stdio loop and read the reply.
+async fn over_stdio(frame: serde_json::Value) -> serde_json::Value {
+    let mut transport = StdioTransport::new(router())
+        .protocol_support(ProtocolSupport::try_new([PROTOCOL_VERSION_2026_07_28]).unwrap());
+    let (mut stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, stdout_reader) = tokio::io::duplex(8192);
+    let handle = tokio::spawn(async move {
+        let _ = transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await;
+    });
+
+    stdin_writer
+        .write_all(format!("{frame}\n").as_bytes())
+        .await
+        .unwrap();
+    drop(stdin_writer);
+
+    let mut line = String::new();
+    BufReader::new(stdout_reader)
+        .read_line(&mut line)
+        .await
+        .unwrap();
+    let _ = handle.await;
+    serde_json::from_str(&line).unwrap_or_else(|e| panic!("reply is not JSON ({e}): {line}"))
+}
+
+fn tools_list(id: serde_json::Value, meta: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/list",
+        "params": { "_meta": meta }
+    })
+}
+
+fn supported_meta() -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION_2026_07_28,
+        "io.modelcontextprotocol/clientCapabilities": {}
+    })
+}
+
+/// The control. A request the server accepts echoes its id, so a failure in
+/// the tests below is about the error path rather than about ids generally.
+#[tokio::test]
+async fn a_successful_request_echoes_its_id() {
+    let response = over_stdio(tools_list(serde_json::json!(42), supported_meta())).await;
+    assert_eq!(response["id"], 42);
+    assert!(response.get("result").is_some(), "{response}");
+}
+
+/// #1372 case B: `-32022`, a protocol version the server does not support.
+#[tokio::test]
+async fn an_unsupported_protocol_version_error_keeps_the_id() {
+    let response = over_stdio(tools_list(
+        serde_json::json!(42),
+        serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+            "io.modelcontextprotocol/clientCapabilities": {}
+        }),
+    ))
+    .await;
+
+    assert_eq!(response["error"]["code"], -32022, "{response}");
+    assert_eq!(response["id"], 42, "the id is in the frame: {response}");
+}
+
+/// #1372 case C: `-32602`, a required `_meta` key missing. A different error
+/// path from case B, and it had the same defect.
+#[tokio::test]
+async fn a_missing_meta_key_error_keeps_the_id() {
+    let response = over_stdio(tools_list(
+        serde_json::json!(42),
+        serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": PROTOCOL_VERSION_2026_07_28
+        }),
+    ))
+    .await;
+
+    assert_eq!(response["error"]["code"], -32602, "{response}");
+    assert_eq!(response["id"], 42, "the id is in the frame: {response}");
+}
+
+/// JSON-RPC ids are strings or numbers, and a string id has to survive as a
+/// string rather than being coerced.
+#[tokio::test]
+async fn a_string_id_survives_as_a_string() {
+    let response = over_stdio(tools_list(
+        serde_json::json!("req-abc"),
+        serde_json::json!({
+            "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+            "io.modelcontextprotocol/clientCapabilities": {}
+        }),
+    ))
+    .await;
+
+    assert_eq!(response["error"]["code"], -32022, "{response}");
+    assert_eq!(response["id"], "req-abc", "{response}");
+}
+
+/// The boundary this fix deliberately does not cross. A `-32600` says the
+/// frame was never a valid request, and this crate refuses every malformed
+/// envelope shape uniformly with a null id even when an id is readable
+/// (`adversarial_input.rs`). JSON-RPC 2.0 section 5 names Invalid Request in
+/// exactly that parenthetical.
+#[tokio::test]
+async fn a_structurally_invalid_envelope_still_answers_with_a_null_id() {
+    let response = over_stdio(serde_json::json!({"jsonrpc": "2.0", "id": 6})).await;
+
+    assert_eq!(response["error"]["code"], -32600, "{response}");
+    assert!(
+        response["id"].is_null(),
+        "a frame that was never a request correlates to nothing: {response}"
+    );
+}
+
+/// The other half of the rule. A batch has no single id to answer with, so
+/// `null` is the honest answer rather than one member's id standing in for
+/// the whole rejection.
+#[tokio::test]
+async fn a_rejected_batch_still_answers_with_a_null_id() {
+    let batch = serde_json::json!([
+        tools_list(
+            serde_json::json!(1),
+            serde_json::json!({
+                "io.modelcontextprotocol/protocolVersion": "2025-11-25",
+                "io.modelcontextprotocol/clientCapabilities": {}
+            })
+        ),
+        tools_list(serde_json::json!(2), supported_meta()),
+    ]);
+    let response = over_stdio(batch).await;
+
+    // Whatever the server decides about the batch, it must not claim one
+    // member's id for a reply covering both.
+    if response.get("error").is_some() {
+        assert!(
+            response["id"].is_null(),
+            "a whole-batch rejection cannot borrow a member's id: {response}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

An error response produced by transport-level inspection returned `"id": null` even when the request carried a present, parseable id. Reproduced exactly as reported, on current main.

## Scope: five sites, not one

The report identifies the stdio `process_line` path. Auditing every `inspect_incoming_value` call site turned up five with the same defect:

| Site | Path |
|---|---|
| `stdio.rs:686` | `process_line`, the reported one |
| `stdio.rs:1659` | bidirectional stdio |
| `stdio.rs:2157` | stdio subscriptions |
| `websocket.rs:1034` | bidirectional websocket |
| `websocket.rs:1212` | websocket message handling |

Four further inspection sites are notification paths that correctly send no response at all, and are left alone. HTTP is unaffected: it has no transport-level inspection and reaches the id-preserving path in `process_single_request`.

## Why it only shows up on these transports

`process_single_request` already answers inspection failures with `Some(req.id)` (`jsonrpc.rs:509`). The stdio and websocket loops inspect the raw frame *first*, before it is typed, and return early with `None`. So the same request answered through `call_single` keeps its id and answered through the stdio loop loses it, which is why the library-level tests never saw this.

## Plan

- add a frame-level `correlating_id` to `framing.rs`, the module both transports already share for frame classification
- use it at all five sites
- pin response-id correlation in tests for both the `-32022` and `-32602` paths, and add the id assertions the report notes are missing from the existing stateless error tests

Closes #1372.