### PR TITLE
feat(client): configure final per-request log level

### DIFF
--- a/crates/tower-mcp/src/client/mod.rs
+++ b/crates/tower-mcp/src/client/mod.rs
@@ -121,7 +121,7 @@ use crate::protocol::{
     InputRequests, InputResponse, InputResponses, JsonRpcNotification, JsonRpcRequest,
     ListPromptsParams, ListPromptsResult, ListResourceTemplatesParams, ListResourceTemplatesResult,
     ListResourcesParams, ListResourcesResult, ListRootsResult, ListToolsParams, ListToolsResult,
-    PromptDefinition, ReadResourceParams, ReadResourceResult, RequestId, RequestMeta,
+    LogLevel, PromptDefinition, ReadResourceParams, ReadResourceResult, RequestId, RequestMeta,
     RequestOutcome, ResourceDefinition, ResourceTemplateDefinition, Root, RootsCapability,
     SamplingCapability, SubscriptionFilter, SubscriptionsAcknowledgedParams,
     SubscriptionsListenParams, SubscriptionsListenResult, TaskObject, TaskRequestParams,
@@ -449,6 +449,8 @@ pub struct McpClient {
     /// Allocator for per-request progress tokens; `None` when the client did
     /// not opt into progress.
     progress_tokens: Option<Arc<AtomicI64>>,
+    /// Default log threshold attached to future 2026-07-28 requests.
+    request_log_level: RwLock<Option<LogLevel>>,
     /// Allocator for JSON-RPC request ids, shared with the message loop so
     /// caller-issued and loop-issued ids never collide.
     next_request_id: Arc<AtomicI64>,
@@ -463,12 +465,14 @@ struct ClientSettings {
     max_mrtr_rounds: usize,
     cache_config: ClientCacheConfig,
     request_progress: bool,
+    request_log_level: Option<LogLevel>,
 }
 
 /// Builder for configuring and connecting an [`McpClient`].
 ///
-/// Everything here is settled before the connection opens, because it is what
-/// the client declares about itself during the handshake. Declaring a
+/// Most settings here are settled before the connection opens, because they
+/// describe what the client declares during the handshake. Per-request
+/// defaults may instead seed runtime-mutable client state. Declaring a
 /// capability is a promise to answer the matching server request, so pair
 /// [`with_sampling`](Self::with_sampling) and
 /// [`with_elicitation`](Self::with_elicitation) with a [`ClientHandler`] that
@@ -510,6 +514,7 @@ pub struct McpClientBuilder {
     max_mrtr_rounds: usize,
     cache_config: ClientCacheConfig,
     request_progress: bool,
+    request_log_level: Option<LogLevel>,
 }
 
 impl McpClientBuilder {
@@ -527,6 +532,7 @@ impl McpClientBuilder {
             max_mrtr_rounds: 8,
             cache_config: ClientCacheConfig::default(),
             request_progress: false,
+            request_log_level: None,
         }
     }
 
@@ -546,6 +552,20 @@ impl McpClientBuilder {
     /// [`RequestContext::report_progress`]: crate::context::RequestContext::report_progress
     pub fn request_progress(mut self) -> Self {
         self.request_progress = true;
+        self
+    }
+
+    /// Set the log threshold attached to final-protocol requests.
+    ///
+    /// This opts into the deprecated 2026-07-28 per-request logging mechanism:
+    /// each request carries `io.modelcontextprotocol/logLevel`, allowing the
+    /// server to emit matching `notifications/message` frames. The setting is
+    /// ignored by stable lifecycles and does not send `logging/setLevel`.
+    ///
+    /// The value seeds the connected client and may later be changed or
+    /// cleared with [`McpClient::set_request_log_level`]. It is off by default.
+    pub fn request_log_level(mut self, level: LogLevel) -> Self {
+        self.request_log_level = Some(level);
         self
     }
 
@@ -658,6 +678,7 @@ impl McpClientBuilder {
                 max_mrtr_rounds: self.max_mrtr_rounds,
                 cache_config: self.cache_config,
                 request_progress: self.request_progress,
+                request_log_level: self.request_log_level,
             },
         )
         .await
@@ -715,6 +736,7 @@ impl McpClient {
             max_mrtr_rounds,
             cache_config,
             request_progress,
+            request_log_level,
         } = settings;
         let supports_session_recovery = transport.supports_session_recovery();
         let (command_tx, command_rx) = mpsc::channel::<LoopCommand>(64);
@@ -759,6 +781,7 @@ impl McpClient {
             max_mrtr_rounds,
             response_cache,
             progress_tokens: request_progress.then(|| Arc::new(AtomicI64::new(1))),
+            request_log_level: RwLock::new(request_log_level),
             next_request_id,
         })
     }
