### PR TITLE
feat(tasks): construct task resume contexts

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -472,6 +472,39 @@ pub struct TaskResumeContext {
     pub input_responses: InputResponses,
 }
 
+impl TaskResumeContext {
+    /// Create the context needed to resume a task handler.
+    ///
+    /// External [`TaskStore`] implementations use this when reconstructing a
+    /// task from durable state in [`TaskStore::resume_context`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::async_task::TaskResumeContext;
+    ///
+    /// let resume = TaskResumeContext::new(
+    ///     "build_report",
+    ///     serde_json::json!({"format": "pdf"}),
+    ///     Default::default(),
+    /// );
+    ///
+    /// assert_eq!(resume.tool_name, "build_report");
+    /// ```
+    #[must_use]
+    pub fn new(
+        tool_name: impl Into<String>,
+        arguments: serde_json::Value,
+        input_responses: InputResponses,
+    ) -> Self {
+        Self {
+            tool_name: tool_name.into(),
+            arguments,
+            input_responses,
+        }
+    }
+}
+
 impl AppliedInputResponses {
     /// Whether every outstanding request has now been answered.
     pub fn is_complete(&self) -> bool {
@@ -1710,10 +1743,12 @@ impl TaskStore for MemoryTaskStore {
         Ok(tasks
             .get(task_id)
             .filter(|task| !task.is_expired())
-            .map(|task| TaskResumeContext {
-                tool_name: task.tool_name.clone(),
-                arguments: task.arguments.clone(),
-                input_responses: task.input_responses.clone(),
+            .map(|task| {
+                TaskResumeContext::new(
+                    task.tool_name.clone(),
+                    task.arguments.clone(),
+                    task.input_responses.clone(),
+                )
             }))
     }
 
@@ -1918,6 +1953,30 @@ mod tests {
     use crate::protocol::{
         ElicitAction, ElicitResult, InputRequest, InputResponse, ListRootsParams,
     };
+
+    #[test]
+    fn task_resume_context_constructor_preserves_every_field() {
+        let input_responses = InputResponses::from([(
+            "approval".to_string(),
+            InputResponse::Elicit(ElicitResult {
+                action: ElicitAction::Accept,
+                content: None,
+                meta: None,
+            }),
+        )]);
+        let context = TaskResumeContext::new(
+            "build_report",
+            serde_json::json!({"format": "pdf"}),
+            input_responses.clone(),
+        );
+
+        assert_eq!(context.tool_name, "build_report");
+        assert_eq!(context.arguments, serde_json::json!({"format": "pdf"}));
+        assert_eq!(
+            serde_json::to_value(&context.input_responses).unwrap(),
+            serde_json::to_value(&input_responses).unwrap()
+        );
+    }
 
     #[tokio::test]
     async fn test_create_task() {

--- a/crates/tower-mcp/tests/external_task_store.rs
+++ b/crates/tower-mcp/tests/external_task_store.rs
@@ -6,6 +6,10 @@
 //! `E0451` and there was nothing else to hand back, which made the whole trait
 //! closed despite existing for exactly this purpose.
 //!
+//! #1409 found the same downstream boundary on resumption:
+//! `TaskResumeContext` is non-exhaustive, so an external store needs its public
+//! constructor to implement `TaskStore::resume_context`.
+//!
 //! This file deliberately uses only the public API. If any part of the trait
 //! becomes unimplementable from outside again, this stops compiling, which is
 //! the real assertion. Asserting a constructor exists would not catch the trait
@@ -19,7 +23,8 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use serde_json::json;
 use tower_mcp::async_task::{
-    CancellationToken, Result as TaskResult, TaskOwner, TaskSnapshot, TaskStore, TaskStoreError,
+    CancellationToken, Result as TaskResult, TaskOwner, TaskResumeContext, TaskSnapshot, TaskStore,
+    TaskStoreError,
 };
 use tower_mcp::client::{ChannelTransport, McpClient};
 use tower_mcp::protocol::{CallToolResult, InputRequests, InputResponses, TaskObject, TaskStatus};
@@ -33,6 +38,9 @@ struct ExternalStore {
 }
 
 struct Record {
+    tool_name: String,
+    arguments: serde_json::Value,
+    input_responses: InputResponses,
     object: TaskObject,
     owner: TaskOwner,
     result: Option<CallToolResult>,
@@ -50,8 +58,8 @@ impl ExternalStore {
 impl TaskStore for ExternalStore {
     async fn create_task(
         &self,
-        _tool_name: &str,
-        _arguments: serde_json::Value,
+        tool_name: &str,
+        arguments: serde_json::Value,
         ttl: Option<u64>,
         owner: TaskOwner,
     ) -> TaskResult<(String, CancellationToken)> {
@@ -73,6 +81,9 @@ impl TaskStore for ExternalStore {
         self.tasks.lock().unwrap().insert(
             id.clone(),
             Record {
+                tool_name: tool_name.to_string(),
+                arguments,
+                input_responses: InputResponses::default(),
                 object,
                 owner,
                 result: None,
@@ -186,6 +197,16 @@ impl TaskStore for ExternalStore {
         self.get_task_result(task_id).await
     }
 
+    async fn resume_context(&self, task_id: &str) -> TaskResult<Option<TaskResumeContext>> {
+        Ok(self.with(task_id, |record| {
+            TaskResumeContext::new(
+                record.tool_name.clone(),
+                record.arguments.clone(),
+                record.input_responses.clone(),
+            )
+        }))
+    }
+
     async fn set_task_meta(&self, task_id: &str, meta: serde_json::Value) -> TaskResult<bool> {
         Ok(self.with(task_id, |r| r.object.meta = Some(meta)).is_some())
     }
@@ -255,4 +276,19 @@ async fn a_constructed_token_carries_cancellation() {
         "every clone observes the same flag, which is what the store relies on"
     );
     assert!(CancellationToken::default().is_cancelled().eq(&false));
+}
+
+/// The non-exhaustive resume context remains constructible downstream.
+#[tokio::test]
+async fn an_external_store_can_construct_a_resume_context() {
+    let store = ExternalStore::default();
+    let (task_id, _) = store
+        .create_task("build_report", json!({"format": "pdf"}), None, None)
+        .await
+        .unwrap();
+
+    let resume = store.resume_context(&task_id).await.unwrap().unwrap();
+    assert_eq!(resume.tool_name, "build_report");
+    assert_eq!(resume.arguments, json!({"format": "pdf"}));
+    assert!(resume.input_responses.is_empty());
 }


### PR DESCRIPTION
## Summary

- add a public `TaskResumeContext::new` constructor while preserving the non-exhaustive type
- use the constructor in `MemoryTaskStore`
- extend the downstream-style `TaskStore` integration test to implement `resume_context` through the public API

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo test -p tower-mcp --all-features --test external_task_store`
- `cargo check -p tower-mcp --no-default-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- all-feature rustdoc and constructor doctest

Closes #1409
