### PR TITLE
fix(http): authorize final task subscriptions

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -2790,6 +2790,14 @@ impl McpRouter {
                         ),
                     ));
                 }
+                if self.final_tasks_enabled()
+                    && let Some(task_ids) = requested.task_ids.as_deref()
+                {
+                    for task_id in task_ids {
+                        self.authorize_task_subscription(task_id, &extensions)
+                            .await?;
+                    }
+                }
                 let notifications = crate::transport::subscriptions::accepted_subscription_filter(
                     requested,
                     self.final_tasks_enabled(),

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -157,6 +157,39 @@ impl McpRouter {
         }
     }
 
+    /// Verify the caller may subscribe to status changes for this task.
+    ///
+    /// Listen filters deliberately collapse missing, expired, and foreign
+    /// task IDs into the same not-found response. Unlike a direct task method,
+    /// a subscription request must not reveal which candidate IDs were once
+    /// valid, even to their former owner.
+    #[cfg(feature = "stateless")]
+    pub(super) async fn authorize_task_subscription(
+        &self,
+        task_id: &str,
+        extensions: &crate::context::Extensions,
+    ) -> Result<()> {
+        let owner = self
+            .inner
+            .task_store
+            .task_owner(task_id)
+            .await
+            .map_err(|error| self.task_store_error(TaskOperation::Get, Some(task_id), error))?;
+        let allowed = owner.as_ref().is_some_and(|owner| {
+            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
+        });
+        if allowed {
+            return Ok(());
+        }
+
+        tracing::debug!(
+            target: "mcp::tasks",
+            task_id = %task_id,
+            "task subscription refused: task is absent or principal does not own it"
+        );
+        Err(self.task_error(TaskOperation::Get, Some(task_id), TaskFailure::NotFound))
+    }
+
     /// Serve a final `tasks/get` as a status-discriminated `DetailedTask`.
     pub(super) async fn final_get_task(
         &self,

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -6702,6 +6702,75 @@ async fn expiry_is_disclosed_to_the_owner_and_to_nobody_else() {
     );
 }
 
+/// A listen filter is an existence probe over an arbitrary list of IDs, so it
+/// must not disclose even owner-visible expiry state while authorizing them.
+#[cfg(all(feature = "oauth", feature = "stateless"))]
+#[tokio::test]
+async fn task_subscription_authorization_hides_expired_and_foreign_tasks() {
+    fn as_principal(subject: &str) -> Extensions {
+        let mut extensions = tasks_client_extensions();
+        extensions.insert(crate::oauth::token::TokenClaims {
+            sub: Some(subject.to_string()),
+            iss: None,
+            aud: None,
+            exp: None,
+            scope: None,
+            client_id: None,
+            extra: HashMap::new(),
+        });
+        extensions
+    }
+
+    let store = std::sync::Arc::new(crate::async_task::MemoryTaskStore::new());
+    let (task_id, _) = store
+        .create_task("work", serde_json::json!({}), None, Some("alice".into()))
+        .await
+        .unwrap();
+    assert!(store.set_ttl(&task_id, 1).await.unwrap());
+    tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+    let router = McpRouter::new().task_store(store).with_tasks();
+
+    let listen = |id: String, who: Extensions| {
+        let router = router.clone();
+        async move {
+            router
+                .handle(
+                    RequestId::Number(10),
+                    McpRequest::SubscriptionsListen(SubscriptionsListenParams {
+                        notifications: Some(SubscriptionFilter {
+                            task_ids: Some(vec![id]),
+                            ..Default::default()
+                        }),
+                        meta: None,
+                    }),
+                    who,
+                )
+                .await
+        }
+    };
+
+    let owner_saw = listen(task_id.clone(), as_principal("alice")).await;
+    let stranger_saw = listen(task_id.clone(), as_principal("bob")).await;
+    let never_issued = listen("never-issued".to_string(), as_principal("bob")).await;
+    let (
+        Err(crate::error::Error::JsonRpc(owner_error)),
+        Err(crate::error::Error::JsonRpc(stranger_error)),
+        Err(crate::error::Error::JsonRpc(missing_error)),
+    ) = (owner_saw, stranger_saw, never_issued)
+    else {
+        panic!("expired, foreign, and missing task subscriptions must all be refused");
+    };
+
+    for error in [&owner_error, &stranger_error] {
+        assert_eq!(error.code, missing_error.code);
+        assert_eq!(error.data, missing_error.data);
+        assert_eq!(
+            error.message.replace(&task_id, "<id>"),
+            missing_error.message.replace("never-issued", "<id>")
+        );
+    }
+}
+
 /// #1249: a task that expires between authorization and the operation is
 /// reported to its owner as expired, not as one that never existed. The
 /// operation returning nothing is not enough to conclude "missing"; resolving

