### PR TITLE
docs: mark the features deprecated in 2026-07-28 (closes #1371)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ it. The 2026-07-28 build adds sessionless dispatch, `server/discover`,
 `subscriptions/listen`, per-request `_meta`, response-cache hints, Multi Round-Trip
 Requests, and the Tasks extension (opt in with `McpRouter::with_tasks`).
 
+Four of those are Deprecated by the specification as of 2026-07-28 and remain
+supported here: sampling, logging, and roots (SEP-2577), and Dynamic Client
+Registration (superseded by Client ID Metadata Documents, which this crate
+already prefers). They become eligible for removal from the specification in the
+first revision released on or after 2027-07-28. Nothing is scheduled for removal
+from this crate; see the [deprecated
+features](https://docs.rs/tower-mcp/latest/tower_mcp/#deprecated-by-the-specification)
+section for the migration paths.
+
 The [official MCP conformance suite](https://github.com/modelcontextprotocol/conformance)
 runs on every PR in
 [`conformance.yml`](https://github.com/joshrotenberg/tower-mcp/actions/workflows/conformance.yml),

--- a/crates/tower-mcp-types/src/protocol.rs
+++ b/crates/tower-mcp-types/src/protocol.rs
@@ -537,7 +537,19 @@ impl std::fmt::Display for LogLevel {
     }
 }
 
-/// Parameters for logging message notification
+/// Parameters for a `notifications/message` logging notification.
+///
+/// # Deprecated in MCP 2026-07-28
+///
+/// Logging is Deprecated by
+/// [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577),
+/// with an earliest removal of the first specification revision released on
+/// or after **2027-07-28**. `logging/setLevel` is already gone from the
+/// 2026-07-28 lifecycle; a request authorizes log delivery per call through
+/// `_meta`.
+///
+/// The documented migration path is `stderr` for stdio transports, and
+/// [OpenTelemetry](https://opentelemetry.io/) for observability.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoggingMessageParams {
     /// Severity level of the message
@@ -1108,8 +1120,16 @@ pub struct ClientTasksElicitationCapability {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ClientTasksElicitationCreateCapability {}
 
-/// Client capability for roots (filesystem access)
 /// Capabilities related to filesystem roots.
+///
+/// # Deprecated in MCP 2026-07-28
+///
+/// Roots is Deprecated by
+/// [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577),
+/// with an earliest removal of the first specification revision released on
+/// or after **2027-07-28**. The documented migration path is to pass
+/// directories or files through tool parameters, resource URIs, or server
+/// configuration instead.
 ///
 /// When `list_changed` is `true`, the client supports sending
 /// `notifications/roots/list_changed` to inform the server that the
@@ -1525,16 +1545,34 @@ impl ModelPreferences {
     }
 }
 
-/// Context inclusion mode for sampling
+/// Context inclusion mode for sampling.
+///
+/// Only [`None`](IncludeContext::None) survives the `2025-11-25`
+/// deprecation of the other two (SEP-2596). Sampling as a whole is also
+/// Deprecated as of `2026-07-28` (SEP-2577); see [`CreateMessageParams`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum IncludeContext {
-    /// Include context from all connected MCP servers
+    /// Include context from all connected MCP servers.
+    #[deprecated(
+        since = "0.23.0",
+        note = "Deprecated in MCP 2025-11-25 by SEP-2596. Omit the field or use \
+                `IncludeContext::None`. Removal follows Sampling (SEP-2577), \
+                whose earliest removal is the first revision released on or \
+                after 2027-07-28."
+    )]
     AllServers,
-    /// Include context from this server only
+    /// Include context from this server only.
+    #[deprecated(
+        since = "0.23.0",
+        note = "Deprecated in MCP 2025-11-25 by SEP-2596. Omit the field or use \
+                `IncludeContext::None`. Removal follows Sampling (SEP-2577), \
+                whose earliest removal is the first revision released on or \
+                after 2027-07-28."
+    )]
     ThisServer,
-    /// Don't include any additional context
+    /// Don't include any additional context.
     #[default]
     None,
 }
@@ -1828,7 +1866,23 @@ impl SamplingContentOrArray {
     }
 }
 
-/// Parameters for sampling/createMessage request
+/// Parameters for a `sampling/createMessage` request.
+///
+/// # Deprecated in MCP 2026-07-28
+///
+/// Sampling is Deprecated by
+/// [SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577).
+/// It remains part of the specification and is still served here, but new
+/// implementations should not adopt it, and existing ones should migrate
+/// before its earliest removal: the first specification revision released on
+/// or after **2027-07-28**.
+///
+/// The documented migration path is to integrate with an LLM provider's API
+/// directly rather than asking the client to sample on the server's behalf.
+///
+/// Nothing is removed from this crate on that date. Removal from the
+/// specification does not oblige an SDK to drop a feature, and this crate's
+/// own support follows its release policy, not the specification's calendar.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateMessageParams {
@@ -6677,6 +6731,10 @@ mod tests {
         assert_eq!(prefs.cost_priority, Some(0.0)); // Clamped to min
     }
 