@@ -795,6 +818,22 @@ impl McpClient {
     /// authenticated principal changes.
     pub async fn set_cache_partition(&self, partition: impl Into<String>) {
         self.response_cache.set_partition(partition.into()).await;
+    }
+
+    /// Set the log threshold attached to future final-protocol requests.
+    ///
+    /// Passing `Some(level)` opts subsequently prepared 2026-07-28 requests
+    /// into log delivery at that threshold. Passing `None` clears the default,
+    /// so later requests omit `io.modelcontextprotocol/logLevel` again. Stable
+    /// lifecycles are unaffected; this method does not send
+    /// `logging/setLevel`.
+    ///
+    /// Each wire request snapshots the value while its metadata is prepared.
+    /// Requests already serialized or in flight retain their previous value;
+    /// later MRTR rounds, retries, task operations, and subscription requests
+    /// take a fresh snapshot.
+    pub async fn set_request_log_level(&self, level: Option<LogLevel>) {
+        *self.request_log_level.write().await = level;
     }
 
     /// Return the number of response-cache entries held by this client.
@@ -1523,6 +1562,7 @@ impl McpClient {
             ))
         })?;
         let params = self.with_final_request_meta(params).await?;
+        let params = self.with_request_log_level(params).await;
         let (id_tx, id_rx) = oneshot::channel();
         let (acknowledgment_tx, acknowledgment_rx) = oneshot::channel();
         let (response_tx, response_rx) = oneshot::channel();
@@ -2302,6 +2342,7 @@ impl McpClient {
         let params_value = serde_json::to_value(params)
             .map_err(|e| Error::Transport(format!("Failed to serialize params: {}", e)))?;
         let params_value = self.with_final_request_meta(params_value).await?;
+        let params_value = self.with_request_log_level(params_value).await;
         let params_value = self.with_progress_token(params_value);
 
         let id = RequestId::Number(self.next_request_id.fetch_add(1, Ordering::Relaxed));
@@ -2496,6 +2537,43 @@ impl McpClient {
             let token = tokens.fetch_add(1, Ordering::Relaxed);
             meta.insert("progressToken".to_string(), serde_json::json!(token));
         }
+        params
+    }
+
+    /// Attach the client's default log threshold to one final-protocol request.
+    ///
+    /// This runs after required final metadata has been assembled, including
+    /// on the first `server/discover` request. An explicit per-call level wins.
+    /// Notifications intentionally do not pass through this helper because
+    /// `logLevel` belongs to request metadata.
+    async fn with_request_log_level(&self, mut params: serde_json::Value) -> serde_json::Value {
+        const PROTOCOL_VERSION_KEY: &str = "io.modelcontextprotocol/protocolVersion";
+        const LOG_LEVEL_KEY: &str = "io.modelcontextprotocol/logLevel";
+
+        let should_attach = params
+            .get("_meta")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|meta| {
+                meta.get(PROTOCOL_VERSION_KEY)
+                    .and_then(serde_json::Value::as_str)
+                    == Some(crate::protocol::PROTOCOL_VERSION_2026_07_28)
+                    && !meta.contains_key(LOG_LEVEL_KEY)
+            });
+        if !should_attach {
+            return params;
+        }
+
+        let Some(level) = *self.request_log_level.read().await else {
+            return params;
+        };
+        let meta = params
+            .get_mut("_meta")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("request metadata was validated as an object");
+        meta.insert(
+            LOG_LEVEL_KEY.to_string(),
+            serde_json::to_value(level).expect("LogLevel is serializable"),
+        );
         params
     }
 

--- a/crates/tower-mcp/src/client/tests.rs
+++ b/crates/tower-mcp/src/client/tests.rs
@@ -290,6 +290,10 @@ async fn final_discover_injects_metadata_on_every_request() {
             "test-client"
         );
         assert!(meta["io.modelcontextprotocol/clientCapabilities"].is_object());
+        assert!(
+            meta.get("io.modelcontextprotocol/logLevel").is_none(),
+            "final clients must not opt into logging by default"
+        );
     }
 }
 
@@ -302,6 +306,123 @@ fn final_discover_result() -> serde_json::Value {
         "ttlMs": 0,
         "cacheScope": "private"
     })
