### PR TITLE
fix(tasks): restore TaskContext during task replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -87,7 +87,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1525,7 +1525,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2166,7 +2166,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2223,7 +2223,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2727,7 +2727,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3496,7 +3496,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -557,6 +557,11 @@ impl McpRouter {
         };
 
         let mut ctx = RequestContext::new(RequestId::String(task_id.to_string()));
+        // Replay rebuilds a request context, but it is still an invocation of
+        // the same task. Restore its stable identity without a process-local
+        // live handle so MRTR handlers can correlate every input round.
+        ctx.extensions_mut()
+            .insert(crate::tool::TaskContext::new(task_id.to_string()));
         // The answers reach the handler through the same MRTR extension a
         // client retry populates. Only a `stateless` build can register an
         // `mrtr_handler`, so a build without it can never park a task and

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -1923,10 +1923,10 @@ fn a_transport_error_is_not_attributed_to_a_tool() {
     assert!(!error.message.contains("provider tool"));
 }
 
-/// #1208: the full task input round trip. The handler asks, the task
+/// #1208/#1386: the full task input round trip. The handler asks, the task
 /// parks in `input_required` carrying the requests, the client answers
-/// with `tasks/update`, the router re-invokes the handler with the
-/// answers, and the task completes.
+/// with `tasks/update`, and the router re-invokes the handler with both the
+/// accumulated answers and the same non-live task identity on every round.
 #[cfg(feature = "stateless")]
 #[tokio::test]
 async fn a_task_resumes_after_its_input_is_answered() {
@@ -1936,30 +1936,52 @@ async fn a_task_resumes_after_its_input_is_answered() {
         InputRequiredResult, RequestOutcome,
     };
 
+    fn ask(key: &str, message: &str) -> InputRequests {
+        let mut requests: InputRequests = Default::default();
+        requests.insert(
+            key.to_string(),
+            InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                mode: None,
+                message: message.to_string(),
+                requested_schema: ElicitFormSchema::new(),
+                meta: None,
+            })),
+        );
+        requests
+    }
+
+    let seen_contexts = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let handler_contexts = seen_contexts.clone();
     let asks = ToolBuilder::new("asks")
         .description("Needs a decision")
         .task_support(TaskSupportMode::Optional)
-        .mrtr_handler::<serde_json::Value, _, _>(|ctx, _input| async move {
-            // Resume leg: the answers are readable exactly as a non-task
-            // MRTR handler sees them on the client's retry.
-            if let Some(responses) = ctx.input_responses()
-                && responses.contains_key("decision")
-            {
-                return Ok(RequestOutcome::Complete(CallToolResult::text("approved")));
+        .mrtr_handler::<serde_json::Value, _, _>(move |ctx, _input| {
+            let seen_contexts = handler_contexts.clone();
+            async move {
+                seen_contexts.lock().unwrap().push(
+                    ctx.extension::<crate::tool::TaskContext>()
+                        .map(|task| (task.task_id().to_string(), task.is_live())),
+                );
+
+                // Resume legs see every answer accumulated so far, exactly as
+                // a non-task MRTR handler sees them on the client's retry.
+                if ctx.input_responses().is_some_and(|responses| {
+                    responses.contains_key("decision") && responses.contains_key("reason")
+                }) {
+                    return Ok(RequestOutcome::Complete(CallToolResult::text("approved")));
+                }
+                let (key, message) = if ctx
+                    .input_responses()
+                    .is_some_and(|responses| responses.contains_key("decision"))
+                {
+                    ("reason", "why?")
+                } else {
+                    ("decision", "approve?")
+                };
+                Ok(RequestOutcome::input_required(
+                    InputRequiredResult::with_requests(ask(key, message)),
+                ))
             }
-            let mut requests: InputRequests = Default::default();
-            requests.insert(
-                "decision".to_string(),
-                InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
-                    mode: None,
-                    message: "approve?".to_string(),
-                    requested_schema: ElicitFormSchema::new(),
-                    meta: None,
-                })),
-            );
-            Ok(RequestOutcome::input_required(
-                InputRequiredResult::with_requests(requests),
-            ))
         })
         .build();
 
@@ -2013,8 +2035,12 @@ async fn a_task_resumes_after_its_input_is_answered() {
         .unwrap()
         .unwrap();
     assert!(outstanding.contains_key("decision"));
+    assert_eq!(
+        seen_contexts.lock().unwrap().clone(),
+        vec![Some((task_id.clone(), false))]
+    );
 
-    // The client answers.
+    // The client answers the first round.
     let update = router
         .ready()
         .await
@@ -2037,7 +2063,56 @@ async fn a_task_resumes_after_its_input_is_answered() {
         .unwrap();
     assert!(update.inner.is_ok(), "update must be acknowledged");
 
-    // The handler runs again and the task completes with its answer.
+    // The handler runs again with the same task identity and asks a second,
+    // distinct question.
+    let mut parked_again = false;
+    for _ in 0..50 {
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        let task = store.get_task(&task_id).await.unwrap().unwrap();
+        let outstanding = store
+            .outstanding_input_requests(&task_id)
+            .await
+            .unwrap()
+            .unwrap();
+        if task.status == TaskStatus::InputRequired && outstanding.contains_key("reason") {
+            parked_again = true;
+            break;
+        }
+        assert_ne!(task.status, TaskStatus::Failed, "must park again, not fail");
+    }
+    assert!(parked_again, "the task must reach a second input round");
+    assert_eq!(
+        seen_contexts.lock().unwrap().clone(),
+        vec![
+            Some((task_id.clone(), false)),
+            Some((task_id.clone(), false)),
+        ]
+    );
+
+    // Answering the second round resumes the same task once more.
+    let update = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(3),
+            inner: McpRequest::UpdateTask(UpdateTaskParams {
+                task_id: task_id.clone(),
+                input_responses: [(
+                    "reason".to_string(),
+                    serde_json::json!({"action": "accept"}),
+                )]
+                .into_iter()
+                .collect(),
+                meta: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    assert!(update.inner.is_ok(), "update must be acknowledged");
+
+    // The third invocation completes with both answers available.
     let mut completed = None;
     for _ in 0..50 {
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
@@ -2054,6 +2129,14 @@ async fn a_task_resumes_after_its_input_is_answered() {
     }
     let completed = completed.expect("the task must complete after resuming");
     assert_eq!(completed.all_text(), "approved");
+    assert_eq!(
+        seen_contexts.lock().unwrap().clone(),
+        vec![
+            Some((task_id.clone(), false)),
+            Some((task_id.clone(), false)),
+            Some((task_id, false)),
+        ]
+    );
 }
 
 /// #1306: replay uses the root router's selected panic disclosure policy,


### PR DESCRIPTION
## Summary

- restore a non-live `TaskContext` when replaying an input-required task
- preserve the original task ID across every MRTR invocation
- extend the task lifecycle regression through two input rounds
- bump `h2` to `0.4.16` to resolve RUSTSEC-2026-0258 found by CI

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p tower-mcp --lib --features stateless`
- `cargo test -p tower-mcp --all-targets --all-features`
- `cargo check --workspace --all-targets --all-features --locked`

Closes #1386
