### PR TITLE
fix(http): isolate legacy resource subscriptions

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -113,6 +113,7 @@
 //! }
 //! ```
 
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::{Arc, RwLock};
 
@@ -342,6 +343,11 @@ pub struct RequestContext {
     extensions: Arc<Extensions>,
     /// Minimum log level set by the client (shared with router for dynamic updates)
     min_log_level: Option<Arc<RwLock<LogLevel>>>,
+    /// Resource URIs subscribed by this legacy session. Router-created
+    /// contexts attach the shared set so handlers cannot notify a session
+    /// about resources it did not subscribe to. Manually created contexts
+    /// leave this unset and retain the historical best-effort behavior.
+    resource_subscriptions: Option<Arc<RwLock<HashSet<String>>>>,
     /// Whether this request arrived on the 2026-07-28 lifecycle, where the
     /// server never initiates JSON-RPC requests. Distinguishes "the protocol
     /// has no route for this" from "a transport did not wire one up", which
@@ -435,6 +441,7 @@ impl RequestContext {
             final_lifecycle: false,
             extensions: Arc::new(Extensions::new()),
             min_log_level: None,
+            resource_subscriptions: None,
         }
     }
 
@@ -461,11 +468,26 @@ impl RequestContext {
 
     /// Mark this context as serving a 2026-07-28 request.
     ///
-    /// Only affects diagnostics: the final lifecycle has no server-initiated
-    /// requests, so the router does not attach a requester, and this lets the
-    /// resulting error say why rather than blaming configuration.
+    /// The final lifecycle has no server-initiated requests, so the router
+    /// does not attach a requester, and this lets the resulting error say why
+    /// rather than blaming configuration. It also keeps resource update
+    /// notifications eligible for final `subscriptions/listen` routing rather
+    /// than applying the legacy session subscription set.
     pub(crate) fn with_final_lifecycle(mut self, final_lifecycle: bool) -> Self {
         self.final_lifecycle = final_lifecycle;
+        self
+    }
+
+    /// Attach the resource subscription set for a legacy session.
+    ///
+    /// The set is shared with the router so subscribe and unsubscribe requests
+    /// take effect for subsequent handler notifications without rebuilding the
+    /// context.
+    pub(crate) fn with_resource_subscriptions(
+        mut self,
+        subscriptions: Arc<RwLock<HashSet<String>>>,
+    ) -> Self {
+        self.resource_subscriptions = Some(subscriptions);
         self
     }
 
@@ -726,9 +748,25 @@ impl RequestContext {
     }
 
     /// Notify subscribed clients that one resource changed.
+    ///
+    /// Router-created legacy contexts send only when this session subscribed
+    /// to the exact URI. Manually created contexts retain the historical
+    /// best-effort send behavior because they have no subscription set. Final
+    /// 2026-07-28 contexts always enqueue the notification here; their
+    /// `subscriptions/listen` routing applies the final subscription policy.
     pub fn notify_resource_updated(&self, uri: impl Into<String>) -> bool {
+        let uri = uri.into();
+        if !self.final_lifecycle
+            && let Some(subscriptions) = &self.resource_subscriptions
+            && !subscriptions
+                .read()
+                .is_ok_and(|subscribed| subscribed.contains(&uri))
+        {
+            return false;
+        }
+
         self.notification_tx.as_ref().is_some_and(|tx| {
-            tx.try_send(ServerNotification::ResourceUpdated { uri: uri.into() })
+            tx.try_send(ServerNotification::ResourceUpdated { uri })
                 .is_ok()
         })
     }
@@ -1300,6 +1338,72 @@ mod tests {
 
         // Channel should be empty
         assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn legacy_resource_update_is_sent_for_a_subscribed_uri() {
+        let (tx, mut rx) = notification_channel(10);
+        let subscriptions = Arc::new(RwLock::new(HashSet::from([
+            "file:///subscribed.txt".to_string()
+        ])));
+        let ctx = RequestContext::new(RequestId::Number(1))
+            .with_notification_sender(tx)
+            .with_resource_subscriptions(subscriptions);
+
+        assert!(ctx.notify_resource_updated("file:///subscribed.txt"));
+        match rx.try_recv().expect("subscribed update should be sent") {
+            ServerNotification::ResourceUpdated { uri } => {
+                assert_eq!(uri, "file:///subscribed.txt");
+            }
+            notification => panic!("expected resource update, got {notification:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_resource_update_is_suppressed_for_an_unsubscribed_uri() {
+        let (tx, mut rx) = notification_channel(10);
+        let subscriptions = Arc::new(RwLock::new(HashSet::from([
+            "file:///subscribed.txt".to_string()
+        ])));
+        let ctx = RequestContext::new(RequestId::Number(1))
+            .with_notification_sender(tx)
+            .with_resource_subscriptions(subscriptions);
+
+        assert!(!ctx.notify_resource_updated("file:///other.txt"));
+        assert!(
+            rx.try_recv().is_err(),
+            "unsubscribed update must not be enqueued"
+        );
+    }
+
+    #[test]
+    fn final_resource_update_bypasses_the_legacy_subscription_guard() {
+        let (tx, mut rx) = notification_channel(10);
+        let subscriptions = Arc::new(RwLock::new(HashSet::new()));
+        let ctx = RequestContext::new(RequestId::Number(1))
+            .with_notification_sender(tx)
+            .with_resource_subscriptions(subscriptions)
+            .with_final_lifecycle(true);
+
+        assert!(ctx.notify_resource_updated("file:///final.txt"));
+        match rx.try_recv().expect("final update should be routed") {
+            ServerNotification::ResourceUpdated { uri } => {
+                assert_eq!(uri, "file:///final.txt");
+            }
+            notification => panic!("expected resource update, got {notification:?}"),
+        }
+    }
+
+    #[test]
+    fn manually_created_context_preserves_resource_update_behavior() {
+        let (tx, mut rx) = notification_channel(10);
+        let ctx = RequestContext::new(RequestId::Number(1)).with_notification_sender(tx);
+
+        assert!(ctx.notify_resource_updated("file:///manual.txt"));
+        assert!(matches!(
+            rx.try_recv(),
+            Ok(ServerNotification::ResourceUpdated { uri }) if uri == "file:///manual.txt"
+        ));
     }
 
     #[test]

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -104,6 +104,12 @@ fn is_final_protocol_request(_extensions: &crate::context::Extensions) -> bool {
 pub struct McpRouter {
     inner: Arc<McpRouterInner>,
     session: SessionState,
+    /// Legacy `resources/subscribe` membership for this logical session.
+    ///
+    /// Ordinary router clones share this state because transports clone a
+    /// session router for each request. [`Self::with_fresh_session`] replaces
+    /// it so one client's membership cannot affect another client.
+    subscriptions: Arc<RwLock<HashSet<String>>>,
 }
 
 impl std::fmt::Debug for McpRouter {
@@ -207,8 +213,6 @@ struct McpRouterInner {
     client_requester: Option<ClientRequesterHandle>,
     /// Task store for async operations
     task_store: Arc<dyn TaskStore>,
-    /// Subscribed resource URIs
-    subscriptions: Arc<RwLock<HashSet<String>>>,
     /// Handler for completion requests
     completion_handler: Option<CompletionHandler>,
     /// Filter for tools based on session state
@@ -307,6 +311,41 @@ impl McpRouter {
             // an explicit ResourceTemplateFilter (#1399).
             return Err(filter.denial_error(concrete_uri));
         }
+        Ok(())
+    }
+
+    /// Authorize access to an exact statically registered resource.
+    ///
+    /// Legacy resource subscriptions deliberately retain their existing
+    /// exact-static scope. This helper gives subscribe and unsubscribe the
+    /// same disabled/filter policy and concrete-target denial behavior as a
+    /// static resource read without expanding the accepted URI universe to
+    /// dynamic resources or templates.
+    fn authorize_static_resource_subscription(
+        &self,
+        request_extensions: &Extensions,
+        uri: &str,
+    ) -> Result<()> {
+        let disabled = self.inner.disabled_resources.read().unwrap().contains(uri);
+        if disabled {
+            return Err(Error::JsonRpc(JsonRpcError::resource_not_found(uri)));
+        }
+
+        let resource = self
+            .inner
+            .resources
+            .get(uri)
+            .ok_or_else(|| Error::JsonRpc(JsonRpcError::resource_not_found(uri)))?;
+        let context = self.capability_filter_context(
+            request_extensions,
+            CapabilityOperation::Access { target: uri },
+        );
+        if let Some(filter) = &self.inner.resource_filter
+            && !filter.is_visible_with_context(&context, resource)
+        {
+            return Err(filter.denial_error(uri));
+        }
+
         Ok(())
     }
 
@@ -475,7 +514,6 @@ impl McpRouter {
                 subscription_observer: Arc::new(RwLock::new(None)),
                 client_requester: None,
                 task_store: Arc::new(MemoryTaskStore::new()),
-                subscriptions: Arc::new(RwLock::new(HashSet::new())),
                 extensions: Arc::new(crate::context::Extensions::new()),
                 protocol_extensions: HashMap::new(),
                 completion_handler: None,
@@ -504,6 +542,7 @@ impl McpRouter {
                 dynamic_resource_templates: None,
             }),
             session: SessionState::new(),
+            subscriptions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -511,13 +550,15 @@ impl McpRouter {
     ///
     /// Use this when creating a new logical session (e.g., per HTTP connection).
     /// The router configuration (tools, resources, prompts) is shared, but the
-    /// session state (phase, extensions) is independent.
+    /// session state (phase, extensions) and legacy resource subscriptions are
+    /// independent.
     ///
     /// This is typically called by transports when establishing a new client session.
     pub fn with_fresh_session(&self) -> Self {
         Self {
             inner: self.inner.clone(),
             session: SessionState::new(),
+            subscriptions: Arc::new(RwLock::new(HashSet::new())),
         }
     }
 
@@ -972,6 +1013,11 @@ impl McpRouter {
         // restricted requests stay on their associated response channel.
         let final_lifecycle = is_final_protocol_request(per_request);
         let ctx = ctx.with_final_lifecycle(final_lifecycle);
+        let ctx = if final_lifecycle {
+            ctx
+        } else {
+            ctx.with_resource_subscriptions(self.subscriptions.clone())
+        };
         let ctx = if !final_lifecycle
             && let Some(requester) = merged
                 .get::<ClientRequesterHandle>()
@@ -2421,12 +2467,7 @@ impl McpRouter {
             }
 
             McpRequest::SubscribeResource(params) => {
-                // Verify the resource exists
-                if !self.inner.resources.contains_key(&params.uri) {
-                    return Err(Error::JsonRpc(JsonRpcError::resource_not_found(
-                        &params.uri,
-                    )));
-                }
+                self.authorize_static_resource_subscription(&extensions, &params.uri)?;
 
                 tracing::debug!(uri = %params.uri, "Subscribing to resource");
                 self.subscribe(&params.uri);
@@ -2435,15 +2476,13 @@ impl McpRouter {
             }
 
             McpRequest::UnsubscribeResource(params) => {
-                // Verify the resource exists
-                if !self.inner.resources.contains_key(&params.uri) {
-                    return Err(Error::JsonRpc(JsonRpcError::resource_not_found(
-                        &params.uri,
-                    )));
-                }
+                // Authorize before consulting or mutating membership. Otherwise
+                // success for an existing subscription and denial for an
+                // unowned URI would disclose session state for hidden resources.
+                self.authorize_static_resource_subscription(&extensions, &params.uri)?;
+                self.unsubscribe(&params.uri);
 
                 tracing::debug!(uri = %params.uri, "Unsubscribing from resource");
-                self.unsubscribe(&params.uri);
 
                 Ok(McpResponse::UnsubscribeResource(EmptyResult {}))
             }

--- a/crates/tower-mcp/src/router/builder.rs
+++ b/crates/tower-mcp/src/router/builder.rs
@@ -1005,7 +1005,11 @@ impl McpRouter {
     /// The filter receives the current session state and each resource, returning
     /// `true` if the resource should be visible to this session. Resources that
     /// don't pass the filter will not appear in `resources/list` responses and will
-    /// return an error if read directly.
+    /// return an error if read directly. The same policy authorizes exact static
+    /// resources for `resources/subscribe` and `resources/unsubscribe`; contextual
+    /// filters receive a [`CapabilityOperation::Access`] whose target is the
+    /// requested URI. Authorization runs before subscription membership is read or
+    /// changed, so hidden resources cannot disclose whether a session subscribed.
     ///
     /// Resource templates require a separate
     /// [`resource_template_filter`](Self::resource_template_filter), because
@@ -1145,9 +1149,11 @@ impl McpRouter {
 
     /// Disable a resource by concrete URI. Disabled resources are hidden from
     /// `resources/list` and return a not-found error from `resources/read`,
-    /// including when the URI would otherwise resolve through a template. A
-    /// disabled concrete URI does not hide the template definition or disable
-    /// sibling URIs served by the same template.
+    /// `resources/subscribe`, and `resources/unsubscribe`, including when the URI
+    /// would otherwise resolve through a template. Existing subscription membership
+    /// remains inaccessible until the resource is re-enabled, or is discarded when
+    /// the session ends. A disabled concrete URI does not hide the template
+    /// definition or disable sibling URIs served by the same template.
     pub fn disable_resource(&self, uri: impl Into<String>) {
         let mut set = self.inner.disabled_resources.write().unwrap();
         set.insert(uri.into());

--- a/crates/tower-mcp/src/router/notify.rs
+++ b/crates/tower-mcp/src/router/notify.rs
@@ -78,17 +78,23 @@ impl McpRouter {
         ))
     }
 
-    /// Check if a resource URI is currently subscribed
+    /// Check whether this logical session subscribed to a resource URI.
+    ///
+    /// Ordinary [`McpRouter`] clones share the same logical session and
+    /// subscription state. Routers created with
+    /// [`McpRouter::with_fresh_session`] have independent membership.
     pub fn is_subscribed(&self, uri: &str) -> bool {
-        if let Ok(subs) = self.inner.subscriptions.read() {
+        if let Ok(subs) = self.subscriptions.read() {
             return subs.contains(uri);
         }
         false
     }
 
-    /// Get a list of all subscribed resource URIs
+    /// Get this logical session's subscribed resource URIs.
+    ///
+    /// This is not an aggregate across HTTP or other transport sessions.
     pub fn subscribed_uris(&self) -> Vec<String> {
-        if let Ok(subs) = self.inner.subscriptions.read() {
+        if let Ok(subs) = self.subscriptions.read() {
             return subs.iter().cloned().collect();
         }
         Vec::new()
@@ -96,7 +102,7 @@ impl McpRouter {
 
     /// Subscribe to a resource URI
     pub(super) fn subscribe(&self, uri: &str) -> bool {
-        if let Ok(mut subs) = self.inner.subscriptions.write() {
+        if let Ok(mut subs) = self.subscriptions.write() {
             return subs.insert(uri.to_string());
         }
         false
@@ -104,7 +110,7 @@ impl McpRouter {
 
     /// Unsubscribe from a resource URI
     pub(super) fn unsubscribe(&self, uri: &str) -> bool {
-        if let Ok(mut subs) = self.inner.subscriptions.write() {
+        if let Ok(mut subs) = self.subscriptions.write() {
             return subs.remove(uri);
         }
         false

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -3969,6 +3969,245 @@ async fn test_get_nonexistent_task() {
 // Resource Subscription Tests
 // =========================================================================
 
+async fn subscribe_resource(
+    router: &McpRouter,
+    id: i64,
+    uri: &str,
+    extensions: Extensions,
+) -> Result<McpResponse> {
+    router
+        .handle(
+            RequestId::Number(id),
+            McpRequest::SubscribeResource(SubscribeResourceParams {
+                uri: uri.to_string(),
+                meta: None,
+            }),
+            extensions,
+        )
+        .await
+}
+
+async fn unsubscribe_resource(
+    router: &McpRouter,
+    id: i64,
+    uri: &str,
+    extensions: Extensions,
+) -> Result<McpResponse> {
+    router
+        .handle(
+            RequestId::Number(id),
+            McpRequest::UnsubscribeResource(UnsubscribeResourceParams {
+                uri: uri.to_string(),
+                meta: None,
+            }),
+            extensions,
+        )
+        .await
+}
+
+#[test]
+fn resource_subscription_state_is_shared_by_logical_session_clones() {
+    let router = McpRouter::new();
+    let clone = router.clone();
+
+    assert!(router.subscribe("file:///shared.txt"));
+    assert!(clone.is_subscribed("file:///shared.txt"));
+    assert!(clone.unsubscribe("file:///shared.txt"));
+    assert!(!router.is_subscribed("file:///shared.txt"));
+}
+
+#[test]
+fn resource_subscription_state_isolated_between_fresh_sessions() {
+    let base = McpRouter::new();
+    let first = base.with_fresh_session();
+    let second = base.with_fresh_session();
+
+    assert!(first.subscribe("file:///private.txt"));
+    assert!(first.is_subscribed("file:///private.txt"));
+    assert!(!base.is_subscribed("file:///private.txt"));
+    assert!(!second.is_subscribed("file:///private.txt"));
+}
+
+#[tokio::test]
+async fn fresh_sessions_unsubscribe_independently() {
+    use crate::resource::ResourceBuilder;
+
+    let base = McpRouter::new().resource(
+        ResourceBuilder::new("file:///shared.txt")
+            .name("Shared")
+            .text("shared"),
+    );
+    let mut first = base.with_fresh_session();
+    let mut second = base.with_fresh_session();
+    init_router(&mut first).await;
+    init_router(&mut second).await;
+
+    subscribe_resource(&first, 1, "file:///shared.txt", Extensions::new())
+        .await
+        .unwrap();
+    subscribe_resource(&second, 2, "file:///shared.txt", Extensions::new())
+        .await
+        .unwrap();
+    unsubscribe_resource(&second, 3, "file:///shared.txt", Extensions::new())
+        .await
+        .unwrap();
+
+    assert!(first.is_subscribed("file:///shared.txt"));
+    assert!(!second.is_subscribed("file:///shared.txt"));
+}
+
+#[tokio::test]
+async fn disabled_resource_cannot_be_subscribed() {
+    use crate::resource::ResourceBuilder;
+
+    let mut router = McpRouter::new().resource(
+        ResourceBuilder::new("file:///disabled.txt")
+            .name("Disabled")
+            .text("hidden"),
+    );
+    router.disable_resource("file:///disabled.txt");
+    init_router(&mut router).await;
+
+    let error = subscribe_resource(&router, 1, "file:///disabled.txt", Extensions::new())
+        .await
+        .expect_err("disabled resources must not be subscribable");
+
+    assert!(matches!(error, Error::JsonRpc(error) if error.code == -32602));
+    assert!(!router.is_subscribed("file:///disabled.txt"));
+}
+
+#[derive(Clone)]
+struct SubscriptionPrincipal(&'static str);
+
+fn subscription_principal(principal: &'static str) -> Extensions {
+    let mut extensions = Extensions::new();
+    extensions.insert(SubscriptionPrincipal(principal));
+    extensions
+}
+
+#[tokio::test]
+async fn resource_filter_authorizes_subscribe_with_request_context() {
+    use crate::filter::{CapabilityFilter, DenialBehavior};
+    use crate::resource::{Resource, ResourceBuilder};
+
+    let mut router = McpRouter::new()
+        .resource(
+            ResourceBuilder::new("file:///filtered.txt")
+                .name("Filtered")
+                .text("filtered"),
+        )
+        .resource_filter(
+            CapabilityFilter::new_with_context(|context, resource: &Resource| {
+                matches!(
+                    context.operation(),
+                    CapabilityOperation::Access { target } if target == resource.uri
+                ) && context
+                    .extension::<SubscriptionPrincipal>()
+                    .is_some_and(|principal| principal.0 == "allowed")
+            })
+            .denial_behavior(DenialBehavior::custom(|target| {
+                Error::JsonRpc(JsonRpcError::forbidden(format!(
+                    "subscription denied for {target}"
+                )))
+            })),
+        );
+    init_router(&mut router).await;
+
+    let denied = subscribe_resource(
+        &router,
+        1,
+        "file:///filtered.txt",
+        subscription_principal("denied"),
+    )
+    .await
+    .expect_err("the per-request principal must be enforced");
+    assert!(matches!(
+        denied,
+        Error::JsonRpc(error)
+            if error.code == -32007 && error.message.contains("file:///filtered.txt")
+    ));
+    assert!(!router.is_subscribed("file:///filtered.txt"));
+
+    subscribe_resource(
+        &router,
+        2,
+        "file:///filtered.txt",
+        subscription_principal("allowed"),
+    )
+    .await
+    .expect("the allowed principal should subscribe");
+    assert!(router.is_subscribed("file:///filtered.txt"));
+}
+
+#[tokio::test]
+async fn hidden_unsubscribe_denial_does_not_disclose_or_mutate_membership() {
+    use crate::filter::{CapabilityFilter, DenialBehavior};
+    use crate::resource::{Resource, ResourceBuilder};
+
+    let base = McpRouter::new()
+        .resource(
+            ResourceBuilder::new("file:///revoked.txt")
+                .name("Revoked")
+                .text("revoked"),
+        )
+        .resource_filter(
+            CapabilityFilter::new_with_context(|context, _resource: &Resource| {
+                context
+                    .extension::<SubscriptionPrincipal>()
+                    .is_some_and(|principal| principal.0 == "allowed")
+            })
+            .denial_behavior(DenialBehavior::custom(|target| {
+                Error::JsonRpc(JsonRpcError::forbidden(format!(
+                    "unsubscribe denied for {target}"
+                )))
+            })),
+        );
+    let mut subscribed = base.with_fresh_session();
+    let mut unowned = base.with_fresh_session();
+    init_router(&mut subscribed).await;
+    init_router(&mut unowned).await;
+
+    subscribe_resource(
+        &subscribed,
+        1,
+        "file:///revoked.txt",
+        subscription_principal("allowed"),
+    )
+    .await
+    .unwrap();
+
+    let subscribed_denial = unsubscribe_resource(
+        &subscribed,
+        2,
+        "file:///revoked.txt",
+        subscription_principal("denied"),
+    )
+    .await
+    .expect_err("a hidden subscribed URI must be denied before membership mutation");
+
+    let unowned_denial = unsubscribe_resource(
+        &unowned,
+        3,
+        "file:///revoked.txt",
+        subscription_principal("denied"),
+    )
+    .await
+    .expect_err("an unowned hidden URI must receive the same denial");
+
+    let Error::JsonRpc(subscribed_denial) = subscribed_denial else {
+        panic!("expected JSON-RPC denial for subscribed URI");
+    };
+    let Error::JsonRpc(unowned_denial) = unowned_denial else {
+        panic!("expected JSON-RPC denial for unowned URI");
+    };
+    assert_eq!(subscribed_denial.code, -32007);
+    assert_eq!(subscribed_denial.code, unowned_denial.code);
+    assert_eq!(subscribed_denial.message, unowned_denial.message);
+    assert_eq!(subscribed_denial.data, unowned_denial.data);
+    assert!(subscribed.is_subscribed("file:///revoked.txt"));
+    assert!(!unowned.is_subscribed("file:///revoked.txt"));
+}
+
 #[tokio::test]
 async fn test_subscribe_to_resource() {
     use crate::resource::ResourceBuilder;

--- a/crates/tower-mcp/src/session_store.rs
+++ b/crates/tower-mcp/src/session_store.rs
@@ -4,10 +4,12 @@
 //! - **Persistent metadata** ([`SessionRecord`]) -- serializable, can be stored
 //!   in Redis, Postgres, etc. Persisted via the [`SessionStore`] trait.
 //! - **Runtime state** -- broadcast channels, pending request handles, service
-//!   instances. Held in-memory per server instance; cannot be serialized.
-//!   This includes legacy server-to-client requests associated with an
-//!   originating HTTP POST. Shared session metadata does not make those live
-//!   exchanges portable; use session affinity while they are in flight.
+//!   instances, and legacy `resources/subscribe` memberships. Held in-memory
+//!   per server instance; cannot be serialized. This includes legacy
+//!   server-to-client requests associated with an originating HTTP POST.
+//!   Shared session metadata does not make those live exchanges portable; use
+//!   session affinity while they are in flight. A restored session starts with
+//!   no legacy resource subscriptions, so clients must resubscribe.
 //!
 //! By default transports use [`MemorySessionStore`], which keeps metadata in an
 //! in-process `HashMap` (behavior identical to earlier versions). External
@@ -41,9 +43,11 @@ use crate::protocol::{ClientCapabilities, Implementation};
 
 /// Serializable session metadata persisted by a [`SessionStore`].
 ///
-/// Contains everything needed to reconstruct a session after a restart or
-/// across server instances. Does **not** contain runtime state (channels,
-/// pending requests) -- those are rebuilt locally on restore.
+/// Contains the persistent metadata needed to reconstruct a session after a
+/// restart or across server instances. Does **not** contain runtime state
+/// (channels, pending requests, or legacy `resources/subscribe` memberships) --
+/// those are rebuilt locally on restore. In particular, a restored session has
+/// no legacy resource subscriptions until the client resubscribes.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct SessionRecord {

--- a/crates/tower-mcp/src/transport/http.rs
+++ b/crates/tower-mcp/src/transport/http.rs
@@ -263,7 +263,6 @@ use tokio::sync::{Mutex, RwLock, broadcast, oneshot};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::BroadcastStream;
 
-#[cfg(feature = "stateless")]
 use crate::context::ServerNotification;
 use crate::context::{
     ChannelClientRequester, ClientRequesterHandle, NotificationReceiver, OutgoingRequest,
@@ -495,8 +494,9 @@ pub struct HttpTransport {
     event_store: Arc<dyn crate::event_store::EventStore>,
     auto_reinit_sessions: bool,
     /// Caller-owned receiver for notifications pushed from outside any
-    /// request handler. Drained by a background task and fanned out to
-    /// every live session's SSE stream.
+    /// request handler. Drained by a background task and routed to live
+    /// session SSE streams. Legacy resource updates honor each router-backed
+    /// session's `resources/subscribe` membership.
     external_notifications: Option<NotificationReceiver>,
     #[cfg(feature = "stateless")]
     stateless_config: Option<crate::stateless::StatelessConfig>,
@@ -606,7 +606,11 @@ impl HttpTransport {
     ///
     /// This accepts any `Service<RouterRequest>` implementation, such as
     /// [`McpProxy`](crate::proxy::McpProxy). The service is cloned for each
-    /// HTTP session.
+    /// HTTP session, but the transport cannot make arbitrary service-internal
+    /// state session-local. In particular, passing an [`McpRouter`] directly
+    /// here shares that router's logical-session state, including legacy
+    /// `resources/subscribe` membership. Use [`HttpTransport::new`] for an
+    /// `McpRouter`; it creates a fresh, isolated router session per client.
     ///
     /// Notification bridging and sampling are **not** set up automatically.
     /// The caller should configure these on the service before passing it in.
@@ -667,7 +671,7 @@ impl HttpTransport {
     }
 
     /// Create an HTTP transport that drains a caller-owned notification
-    /// channel and fans the items out to every live session's SSE stream.
+    /// channel and routes the items to live session SSE streams.
     ///
     /// This mirrors [`GenericStdioTransport::with_notifications`](crate::transport::stdio::GenericStdioTransport::with_notifications)
     /// and is the supported way to push server-originated notifications
@@ -677,13 +681,15 @@ impl HttpTransport {
     ///
     /// Per-session notification channels (in-handler `ctx.send_log()`,
     /// progress updates) are unaffected. The external channel runs in
-    /// parallel and broadcasts to every active session; MCP clients are
-    /// expected to ignore notifications they didn't subscribe to.
+    /// parallel. For legacy router-backed sessions,
+    /// [`ServerNotification::ResourceUpdated`] is delivered only to sessions
+    /// that successfully called `resources/subscribe` for that exact URI.
+    /// Other notification kinds continue to reach every active session.
     ///
     /// # Example
     ///
     /// ```rust,no_run
-    /// use tower_mcp::{BoxError, McpRouter};
+    /// use tower_mcp::{BoxError, McpRouter, ResourceBuilder};
     /// use tower_mcp::context::{ServerNotification, notification_channel};
     /// use tower_mcp::transport::http::HttpTransport;
     ///
@@ -691,7 +697,13 @@ impl HttpTransport {
     /// async fn main() -> Result<(), BoxError> {
     ///     let (notif_tx, notif_rx) = notification_channel(256);
     ///
-    ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
+    ///     let router = McpRouter::new()
+    ///         .server_info("my-server", "1.0.0")
+    ///         .resource(
+    ///             ResourceBuilder::new("claude://chats/123")
+    ///                 .name("Chat 123")
+    ///                 .text("chat contents"),
+    ///         );
     ///
     ///     // Hold onto notif_tx in your application state so background tasks
     ///     // can push notifications. tx is `Clone`.
@@ -718,8 +730,13 @@ impl HttpTransport {
     ///
     /// Useful when wrapping a pre-built service via
     /// [`from_service`](Self::from_service), where setting a sender on the
-    /// router isn't part of the flow. See [`with_notifications`](Self::with_notifications)
-    /// for the typical router-based path.
+    /// router isn't part of the flow. A service-backed session exposes no
+    /// router whose resource subscriptions the transport can inspect, so all
+    /// external notifications retain the caller-owned broadcast behavior in
+    /// that mode. Filter the supplied channel before sending when a custom
+    /// service needs narrower delivery. See
+    /// [`with_notifications`](Self::with_notifications) for the typical
+    /// router-based path.
     pub fn external_notifications(mut self, notification_rx: NotificationReceiver) -> Self {
         self.external_notifications = Some(notification_rx);
         self
@@ -1067,9 +1084,11 @@ impl HttpTransport {
     /// supply an external store (Redis, Postgres, etc.) to share session
     /// metadata across server instances behind a load balancer.
     ///
-    /// Runtime state (broadcast channels, pending requests, service
-    /// instances) is always kept per-instance; only persistent metadata is
-    /// mirrored to the store.
+    /// Runtime state (broadcast channels, pending requests, service instances,
+    /// and legacy `resources/subscribe` memberships) is always kept
+    /// per-instance; only persistent metadata is mirrored to the store. A
+    /// client whose session is restored on another instance must resubscribe to
+    /// resources.
     ///
     /// # Example
     ///
@@ -1573,8 +1592,8 @@ impl HttpTransport {
 }
 
 /// Check if an origin is a localhost origin (safe from DNS rebinding).
-/// Drain a caller-supplied notification channel and fan items out to every
-/// live session's SSE broadcast.
+/// Drain a caller-supplied notification channel and route items to live
+/// session SSE broadcasts.
 ///
 /// No-op when `rx` is `None`. When present, spawns a long-running task that
 /// runs for the lifetime of the transport (until the channel closes).
@@ -1591,7 +1610,9 @@ fn spawn_external_notification_fanout(
             #[cfg(feature = "stateless")]
             modern_subscriptions.publish(&notification);
             if let Some(json) = crate::transport::stdio::serialize_notification(&notification) {
-                sessions.broadcast_to_all(&json).await;
+                sessions
+                    .broadcast_external_notification(&notification, &json)
+                    .await;
             }
         }
         tracing::debug!("External notification channel closed; fan-out task exiting");

--- a/crates/tower-mcp/src/transport/http/session.rs
+++ b/crates/tower-mcp/src/transport/http/session.rs
@@ -165,10 +165,11 @@ impl Session {
     ///
     /// The router is pre-marked initialized and the protocol version is
     /// restored from the record. Runtime state (broadcast channels,
-    /// pending-request table) is freshly allocated — in-flight state from
-    /// before the rebuild is not recovered. The `event_counter` is left at
-    /// zero; the [`SessionRegistry`] seeds it from the event store so
-    /// future event IDs don't collide with buffered ones.
+    /// pending-request table, and legacy resource subscription memberships) is
+    /// freshly allocated — in-flight state from before the rebuild is not
+    /// recovered. Clients must resubscribe to resources after restoration. The
+    /// `event_counter` is left at zero; the [`SessionRegistry`] seeds it from
+    /// the event store so future event IDs don't collide with buffered ones.
     fn restored(
         record: &crate::session_store::SessionRecord,
         router: McpRouter,
@@ -276,6 +277,23 @@ impl Session {
                     "Notification received on service-based session (not forwarded)"
                 );
             }
+        }
+    }
+
+    /// Whether an externally supplied notification belongs on this session's
+    /// legacy SSE stream.
+    ///
+    /// Router-backed resource updates honor the exact URI memberships created
+    /// by `resources/subscribe`. A boxed service exposes no router state for
+    /// the transport to inspect, so it retains the caller-owned broadcast
+    /// behavior that [`HttpTransport::from_service`] has always provided.
+    fn accepts_external_notification(&self, notification: &ServerNotification) -> bool {
+        match (notification, &self.service_source) {
+            (
+                ServerNotification::ResourceUpdated { uri },
+                SessionServiceSource::Router { router, .. },
+            ) => router.is_subscribed(uri),
+            _ => true,
         }
     }
 
@@ -723,9 +741,10 @@ impl SessionRegistry {
     ///
     /// The caller must ensure the record's ID is not already live locally;
     /// on success the session is inserted into the local registry, the
-    /// event counter is seeded so new event IDs don't collide with
-    /// buffered ones, and the record's `last_accessed` is refreshed and
-    /// saved back to the store.
+    /// event counter is seeded so new event IDs don't collide with buffered
+    /// ones, and the record's `last_accessed` is refreshed and saved back to
+    /// the store. Legacy resource subscription memberships are not persisted;
+    /// the restored session starts empty and the client must resubscribe.
     async fn restore_from_record(
         &self,
         record: crate::session_store::SessionRecord,
@@ -842,16 +861,23 @@ impl SessionRegistry {
         removed
     }
 
-    /// Send a pre-serialized JSON notification to every live session's SSE
-    /// broadcast channel.
+    /// Route a pre-serialized external notification to live session SSE
+    /// broadcast channels.
     ///
-    /// Used by the external-notification fan-out task. Failures to send
-    /// (no SSE subscribers attached to a session yet) are silent — the
-    /// broadcast channel drops the message naturally.
-    pub(super) async fn broadcast_to_all(&self, json: &str) {
+    /// Resource updates are limited to subscribed router-backed sessions;
+    /// other notification kinds and service-backed sessions preserve the
+    /// existing broadcast behavior. Failures to send (no SSE receiver
+    /// attached to a session yet) are silent.
+    pub(super) async fn broadcast_external_notification(
+        &self,
+        notification: &ServerNotification,
+        json: &str,
+    ) {
         let sessions = self.sessions.read().await;
         for session in sessions.values() {
-            let _ = session.notifications_tx.send(json.to_string());
+            if session.accepts_external_notification(notification) {
+                let _ = session.notifications_tx.send(json.to_string());
+            }
         }
     }
 

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -3389,7 +3389,18 @@ fn test_effective_host_returns_none_when_both_missing() {
 // External notification fan-out
 // =========================================================================
 
-/// Initialize a session against `app` and return its session id.
+const EXTERNAL_RESOURCE_URI: &str = "claude://chats/abc";
+
+fn external_notification_router() -> McpRouter {
+    create_test_router().resource(
+        crate::ResourceBuilder::new(EXTERNAL_RESOURCE_URI)
+            .name("External notification test resource")
+            .text("test"),
+    )
+}
+
+/// Initialize a session against `app`, complete the legacy handshake, and
+/// return its session id.
 async fn init_session(app: &Router) -> String {
     let req = Request::builder()
         .method("POST")
@@ -3412,43 +3423,233 @@ async fn init_session(app: &Router) -> String {
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    resp.headers()
+    let session_id = resp
+        .headers()
         .get(MCP_SESSION_ID_HEADER)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
-        .expect("initialize must return a session id")
+        .expect("initialize must return a session id");
+    send_initialized(app, &session_id).await;
+    session_id
+}
+
+async fn set_resource_subscription(
+    app: &Router,
+    session_id: &str,
+    subscribe: bool,
+    request_id: i64,
+) {
+    let method = if subscribe {
+        "resources/subscribe"
+    } else {
+        "resources/unsubscribe"
+    };
+    let request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header(MCP_SESSION_ID_HEADER, session_id)
+        .body(Body::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "method": method,
+                "params": { "uri": EXTERNAL_RESOURCE_URI }
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["id"], request_id);
+    assert!(
+        json.get("result").is_some(),
+        "{method} failed for session {session_id}: {json}"
+    );
+}
+
+async fn session_broadcast_receiver(
+    session_handle: &SessionHandle,
+    session_id: &str,
+) -> broadcast::Receiver<String> {
+    let sessions = session_handle.store.sessions.read().await;
+    sessions
+        .get(session_id)
+        .expect("session should be registered")
+        .notifications_tx
+        .subscribe()
+}
+
+async fn router_session_is_subscribed(
+    session_handle: &SessionHandle,
+    session_id: &str,
+    uri: &str,
+) -> bool {
+    let sessions = session_handle.store.sessions.read().await;
+    let session = sessions
+        .get(session_id)
+        .expect("session should be registered");
+    match &session.service_source {
+        SessionServiceSource::Router { router, .. } => router.is_subscribed(uri),
+        SessionServiceSource::Boxed(_) => panic!("expected a router-backed session"),
+    }
 }
 
 #[tokio::test]
-async fn test_external_notification_reaches_single_session() {
+async fn external_resource_updates_follow_each_router_sessions_subscriptions() {
     let (notif_tx, notif_rx) = notification_channel(8);
-    let transport = HttpTransport::with_notifications(create_test_router(), notif_rx);
+    let transport = HttpTransport::with_notifications(external_notification_router(), notif_rx);
     let (app, session_handle) = transport.into_router_with_handle();
 
-    let session_id = init_session(&app).await;
+    let session_a = init_session(&app).await;
+    let session_b = init_session(&app).await;
+    assert_ne!(session_a, session_b);
 
-    // Subscribe to the session's broadcast channel before firing.
-    let mut rx = {
-        let sessions = session_handle.store.sessions.read().await;
-        let session = sessions
-            .get(&session_id)
-            .expect("session should be registered");
-        session.notifications_tx.subscribe()
-    };
+    set_resource_subscription(&app, &session_a, true, 10).await;
+
+    let mut rx_a = session_broadcast_receiver(&session_handle, &session_a).await;
+    let mut rx_b = session_broadcast_receiver(&session_handle, &session_b).await;
 
     notif_tx
         .send(crate::context::ServerNotification::ResourceUpdated {
-            uri: "claude://chats/abc".to_string(),
+            uri: EXTERNAL_RESOURCE_URI.to_string(),
         })
         .await
         .unwrap();
 
-    let json = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+    let json_a = tokio::time::timeout(Duration::from_secs(1), rx_a.recv())
         .await
-        .expect("notification should arrive within timeout")
+        .expect("subscribed session A should receive the update")
         .expect("broadcast channel closed");
-    assert!(json.contains("notifications/resources/updated"));
-    assert!(json.contains("claude://chats/abc"));
+    assert!(json_a.contains("notifications/resources/updated"));
+    assert!(json_a.contains(EXTERNAL_RESOURCE_URI));
+    assert!(matches!(
+        rx_b.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+
+    // The same URI can be owned independently: B subscribing and A
+    // unsubscribing must not change the other session's membership.
+    set_resource_subscription(&app, &session_b, true, 11).await;
+    set_resource_subscription(&app, &session_a, false, 12).await;
+    notif_tx
+        .send(crate::context::ServerNotification::ResourceUpdated {
+            uri: EXTERNAL_RESOURCE_URI.to_string(),
+        })
+        .await
+        .unwrap();
+
+    let json_b = tokio::time::timeout(Duration::from_secs(1), rx_b.recv())
+        .await
+        .expect("subscribed session B should receive the update")
+        .expect("broadcast channel closed");
+    assert!(json_b.contains("notifications/resources/updated"));
+    assert!(matches!(
+        rx_a.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
+async fn terminated_router_session_subscription_is_not_inherited() {
+    let (notif_tx, notif_rx) = notification_channel(8);
+    let transport = HttpTransport::with_notifications(external_notification_router(), notif_rx);
+    let (app, session_handle) = transport.into_router_with_handle();
+
+    let old_session = init_session(&app).await;
+    set_resource_subscription(&app, &old_session, true, 20).await;
+    assert!(session_handle.terminate_session(&old_session).await);
+
+    let new_session = init_session(&app).await;
+    let mut new_rx = session_broadcast_receiver(&session_handle, &new_session).await;
+
+    // The list-changed notification is an ordered barrier: it always fans out
+    // and proves the preceding resource update was processed. If the new
+    // session inherited the old membership, the resource update arrives first.
+    notif_tx
+        .send(crate::context::ServerNotification::ResourceUpdated {
+            uri: EXTERNAL_RESOURCE_URI.to_string(),
+        })
+        .await
+        .unwrap();
+    notif_tx
+        .send(crate::context::ServerNotification::ResourcesListChanged)
+        .await
+        .unwrap();
+
+    let json = tokio::time::timeout(Duration::from_secs(1), new_rx.recv())
+        .await
+        .expect("list-changed barrier should reach the new session")
+        .expect("broadcast channel closed");
+    assert!(
+        json.contains("notifications/resources/list_changed"),
+        "{json}"
+    );
+    assert!(matches!(
+        new_rx.try_recv(),
+        Err(broadcast::error::TryRecvError::Empty)
+    ));
+}
+
+#[tokio::test]
+async fn restored_router_session_does_not_restore_legacy_subscriptions() {
+    use crate::session_store::{MemorySessionStore, SessionStore};
+
+    let store = Arc::new(MemorySessionStore::new());
+    let store_dyn: Arc<dyn SessionStore> = store.clone();
+
+    // First instance: establish a persisted session and a runtime-only legacy
+    // subscription, then drop the instance while retaining its store record.
+    let session_id = {
+        let transport = HttpTransport::new(external_notification_router())
+            .disable_origin_validation()
+            .session_store(store_dyn.clone());
+        let (app, session_handle) = transport.into_router_with_handle();
+        let session_id = init_session(&app).await;
+        set_resource_subscription(&app, &session_id, true, 30).await;
+        assert!(
+            router_session_is_subscribed(&session_handle, &session_id, EXTERNAL_RESOURCE_URI).await
+        );
+        session_id
+    };
+
+    assert!(
+        store.load(&session_id).await.unwrap().is_some(),
+        "persistent session record should survive the first instance"
+    );
+
+    // Second instance: the first request restores the session from its record.
+    let transport = HttpTransport::new(external_notification_router())
+        .disable_origin_validation()
+        .session_store(store_dyn);
+    let (app, session_handle) = transport.into_router_with_handle();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .header(MCP_SESSION_ID_HEADER, &session_id)
+        .body(Body::from(
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 31,
+                "method": "resources/list"
+            })
+            .to_string(),
+        ))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    assert!(
+        !router_session_is_subscribed(&session_handle, &session_id, EXTERNAL_RESOURCE_URI).await,
+        "restored sessions must start with empty legacy subscription membership"
+    );
 }
 
 #[tokio::test]
@@ -3486,6 +3687,37 @@ async fn test_external_notification_fans_out_to_all_sessions() {
         .unwrap();
     assert!(json_a.contains("notifications/resources/list_changed"));
     assert!(json_b.contains("notifications/resources/list_changed"));
+}
+
+#[tokio::test]
+async fn service_backed_external_resource_updates_preserve_broadcast_behavior() {
+    let (notif_tx, notif_rx) = notification_channel(8);
+    let transport =
+        HttpTransport::from_service(create_test_router()).external_notifications(notif_rx);
+    let (app, session_handle) = transport.into_router_with_handle();
+
+    let session_a = init_session(&app).await;
+    let session_b = init_session(&app).await;
+    let mut rx_a = session_broadcast_receiver(&session_handle, &session_a).await;
+    let mut rx_b = session_broadcast_receiver(&session_handle, &session_b).await;
+
+    // A boxed service exposes no router subscription state to HttpTransport,
+    // so caller-supplied notifications retain the compatibility broadcast.
+    notif_tx
+        .send(crate::context::ServerNotification::ResourceUpdated {
+            uri: EXTERNAL_RESOURCE_URI.to_string(),
+        })
+        .await
+        .unwrap();
+
+    for rx in [&mut rx_a, &mut rx_b] {
+        let json = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("service-backed session should receive the broadcast")
+            .expect("broadcast channel closed");
+        assert!(json.contains("notifications/resources/updated"));
+        assert!(json.contains(EXTERNAL_RESOURCE_URI));
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- scope legacy `resources/subscribe` membership to each logical MCP session
- authorize subscribe and unsubscribe against disabled resources and contextual visibility policy before inspecting membership
- deliver handler-originated and external resource updates only to subscribed router-backed sessions
- keep final `subscriptions/listen` behavior unchanged and document service-backed/restored-session compatibility semantics

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo test -p tower-mcp --all-features --lib` (1,154 passed)
- no-default-feature subscription regressions
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`

Closes #1400
