### PR TITLE
fix(http): bound final subscription streams

### DIFF
--- a/crates/tower-mcp/src/guides/deployment.rs
+++ b/crates/tower-mcp/src/guides/deployment.rs
@@ -141,6 +141,36 @@ The default session TTL is 30 minutes and the default cleanup interval is one
 minute. There is no default maximum; set one to bound per-process session
 memory. The built-in session and event stores are in-memory.
 
+Final `subscriptions/listen` streams have a separate, bounded policy because
+they do not consume legacy session slots. By default, a transport admits up to
+256 active final subscriptions. Each stream accepts at most 64 KiB of combined
+request-ID/filter metadata and retains 64 notifications or 256 KiB of
+serialized notification data.
+Configure lower host-specific and per-principal limits where appropriate:
+
+```rust,no_run
+# #[cfg(feature = "stateless")]
+# {
+use tower_mcp::{HttpTransport, McpRouter, SubscriptionLimits};
+
+let limits = SubscriptionLimits::default()
+    .max_active(128)
+    .max_active_per_principal(8)
+    .max_metadata_bytes(32 * 1024)
+    .max_buffered_messages(32)
+    .max_buffered_bytes(128 * 1024);
+let transport = HttpTransport::new(McpRouter::new())
+    .subscription_limits(limits);
+# let _ = transport;
+# }
+```
+
+Admission beyond a configured stream limit returns a JSON-RPC error without
+opening an SSE response. If a reader falls behind either per-stream buffer
+budget, only that stream closes with an in-band terminal error. The client can
+reconnect; for asynchronous tools, `tasks/get` remains the authoritative way
+to recover current task state.
+
 The method named `stateless(StatelessConfig)` controls a historical SEP-1442
 compatibility path. It does **not** enable the released 2026-07-28 lifecycle.
 For new deployments, enable `protocol-2026-07-28` and select versions with

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -717,6 +717,9 @@ pub use transport::subscriptions::{
 #[cfg(feature = "http")]
 pub use transport::{HttpTransport, SessionHandle, SessionInfo};
 
+#[cfg(all(feature = "http", feature = "stateless"))]
+pub use transport::SubscriptionLimits;
+
 #[cfg(feature = "websocket")]
 pub use transport::WebSocketTransport;
 

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -320,6 +320,78 @@ pub const MCP_PARAM_HEADER_PREFIX: &str = "mcp-param-";
 /// See [`HttpTransport::max_body_size`].
 pub const DEFAULT_MAX_BODY_SIZE: usize = 4 * 1024 * 1024;
 
+/// Resource limits for final-protocol `subscriptions/listen` streams.
+///
+/// These limits apply only to sessionless HTTP subscriptions negotiated with
+/// the 2026-07-28 protocol. They bound both the number of live streams and the
+/// notification backlog retained for a client that stops reading.
+///
+/// Defaults are deliberately finite: 256 active streams per transport, 64 KiB
+/// of serialized request identity/filter metadata, 64 queued notifications,
+/// and 256 KiB of serialized notification data per stream. Per-principal
+/// admission is optional and disabled by default.
+#[cfg(feature = "stateless")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SubscriptionLimits {
+    /// Maximum active final subscriptions across this transport.
+    pub max_active: usize,
+    /// Optional maximum active subscriptions for one authenticated principal.
+    pub max_active_per_principal: Option<usize>,
+    /// Maximum combined serialized request-ID and negotiated-filter bytes.
+    pub max_metadata_bytes: usize,
+    /// Maximum queued notifications for one stream.
+    pub max_buffered_messages: usize,
+    /// Maximum serialized notification bytes queued for one stream.
+    pub max_buffered_bytes: usize,
+}
+
+#[cfg(feature = "stateless")]
+impl Default for SubscriptionLimits {
+    fn default() -> Self {
+        Self {
+            max_active: 256,
+            max_active_per_principal: None,
+            max_metadata_bytes: 64 * 1024,
+            max_buffered_messages: 64,
+            max_buffered_bytes: 256 * 1024,
+        }
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl SubscriptionLimits {
+    /// Set the process-local active subscription limit.
+    pub fn max_active(mut self, max: usize) -> Self {
+        self.max_active = max;
+        self
+    }
+
+    /// Set the active subscription limit for each authenticated principal.
+    pub fn max_active_per_principal(mut self, max: usize) -> Self {
+        self.max_active_per_principal = Some(max);
+        self
+    }
+
+    /// Set the serialized request-ID and negotiated-filter budget per stream.
+    pub fn max_metadata_bytes(mut self, max: usize) -> Self {
+        self.max_metadata_bytes = max;
+        self
+    }
+
+    /// Set the queued notification count limit for each stream.
+    pub fn max_buffered_messages(mut self, max: usize) -> Self {
+        self.max_buffered_messages = max;
+        self
+    }
+
+    /// Set the serialized queued-notification byte limit for each stream.
+    pub fn max_buffered_bytes(mut self, max: usize) -> Self {
+        self.max_buffered_bytes = max;
+        self
+    }
+}
+
 /// SSE event type for JSON-RPC messages
 const SSE_MESSAGE_EVENT: &str = "message";
 
@@ -428,6 +500,9 @@ pub struct HttpTransport {
     external_notifications: Option<NotificationReceiver>,
     #[cfg(feature = "stateless")]
     stateless_config: Option<crate::stateless::StatelessConfig>,
+    /// Admission and buffering policy for final subscription streams.
+    #[cfg(feature = "stateless")]
+    subscription_limits: SubscriptionLimits,
     /// When true, 2026-07-28 stateless responses carry server identity in
     /// `_meta["io.modelcontextprotocol/serverInfo"]`.
     ///
@@ -474,6 +549,8 @@ impl HttpTransport {
             external_notifications: None,
             #[cfg(feature = "stateless")]
             stateless_config: None,
+            #[cfg(feature = "stateless")]
+            subscription_limits: SubscriptionLimits::default(),
             #[cfg(feature = "stateless")]
             stamp_server_info: true,
             #[cfg(feature = "oauth")]
@@ -576,6 +653,8 @@ impl HttpTransport {
             external_notifications: None,
             #[cfg(feature = "stateless")]
             stateless_config: None,
+            #[cfg(feature = "stateless")]
+            subscription_limits: SubscriptionLimits::default(),
             #[cfg(feature = "stateless")]
             stamp_server_info: true,
             #[cfg(feature = "oauth")]
@@ -808,6 +887,33 @@ impl HttpTransport {
     #[cfg(feature = "stateless")]
     pub fn stamp_server_info(mut self, enabled: bool) -> Self {
         self.stamp_server_info = enabled;
+        self
+    }
+
+    /// Configure admission and buffering limits for final subscriptions.
+    ///
+    /// The policy is process-local to this transport. A stream that exceeds
+    /// either buffering budget is closed with an observable terminal error;
+    /// clients can reconnect and use `tasks/get` for authoritative task state.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use tower_mcp::{HttpTransport, McpRouter, SubscriptionLimits};
+    ///
+    /// let limits = SubscriptionLimits::default()
+    ///     .max_active(128)
+    ///     .max_active_per_principal(8)
+    ///     .max_metadata_bytes(32 * 1024)
+    ///     .max_buffered_messages(32)
+    ///     .max_buffered_bytes(128 * 1024);
+    /// let transport = HttpTransport::new(McpRouter::new())
+    ///     .subscription_limits(limits);
+    /// # let _ = transport;
+    /// ```
+    #[cfg(feature = "stateless")]
+    pub fn subscription_limits(mut self, limits: SubscriptionLimits) -> Self {
+        self.subscription_limits = limits;
         self
     }
 
@@ -1196,6 +1302,7 @@ impl HttpTransport {
     fn build_state(&self) -> Arc<AppState> {
         #[cfg(feature = "stateless")]
         let modern_subscriptions = Arc::new(ModernSubscriptionRegistry::new(
+            self.subscription_limits,
             match &self.service_source {
                 ServiceSource::Router { router, .. } if self.stamp_server_info => {
                     Some(router.implementation())

--- a/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
+++ b/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
@@ -25,11 +25,148 @@ pub(super) fn stash_per_request_meta(req: &JsonRpcRequest, ext: &mut crate::rout
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(super) enum SubscriptionPrincipal {
+    #[cfg(feature = "oauth")]
+    OAuthSubject {
+        issuer: Option<String>,
+        subject: String,
+    },
+    #[cfg(feature = "oauth")]
+    OAuthClient {
+        issuer: Option<String>,
+        client_id: String,
+    },
+    AuthClient(String),
+}
+
+pub(super) fn subscription_principal(
+    extensions: &axum::http::Extensions,
+) -> Option<SubscriptionPrincipal> {
+    #[cfg(feature = "oauth")]
+    if let Some(claims) = extensions.get::<crate::oauth::token::TokenClaims>()
+        && let Some(subject) = claims.sub.as_ref()
+        && !subject.trim().is_empty()
+    {
+        return Some(SubscriptionPrincipal::OAuthSubject {
+            issuer: claims.iss.clone(),
+            subject: subject.clone(),
+        });
+    }
+    #[cfg(feature = "oauth")]
+    if let Some(claims) = extensions.get::<crate::oauth::token::TokenClaims>()
+        && let Some(client_id) = claims.client_id.as_ref()
+        && !client_id.trim().is_empty()
+    {
+        return Some(SubscriptionPrincipal::OAuthClient {
+            issuer: claims.iss.clone(),
+            client_id: client_id.clone(),
+        });
+    }
+
+    extensions
+        .get::<crate::auth::AuthInfo>()
+        .map(|info| info.client_id.as_str())
+        .filter(|client_id| !client_id.trim().is_empty())
+        .map(|client_id| SubscriptionPrincipal::AuthClient(client_id.to_string()))
+}
+
+pub(super) struct QueuedSubscriptionMessage {
+    json: String,
+    buffered_bytes: Arc<std::sync::atomic::AtomicUsize>,
+    byte_len: usize,
+}
+
+impl QueuedSubscriptionMessage {
+    #[cfg(test)]
+    pub(super) fn as_str(&self) -> &str {
+        &self.json
+    }
+
+    fn into_json(mut self) -> String {
+        std::mem::take(&mut self.json)
+    }
+}
+
+impl Drop for QueuedSubscriptionMessage {
+    fn drop(&mut self) {
+        self.buffered_bytes
+            .fetch_sub(self.byte_len, Ordering::AcqRel);
+    }
+}
+
+pub(super) enum SubscriptionTerminal {
+    BufferOverflow(String),
+    Drained(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SubscriptionAdmissionError {
+    GlobalLimit,
+    PrincipalLimit,
+    MetadataTooLarge,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubscriptionQueueError {
+    BufferOverflow,
+    Disconnected,
+}
+
+pub(super) struct ModernSubscriptionRegistration {
+    pub(super) notifications: mpsc::Receiver<QueuedSubscriptionMessage>,
+    pub(super) terminal: oneshot::Receiver<SubscriptionTerminal>,
+    pub(super) guard: ModernSubscriptionGuard,
+}
+
 pub(super) struct ModernSubscription {
     subscription_id: RequestId,
     filter: SubscriptionFilter,
-    tx: mpsc::UnboundedSender<String>,
+    principal: Option<SubscriptionPrincipal>,
+    tx: mpsc::Sender<QueuedSubscriptionMessage>,
+    terminal_tx: Option<oneshot::Sender<SubscriptionTerminal>>,
+    buffered_bytes: Arc<std::sync::atomic::AtomicUsize>,
+    max_buffered_messages: usize,
+    max_buffered_bytes: usize,
     started: std::time::Instant,
+}
+
+impl ModernSubscription {
+    fn try_enqueue(&self, json: String) -> std::result::Result<(), SubscriptionQueueError> {
+        if self.max_buffered_messages == 0 {
+            return Err(SubscriptionQueueError::BufferOverflow);
+        }
+
+        let byte_len = json.len();
+        let reserved = self
+            .buffered_bytes
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current
+                    .checked_add(byte_len)
+                    .filter(|next| *next <= self.max_buffered_bytes)
+            })
+            .is_ok();
+        if !reserved {
+            return Err(SubscriptionQueueError::BufferOverflow);
+        }
+
+        let message = QueuedSubscriptionMessage {
+            json,
+            buffered_bytes: self.buffered_bytes.clone(),
+            byte_len,
+        };
+        match self.tx.try_send(message) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Full(message)) => {
+                drop(message);
+                Err(SubscriptionQueueError::BufferOverflow)
+            }
+            Err(mpsc::error::TrySendError::Closed(message)) => {
+                drop(message);
+                Err(SubscriptionQueueError::Disconnected)
+            }
+        }
+    }
 }
 
 /// Process-local registry for sessionless final-protocol subscriptions.
@@ -39,18 +176,21 @@ pub(super) struct ModernSubscription {
 pub(super) struct ModernSubscriptionRegistry {
     next_key: AtomicU64,
     pub(super) subscriptions: std::sync::Mutex<HashMap<u64, ModernSubscription>>,
+    limits: SubscriptionLimits,
     server_info: Option<Implementation>,
     observer: Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>>,
 }
 
 impl ModernSubscriptionRegistry {
     pub(super) fn new(
+        limits: SubscriptionLimits,
         server_info: Option<Implementation>,
         observer: Option<Arc<dyn crate::transport::subscriptions::SubscriptionObserver>>,
     ) -> Self {
         Self {
             next_key: AtomicU64::new(0),
             subscriptions: std::sync::Mutex::new(HashMap::new()),
+            limits,
             server_info,
             observer,
         }
@@ -70,29 +210,68 @@ impl ModernSubscriptionRegistry {
         }
     }
 
-    pub(super) fn register(
+    pub(super) fn try_register(
         self: &Arc<Self>,
         subscription_id: RequestId,
         filter: SubscriptionFilter,
-    ) -> (mpsc::UnboundedReceiver<String>, ModernSubscriptionGuard) {
+        principal: Option<SubscriptionPrincipal>,
+    ) -> std::result::Result<ModernSubscriptionRegistration, SubscriptionAdmissionError> {
+        let metadata_bytes = serde_json::to_vec(&subscription_id)
+            .map(|serialized| serialized.len())
+            .unwrap_or(usize::MAX)
+            .saturating_add(
+                serde_json::to_vec(&filter)
+                    .map(|serialized| serialized.len())
+                    .unwrap_or(usize::MAX),
+            );
+        if metadata_bytes > self.limits.max_metadata_bytes {
+            return Err(SubscriptionAdmissionError::MetadataTooLarge);
+        }
+
+        let mut subscriptions = self.subscriptions.lock().unwrap();
+        if subscriptions.len() >= self.limits.max_active {
+            return Err(SubscriptionAdmissionError::GlobalLimit);
+        }
+        if let (Some(principal), Some(max)) =
+            (principal.as_ref(), self.limits.max_active_per_principal)
+            && subscriptions
+                .values()
+                .filter(|subscription| subscription.principal.as_ref() == Some(principal))
+                .count()
+                >= max
+        {
+            return Err(SubscriptionAdmissionError::PrincipalLimit);
+        }
+
         let key = self.next_key.fetch_add(1, Ordering::Relaxed);
-        let (tx, rx) = mpsc::unbounded_channel();
-        self.subscriptions.lock().unwrap().insert(
+        let channel_capacity = self
+            .limits
+            .max_buffered_messages
+            .clamp(1, tokio::sync::Semaphore::MAX_PERMITS);
+        let (tx, notifications) = mpsc::channel(channel_capacity);
+        let (terminal_tx, terminal) = oneshot::channel();
+        subscriptions.insert(
             key,
             ModernSubscription {
                 subscription_id,
                 filter,
+                principal,
                 tx,
+                terminal_tx: Some(terminal_tx),
+                buffered_bytes: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                max_buffered_messages: self.limits.max_buffered_messages,
+                max_buffered_bytes: self.limits.max_buffered_bytes,
                 started: std::time::Instant::now(),
             },
         );
-        (
-            rx,
-            ModernSubscriptionGuard {
+        Ok(ModernSubscriptionRegistration {
+            notifications,
+            terminal,
+            guard: ModernSubscriptionGuard {
                 key,
                 registry: self.clone(),
             },
-        )
+        })
     }
 
     /// Route subscription-scoped notifications and return whether the
@@ -110,31 +289,58 @@ impl ModernSubscriptionRegistry {
             return false;
         }
 
-        let mut subscriptions = self.subscriptions.lock().unwrap();
-        tracing::trace!(
-            active_subscriptions = subscriptions.len(),
-            notification = ?notification,
-            "Routing final-protocol subscription notification"
-        );
-        subscriptions.retain(|_, subscription| {
-            let keep = if subscription_matches(notification, &subscription.filter)
-                && let Some(json) =
+        let removed = {
+            let mut subscriptions = self.subscriptions.lock().unwrap();
+            tracing::trace!(
+                active_subscriptions = subscriptions.len(),
+                notification = ?notification,
+                "Routing final-protocol subscription notification"
+            );
+            let mut removals = Vec::new();
+            for (key, subscription) in subscriptions.iter() {
+                let result = if subscription_matches(notification, &subscription.filter) {
                     tagged_subscription_notification(notification, &subscription.subscription_id)
-            {
-                subscription.tx.send(json).is_ok()
-            } else {
-                !subscription.tx.is_closed()
-            };
-            if !keep {
-                // Detected here rather than at guard drop: the entry is
-                // removed exactly once, so the close is reported exactly once.
-                self.observe_close(
-                    subscription,
-                    crate::transport::subscriptions::SubscriptionCloseReason::Disconnected,
-                );
+                        .map(|json| subscription.try_enqueue(json))
+                        .unwrap_or(Ok(()))
+                } else if subscription.tx.is_closed() {
+                    Err(SubscriptionQueueError::Disconnected)
+                } else {
+                    Ok(())
+                };
+                if let Err(error) = result {
+                    removals.push((*key, error));
+                }
             }
-            keep
-        });
+            removals
+                .into_iter()
+                .filter_map(|(key, error)| {
+                    subscriptions
+                        .remove(&key)
+                        .map(|subscription| (subscription, error))
+                })
+                .collect::<Vec<_>>()
+        };
+
+        for (mut subscription, error) in removed {
+            let reason = match error {
+                SubscriptionQueueError::BufferOverflow => {
+                    let response = JsonRpcResponse::error(
+                        Some(subscription.subscription_id.clone()),
+                        JsonRpcError::internal_error("Subscription notification buffer exceeded"),
+                    );
+                    if let Ok(json) = serde_json::to_string(&response)
+                        && let Some(terminal_tx) = subscription.terminal_tx.take()
+                    {
+                        let _ = terminal_tx.send(SubscriptionTerminal::BufferOverflow(json));
+                    }
+                    crate::transport::subscriptions::SubscriptionCloseReason::BufferOverflow
+                }
+                SubscriptionQueueError::Disconnected => {
+                    crate::transport::subscriptions::SubscriptionCloseReason::Disconnected
+                }
+            };
+            self.observe_close(&subscription, reason);
+        }
         true
     }
 
@@ -152,7 +358,7 @@ impl ModernSubscriptionRegistry {
                 .collect::<Vec<_>>()
         };
         let count = subscriptions.len();
-        for subscription in subscriptions {
+        for mut subscription in subscriptions {
             self.observe_close(
                 &subscription,
                 crate::transport::subscriptions::SubscriptionCloseReason::Drained,
@@ -161,8 +367,10 @@ impl ModernSubscriptionRegistry {
                 subscription.subscription_id,
                 self.server_info.clone(),
             );
-            if let Ok(json) = serde_json::to_string(&response) {
-                let _ = subscription.tx.send(json);
+            if let Ok(json) = serde_json::to_string(&response)
+                && let Some(terminal_tx) = subscription.terminal_tx.take()
+            {
+                let _ = terminal_tx.send(SubscriptionTerminal::Drained(json));
             }
         }
         count
@@ -171,7 +379,7 @@ impl ModernSubscriptionRegistry {
 
 impl Default for ModernSubscriptionRegistry {
     fn default() -> Self {
-        Self::new(None, None)
+        Self::new(SubscriptionLimits::default(), None, None)
     }
 }
 
@@ -536,9 +744,20 @@ pub(super) async fn handle_modern_subscriptions_listen_sse(
         }
     };
 
-    let (rx, guard) = state
-        .modern_subscriptions
-        .register(subscription_id.clone(), accepted.clone());
+    let registration = match state.modern_subscriptions.try_register(
+        subscription_id.clone(),
+        accepted.clone(),
+        subscription_principal(http_extensions),
+    ) {
+        Ok(registration) => registration,
+        Err(_) => {
+            return json_rpc_error_response_with_status(
+                Some(subscription_id),
+                JsonRpcError::internal_error("Subscription limit reached"),
+                StatusCode::OK,
+            );
+        }
+    };
     let acknowledgment = serde_json::json!({
         "jsonrpc": "2.0",
         "method": "notifications/subscriptions/acknowledged",
@@ -553,25 +772,100 @@ pub(super) async fn handle_modern_subscriptions_listen_sse(
 
     struct ModernListenStream {
         first: Option<String>,
-        rx: mpsc::UnboundedReceiver<String>,
+        notifications: mpsc::Receiver<QueuedSubscriptionMessage>,
+        terminal: Option<oneshot::Receiver<SubscriptionTerminal>>,
+        graceful_completion: Option<String>,
+        done: bool,
         _guard: ModernSubscriptionGuard,
     }
 
     let stream = futures::stream::unfold(
         ModernListenStream {
             first: Some(acknowledgment),
-            rx,
-            _guard: guard,
+            notifications: registration.notifications,
+            terminal: Some(registration.terminal),
+            graceful_completion: None,
+            done: false,
+            _guard: registration.guard,
         },
         |mut state| async move {
-            let message = match state.first.take() {
-                Some(first) => Some(first),
-                None => state.rx.recv().await,
-            }?;
-            Some((
-                Ok::<_, Infallible>(Event::default().event(SSE_MESSAGE_EVENT).data(message)),
-                state,
-            ))
+            if state.done {
+                return None;
+            }
+            if let Some(first) = state.first.take() {
+                return Some((
+                    Ok::<_, Infallible>(Event::default().event(SSE_MESSAGE_EVENT).data(first)),
+                    state,
+                ));
+            }
+
+            loop {
+                if let Some(completion) = state.graceful_completion.as_ref() {
+                    if let Some(message) = state.notifications.recv().await {
+                        return Some((
+                            Ok(Event::default()
+                                .event(SSE_MESSAGE_EVENT)
+                                .data(message.into_json())),
+                            state,
+                        ));
+                    }
+                    let completion = completion.clone();
+                    state.graceful_completion = None;
+                    state.done = true;
+                    return Some((
+                        Ok(Event::default().event(SSE_MESSAGE_EVENT).data(completion)),
+                        state,
+                    ));
+                }
+
+                let Some(mut terminal) = state.terminal.take() else {
+                    let message = state.notifications.recv().await?;
+                    return Some((
+                        Ok(Event::default()
+                            .event(SSE_MESSAGE_EVENT)
+                            .data(message.into_json())),
+                        state,
+                    ));
+                };
+
+                tokio::select! {
+                    biased;
+                    terminal_result = &mut terminal => {
+                        match terminal_result {
+                            Ok(SubscriptionTerminal::BufferOverflow(error)) => {
+                                state.notifications.close();
+                                while state.notifications.try_recv().is_ok() {}
+                                state.done = true;
+                                return Some((
+                                    Ok(Event::default().event(SSE_MESSAGE_EVENT).data(error)),
+                                    state,
+                                ));
+                            }
+                            Ok(SubscriptionTerminal::Drained(completion)) => {
+                                state.graceful_completion = Some(completion);
+                            }
+                            Err(_) => {
+                                // No terminal control remains. Drain any data
+                                // the sender queued before it disconnected.
+                            }
+                        }
+                    }
+                    message = state.notifications.recv() => {
+                        state.terminal = Some(terminal);
+                        if let Some(message) = message {
+                            return Some((
+                                Ok(Event::default()
+                                    .event(SSE_MESSAGE_EVENT)
+                                    .data(message.into_json())),
+                                state,
+                            ));
+                        }
+                        // The sender can close immediately after sending its
+                        // out-of-band terminal control. Loop once so the
+                        // terminal receiver wins before ending the stream.
+                    }
+                }
+            }
         },
     );
 

--- a/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
+++ b/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
@@ -132,6 +132,9 @@ pub(super) struct ModernSubscription {
 }
 
 impl ModernSubscription {
+    // `fetch_update` is available on our MSRV; Rust 1.99 renames it to
+    // `try_update`, which cannot be used until the MSRV advances.
+    #[allow(deprecated)]
     fn try_enqueue(&self, json: String) -> std::result::Result<(), SubscriptionQueueError> {
         if self.max_buffered_messages == 0 {
             return Err(SubscriptionQueueError::BufferOverflow);

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -244,6 +244,7 @@ fn final_result_fields_preserve_explicit_values_and_legacy_wire_shape() {
 #[tokio::test]
 #[cfg(feature = "stateless")]
 async fn modern_subscription_registry_reports_closes() {
+    use super::stateless_dispatch::SubscriptionTerminal;
     use crate::transport::subscriptions::{
         SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver,
     };
@@ -260,29 +261,38 @@ async fn modern_subscription_registry_reports_closes() {
 
     let observer = Arc::new(RecordingObserver::default());
     let registry = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default(),
         None,
         Some(observer.clone()),
     ));
 
     // A dropped guard is a client disconnect.
-    let (_rx, guard) = registry.register(
-        RequestId::String("disconnects".into()),
-        SubscriptionFilter {
-            tools_list_changed: Some(true),
-            ..SubscriptionFilter::default()
-        },
-    );
-    drop(guard);
+    let disconnected = registry
+        .try_register(
+            RequestId::String("disconnects".into()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+            None,
+        )
+        .unwrap();
+    drop(disconnected.guard);
 
     // A drained registry is a graceful server-side close.
-    let (_rx2, guard2) = registry.register(
-        RequestId::String("drains".into()),
-        SubscriptionFilter::default(),
-    );
+    let drained = registry
+        .try_register(
+            RequestId::String("drains".into()),
+            SubscriptionFilter::default(),
+            None,
+        )
+        .unwrap();
     assert_eq!(registry.close_all(), 1);
+    let terminal = drained.terminal.await.unwrap();
+    assert!(matches!(terminal, SubscriptionTerminal::Drained(_)));
     // The entry is already gone, so the later guard drop must not
     // produce a second record.
-    drop(guard2);
+    drop(drained.guard);
 
     let closes = observer.closes.lock().unwrap();
     assert_eq!(closes.len(), 2, "one record per stream: {closes:?}");
@@ -302,31 +312,301 @@ async fn modern_subscription_registry_reports_closes() {
 #[cfg(feature = "stateless")]
 async fn modern_subscription_registry_filters_and_tags_notifications() {
     let registry = Arc::new(ModernSubscriptionRegistry::default());
-    let (mut rx, guard) = registry.register(
-        RequestId::String("listen-1".to_string()),
-        SubscriptionFilter {
-            tools_list_changed: Some(true),
-            ..SubscriptionFilter::default()
-        },
-    );
+    let mut registration = registry
+        .try_register(
+            RequestId::String("listen-1".to_string()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+            None,
+        )
+        .unwrap();
 
     assert!(registry.publish(&ServerNotification::PromptsListChanged));
     assert!(matches!(
-        rx.try_recv(),
+        registration.notifications.try_recv(),
         Err(mpsc::error::TryRecvError::Empty)
     ));
 
     assert!(registry.publish(&ServerNotification::ToolsListChanged));
-    let message = rx.recv().await.expect("matching notification");
-    let json: serde_json::Value = serde_json::from_str(&message).unwrap();
+    let message = registration
+        .notifications
+        .recv()
+        .await
+        .expect("matching notification");
+    let json: serde_json::Value = serde_json::from_str(message.as_str()).unwrap();
     assert_eq!(json["method"], "notifications/tools/list_changed");
     assert_eq!(
         json["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
         "listen-1"
     );
 
-    drop(guard);
+    drop(registration.guard);
     assert!(registry.subscriptions.lock().unwrap().is_empty());
+}
+
+#[test]
+#[cfg(feature = "stateless")]
+fn modern_subscription_registry_enforces_global_and_principal_limits() {
+    use super::stateless_dispatch::{SubscriptionAdmissionError, SubscriptionPrincipal};
+
+    let global = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default().max_active(1),
+        None,
+        None,
+    ));
+    let first = global
+        .try_register(
+            RequestId::String("global-1".into()),
+            SubscriptionFilter::default(),
+            None,
+        )
+        .unwrap();
+    let rejected = global.try_register(
+        RequestId::String("global-2".into()),
+        SubscriptionFilter::default(),
+        None,
+    );
+    assert!(matches!(
+        rejected,
+        Err(SubscriptionAdmissionError::GlobalLimit)
+    ));
+    drop(first.guard);
+    let reopened = global
+        .try_register(
+            RequestId::String("global-3".into()),
+            SubscriptionFilter::default(),
+            None,
+        )
+        .expect("dropping a guard must reopen the global slot");
+    drop(reopened.guard);
+
+    let per_principal = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default()
+            .max_active(4)
+            .max_active_per_principal(1),
+        None,
+        None,
+    ));
+    let alice = Some(SubscriptionPrincipal::AuthClient("alice".into()));
+    let bob = Some(SubscriptionPrincipal::AuthClient("bob".into()));
+    let alice_first = per_principal
+        .try_register(
+            RequestId::String("alice-1".into()),
+            SubscriptionFilter::default(),
+            alice.clone(),
+        )
+        .unwrap();
+    let alice_rejected = per_principal.try_register(
+        RequestId::String("alice-2".into()),
+        SubscriptionFilter::default(),
+        alice,
+    );
+    assert!(matches!(
+        alice_rejected,
+        Err(SubscriptionAdmissionError::PrincipalLimit)
+    ));
+    let bob_allowed = per_principal
+        .try_register(
+            RequestId::String("bob-1".into()),
+            SubscriptionFilter::default(),
+            bob,
+        )
+        .expect("one principal must not consume another principal's quota");
+    drop(alice_first.guard);
+    drop(bob_allowed.guard);
+
+    let bounded_metadata = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default().max_metadata_bytes(8),
+        None,
+        None,
+    ));
+    let oversized = bounded_metadata.try_register(
+        RequestId::String("filter-too-large".into()),
+        SubscriptionFilter {
+            resource_subscriptions: Some(vec!["file:///a-long-resource-name".into()]),
+            ..SubscriptionFilter::default()
+        },
+        None,
+    );
+    assert!(matches!(
+        oversized,
+        Err(SubscriptionAdmissionError::MetadataTooLarge)
+    ));
+    assert_eq!(bounded_metadata.len(), 0);
+
+    let empty_filter_bytes = serde_json::to_vec(&SubscriptionFilter::default())
+        .unwrap()
+        .len();
+    let bounded_id = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default().max_metadata_bytes(empty_filter_bytes + 8),
+        None,
+        None,
+    ));
+    let oversized_id = bounded_id.try_register(
+        RequestId::String("x".repeat(64)),
+        SubscriptionFilter::default(),
+        None,
+    );
+    assert!(matches!(
+        oversized_id,
+        Err(SubscriptionAdmissionError::MetadataTooLarge)
+    ));
+    assert_eq!(bounded_id.len(), 0);
+    let small_id = bounded_id
+        .try_register(RequestId::Number(1), SubscriptionFilter::default(), None)
+        .expect("the same filter with a compact ID must fit the metadata budget");
+    drop(small_id.guard);
+
+    let oversized_message_limit = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default().max_buffered_messages(usize::MAX),
+        None,
+        None,
+    ));
+    let registration = oversized_message_limit
+        .try_register(
+            RequestId::String("large-host-setting".into()),
+            SubscriptionFilter::default(),
+            None,
+        )
+        .expect("an oversized host setting must be clamped, not panic remotely");
+    drop(registration.guard);
+}
+
+#[test]
+#[cfg(all(feature = "stateless", feature = "oauth"))]
+fn modern_subscription_principal_prefers_oauth_and_supports_client_credentials() {
+    use super::stateless_dispatch::{SubscriptionPrincipal, subscription_principal};
+
+    let mut extensions = axum::http::Extensions::new();
+    extensions.insert(crate::auth::AuthInfo {
+        client_id: "generic-client".into(),
+        claims: None,
+    });
+    extensions.insert(crate::oauth::token::TokenClaims {
+        sub: Some("alice".into()),
+        iss: Some("https://issuer.example".into()),
+        aud: None,
+        exp: None,
+        scope: None,
+        client_id: Some("oauth-client".into()),
+        extra: std::collections::HashMap::new(),
+    });
+    assert_eq!(
+        subscription_principal(&extensions),
+        Some(SubscriptionPrincipal::OAuthSubject {
+            issuer: Some("https://issuer.example".into()),
+            subject: "alice".into(),
+        })
+    );
+
+    extensions.insert(crate::oauth::token::TokenClaims {
+        sub: None,
+        iss: Some("https://issuer.example".into()),
+        aud: None,
+        exp: None,
+        scope: None,
+        client_id: Some("oauth-client".into()),
+        extra: std::collections::HashMap::new(),
+    });
+    assert_eq!(
+        subscription_principal(&extensions),
+        Some(SubscriptionPrincipal::OAuthClient {
+            issuer: Some("https://issuer.example".into()),
+            client_id: "oauth-client".into(),
+        })
+    );
+}
+
+#[tokio::test]
+#[cfg(feature = "stateless")]
+async fn modern_subscription_registry_bounds_messages_and_reports_overflow_once() {
+    use super::stateless_dispatch::SubscriptionTerminal;
+    use crate::transport::subscriptions::{
+        SubscriptionClose, SubscriptionCloseReason, SubscriptionObserver,
+    };
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        closes: std::sync::Mutex<Vec<SubscriptionClose>>,
+    }
+    impl SubscriptionObserver for RecordingObserver {
+        fn on_close(&self, close: SubscriptionClose) {
+            self.closes.lock().unwrap().push(close);
+        }
+    }
+
+    let observer = Arc::new(RecordingObserver::default());
+    let registry = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default().max_buffered_messages(1),
+        None,
+        Some(observer.clone()),
+    ));
+    let registration = registry
+        .try_register(
+            RequestId::String("overflow".into()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+            None,
+        )
+        .unwrap();
+
+    assert!(registry.publish(&ServerNotification::ToolsListChanged));
+    assert_eq!(registry.len(), 1);
+    assert!(registry.publish(&ServerNotification::ToolsListChanged));
+    assert_eq!(registry.len(), 0);
+
+    let terminal = registration.terminal.await.unwrap();
+    let SubscriptionTerminal::BufferOverflow(json) = terminal else {
+        panic!("message overflow must terminate with an error");
+    };
+    let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(json["id"], "overflow");
+    assert_eq!(json["error"]["code"], -32603);
+
+    drop(registration.guard);
+    let closes = observer.closes.lock().unwrap();
+    assert_eq!(
+        closes.len(),
+        1,
+        "guard drop must not double-report overflow"
+    );
+    assert_eq!(closes[0].reason, SubscriptionCloseReason::BufferOverflow);
+}
+
+#[tokio::test]
+#[cfg(feature = "stateless")]
+async fn modern_subscription_registry_enforces_the_byte_budget() {
+    use super::stateless_dispatch::SubscriptionTerminal;
+
+    let registry = Arc::new(ModernSubscriptionRegistry::new(
+        SubscriptionLimits::default()
+            .max_buffered_messages(4)
+            .max_buffered_bytes(1),
+        None,
+        None,
+    ));
+    let registration = registry
+        .try_register(
+            RequestId::String("byte-overflow".into()),
+            SubscriptionFilter {
+                tools_list_changed: Some(true),
+                ..SubscriptionFilter::default()
+            },
+            None,
+        )
+        .unwrap();
+
+    assert!(registry.publish(&ServerNotification::ToolsListChanged));
+    assert_eq!(registry.len(), 0);
+    assert!(matches!(
+        registration.terminal.await.unwrap(),
+        SubscriptionTerminal::BufferOverflow(_)
+    ));
+    drop(registration.guard);
 }
 
 #[tokio::test]

--- a/crates/tower-mcp/src/transport/mod.rs
+++ b/crates/tower-mcp/src/transport/mod.rs
@@ -43,6 +43,9 @@ pub use stdio::{
 #[cfg(feature = "http")]
 pub use http::{HttpTransport, SessionHandle, SessionInfo};
 
+#[cfg(all(feature = "http", feature = "stateless"))]
+pub use http::SubscriptionLimits;
+
 #[cfg(feature = "websocket")]
 pub use websocket::WebSocketTransport;
 

--- a/crates/tower-mcp/src/transport/subscriptions.rs
+++ b/crates/tower-mcp/src/transport/subscriptions.rs
@@ -97,6 +97,8 @@ pub enum SubscriptionCloseReason {
     Cancelled,
     /// The client connection or response stream dropped.
     Disconnected,
+    /// The stream's bounded notification backlog was exceeded.
+    BufferOverflow,
     /// The server drained the stream gracefully (shutdown or an explicit
     /// close), sending the terminal `SubscriptionsListenResult` first where
     /// the transport still could.

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -31,6 +31,59 @@ fn app() -> axum::Router {
         .into_router()
 }
 
+#[cfg(feature = "stateless")]
+fn final_request(id: &str, method: &str, params: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .header("Mcp-Protocol-Version", "2026-07-28")
+        .header("Mcp-Method", method)
+        .body(Body::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params,
+            })
+            .to_string(),
+        ))
+        .unwrap()
+}
+
+#[cfg(feature = "stateless")]
+fn final_meta() -> serde_json::Value {
+    serde_json::json!({
+        "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+        "io.modelcontextprotocol/clientCapabilities": {},
+    })
+}
+
+#[cfg(feature = "stateless")]
+async fn response_text(response: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[cfg(feature = "stateless")]
+async fn next_body_data(body: &mut Body) -> String {
+    use http_body_util::BodyExt;
+
+    loop {
+        let frame = tokio::time::timeout(std::time::Duration::from_secs(10), body.frame())
+            .await
+            .expect("timed out waiting for SSE data")
+            .expect("SSE stream ended early")
+            .expect("SSE stream failed");
+        if let Ok(data) = frame.into_data() {
+            return String::from_utf8(data.to_vec()).unwrap();
+        }
+    }
+}
+
 /// POST a `subscriptions/listen` request with the given protocol version.
 async fn post_subscriptions_listen(protocol_version: Option<&str>) -> axum::response::Response {
     let mut builder = Request::builder()
@@ -214,6 +267,253 @@ async fn subscriptions_listen_requires_notification_filter() {
 
 #[cfg(feature = "stateless")]
 #[tokio::test]
+async fn subscription_capacity_rejects_n_plus_one_without_blocking_other_requests() {
+    let (app, handle) = HttpTransport::new(router())
+        .subscription_limits(tower_mcp::SubscriptionLimits::default().max_active(1))
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_router_with_handle();
+    let listen_params = || {
+        serde_json::json!({
+            "_meta": final_meta(),
+            "notifications": { "resourceSubscriptions": ["file:///wanted"] },
+        })
+    };
+
+    let first = app
+        .clone()
+        .oneshot(final_request(
+            "listen-capacity-1",
+            "subscriptions/listen",
+            listen_params(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(handle.subscription_count(), 1);
+
+    let rejected = app
+        .clone()
+        .oneshot(final_request(
+            "listen-capacity-2",
+            "subscriptions/listen",
+            listen_params(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(rejected.status(), StatusCode::OK);
+    let rejected: serde_json::Value = serde_json::from_str(&response_text(rejected).await).unwrap();
+    assert_eq!(rejected["id"], "listen-capacity-2");
+    assert_eq!(rejected["error"]["code"], -32603);
+    assert_eq!(rejected["error"]["message"], "Subscription limit reached");
+    assert_eq!(handle.subscription_count(), 1);
+
+    let tools = app
+        .clone()
+        .oneshot(final_request(
+            "tools-while-full",
+            "tools/list",
+            serde_json::json!({ "_meta": final_meta() }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(tools.status(), StatusCode::OK);
+    let tools: serde_json::Value = serde_json::from_str(&response_text(tools).await).unwrap();
+    assert_eq!(tools["id"], "tools-while-full");
+    assert_eq!(tools["result"]["tools"][0]["name"], "echo");
+
+    drop(first);
+    assert_eq!(handle.subscription_count(), 0);
+
+    let reopened = app
+        .oneshot(final_request(
+            "listen-capacity-3",
+            "subscriptions/listen",
+            listen_params(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(reopened.status(), StatusCode::OK);
+    assert_eq!(handle.subscription_count(), 1);
+    drop(reopened);
+    assert_eq!(handle.subscription_count(), 0);
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn authenticated_principal_capacity_isolated_on_the_http_path() {
+    use tower_mcp::SubscriptionLimits;
+    use tower_mcp::auth::{ApiKeyValidator, AuthLayer};
+
+    let (transport, handle) = HttpTransport::new(router())
+        .subscription_limits(
+            SubscriptionLimits::default()
+                .max_active(3)
+                .max_active_per_principal(1),
+        )
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_router_with_handle();
+    let app = transport.layer(AuthLayer::new(ApiKeyValidator::new([
+        "alice-key-1".to_string(),
+        "bob-key-1".to_string(),
+    ])));
+    let params = || {
+        serde_json::json!({
+            "_meta": final_meta(),
+            "notifications": { "toolsListChanged": true },
+        })
+    };
+    let request = |id: &str, key: &'static str| {
+        let mut request = final_request(id, "subscriptions/listen", params());
+        request
+            .headers_mut()
+            .insert("Authorization", axum::http::HeaderValue::from_static(key));
+        request
+    };
+
+    let alice = app
+        .clone()
+        .oneshot(request("alice-1", "alice-key-1"))
+        .await
+        .unwrap();
+    assert_eq!(alice.status(), StatusCode::OK);
+    assert_eq!(handle.subscription_count(), 1);
+
+    let alice_rejected = app
+        .clone()
+        .oneshot(request("alice-2", "alice-key-1"))
+        .await
+        .unwrap();
+    assert_eq!(alice_rejected.status(), StatusCode::OK);
+    let error: serde_json::Value =
+        serde_json::from_str(&response_text(alice_rejected).await).unwrap();
+    assert_eq!(error["id"], "alice-2");
+    assert_eq!(error["error"]["code"], -32603);
+
+    let bob = app.oneshot(request("bob-1", "bob-key-1")).await.unwrap();
+    assert_eq!(bob.status(), StatusCode::OK);
+    assert_eq!(handle.subscription_count(), 2);
+
+    drop(alice);
+    drop(bob);
+    assert_eq!(handle.subscription_count(), 0);
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn notification_overflow_closes_only_the_slow_subscription() {
+    use std::sync::{Arc, Mutex};
+    use tower_mcp::{
+        SubscriptionClose, SubscriptionCloseReason, SubscriptionLimits, SubscriptionObserver,
+    };
+
+    #[derive(Default)]
+    struct RecordingObserver {
+        closes: Mutex<Vec<SubscriptionClose>>,
+    }
+    impl SubscriptionObserver for RecordingObserver {
+        fn on_close(&self, close: SubscriptionClose) {
+            self.closes.lock().unwrap().push(close);
+        }
+    }
+
+    let observer = Arc::new(RecordingObserver::default());
+    let router = router().with_subscription_observer(observer.clone());
+    let publisher = router.clone();
+    let (app, handle) = HttpTransport::new(router)
+        .subscription_limits(
+            SubscriptionLimits::default()
+                .max_active(2)
+                .max_buffered_messages(1),
+        )
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_router_with_handle();
+    let listen_params = || {
+        serde_json::json!({
+            "_meta": final_meta(),
+            "notifications": { "resourceSubscriptions": ["file:///wanted"] },
+        })
+    };
+
+    let slow = app
+        .clone()
+        .oneshot(final_request(
+            "listen-slow",
+            "subscriptions/listen",
+            listen_params(),
+        ))
+        .await
+        .unwrap();
+    let healthy = app
+        .oneshot(final_request(
+            "listen-healthy",
+            "subscriptions/listen",
+            listen_params(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(handle.subscription_count(), 2);
+
+    let mut healthy_body = healthy.into_body();
+    let acknowledgment = next_body_data(&mut healthy_body).await;
+    assert!(acknowledgment.contains("notifications/subscriptions/acknowledged"));
+
+    assert!(publisher.notify_resource_updated("file:///wanted"));
+    let first = next_body_data(&mut healthy_body).await;
+    assert!(first.contains("notifications/resources/updated"));
+
+    // The unread stream still has its first notification buffered, while the
+    // healthy stream has made room. A second publish must evict only the slow
+    // subscriber.
+    assert!(publisher.notify_resource_updated("file:///wanted"));
+    assert_eq!(handle.subscription_count(), 1);
+    let second = next_body_data(&mut healthy_body).await;
+    assert!(second.contains("notifications/resources/updated"));
+
+    let slow = response_text(slow).await;
+    let acknowledged = slow
+        .find("notifications/subscriptions/acknowledged")
+        .expect("overflowed stream must still acknowledge first");
+    let terminal = slow
+        .find("\"code\":-32603")
+        .expect("overflowed stream must end with an internal JSON-RPC error");
+    assert!(
+        acknowledged < terminal,
+        "acknowledgment must precede error: {slow}"
+    );
+    assert!(slow.contains("Subscription notification buffer exceeded"));
+    assert!(
+        !slow.contains("notifications/resources/updated"),
+        "queued data is discarded when a stream overflows: {slow}"
+    );
+
+    {
+        let closes = observer.closes.lock().unwrap();
+        let overflows: Vec<_> = closes
+            .iter()
+            .filter(|close| {
+                close.subscription_id == tower_mcp::RequestId::String("listen-slow".into())
+            })
+            .collect();
+        assert_eq!(overflows.len(), 1, "overflow is observed exactly once");
+        assert_eq!(overflows[0].reason, SubscriptionCloseReason::BufferOverflow);
+    }
+
+    assert_eq!(handle.close_subscriptions(), 1);
+    let rest = axum::body::to_bytes(healthy_body, usize::MAX)
+        .await
+        .unwrap();
+    assert!(
+        String::from_utf8(rest.to_vec())
+            .unwrap()
+            .contains("\"resultType\":\"complete\"")
+    );
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
 async fn server_gracefully_drains_http_subscription_streams() {
     let router = router();
     let publisher = router.clone();
@@ -248,10 +548,14 @@ async fn server_gracefully_drains_http_subscription_streams() {
     let acknowledgment = body
         .find("notifications/subscriptions/acknowledged")
         .expect("stream must begin with an acknowledgment");
+    let notification = body
+        .find("notifications/resources/updated")
+        .expect("queued notifications must be drained");
     let completion = body
         .find("\"resultType\":\"complete\"")
         .expect("stream must end with a graceful result");
-    assert!(acknowledgment < completion);
+    assert!(acknowledgment < notification);
+    assert!(notification < completion);
     assert!(body.contains("\"id\":\"graceful-http\""));
     assert!(body.contains("\"io.modelcontextprotocol/subscriptionId\":\"graceful-http\""));
     assert!(body.contains("\"io.modelcontextprotocol/serverInfo\""));
@@ -497,6 +801,92 @@ mod tasks {
             body.contains("\"io.modelcontextprotocol/subscriptionId\":\"listen-1\""),
             "the notification must be tagged with the subscription: {body}"
         );
+    }
+
+    /// Closing an overloaded notification stream must not affect the task
+    /// store: clients can reconnect and recover the authoritative state with
+    /// `tasks/get`.
+    #[tokio::test]
+    async fn task_state_remains_available_after_subscription_buffer_overflow() {
+        let delayed = ToolBuilder::new("delayed")
+            .description("Complete after the listen stream has been registered")
+            .task_support(TaskSupportMode::Optional)
+            .handler(|_: serde_json::Value| async move {
+                tokio::time::sleep(Duration::from_millis(500)).await;
+                Ok(CallToolResult::text("done"))
+            })
+            .build();
+        let task_router = McpRouter::new()
+            .server_info("listen-test-server", "1.0.0")
+            .tool(delayed)
+            .with_tasks();
+        let (app, handle) = HttpTransport::new(task_router)
+            .subscription_limits(tower_mcp::SubscriptionLimits::default().max_buffered_messages(0))
+            .disable_origin_validation()
+            .disable_host_validation()
+            .into_router_with_handle();
+
+        let create = app
+            .clone()
+            .oneshot(final_request(
+                "call-overflow",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "delayed",
+                    "arguments": {},
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::OK);
+        let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
+        let task_id = created["result"]["taskId"].as_str().unwrap().to_string();
+
+        let listen = app
+            .clone()
+            .oneshot(final_request(
+                "listen-overflow",
+                "subscriptions/listen",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "notifications": { "taskIds": [&task_id] },
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(listen.status(), StatusCode::OK);
+        assert_eq!(handle.subscription_count(), 1);
+
+        let body = tokio::time::timeout(Duration::from_secs(10), body_string(listen))
+            .await
+            .expect("task completion must overflow and close the listen stream");
+        let acknowledgment = body
+            .find("notifications/subscriptions/acknowledged")
+            .expect("overflowed stream must acknowledge first");
+        let terminal = body
+            .find("\"code\":-32603")
+            .expect("overflowed stream must end with an internal JSON-RPC error");
+        assert!(acknowledgment < terminal);
+        assert!(body.contains("Subscription notification buffer exceeded"));
+        assert_eq!(handle.subscription_count(), 0);
+
+        let mut get_request = final_request(
+            "get-after-overflow",
+            "tasks/get",
+            serde_json::json!({ "_meta": meta(true), "taskId": &task_id }),
+        );
+        get_request
+            .headers_mut()
+            .insert("Mcp-Name", task_id.parse().unwrap());
+        let get = app.oneshot(get_request).await.unwrap();
+        let status = get.status();
+        let get_body = body_string(get).await;
+        assert_eq!(status, StatusCode::OK, "unexpected tasks/get: {get_body}");
+        let get: serde_json::Value = serde_json::from_str(&get_body).unwrap();
+        assert_eq!(get["id"], "get-after-overflow");
+        assert_eq!(get["result"]["taskId"], task_id);
+        assert_eq!(get["result"]["status"], "completed");
     }
 
     /// A subscriber that named a different owned task never receives this one.


### PR DESCRIPTION
Closes #1395

This bounds final-protocol HTTP subscriptions by default and exposes SubscriptionLimits for host policy.

What changed:
- enforce per-transport active-stream and optional per-principal admission limits
- bound retained request ID/filter metadata, queued message count, and queued serialized bytes
- use bounded queues and close only a lagging stream with an observable JSON-RPC terminal error
- preserve acknowledgment ordering, graceful drain ordering, and authoritative tasks/get recovery
- identify OAuth subject/client-credentials and generic AuthInfo principals without cross-issuer collisions
- document finite defaults and reconnect behavior

Validation:
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- HTTP-only and HTTP+stateless deployment doctests
- focused admission, metadata, principal, overflow-isolation, observer, graceful-drain, and tasks/get regressions