--- a/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
+++ b/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
@@ -476,6 +476,10 @@ pub(super) async fn handle_modern_subscriptions_listen_sse(
     };
     let mut ext = crate::router::Extensions::new();
     ext.insert(state.protocol_support.clone());
+    #[cfg(feature = "oauth")]
+    if let Some(claims) = http_extensions.get::<crate::oauth::token::TokenClaims>() {
+        ext.insert(claims.clone());
+    }
     stash_per_request_meta(&request, &mut ext);
     crate::transport::extension_bridge::apply_extension_bridges(
         &state.extension_bridges,

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -460,7 +460,7 @@ mod tasks {
                 "subscriptions/listen",
                 serde_json::json!({
                     "_meta": meta(true),
-                    "notifications": { "taskIds": [task_id, "some-other-task"] },
+                    "notifications": { "taskIds": [task_id] },
                 }),
             ))
             .await
@@ -478,7 +478,7 @@ mod tasks {
             "stream must begin with an acknowledgment: {body}"
         );
         assert!(
-            body.contains(&format!("\"taskIds\":[\"{task_id}\",\"some-other-task\"]")),
+            body.contains(&format!("\"taskIds\":[\"{task_id}\"]")),
             "the acknowledgment must echo the accepted task IDs: {body}"
         );
         assert!(
@@ -499,7 +499,7 @@ mod tasks {
         );
     }
 
