### PR TITLE
fix(router): authorize resource template access

### DIFF
--- a/crates/tower-mcp/src/filter.rs
+++ b/crates/tower-mcp/src/filter.rs
@@ -36,15 +36,16 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::context::Extensions;
 use crate::error::{Error, JsonRpcError};
 use crate::prompt::Prompt;
-use crate::resource::Resource;
+use crate::resource::{Resource, ResourceTemplate};
 use crate::session::SessionState;
 use crate::tool::Tool;
 
 /// Trait for capabilities that can be filtered by session.
 ///
-/// Implemented for [`Tool`], [`Resource`], and [`Prompt`].
+/// Implemented for [`Tool`], [`Resource`], [`ResourceTemplate`], and [`Prompt`].
 pub trait Filterable: Send + Sync {
     /// Returns the name of this capability.
     fn name(&self) -> &str;
@@ -57,6 +58,12 @@ impl Filterable for Tool {
 }
 
 impl Filterable for Resource {
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Filterable for ResourceTemplate {
     fn name(&self) -> &str {
         &self.name
     }
@@ -123,6 +130,83 @@ impl DenialBehavior {
     }
 }
 
+/// The operation for which a capability policy is being evaluated.
+///
+/// List operations decide whether a definition may be disclosed. Access
+/// operations authorize a concrete target before its handler is invoked.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CapabilityOperation<'a> {
+    /// The capability is being considered for a list or generated catalog.
+    List,
+    /// The capability is being accessed directly.
+    Access {
+        /// The concrete client-supplied target, such as a tool name or
+        /// resolved resource URI.
+        target: &'a str,
+    },
+}
+
+/// Request-aware context supplied to contextual capability filters.
+///
+/// This is intentionally lighter than [`crate::RequestContext`]: evaluating a
+/// visibility policy must not register cancellation or in-flight request
+/// state. Router-level extensions are merged with per-request extensions, and
+/// per-request values win when the same type is present in both maps.
+pub struct CapabilityFilterContext<'a> {
+    session: &'a SessionState,
+    extensions: Extensions,
+    operation: CapabilityOperation<'a>,
+}
+
+impl<'a> CapabilityFilterContext<'a> {
+    pub(crate) fn new(
+        session: &'a SessionState,
+        router_extensions: &Extensions,
+        request_extensions: &Extensions,
+        operation: CapabilityOperation<'a>,
+    ) -> Self {
+        let mut extensions = router_extensions.clone();
+        extensions.merge(request_extensions);
+        Self {
+            session,
+            extensions,
+            operation,
+        }
+    }
+
+    /// Return the logical MCP session being evaluated.
+    pub fn session(&self) -> &SessionState {
+        self.session
+    }
+
+    /// Return a typed router- or request-level extension.
+    ///
+    /// If both scopes contain the same type, the per-request value is
+    /// returned.
+    pub fn extension<T: Send + Sync + 'static>(&self) -> Option<&T> {
+        self.extensions.get::<T>()
+    }
+
+    /// Return all merged extensions visible to the policy.
+    pub fn extensions(&self) -> &Extensions {
+        &self.extensions
+    }
+
+    /// Return the operation being authorized.
+    pub fn operation(&self) -> CapabilityOperation<'a> {
+        self.operation
+    }
+
+    /// Return the concrete target for an access operation.
+    pub fn target(&self) -> Option<&'a str> {
+        match self.operation {
+            CapabilityOperation::List => None,
+            CapabilityOperation::Access { target } => Some(target),
+        }
+    }
+}
+
 /// A filter for capabilities based on session state.
 ///
 /// Use this to control which tools, resources, or prompts are visible
@@ -145,7 +229,7 @@ impl DenialBehavior {
 /// ```
 pub struct CapabilityFilter<T: Filterable> {
     #[allow(clippy::type_complexity)]
-    filter: Arc<dyn Fn(&SessionState, &T) -> bool + Send + Sync>,
+    filter: Arc<dyn for<'a> Fn(&CapabilityFilterContext<'a>, &T) -> bool + Send + Sync>,
     denial: DenialBehavior,
 }
 