+    // The variants are Deprecated, not Removed: a peer may still send
+    // them and they still have to round-trip, so these keep testing
+    // them deliberately.
+    #[allow(deprecated)]
     #[test]
     fn test_include_context_serialization() {
         assert_eq!(
@@ -6734,6 +6792,10 @@ mod tests {
         assert_eq!(json["mimeType"], "image/png");
     }
 
+    // The variants are Deprecated, not Removed: a peer may still send
+    // them and they still have to round-trip, so these keep testing
+    // them deliberately.
+    #[allow(deprecated)]
     #[test]
     fn test_create_message_params() {
         let params = CreateMessageParams::new(

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -491,6 +491,30 @@
 //!   stateless session model, `server/discover`, per-request `_meta`
 //! - [SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/2243) --
 //!   strict HTTP headers (`Mcp-Method`, `Mcp-Name`, `MCP-Protocol-Version`)
+//!
+//! ## Deprecated by the specification
+//!
+//! `2026-07-28` introduced a [feature lifecycle
+//! policy](https://modelcontextprotocol.io/community/feature-lifecycle)
+//! (SEP-2596) and a [registry of what is on its way
+//! out](https://modelcontextprotocol.io/specification/2026-07-28/deprecated).
+//! These are Deprecated, meaning still part of the specification and still
+//! served here, but new code should not adopt them:
+//!
+//! | Feature | SEP | Earliest removal | Migration |
+//! |---|---|---|---|
+//! | Roots | SEP-2577 | 2027-07-28 | tool parameters, resource URIs, or server configuration |
+//! | Sampling | SEP-2577 | 2027-07-28 | integrate with an LLM provider's API directly |
+//! | Logging | SEP-2577 | 2027-07-28 | `stderr` for stdio; OpenTelemetry for observability |
+//! | Dynamic Client Registration | PR #2858 | 2027-07-28 | Client ID Metadata Documents, which this crate already prefers |
+//! | `includeContext: "thisServer"` / `"allServers"` | SEP-2596 | follows Sampling | omit, or use `"none"` |
+//! | HTTP+SSE transport | SEP-2596 | three months after SEP-2596 is Final | Streamable HTTP |
+//!
+//! "Earliest removal" is when a feature becomes *eligible* for removal from
+//! the specification, which is the first revision released on or after that
+//! date. Removal there does not oblige this crate to drop anything; that
+//! follows this crate's own release policy. Nothing here is scheduled for
+//! removal today.
 
 // Every public item here is documented, and this is what keeps it that way.
 // CI runs clippy with `-D warnings`, so this is a failure there; `warn`


### PR DESCRIPTION
## Summary

Surface the 2026-07-28 deprecations in the API, so a reader planning a year out sees them.

## What is deprecated upstream

| Feature | SEP | Earliest removal | Migration |
|---|---|---|---|
| Roots | SEP-2577 | first revision on or after 2027-07-28 | tool parameters, resource URIs, server config |
| Sampling | SEP-2577 | same | integrate with LLM provider APIs directly |
| Logging | SEP-2577 | same | stderr for stdio; OpenTelemetry for observability |
| Dynamic Client Registration | PR #2858 | same | Client ID Metadata Documents |
| `includeContext: "thisServer"` / `"allServers"` | SEP-2596 | follows Sampling | omit, or use `"none"` |
| HTTP+SSE transport | SEP-2596 | three months after SEP-2596 is Final | Streamable HTTP |

## Depth, and why it stops where it does

`#[deprecated]` fires at use sites, including ours, and CI runs with `-D warnings`. Measured:

- protocol types (`LogLevel`, `LoggingMessageParams`, `CreateMessageParams`): ~200 use sites
- `RequestContext::sample` / `send_log`: 40 sites across 11 files, 7 of them production

So the attribute goes where it is cheap and exactly right, and prose carries the rest:

- **`#[deprecated]`** on `IncludeContext::ThisServer` and `AllServers`. Four sites, and these are specific *values* the spec deprecated, which is precisely what a user should stop selecting.
- **Rustdoc notices** naming the SEP and the earliest removal on the sampling, logging, and roots surface, plus module-level notes.

A blanket `#![allow(deprecated)]` across the transports would have masked the next real deprecation in those files, which costs more than the warning is worth.

Nothing is removed. These are Deprecated, not Removed, and the policy guarantees at least twelve months.

Closes #1371.