-    /// A subscriber that named a different task hears nothing.
+    /// A subscriber that named a different owned task never receives this one.
     #[tokio::test]
     async fn an_unnamed_task_never_reaches_a_stream() {
         let (app, handle) = HttpTransport::new(task_router())
@@ -523,6 +523,22 @@ mod tasks {
         let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
         let task_id = created["result"]["taskId"].as_str().unwrap().to_string();
 
+        let other = app
+            .clone()
+            .oneshot(final_request(
+                "call-2",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "slow",
+                    "arguments": {},
+                }),
+            ))
+            .await
+            .unwrap();
+        let other: serde_json::Value = serde_json::from_str(&body_string(other).await).unwrap();
+        let other_task_id = other["result"]["taskId"].as_str().unwrap().to_string();
+
         let listen = app
             .clone()
             .oneshot(final_request(
@@ -530,7 +546,7 @@ mod tasks {
                 "subscriptions/listen",
                 serde_json::json!({
                     "_meta": meta(true),
-                    "notifications": { "taskIds": ["a-task-this-client-does-not-own"] },
+                    "notifications": { "taskIds": [other_task_id] },
                 }),
             ))
             .await
@@ -551,6 +567,171 @@ mod tasks {
             !body.contains(&task_id),
             "the unrelated task ID must not leak: {body}"
         );
+    }
+
+    #[cfg(feature = "oauth")]
+    fn oauth_token(subject: &str, audience: &str) -> String {
+        jsonwebtoken::encode(
+            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::HS256),
+            &serde_json::json!({
+                "sub": subject,
+                "aud": audience,
+                "scope": "mcp:read",
+            }),
+            &jsonwebtoken::EncodingKey::from_secret(b"subscription-auth-test-secret"),
+        )
+        .unwrap()
+    }
+
+    #[cfg(feature = "oauth")]
+    fn authenticated_final_request(
+        id: &str,
+        method: &str,
+        params: serde_json::Value,
+        token: &str,
+    ) -> Request<Body> {
+        let mut request = final_request(id, method, params);
+        request.headers_mut().insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {token}").parse().unwrap(),
+        );
+        request
+    }
+
+    /// The protected HTTP builder must carry validated claims through the
+    /// transport-owned listen path, and the router must enforce TaskOwner
+    /// before registering the stream.
+    #[cfg(feature = "oauth")]
+    #[tokio::test]
+    async fn oauth_listen_accepts_only_the_task_owner() {
+        const RESOURCE: &str = "https://mcp.example.com/subscriptions";
+
+        let metadata = tower_mcp::oauth::ProtectedResourceMetadata::new(RESOURCE)
+            .authorization_server("https://auth.example.com")
+            .scope("mcp:read");
+        let validator =
+            tower_mcp::oauth::JwtValidator::from_secret(b"subscription-auth-test-secret")
+                .disable_exp_validation();
+        let (app, handle) = HttpTransport::new(task_router())
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_oauth_router_with_handle(
+                validator,
+                metadata,
+                tower_mcp::oauth::ScopePolicy::new().default_scope("mcp:read"),
+            )
+            .unwrap();
+        let alice = oauth_token("alice", RESOURCE);
+        let bob = oauth_token("bob", RESOURCE);
+
+        let create = app
+            .clone()
+            .oneshot(authenticated_final_request(
+                "call-alice",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "slow",
+                    "arguments": {},
+                }),
+                &alice,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::OK);
+        let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
+        let task_id = created["result"]["taskId"].as_str().unwrap().to_string();
+
+        let listen_params = |task_id: &str| {
+            serde_json::json!({
+                "_meta": meta(true),
+                "notifications": { "taskIds": [task_id] },
+            })
+        };
+        let foreign = app
+            .clone()
+            .oneshot(authenticated_final_request(
+                "listen-bob",
+                "subscriptions/listen",
+                listen_params(&task_id),
+                &bob,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(foreign.status(), StatusCode::BAD_REQUEST);
+        let foreign: serde_json::Value = serde_json::from_str(&body_string(foreign).await).unwrap();
+
+        let missing_id = "task_that_was_never_issued";
+        let missing = app
+            .clone()
+            .oneshot(authenticated_final_request(
+                "listen-missing",
+                "subscriptions/listen",
+                listen_params(missing_id),
+                &bob,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(missing.status(), StatusCode::BAD_REQUEST);
+        let missing: serde_json::Value = serde_json::from_str(&body_string(missing).await).unwrap();
+        assert_eq!(foreign["error"]["code"], missing["error"]["code"]);
+        assert_eq!(foreign["error"]["data"], missing["error"]["data"]);
+        assert_eq!(
+            foreign["error"]["message"]
+                .as_str()
+                .unwrap()
+                .replace(&task_id, "<id>"),
+            missing["error"]["message"]
+                .as_str()
+                .unwrap()
+                .replace(missing_id, "<id>"),
+            "a foreign task must look exactly like a missing task"
+        );
+
+        let mixed = app
+            .clone()
+            .oneshot(authenticated_final_request(
+                "listen-mixed",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "notifications": { "taskIds": [&task_id, missing_id] },
+                }),
+                &alice,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(mixed.status(), StatusCode::BAD_REQUEST);
+        let mixed: serde_json::Value = serde_json::from_str(&body_string(mixed).await).unwrap();
+        assert_eq!(mixed["error"]["code"], missing["error"]["code"]);
+        assert_eq!(handle.subscription_count(), 0);
+
+        let anonymous = app
+            .clone()
+            .oneshot(final_request(
+                "listen-anonymous",
+                "subscriptions/listen",
+                listen_params(&task_id),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(anonymous.status(), StatusCode::UNAUTHORIZED);
+
+        let owned = app
+            .oneshot(authenticated_final_request(
+                "listen-alice",
+                "subscriptions/listen",
+                listen_params(&task_id),
+                &alice,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(owned.status(), StatusCode::OK);
+        assert_eq!(handle.subscription_count(), 1);
+        assert_eq!(handle.close_subscriptions(), 1);
+        let body = body_string(owned).await;
+        assert!(body.contains("notifications/subscriptions/acknowledged"));
+        assert!(body.contains(&task_id));
     }
 
     /// SEP-2663: requesting task notifications without declaring the extension


### PR DESCRIPTION
## Summary

- authorize every requested final task subscription before accepting its listen filter
- bridge validated OAuth claims through the transport-owned `subscriptions/listen` path
- reject missing, expired, foreign, and mixed-invalid task filters without registering a stream

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`

Closes #1390
Closes #1391