@@ -187,6 +271,19 @@ impl<T: Filterable> CapabilityFilter<T> {
     where
         F: Fn(&SessionState, &T) -> bool + Send + Sync + 'static,
     {
+        Self::new_with_context(move |context, capability| filter(context.session(), capability))
+    }
+
+    /// Create a request-aware capability filter.
+    ///
+    /// The policy can inspect the logical session, router or per-request
+    /// extensions, and whether it is evaluating catalog disclosure or direct
+    /// access. For resource templates, an access operation's target is the
+    /// concrete resolved URI rather than the template pattern.
+    pub fn new_with_context<F>(filter: F) -> Self
+    where
+        F: for<'a> Fn(&CapabilityFilterContext<'a>, &T) -> bool + Send + Sync + 'static,
+    {
         Self {
             filter: Arc::new(filter),
             denial: DenialBehavior::default(),
@@ -212,7 +309,19 @@ impl<T: Filterable> CapabilityFilter<T> {
 
     /// Check if the given capability is visible to the session.
     pub fn is_visible(&self, session: &SessionState, capability: &T) -> bool {
-        (self.filter)(session, capability)
+        let empty = Extensions::new();
+        let context =
+            CapabilityFilterContext::new(session, &empty, &empty, CapabilityOperation::List);
+        self.is_visible_with_context(&context, capability)
+    }
+
+    /// Check whether the capability is visible for a request-aware operation.
+    pub fn is_visible_with_context(
+        &self,
+        context: &CapabilityFilterContext<'_>,
+        capability: &T,
+    ) -> bool {
+        (self.filter)(context, capability)
     }
 
     /// Get the error to return when access is denied.
@@ -303,6 +412,9 @@ pub type ToolFilter = CapabilityFilter<Tool>;
 /// Type alias for resource filters.
 pub type ResourceFilter = CapabilityFilter<Resource>;
 
+/// Type alias for resource template filters.
+pub type ResourceTemplateFilter = CapabilityFilter<ResourceTemplate>;
+
 /// Type alias for prompt filters.
 pub type PromptFilter = CapabilityFilter<Prompt>;
 
@@ -310,6 +422,8 @@ pub type PromptFilter = CapabilityFilter<Prompt>;
 mod tests {
     use super::*;
     use crate::CallToolResult;
+    use crate::protocol::ReadResourceResult;
+    use crate::resource::ResourceTemplateBuilder;
     use crate::tool::ToolBuilder;
 
     fn make_test_tool(name: &str) -> Tool {
@@ -317,6 +431,12 @@ mod tests {
             .description("Test tool")
             .handler(|_: serde_json::Value| async { Ok(CallToolResult::text("ok")) })
             .build()
+    }
+
+    fn make_test_template(name: &str) -> ResourceTemplate {
+        ResourceTemplateBuilder::new(format!("test://{name}/{{id}}"))
+            .name(name)
+            .handler(|uri, _variables| async move { Ok(ReadResourceResult::text(uri, "ok")) })
     }
 
     #[test]
@@ -328,6 +448,50 @@ mod tests {
 
         assert!(filter.is_visible(&session, &allowed));
         assert!(!filter.is_visible(&session, &blocked));
+    }
+
+    #[test]
+    fn contextual_filter_sees_session_operation_and_request_extension_precedence() {
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        struct Role(&'static str);
+        #[derive(Debug, PartialEq, Eq)]
+        struct Identity(&'static str);
+
+        let session = SessionState::new();
+        session.insert(Role("admin"));
+        let mut router_extensions = Extensions::new();
+        router_extensions.insert(Identity("router"));
+        let mut request_extensions = Extensions::new();
+        request_extensions.insert(Identity("request"));
+        let tool = make_test_tool("inspect");
+
+        let filter = CapabilityFilter::new_with_context(
+            |context: &CapabilityFilterContext<'_>, tool: &Tool| {
+                context.session().get::<Role>() == Some(Role("admin"))
+                    && context.extension::<Identity>() == Some(&Identity("request"))
+                    && context.extensions().contains::<Identity>()
+                    && context.operation() == (CapabilityOperation::Access { target: "inspect" })
+                    && context.target() == Some("inspect")
+                    && tool.name() == "inspect"
+            },
+        );
+        let context = CapabilityFilterContext::new(
+            &session,
+            &router_extensions,
+            &request_extensions,
+            CapabilityOperation::Access { target: "inspect" },
+        );
+
+        assert!(filter.is_visible_with_context(&context, &tool));
+    }
+
+    #[test]
+    fn resource_template_filter_uses_the_template_name() {
+        let session = SessionState::new();
+        let filter = ResourceTemplateFilter::allow_list(&["public"]);
+
+        assert!(filter.is_visible(&session, &make_test_template("public")));
+        assert!(!filter.is_visible(&session, &make_test_template("private")));
     }
 
     #[test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -635,7 +635,8 @@ pub use error::{
 };
 pub use extension::{ExtensionDeclaration, NegotiatedExtension, NegotiatedExtensions};
 pub use filter::{
-    CapabilityFilter, DenialBehavior, Filterable, PromptFilter, ResourceFilter, ToolFilter,
+    CapabilityFilter, CapabilityFilterContext, CapabilityOperation, DenialBehavior, Filterable,
+    PromptFilter, ResourceFilter, ResourceTemplateFilter, ToolFilter,
 };
 pub use jsonrpc::{JsonRpcLayer, JsonRpcService};
 pub use middleware::{

--- a/crates/tower-mcp/src/registry.rs
+++ b/crates/tower-mcp/src/registry.rs
@@ -435,6 +435,20 @@ impl DynamicResourceTemplatesInner {
 /// when handling `resources/templates/list` and `resources/read` requests.
 /// Static templates are checked before dynamic ones.
 ///
+/// Protocol requests are subject to the router's
+/// [`resource_template_filter`](crate::McpRouter::resource_template_filter).
+/// That policy is evaluated again for every request, including against the
+/// concrete URI selected by `resources/read`. If the router has a
+/// [`resource_filter`](crate::McpRouter::resource_filter) but no resource
+/// template filter, templates fail closed: they are omitted from protocol
+/// listings and cannot be read.
+///
+/// The registry handle is an application-management view, not a client-scoped
+/// protocol view. Its [`list`](Self::list) and [`contains`](Self::contains)
+/// methods deliberately do not apply router filters; do not use their results
+/// as an authorization decision or expose them directly to an untrusted
+/// client.
+///
 /// When a template is registered or unregistered, all connected sessions
 /// receive a `notifications/resources/list_changed` notification.
 ///
@@ -494,11 +508,17 @@ impl DynamicResourceTemplateRegistry {
     }
 
     /// List all currently registered dynamic resource templates.
+    ///
+    /// This is an unfiltered application-management view. Visibility filters
+    /// are applied only when the router handles protocol requests.
     pub fn list(&self) -> Vec<Arc<crate::resource::ResourceTemplate>> {
         self.inner.list()
     }
 
     /// Check if a template with the given URI pattern is registered.
+    ///
+    /// This reports registry state without consulting client visibility
+    /// filters.
     pub fn contains(&self, uri_template: &str) -> bool {
         let templates = self.inner.templates.read().unwrap();
         templates.iter().any(|t| t.uri_template == uri_template)

--- a/crates/tower-mcp/src/resource.rs
+++ b/crates/tower-mcp/src/resource.rs
@@ -1823,6 +1823,28 @@ pub(crate) trait MrtrResourceTemplateHandler: Send + Sync {
 /// [`match_uri`](Self::match_uri) documents the matching rules and shows them
 /// running.
 ///
+/// # Router authorization
+///
+/// Registering a template on an [`McpRouter`](crate::McpRouter) lets a
+/// [`ResourceTemplateFilter`](crate::ResourceTemplateFilter) control both its
+/// definition in `resources/templates/list` and reads resolved through it. For
+/// a read, [`CapabilityFilterContext::target`](crate::CapabilityFilterContext::target)
+/// is the concrete URI rather than the URI pattern, so a policy can expose a
+/// template while protecting particular members of the resource family. The
+/// router performs this check before either an ordinary or an MRTR handler is
+/// invoked.
+///
+/// A router with a [`ResourceFilter`](crate::ResourceFilter) but no resource
+/// template filter fails closed for templates. Configure
+/// [`McpRouter::resource_template_filter`](crate::McpRouter::resource_template_filter)
+/// explicitly when such a server intends to expose templates. With neither
+/// filter configured, templates retain their default public behavior.
+///
+/// [`McpRouter::disable_resource`](crate::McpRouter::disable_resource) is
+/// evaluated against the concrete requested URI before template matching. It
+/// therefore blocks that URI without hiding the template definition or
+/// disabling sibling URIs that the same template serves.
+///
 /// # Example
 ///
 /// ```rust
@@ -2134,6 +2156,11 @@ impl ResourceTemplate {
     /// A template built with `mrtr_handler` has no plain handler to call and
     /// reports that as an error here; use
     /// [`read_outcome_with_context`](Self::read_outcome_with_context).
+    ///
+    /// This is a direct application call and does not pass through an
+    /// [`McpRouter`](crate::McpRouter), so it does not evaluate the router's
+    /// resource-template filter. Callers using a template outside the router
+    /// are responsible for their own authorization.
     pub fn read(
         &self,
         uri: &str,
@@ -2150,6 +2177,11 @@ impl ResourceTemplate {
     }
 
     /// Read a matched resource while preserving an SEP-2322 continuation.
+    ///
+    /// Calling this method directly does not evaluate an
+    /// [`McpRouter`](crate::McpRouter) resource-template filter. The router
+    /// performs that authorization before invoking this method; other callers
+    /// must enforce their own policy.
     pub fn read_outcome_with_context(
         &self,
         ctx: RequestContext,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -20,7 +20,10 @@ use crate::context::{
     ServerNotification,
 };
 use crate::error::{Error, JsonRpcError, Result};
-use crate::filter::{PromptFilter, ResourceFilter, ToolFilter};
+use crate::filter::{
+    CapabilityFilterContext, CapabilityOperation, PromptFilter, ResourceFilter,
+    ResourceTemplateFilter, ToolFilter,
+};
 use crate::prompt::Prompt;
 use crate::protocol::*;
 #[cfg(feature = "dynamic-tools")]
@@ -212,6 +215,8 @@ struct McpRouterInner {
     tool_filter: Option<ToolFilter>,
     /// Filter for resources based on session state
     resource_filter: Option<ResourceFilter>,
+    /// Filter for resource templates and their concrete resolved URIs
+    resource_template_filter: Option<ResourceTemplateFilter>,
     /// Filter for prompts based on session state
     prompt_filter: Option<PromptFilter>,
     /// Router-level extensions (for state and middleware data)
@@ -261,19 +266,80 @@ struct McpRouterInner {
     dynamic_resource_templates: Option<Arc<DynamicResourceTemplatesInner>>,
 }
 
-impl McpRouterInner {
-    /// Generate instructions text from registered tools, resources, and prompts.
-    fn generate_instructions(&self, config: &AutoInstructionsConfig) -> String {
+impl McpRouter {
+    fn capability_filter_context<'a>(
+        &'a self,
+        request_extensions: &Extensions,
+        operation: CapabilityOperation<'a>,
+    ) -> CapabilityFilterContext<'a> {
+        CapabilityFilterContext::new(
+            &self.session,
+            &self.inner.extensions,
+            request_extensions,
+            operation,
+        )
+    }
+
+    fn resource_template_is_visible(
+        &self,
+        context: &CapabilityFilterContext<'_>,
+        template: &ResourceTemplate,
+    ) -> bool {
+        match &self.inner.resource_template_filter {
+            Some(filter) => filter.is_visible_with_context(context, template),
+            None => self.inner.resource_filter.is_none(),
+        }
+    }
+
+    fn authorize_resource_template(
+        &self,
+        context: &CapabilityFilterContext<'_>,
+        template: &ResourceTemplate,
+        concrete_uri: &str,
+    ) -> Result<()> {
+        if let Some(filter) = &self.inner.resource_template_filter {
+            if !filter.is_visible_with_context(context, template) {
+                return Err(filter.denial_error(concrete_uri));
+            }
+        } else if let Some(filter) = &self.inner.resource_filter {
+            // A ResourceFilter cannot safely evaluate a template. Existing
+            // filtered deployments therefore fail closed until they opt into
+            // an explicit ResourceTemplateFilter (#1399).
+            return Err(filter.denial_error(concrete_uri));
+        }
+        Ok(())
+    }
+
+    /// Generate request-filtered instructions from registered capabilities.
+    fn generate_instructions(
+        &self,
+        config: &AutoInstructionsConfig,
+        request_extensions: &Extensions,
+    ) -> String {
         let mut parts = Vec::new();
+        let context = self.capability_filter_context(request_extensions, CapabilityOperation::List);
 
         if let Some(prefix) = &config.prefix {
             parts.push(prefix.clone());
         }
 
         // Tools section
-        if !self.tools.is_empty() {
+        let disabled_tools = self.inner.disabled_tools.read().unwrap().clone();
+        let mut tools: Vec<_> = self
+            .inner
+            .tools
+            .values()
+            .filter(|tool| {
+                !disabled_tools.contains(&tool.name)
+                    && self
+                        .inner
+                        .tool_filter
+                        .as_ref()
+                        .is_none_or(|filter| filter.is_visible_with_context(&context, tool))
+            })
+            .collect();
+        if !tools.is_empty() {
             let mut lines = vec!["## Tools".to_string(), String::new()];
-            let mut tools: Vec<_> = self.tools.values().collect();
             tools.sort_by(|a, b| a.name.cmp(&b.name));
             for tool in tools {
                 let desc = tool.description.as_deref().unwrap_or("No description");
@@ -288,15 +354,33 @@ impl McpRouterInner {
         }
 
         // Resources section
-        if !self.resources.is_empty() || !self.resource_templates.is_empty() {
+        let disabled_resources = self.inner.disabled_resources.read().unwrap().clone();
+        let mut resources: Vec<_> = self
+            .inner
+            .resources
+            .values()
+            .filter(|resource| {
+                !disabled_resources.contains(&resource.uri)
+                    && self
+                        .inner
+                        .resource_filter
+                        .as_ref()
+                        .is_none_or(|filter| filter.is_visible_with_context(&context, resource))
+            })
+            .collect();
+        let mut templates: Vec<_> = self
+            .inner
+            .resource_templates
+            .iter()
+            .filter(|template| self.resource_template_is_visible(&context, template))
+            .collect();
+        if !resources.is_empty() || !templates.is_empty() {
             let mut lines = vec!["## Resources".to_string(), String::new()];
-            let mut resources: Vec<_> = self.resources.values().collect();
             resources.sort_by(|a, b| a.uri.cmp(&b.uri));
             for resource in resources {
                 let desc = resource.description.as_deref().unwrap_or("No description");
                 lines.push(format!("- **{}**: {}", resource.uri, desc));
             }
-            let mut templates: Vec<_> = self.resource_templates.iter().collect();
             templates.sort_by(|a, b| a.uri_template.cmp(&b.uri_template));
             for template in templates {
                 let desc = template.description.as_deref().unwrap_or("No description");
@@ -306,9 +390,22 @@ impl McpRouterInner {
         }
 
         // Prompts section
-        if !self.prompts.is_empty() {
+        let disabled_prompts = self.inner.disabled_prompts.read().unwrap().clone();
+        let mut prompts: Vec<_> = self
+            .inner
+            .prompts
+            .values()
+            .filter(|prompt| {
+                !disabled_prompts.contains(&prompt.name)
+                    && self
+                        .inner
+                        .prompt_filter
+                        .as_ref()
+                        .is_none_or(|filter| filter.is_visible_with_context(&context, prompt))
+            })
+            .collect();
+        if !prompts.is_empty() {
             let mut lines = vec!["## Prompts".to_string(), String::new()];
-            let mut prompts: Vec<_> = self.prompts.values().collect();
             prompts.sort_by(|a, b| a.name.cmp(&b.name));
             for prompt in prompts {
                 let desc = prompt.description.as_deref().unwrap_or("No description");
@@ -384,6 +481,7 @@ impl McpRouter {
                 completion_handler: None,
                 tool_filter: None,
                 resource_filter: None,
+                resource_template_filter: None,
                 prompt_filter: None,
                 min_log_level: Arc::new(RwLock::new(LogLevel::Debug)),
                 page_size: None,
@@ -1391,7 +1489,7 @@ impl McpRouter {
                     capabilities,
                     server_info: self.implementation(),
                     instructions: if let Some(config) = &self.inner.auto_instructions {
-                        Some(self.inner.generate_instructions(config))
+                        Some(self.generate_instructions(config, &extensions))
                     } else {
                         self.inner.instructions.clone()
                     },
@@ -1429,7 +1527,7 @@ impl McpRouter {
                     ttl_ms: None,
                     cache_scope: None,
                     instructions: if let Some(config) = &self.inner.auto_instructions {
-                        Some(self.inner.generate_instructions(config))
+                        Some(self.generate_instructions(config, &extensions))
                     } else {
                         self.inner.instructions.clone()
                     },
@@ -1444,6 +1542,8 @@ impl McpRouter {
                 let final_tasks_negotiated = final_protocol
                     && self.final_tasks_enabled()
                     && client_declares_tasks(&extensions);
+                let filter_context =
+                    self.capability_filter_context(&extensions, CapabilityOperation::List);
                 let filter = self.inner.tool_filter.as_ref();
                 let disabled = self.inner.disabled_tools.read().unwrap().clone();
                 let is_visible = |t: &Tool| {
@@ -1452,7 +1552,7 @@ impl McpRouter {
                             && matches!(t.task_support, TaskSupportMode::Required)
                             && !final_tasks_negotiated)
                         && filter
-                            .map(|f| f.is_visible(&self.session, t))
+                            .map(|f| f.is_visible_with_context(&filter_context, t))
                             .unwrap_or(true)
                 };
                 let definition = |t: &Tool| {
@@ -1540,8 +1640,14 @@ impl McpRouter {
                 };
 
                 // Check tool filter if configured
+                let filter_context = self.capability_filter_context(
+                    &extensions,
+                    CapabilityOperation::Access {
+                        target: &params.name,
+                    },
+                );
                 if let Some(filter) = &self.inner.tool_filter
-                    && !filter.is_visible(&self.session, &tool)
+                    && !filter.is_visible_with_context(&filter_context, &tool)
                 {
                     tracing::info!(
                         target: "mcp::tools",
@@ -2013,6 +2119,8 @@ impl McpRouter {
             }
 
             McpRequest::ListResources(params) => {
+                let filter_context =
+                    self.capability_filter_context(&extensions, CapabilityOperation::List);
                 let disabled = self.inner.disabled_resources.read().unwrap().clone();
                 let is_visible = |r: &Resource| -> bool {
                     !disabled.contains(&r.uri)
@@ -2020,7 +2128,7 @@ impl McpRouter {
                             .inner
                             .resource_filter
                             .as_ref()
-                            .map(|f| f.is_visible(&self.session, r))
+                            .map(|f| f.is_visible_with_context(&filter_context, r))
                             .unwrap_or(true)
                 };
 
@@ -2059,22 +2167,32 @@ impl McpRouter {
             }
 
             McpRequest::ListResourceTemplates(params) => {
+                let filter_context =
+                    self.capability_filter_context(&extensions, CapabilityOperation::List);
+                #[cfg(feature = "dynamic-tools")]
+                let static_patterns: HashSet<String> = self
+                    .inner
+                    .resource_templates
+                    .iter()
+                    .map(|template| template.uri_template.clone())
+                    .collect();
                 let mut resource_templates: Vec<ResourceTemplateDefinition> = self
                     .inner
                     .resource_templates
                     .iter()
+                    .filter(|template| self.resource_template_is_visible(&filter_context, template))
                     .map(|t| t.definition())
                     .collect();
 
-                // Merge dynamic resource templates (static win on collision)
+                // Resolve static/dynamic precedence before filtering. A hidden
+                // static template still shadows a dynamic template with the
+                // same pattern, so policy denial cannot reveal a fallback.
                 #[cfg(feature = "dynamic-tools")]
                 if let Some(ref dynamic) = self.inner.dynamic_resource_templates {
-                    let static_patterns: HashSet<String> = resource_templates
-                        .iter()
-                        .map(|t| t.uri_template.clone())
-                        .collect();
                     for t in dynamic.list() {
-                        if !static_patterns.contains(&t.uri_template) {
+                        if !static_patterns.contains(&t.uri_template)
+                            && self.resource_template_is_visible(&filter_context, &t)
+                        {
                             resource_templates.push(t.definition());
                         }
                     }
@@ -2112,12 +2230,18 @@ impl McpRouter {
                         &params.uri,
                     )));
                 }
+                let filter_context = self.capability_filter_context(
+                    &extensions,
+                    CapabilityOperation::Access {
+                        target: &params.uri,
+                    },
+                );
 
                 // First, try to find a static resource
                 if let Some(resource) = self.inner.resources.get(&params.uri) {
                     // Check resource filter if configured
                     if let Some(filter) = &self.inner.resource_filter
-                        && !filter.is_visible(&self.session, resource)
+                        && !filter.is_visible_with_context(&filter_context, resource)
                     {
                         return Err(filter.denial_error(&params.uri));
                     }
@@ -2160,7 +2284,7 @@ impl McpRouter {
                 if let Some(ref dynamic) = self.inner.dynamic_resources {
                     if let Some(resource) = dynamic.get(&params.uri) {
                         if let Some(filter) = &self.inner.resource_filter
-                            && !filter.is_visible(&self.session, &resource)
+                            && !filter.is_visible_with_context(&filter_context, &resource)
                         {
                             return Err(filter.denial_error(&params.uri));
                         }
@@ -2201,6 +2325,7 @@ impl McpRouter {
                 // Try static templates
                 for template in &self.inner.resource_templates {
                     if let Some(variables) = template.match_uri(&params.uri) {
+                        self.authorize_resource_template(&filter_context, template, &params.uri)?;
                         tracing::debug!(
                             uri = %params.uri,
                             template = %template.uri_template,
@@ -2247,6 +2372,7 @@ impl McpRouter {
                 #[allow(clippy::collapsible_if)]
                 if let Some(ref dynamic) = self.inner.dynamic_resource_templates {
                     if let Some((template, variables)) = dynamic.match_uri(&params.uri) {
+                        self.authorize_resource_template(&filter_context, &template, &params.uri)?;
                         tracing::debug!(
                             uri = %params.uri,
                             template = %template.uri_template,
@@ -2327,6 +2453,8 @@ impl McpRouter {
                 if let Some(initializer) = &self.inner.prompt_initializer {
                     initializer()?;
                 }
+                let filter_context =
+                    self.capability_filter_context(&extensions, CapabilityOperation::List);
                 let disabled = self.inner.disabled_prompts.read().unwrap().clone();
                 let is_visible = |p: &Prompt| -> bool {
                     !disabled.contains(&p.name)
@@ -2334,7 +2462,7 @@ impl McpRouter {
                             .inner
                             .prompt_filter
                             .as_ref()
-                            .map(|f| f.is_visible(&self.session, p))
+                            .map(|f| f.is_visible_with_context(&filter_context, p))
                             .unwrap_or(true)
                 };
 
@@ -2408,8 +2536,14 @@ impl McpRouter {
                 })?;
 
                 // Check prompt filter if configured
+                let filter_context = self.capability_filter_context(
+                    &extensions,
+                    CapabilityOperation::Access {
+                        target: &params.name,
+                    },
+                );
                 if let Some(filter) = &self.inner.prompt_filter
-                    && !filter.is_visible(&self.session, &prompt)
+                    && !filter.is_visible_with_context(&filter_context, &prompt)
                 {
                     return Err(filter.denial_error(&params.name));
                 }

--- a/crates/tower-mcp/src/router/builder.rs
+++ b/crates/tower-mcp/src/router/builder.rs
@@ -1007,6 +1007,14 @@ impl McpRouter {
     /// don't pass the filter will not appear in `resources/list` responses and will
     /// return an error if read directly.
     ///
+    /// Resource templates require a separate
+    /// [`resource_template_filter`](Self::resource_template_filter), because
+    /// their policy must evaluate both a template definition and each concrete
+    /// URI it resolves. If this resource filter is configured without a
+    /// resource template filter, all templates fail closed: they are omitted
+    /// from `resources/templates/list` and matching reads are denied with this
+    /// filter's denial behavior.
+    ///
     /// # Example
     ///
     /// ```rust
@@ -1032,6 +1040,39 @@ impl McpRouter {
     /// ```
     pub fn resource_filter(mut self, filter: ResourceFilter) -> Self {
         Arc::make_mut(&mut self.inner).resource_filter = Some(filter);
+        self
+    }
+
+    /// Set a filter for resource template discovery and resolved reads.
+    ///
+    /// A contextual filter receives [`CapabilityOperation::List`] while a
+    /// template definition is being listed, and an access operation whose
+    /// target is the concrete requested URI before the matched handler runs.
+    /// Denial stops at that matched template and never falls through to a later
+    /// overlapping template.
+    ///
+    /// ```rust
+    /// use tower_mcp::{
+    ///     CapabilityFilter, McpRouter, ReadResourceResult, ResourceTemplate,
+    ///     ResourceTemplateBuilder,
+    /// };
+    ///
+    /// let template = ResourceTemplateBuilder::new("vault://{area}/{id}")
+    ///     .name("vault")
+    ///     .handler(|uri, _variables| async move {
+    ///         Ok(ReadResourceResult::text(uri, "contents"))
+    ///     });
+    ///
+    /// let router = McpRouter::new()
+    ///     .resource_template(template)
+    ///     .resource_template_filter(CapabilityFilter::new_with_context(
+    ///         |context, _template: &ResourceTemplate| {
+    ///             context.target().is_none_or(|uri| !uri.starts_with("vault://private/"))
+    ///         },
+    ///     ));
+    /// ```
+    pub fn resource_template_filter(mut self, filter: ResourceTemplateFilter) -> Self {
+        Arc::make_mut(&mut self.inner).resource_template_filter = Some(filter);
         self
     }
 
@@ -1102,8 +1143,11 @@ impl McpRouter {
         !self.inner.disabled_tools.read().unwrap().contains(name)
     }
 
-    /// Disable a resource by URI. Disabled resources are hidden from
-    /// `resources/list` and return a not-found error from `resources/read`.
+    /// Disable a resource by concrete URI. Disabled resources are hidden from
+    /// `resources/list` and return a not-found error from `resources/read`,
+    /// including when the URI would otherwise resolve through a template. A
+    /// disabled concrete URI does not hide the template definition or disable
+    /// sibling URIs served by the same template.
     pub fn disable_resource(&self, uri: impl Into<String>) {
         let mut set = self.inner.disabled_resources.write().unwrap();
         set.insert(uri.into());

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -1682,6 +1682,575 @@ async fn test_capabilities_include_resources_with_only_templates() {
     }
 }
 
+mod resource_template_filtering_tests {
+    use super::*;
+    use crate::filter::{
+        CapabilityFilter, CapabilityOperation, DenialBehavior, ResourceTemplateFilter,
+    };
+    use crate::resource::{Resource, ResourceTemplate, ResourceTemplateBuilder};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone)]
+    struct TemplatePrincipal(&'static str);
+
+    #[cfg(feature = "stateless")]
+    fn final_principal_extensions(principal: &'static str) -> Extensions {
+        let mut extensions = final_extensions(ClientCapabilities::default());
+        extensions.insert(TemplatePrincipal(principal));
+        extensions
+    }
+
+    fn counted_template(
+        uri_template: &str,
+        name: &str,
+        calls: Arc<AtomicUsize>,
+        body: &'static str,
+    ) -> ResourceTemplate {
+        ResourceTemplateBuilder::new(uri_template)
+            .name(name)
+            .handler(move |uri: String, _variables: HashMap<String, String>| {
+                let calls = calls.clone();
+                async move {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(ReadResourceResult::text(uri, body))
+                }
+            })
+    }
+
+    async fn list_templates(
+        router: &mut McpRouter,
+        request_id: i64,
+    ) -> ListResourceTemplatesResult {
+        let request = RouterRequest {
+            id: RequestId::Number(request_id),
+            inner: McpRequest::ListResourceTemplates(ListResourceTemplatesParams::default()),
+            extensions: Extensions::new(),
+        };
+        let response = router.ready().await.unwrap().call(request).await.unwrap();
+        match response.inner {
+            Ok(McpResponse::ListResourceTemplates(result)) => result,
+            other => panic!("expected resource template list, got {other:?}"),
+        }
+    }
+
+    async fn read_template(
+        router: &mut McpRouter,
+        request_id: i64,
+        uri: &str,
+    ) -> std::result::Result<ReadResourceResult, JsonRpcError> {
+        let request = RouterRequest {
+            id: RequestId::Number(request_id),
+            inner: McpRequest::ReadResource(ReadResourceParams {
+                input_responses: None,
+                request_state: None,
+                uri: uri.to_string(),
+                meta: None,
+            }),
+            extensions: Extensions::new(),
+        };
+        let response = router.ready().await.unwrap().call(request).await.unwrap();
+        match response.inner {
+            Ok(McpResponse::ReadResource(result)) => Ok(result),
+            Err(error) => Err(error),
+            other => panic!("expected resource read response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn resource_template_filter_hides_static_template_and_blocks_handler() {
+        let public_calls = Arc::new(AtomicUsize::new(0));
+        let protected_calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "docs://public/{id}",
+                "Public Documents",
+                public_calls.clone(),
+                "public",
+            ))
+            .resource_template(counted_template(
+                "docs://protected/{id}",
+                "Protected Documents",
+                protected_calls.clone(),
+                "protected",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, template| template.name != "Protected Documents",
+            ));
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+        assert_eq!(
+            listed.resource_templates[0].uri_template,
+            "docs://public/{id}"
+        );
+
+        let denied = read_template(&mut router, 2, "docs://protected/42")
+            .await
+            .expect_err("a hidden template must not be readable");
+        assert_eq!(denied.code, -32601);
+        assert_eq!(protected_calls.load(Ordering::SeqCst), 0);
+
+        let allowed = read_template(&mut router, 3, "docs://public/42")
+            .await
+            .expect("the visible template should remain readable");
+        assert_eq!(allowed.contents[0].text.as_deref(), Some("public"));
+        assert_eq!(public_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stable_template_filter_isolated_between_fresh_sessions() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let base = McpRouter::new()
+            .resource_template(counted_template(
+                "tenant://{id}",
+                "Tenant Data",
+                calls.clone(),
+                "tenant",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new(|session, _template| {
+                session
+                    .get::<TemplatePrincipal>()
+                    .is_some_and(|principal| principal.0 == "allowed")
+            }));
+        let mut allowed = base.with_fresh_session();
+        allowed.session().insert(TemplatePrincipal("allowed"));
+        let mut denied = base.with_fresh_session();
+        denied.session().insert(TemplatePrincipal("denied"));
+        init_router(&mut allowed).await;
+        init_router(&mut denied).await;
+
+        assert_eq!(
+            list_templates(&mut allowed, 1)
+                .await
+                .resource_templates
+                .len(),
+            1
+        );
+        assert!(
+            list_templates(&mut denied, 2)
+                .await
+                .resource_templates
+                .is_empty()
+        );
+        read_template(&mut denied, 3, "tenant://42")
+            .await
+            .expect_err("the denied session must not read the template");
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        read_template(&mut allowed, 4, "tenant://42")
+            .await
+            .expect("the allowed session should read the template");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "stateless")]
+    #[tokio::test]
+    async fn final_template_filter_uses_per_request_principal() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let router = McpRouter::new()
+            .with_extension(TemplatePrincipal("router-denied"))
+            .resource_template(counted_template(
+                "final://{id}",
+                "Final Data",
+                calls.clone(),
+                "final",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |context, _template| {
+                    context
+                        .extension::<TemplatePrincipal>()
+                        .is_some_and(|principal| principal.0 == "allowed")
+                },
+            ));
+        let McpResponse::ListResourceTemplates(allowed_list) = router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::ListResourceTemplates(ListResourceTemplatesParams::default()),
+                final_principal_extensions("allowed"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected template list");
+        };
+        assert_eq!(allowed_list.resource_templates.len(), 1);
+
+        let McpResponse::ListResourceTemplates(denied_list) = router
+            .handle(
+                RequestId::Number(2),
+                McpRequest::ListResourceTemplates(ListResourceTemplatesParams::default()),
+                final_principal_extensions("denied"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected template list");
+        };
+        assert!(denied_list.resource_templates.is_empty());
+
+        let denied = router
+            .handle(
+                RequestId::Number(3),
+                McpRequest::ReadResource(ReadResourceParams {
+                    input_responses: None,
+                    request_state: None,
+                    uri: "final://42".to_string(),
+                    meta: None,
+                }),
+                final_principal_extensions("denied"),
+            )
+            .await
+            .expect_err("the denied request must not read the template");
+        assert!(matches!(denied, Error::JsonRpc(error) if error.code == -32601));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let McpResponse::ReadResource(allowed_read) = router
+            .handle(
+                RequestId::Number(4),
+                McpRequest::ReadResource(ReadResourceParams {
+                    input_responses: None,
+                    request_state: None,
+                    uri: "final://42".to_string(),
+                    meta: None,
+                }),
+                final_principal_extensions("allowed"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected resource read");
+        };
+        assert_eq!(allowed_read.contents[0].text.as_deref(), Some("final"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resource_template_filter_authorizes_the_concrete_uri() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "records://{visibility}/{id}",
+                "Records",
+                calls.clone(),
+                "record",
+            ))
+            .resource_template_filter(
+                ResourceTemplateFilter::new_with_context(|context, _template| {
+                    match context.operation() {
+                        CapabilityOperation::List => true,
+                        CapabilityOperation::Access { target } => {
+                            target.starts_with("records://public/")
+                        }
+                    }
+                })
+                .denial_behavior(DenialBehavior::custom(|target| {
+                    Error::JsonRpc(JsonRpcError::forbidden(format!(
+                        "template policy denied {target}"
+                    )))
+                })),
+            );
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+
+        let denied = read_template(&mut router, 2, "records://private/42")
+            .await
+            .expect_err("the policy must see and deny the resolved private URI");
+        assert_eq!(denied.code, -32007);
+        assert!(denied.message.contains("records://private/42"));
+        assert!(!denied.message.contains("records://{visibility}/{id}"));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let allowed = read_template(&mut router, 3, "records://public/42")
+            .await
+            .expect("the policy should allow the resolved public URI");
+        assert_eq!(allowed.contents[0].text.as_deref(), Some("record"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resource_filter_without_template_filter_fails_closed() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "secrets://{id}",
+                "Secrets",
+                calls.clone(),
+                "secret",
+            ))
+            .resource_filter(
+                CapabilityFilter::new(|_, _resource: &Resource| true)
+                    .denial_behavior(DenialBehavior::Unauthorized),
+            );
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert!(listed.resource_templates.is_empty());
+
+        let denied = read_template(&mut router, 2, "secrets://42")
+            .await
+            .expect_err("an exact-resource policy cannot implicitly authorize templates");
+        assert_eq!(denied.code, -32007);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn explicit_template_filter_overrides_resource_filter_fallback() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "intentional://{id}",
+                "Intentional Template",
+                calls.clone(),
+                "template",
+            ))
+            .resource_filter(CapabilityFilter::new(|_, _resource: &Resource| false))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, _template| true,
+            ));
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+        let read = read_template(&mut router, 2, "intentional://42")
+            .await
+            .expect("an explicit template policy should replace the secure fallback");
+        assert_eq!(read.contents[0].text.as_deref(), Some("template"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resource_template_filter_runs_before_pagination() {
+        let mut router = McpRouter::new()
+            .page_size(1)
+            .resource_template(counted_template(
+                "a-hidden://{id}",
+                "Hidden",
+                Arc::new(AtomicUsize::new(0)),
+                "hidden",
+            ))
+            .resource_template(counted_template(
+                "z-visible://{id}",
+                "Visible",
+                Arc::new(AtomicUsize::new(0)),
+                "visible",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, template| template.name == "Visible",
+            ));
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+        assert_eq!(
+            listed.resource_templates[0].uri_template,
+            "z-visible://{id}"
+        );
+        assert!(
+            listed.next_cursor.is_none(),
+            "a hidden template must not create another observable page"
+        );
+    }
+
+    #[tokio::test]
+    async fn disabled_concrete_uri_blocks_template_without_hiding_definition() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "vault://items/{id}",
+                "Vault Items",
+                calls.clone(),
+                "item",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, _template| true,
+            ));
+        router.disable_resource("vault://items/blocked");
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+
+        let denied = read_template(&mut router, 2, "vault://items/blocked")
+            .await
+            .expect_err("a disabled concrete URI must not reach its template");
+        assert_eq!(denied.code, -32602);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let allowed = read_template(&mut router, 3, "vault://items/allowed")
+            .await
+            .expect("disabling one URI must not disable its template siblings");
+        assert_eq!(allowed.contents[0].text.as_deref(), Some("item"));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn denied_first_overlapping_template_does_not_fall_through() {
+        let first_calls = Arc::new(AtomicUsize::new(0));
+        let fallback_calls = Arc::new(AtomicUsize::new(0));
+        let mut router = McpRouter::new()
+            .resource_template(counted_template(
+                "overlap://{id}",
+                "Denied First",
+                first_calls.clone(),
+                "first",
+            ))
+            .resource_template(counted_template(
+                "overlap://{+path}",
+                "Allowed Fallback",
+                fallback_calls.clone(),
+                "fallback",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, template| template.name == "Allowed Fallback",
+            ));
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert_eq!(listed.resource_templates.len(), 1);
+        assert_eq!(
+            listed.resource_templates[0].uri_template,
+            "overlap://{+path}"
+        );
+
+        let denied = read_template(&mut router, 2, "overlap://42")
+            .await
+            .expect_err("denial of the first route candidate must be final");
+        assert_eq!(denied.code, -32601);
+        assert_eq!(first_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(fallback_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(all(feature = "stateless", feature = "dynamic-tools"))]
+    #[tokio::test]
+    async fn final_dynamic_template_filter_uses_per_request_principal() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let (router, registry) = McpRouter::new()
+            .with_extension(TemplatePrincipal("router-denied"))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |context, _template| {
+                    context
+                        .extension::<TemplatePrincipal>()
+                        .is_some_and(|principal| principal.0 == "allowed")
+                },
+            ))
+            .with_dynamic_resource_templates();
+        registry.register(counted_template(
+            "dynamic-final://{id}",
+            "Dynamic Final",
+            calls.clone(),
+            "dynamic-final",
+        ));
+
+        let McpResponse::ListResourceTemplates(allowed_list) = router
+            .handle(
+                RequestId::Number(1),
+                McpRequest::ListResourceTemplates(ListResourceTemplatesParams::default()),
+                final_principal_extensions("allowed"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected template list");
+        };
+        assert_eq!(allowed_list.resource_templates.len(), 1);
+
+        let McpResponse::ListResourceTemplates(denied_list) = router
+            .handle(
+                RequestId::Number(2),
+                McpRequest::ListResourceTemplates(ListResourceTemplatesParams::default()),
+                final_principal_extensions("denied"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected template list");
+        };
+        assert!(denied_list.resource_templates.is_empty());
+
+        let denied = router
+            .handle(
+                RequestId::Number(3),
+                McpRequest::ReadResource(ReadResourceParams {
+                    input_responses: None,
+                    request_state: None,
+                    uri: "dynamic-final://42".to_string(),
+                    meta: None,
+                }),
+                final_principal_extensions("denied"),
+            )
+            .await
+            .expect_err("the denied request must not invoke the dynamic handler");
+        assert!(matches!(denied, Error::JsonRpc(error) if error.code == -32601));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+
+        let McpResponse::ReadResource(allowed_read) = router
+            .handle(
+                RequestId::Number(4),
+                McpRequest::ReadResource(ReadResourceParams {
+                    input_responses: None,
+                    request_state: None,
+                    uri: "dynamic-final://42".to_string(),
+                    meta: None,
+                }),
+                final_principal_extensions("allowed"),
+            )
+            .await
+            .unwrap()
+        else {
+            panic!("expected dynamic resource read");
+        };
+        assert_eq!(
+            allowed_read.contents[0].text.as_deref(),
+            Some("dynamic-final")
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[cfg(feature = "dynamic-tools")]
+    #[tokio::test]
+    async fn hidden_static_template_shadows_dynamic_without_fallthrough() {
+        let static_calls = Arc::new(AtomicUsize::new(0));
+        let dynamic_calls = Arc::new(AtomicUsize::new(0));
+        let (router, registry) = McpRouter::new()
+            .resource_template(counted_template(
+                "shadow://{id}",
+                "Hidden Static",
+                static_calls.clone(),
+                "static",
+            ))
+            .resource_template_filter(ResourceTemplateFilter::new_with_context(
+                |_context, template| template.name == "Visible Dynamic",
+            ))
+            .with_dynamic_resource_templates();
+        registry.register(counted_template(
+            "shadow://{id}",
+            "Visible Dynamic",
+            dynamic_calls.clone(),
+            "dynamic",
+        ));
+        let mut router = router;
+        init_router(&mut router).await;
+
+        let listed = list_templates(&mut router, 1).await;
+        assert!(
+            listed.resource_templates.is_empty(),
+            "filtering the winning static entry must not reveal its shadowed dynamic twin"
+        );
+        assert_eq!(registry.list().len(), 1);
+
+        let denied = read_template(&mut router, 2, "shadow://42")
+            .await
+            .expect_err("denying the first match must not fall through to a shadowed template");
+        assert_eq!(denied.code, -32601);
+        assert_eq!(static_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(dynamic_calls.load(Ordering::SeqCst), 0);
+    }
+}
+
 // =========================================================================
 // Logging Notification Tests
 // =========================================================================
@@ -5020,6 +5589,99 @@ async fn test_auto_instructions_with_resource_templates() {
 
     assert!(instructions.contains("## Resources"));
     assert!(instructions.contains("- **file:///{path}**: Read a file by path"));
+}
+
+#[tokio::test]
+async fn auto_instructions_do_not_enumerate_filtered_templates() {
+    use crate::filter::CapabilityFilter;
+    use crate::resource::{ResourceTemplate, ResourceTemplateBuilder};
+
+    let template = |pattern: &str, name: &str| {
+        ResourceTemplateBuilder::new(pattern)
+            .name(name)
+            .handler(|uri, _variables| async move {
+                Ok(crate::ReadResourceResult::text(uri, "content"))
+            })
+    };
+    let mut router = McpRouter::new()
+        .auto_instructions()
+        .resource_template(template("public://{id}", "public"))
+        .resource_template(template("secret://{id}", "secret"))
+        .resource_template_filter(CapabilityFilter::new(
+            |_session, template: &ResourceTemplate| template.name == "public",
+        ));
+
+    let result = send_initialize(&mut router).await;
+    let instructions = result.instructions.expect("auto instructions");
+    assert!(instructions.contains("public://{id}"));
+    assert!(!instructions.contains("secret://{id}"));
+}
+
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_auto_instructions_use_per_request_template_policy_context() {
+    use crate::filter::CapabilityFilter;
+    use crate::resource::{ResourceTemplate, ResourceTemplateBuilder};
+
+    #[derive(Clone)]
+    struct TemplateAccess(bool);
+
+    let template = ResourceTemplateBuilder::new("vault://{id}")
+        .name("vault")
+        .handler(
+            |uri, _variables| async move { Ok(crate::ReadResourceResult::text(uri, "content")) },
+        );
+    let router = McpRouter::new()
+        .auto_instructions()
+        .with_extension(TemplateAccess(false))
+        .resource_template(template)
+        .resource_template_filter(CapabilityFilter::new_with_context(
+            |context, _template: &ResourceTemplate| {
+                context
+                    .extension::<TemplateAccess>()
+                    .is_some_and(|access| access.0)
+            },
+        ));
+
+    let mut allowed_extensions = final_extensions(ClientCapabilities::default());
+    allowed_extensions.insert(TemplateAccess(true));
+    let McpResponse::Discover(allowed) = router
+        .handle(
+            RequestId::Number(1),
+            McpRequest::Discover(DiscoverParams::default()),
+            allowed_extensions,
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("expected discover response");
+    };
+    assert!(
+        allowed
+            .instructions
+            .as_deref()
+            .is_some_and(|instructions| instructions.contains("vault://{id}"))
+    );
+
+    let mut denied_extensions = final_extensions(ClientCapabilities::default());
+    denied_extensions.insert(TemplateAccess(false));
+    let McpResponse::Discover(denied) = router
+        .handle(
+            RequestId::Number(2),
+            McpRequest::Discover(DiscoverParams::default()),
+            denied_extensions,
+        )
+        .await
+        .unwrap()
+    else {
+        panic!("expected discover response");
+    };
+    assert!(
+        denied
+            .instructions
+            .as_deref()
+            .is_some_and(|instructions| !instructions.contains("vault://{id}"))
+    );
 }
 
 #[tokio::test]

--- a/examples/capability_filtering.rs
+++ b/examples/capability_filtering.rs
@@ -1,6 +1,6 @@
 //! Capability filtering example - name-based and role-based access control
 //!
-//! This example demonstrates two approaches to capability filtering:
+//! This example demonstrates three aspects of capability filtering:
 //!
 //! ## 1. Name-Based Filtering
 //! Capabilities prefixed with `admin_` or `internal_` are hidden by default.
@@ -17,6 +17,20 @@
 //! In a real application, auth middleware would validate credentials and store
 //! claims in the session using `session.insert(UserClaims { ... })`. The filter
 //! functions then check these claims to decide visibility.
+//!
+//! ## 3. Context-Aware Resource Template Filtering
+//! A resource-template filter receives both the template definition and a
+//! `CapabilityFilterContext`. For discovery, the context identifies a list
+//! operation. For a read, `context.target()` contains the concrete URI, so one
+//! visible template can still protect sensitive members of its URI family.
+//! `context.extension::<T>()` also exposes router- and request-level state,
+//! with request values taking precedence. That is the usual bridge for OAuth
+//! claims on the stateless protocol, where there is no long-lived session to
+//! mutate.
+//!
+//! A router that configures `resource_filter` but not
+//! `resource_template_filter` fails closed for templates. Servers that expose
+//! both exact resources and templates should configure both policies.
 //!
 //! Run with: cargo run --example capability_filtering --features http
 //!
@@ -45,11 +59,29 @@
 //!   -H "MCP-Session-Id: <session-id-from-init>" \
 //!   -d '{"jsonrpc":"2.0","id":4,"method":"resources/list","params":{}}'
 //!
+//! # List resource templates (the project-files template is visible)
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
+//!   -d '{"jsonrpc":"2.0","id":5,"method":"resources/templates/list","params":{}}'
+//!
+//! # Read a public member of the template family
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
+//!   -d '{"jsonrpc":"2.0","id":6,"method":"resources/read","params":{"uri":"files:///public/guide.md"}}'
+//!
+//! # Anonymous users cannot resolve files:///private/... through the template
+//! curl -X POST http://localhost:3000/ \
+//!   -H "Content-Type: application/json" \
+//!   -H "MCP-Session-Id: <session-id-from-init>" \
+//!   -d '{"jsonrpc":"2.0","id":7,"method":"resources/read","params":{"uri":"files:///private/credentials.txt"}}'
+//!
 //! # List prompts (admin/internal prompts are hidden)
 //! curl -X POST http://localhost:3000/ \
 //!   -H "Content-Type: application/json" \
 //!   -H "MCP-Session-Id: <session-id-from-init>" \
-//!   -d '{"jsonrpc":"2.0","id":5,"method":"prompts/list","params":{}}'
+//!   -d '{"jsonrpc":"2.0","id":8,"method":"prompts/list","params":{}}'
 //! ```
 //!
 //! The curl examples above use the 2025-11-25 session-based flow. The 2026-07-28
@@ -59,8 +91,9 @@
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower_mcp::{
-    CallToolResult, CapabilityFilter, DenialBehavior, Filterable, HttpTransport, McpRouter, Prompt,
-    PromptBuilder, Resource, ResourceBuilder, SessionState, Tool, ToolBuilder,
+    CallToolResult, CapabilityFilter, CapabilityFilterContext, DenialBehavior, Filterable,
+    HttpTransport, McpRouter, Prompt, PromptBuilder, ReadResourceResult, Resource, ResourceBuilder,
+    ResourceTemplate, ResourceTemplateBuilder, SessionState, Tool, ToolBuilder,
 };
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -141,6 +174,25 @@ fn is_visible_resource(session: &SessionState, resource: &Resource) -> bool {
 
 fn is_visible_prompt(session: &SessionState, prompt: &Prompt) -> bool {
     is_visible(session, prompt.name())
+}
+
+fn is_visible_resource_template(
+    context: &CapabilityFilterContext<'_>,
+    template: &ResourceTemplate,
+) -> bool {
+    // The template definition itself follows the same name/role policy as the
+    // other capability kinds.
+    if !is_visible(context.session(), template.name()) {
+        return false;
+    }
+
+    // `target()` is None for resources/templates/list and contains the
+    // concrete requested URI for resources/read. Keep the family discoverable,
+    // but require an elevated role for its private members.
+    context.target().is_none_or(|uri| {
+        !uri.starts_with("files:///private/")
+            || is_visible(context.session(), "admin_private_project_files")
+    })
 }
 
 #[tokio::main]
@@ -226,6 +278,18 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .description("Internal metrics data")
         .text("requests_per_second: 1247\nerror_rate: 0.02%");
 
+    // The template definition is public, while the context-aware filter below
+    // applies an additional rule to concrete files:///private/... reads.
+    let project_files = ResourceTemplateBuilder::new("files:///{+path}")
+        .name("project_files")
+        .description("Project files, with private paths restricted to admins")
+        .handler(|uri: String, _variables| async move {
+            Ok(ReadResourceResult::text(
+                uri,
+                "Example project-file content",
+            ))
+        });
+
     // === PROMPTS ===
 
     let greeting = PromptBuilder::new("greeting")
@@ -275,6 +339,7 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
         .resource(api_reference)
         .resource(admin_config)
         .resource(internal_metrics)
+        .resource_template(project_files)
         // Prompts
         .prompt(greeting)
         .prompt(code_review)
@@ -291,6 +356,12 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
                 // Unauthorized - hint that auth might help (useful for debugging)
                 .denial_behavior(DenialBehavior::Unauthorized),
         )
+        // Because this router also has a ResourceFilter, omitting an explicit
+        // template filter would intentionally hide and deny every template.
+        .resource_template_filter(
+            CapabilityFilter::new_with_context(is_visible_resource_template)
+                .denial_behavior(DenialBehavior::NotFound),
+        )
         .prompt_filter(CapabilityFilter::new(is_visible_prompt));
 
     // Create HTTP transport
@@ -302,10 +373,10 @@ async fn main() -> Result<(), tower_mcp::BoxError> {
     tracing::info!("");
     tracing::info!("Access control by role:");
     tracing::info!(
-        "  Anonymous/User: echo, get_time, readme, api_reference, greeting, code_review"
+        "  Anonymous/User: echo, get_time, readme, api_reference, public project files, greeting, code_review"
     );
     tracing::info!(
-        "  Admin: + admin_get_stats, admin_delete_user, admin_system_config, admin_debug_assistant"
+        "  Admin: + admin_get_stats, admin_delete_user, admin_system_config, private project files, admin_debug_assistant"
     );
     tracing::info!("  Developer: + internal_debug_info, internal_metrics, internal_test_prompt");
     tracing::info!("");


### PR DESCRIPTION
## Summary

- add a request-aware `ResourceTemplateFilter` for template discovery and concrete URI access
- enforce template policy for static and dynamic registries across stable and final lifecycles, with fail-closed compatibility when only `ResourceFilter` is configured
- apply filtering to auto-generated instructions and document composition with disabled resources, direct registry access, and concrete template URIs
- expand the capability-filtering example and regression coverage for session/request isolation, pagination, overlapping patterns, dynamic shadowing, custom denials, and handler non-invocation

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --doc --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- template-filter regression matrix with no features, `dynamic-tools`, `stateless`, and all features

Closes #1399