+}
+
+#[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
+#[tokio::test]
+async fn final_request_log_level_seeds_typed_calls_and_preserves_explicit_overrides() {
+    let transport = MockTransport::with_responses(vec![
+        final_discover_result(),
+        serde_json::json!({
+            "resultType": "complete",
+            "tools": [],
+            "ttlMs": 0,
+            "cacheScope": "private"
+        }),
+        serde_json::json!({
+            "resultType": "complete",
+            "content": [{"type": "text", "text": "done"}]
+        }),
+    ]);
+    let outgoing = transport.outgoing.clone();
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .request_log_level(LogLevel::Info)
+        .connect_simple(transport)
+        .await
+        .unwrap();
+
+    client.discover("test-client", "1.0.0").await.unwrap();
+    client.list_tools().await.unwrap();
+    let params = CallToolParams {
+        name: "work".to_string(),
+        arguments: serde_json::json!({}),
+        input_responses: None,
+        request_state: None,
+        meta: Some(RequestMeta {
+            log_level: Some(LogLevel::Warning),
+            ..Default::default()
+        }),
+        task: None,
+    };
+    let _: CallToolResult = client.request("tools/call", &params).await.unwrap();
+    client
+        .notify("notifications/custom", &serde_json::json!({}))
+        .await
+        .unwrap();
+
+    let messages: Vec<serde_json::Value> = outgoing
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|message| serde_json::from_str(message).unwrap())
+        .collect();
+    assert_eq!(messages.len(), 4);
+    assert_eq!(messages[0]["method"], "server/discover");
+    assert_eq!(messages[1]["method"], "tools/list");
+    assert_eq!(messages[2]["method"], "tools/call");
+    assert_eq!(messages[3]["method"], "notifications/custom");
+    for message in &messages[..2] {
+        assert_eq!(
+            message["params"]["_meta"]["io.modelcontextprotocol/logLevel"],
+            "info"
+        );
+    }
+    assert_eq!(
+        messages[2]["params"]["_meta"]["io.modelcontextprotocol/logLevel"], "warning",
+        "an explicit per-call threshold must override the client default"
+    );
+    assert!(
+        messages[3]["params"]["_meta"]
+            .get("io.modelcontextprotocol/logLevel")
+            .is_none(),
+        "request-only log metadata must not leak onto notifications"
+    );
+}
+
+#[tokio::test]
+async fn request_log_level_does_not_change_stable_wire() {
+    let transport = MockTransport::with_responses(vec![
+        mock_initialize_response(),
+        serde_json::json!({
+            "content": [{"type": "text", "text": "done"}]
+        }),
+    ]);
+    let outgoing = transport.outgoing.clone();
+    let client = McpClient::builder()
+        .request_log_level(LogLevel::Info)
+        .connect_simple(transport)
+        .await
+        .unwrap();
+
+    client.initialize("test-client", "1.0.0").await.unwrap();
+    client.set_request_log_level(Some(LogLevel::Warning)).await;
+    client
+        .call_tool("work", serde_json::json!({}))
+        .await
+        .unwrap();
+    client
+        .notify("notifications/custom", &serde_json::json!({}))
+        .await
+        .unwrap();
+
+    let messages: Vec<serde_json::Value> = outgoing
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|message| serde_json::from_str(message).unwrap())
+        .collect();
+    assert_eq!(messages.len(), 4);
+    assert!(
+        messages.iter().all(|message| message["params"]["_meta"]
+            .get("io.modelcontextprotocol/logLevel")
+            .is_none()),
+        "a final-only request default must not alter stable traffic: {messages:?}"
+    );
+    assert!(
+        messages[2]["params"].get("_meta").is_none(),
+        "a stable typed call must retain its ordinary params shape"
+    );
 }
 
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]
@@ -447,6 +568,7 @@ async fn final_subscriptions_correlate_and_cancel_over_message_transport() {
 
     let client = McpClient::builder()
         .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .request_log_level(LogLevel::Info)
         .connect(transport, RecordingHandler(received.clone()))
         .await
         .unwrap();
@@ -470,6 +592,20 @@ async fn final_subscriptions_correlate_and_cancel_over_message_transport() {
         second.acknowledged().await.unwrap().tools_list_changed,
         Some(true)
     );
+    let listen_messages: Vec<serde_json::Value> = outgoing
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|message| serde_json::from_str(message).unwrap())
+        .filter(|message: &serde_json::Value| message["method"] == "subscriptions/listen")
+        .collect();
+    assert_eq!(listen_messages.len(), 2);
+    for message in listen_messages {
+        assert_eq!(
+            message["params"]["_meta"]["io.modelcontextprotocol/logLevel"],
+            "info"
+        );
+    }
 
     for _ in 0..100 {
         if received
@@ -792,6 +928,7 @@ async fn final_tool_call_refreshes_stale_schema_and_retries_once() {
     let outgoing = transport.outgoing.clone();
     let client = McpClient::builder()
         .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .request_log_level(LogLevel::Warning)
         .connect_simple(transport)
         .await
         .unwrap();
@@ -804,16 +941,15 @@ async fn final_tool_call_refreshes_stale_schema_and_retries_once() {
         .unwrap();
     assert_eq!(result.first_text(), Some("retried"));
 
-    let methods: Vec<String> = outgoing
+    let messages: Vec<serde_json::Value> = outgoing
         .lock()
         .unwrap()
         .iter()
-        .map(|message| {
-            serde_json::from_str::<serde_json::Value>(message).unwrap()["method"]
-                .as_str()
-                .unwrap()
-                .to_string()
-        })
+        .map(|message| serde_json::from_str(message).unwrap())
+        .collect();
+    let methods: Vec<&str> = messages
+        .iter()
+        .map(|message| message["method"].as_str().unwrap())
         .collect();
     assert_eq!(
         methods,
@@ -825,6 +961,12 @@ async fn final_tool_call_refreshes_stale_schema_and_retries_once() {
             "tools/call"
         ]
     );
+    for message in messages {
+        assert_eq!(
+            message["params"]["_meta"]["io.modelcontextprotocol/logLevel"], "warning",
+            "every request in the retry flow must retain the configured threshold"
+        );
+    }
 }
 
 #[cfg(any(feature = "protocol-2026-07-28", feature = "stateless"))]

--- a/crates/tower-mcp/tests/channel_transport.rs
+++ b/crates/tower-mcp/tests/channel_transport.rs
@@ -206,6 +206,69 @@ async fn default_constructor_delivers_router_notifications() {
 
 #[cfg(feature = "stateless")]
 #[tokio::test]
+async fn final_typed_tool_calls_follow_request_log_level_updates() {
+    use std::sync::Mutex;
+
+    use tower_mcp::ProtocolSupport;
+    use tower_mcp::extract::{Context, State};
+    use tower_mcp::protocol::LogLevel as ProtocolLogLevel;
+    use tower_mcp::stateless::LogLevel as RequestLogLevel;
+
+    #[derive(Clone, Default)]
+    struct SeenLevels(Arc<Mutex<Vec<Option<RequestLogLevel>>>>);
+
+    let seen = SeenLevels::default();
+    let tool = ToolBuilder::new("inspect_log_level")
+        .description("Records the per-request log threshold")
+        .extractor_handler(
+            seen.clone(),
+            |State(seen): State<SeenLevels>, ctx: Context, RawArgs(_): RawArgs| async move {
+                seen.0
+                    .lock()
+                    .unwrap()
+                    .push(ctx.per_request_meta().and_then(|meta| meta.log_level));
+                Ok(CallToolResult::text("ok"))
+            },
+        )
+        .build();
+    let router = McpRouter::new()
+        .server_info("log-level-test", "1.0.0")
+        .tool(tool);
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .connect_simple(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client
+        .discover("log-level-client", "1.0.0")
+        .await
+        .expect("discover");
+
+    client
+        .call_tool("inspect_log_level", serde_json::json!({}))
+        .await
+        .expect("unset call");
+    client
+        .set_request_log_level(Some(ProtocolLogLevel::Warning))
+        .await;
+    client
+        .call_tool("inspect_log_level", serde_json::json!({}))
+        .await
+        .expect("updated call");
+    client.set_request_log_level(None).await;
+    client
+        .call_tool("inspect_log_level", serde_json::json!({}))
+        .await
+        .expect("cleared call");
+
+    assert_eq!(
+        *seen.0.lock().unwrap(),
+        [None, Some(RequestLogLevel::Warning), None]
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
 async fn final_subscription_listen_filters_channel_transport_notifications() {
     use tower_mcp::ProtocolSupport;
     use tower_mcp::protocol::SubscriptionFilter;

--- a/crates/tower-mcp/tests/client_tasks.rs
+++ b/crates/tower-mcp/tests/client_tasks.rs
@@ -212,6 +212,7 @@ async fn final_call_tool_transparently_completes_server_created_task() {
     let client = McpClient::builder()
         .protocol_support(tower_mcp::ProtocolSupport::try_new(["2026-07-28"]).unwrap())
         .with_tasks()
+        .request_log_level(tower_mcp::protocol::LogLevel::Info)
         .connect_simple(ChannelTransport::new(task_router().with_tasks()))
         .await
         .expect("connect");

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -1157,6 +1157,7 @@ async fn a_live_plus_fallback_tool_serves_an_mrtr_round_trip_through_the_fallbac
     // never elects a task for it: every call reaches the fallback.
     let client = McpClient::builder()
         .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .request_log_level(tower_mcp::protocol::LogLevel::Info)
         .connect_simple(ChannelTransport::new(router))
         .await
         .expect("connect");


### PR DESCRIPTION
## Summary

- add builder and runtime controls for the final per-request log threshold
- snapshot and inject the threshold across typed requests, discovery, retries, tasks, MRTR, and subscriptions
- preserve stable wire behavior, explicit per-call overrides, and request-only notification boundaries

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`

Closes #1404
