### PR TITLE
fix(oauth): bind ValidateAdapter credentials to a resource

### DIFF
--- a/crates/tower-mcp/src/guides/oauth.rs
+++ b/crates/tower-mcp/src/guides/oauth.rs
@@ -127,6 +127,39 @@ five-minute fallback TTL, and refreshes after an unknown key ID with a minimum
 refresh interval. Supply a custom `reqwest::Client` when the deployment needs
 specific TLS roots, proxy behavior, or tighter timeouts.
 
+### Bridge a resource-dedicated credential validator
+
+`ValidateAdapter` can reuse a header-credential
+[`Validate`](crate::auth::Validate)
+implementation when its accepted credentials are provisioned exclusively for
+one MCP resource:
+
+```rust
+use tower_mcp::auth::StaticBearerValidator;
+use tower_mcp::oauth::ValidateAdapter;
+
+let resource = "https://mcp.example.com/mcp";
+let validator = ValidateAdapter::new(StaticBearerValidator::new([
+    "dedicated-resource-token".to_string(),
+]))
+.with_audience(resource);
+```
+
+`with_audience` is a server-side binding assertion. It does not read an `aud`
+claim from the credential or prove that an authorization server issued the
+credential for that resource. Configure it with the exact same canonical URI
+as `ProtectedResourceMetadata::resource`, and use it only when the wrapped
+validator cannot accept the same credential at another resource. Credentials
+shared across services would turn that assertion into a token-substitution
+risk.
+
+`ValidateAdapter::new` deliberately emits no audience until this binding is
+configured, so `OAuthLayer` rejects its claims. Even after configuration,
+`OAuthLayer` still compares the emitted audience with the protected resource;
+the adapter does not disable or weaken that check. The adapter produces only
+minimal typed claims, so implement `TokenValidator` directly when issuer,
+expiry, scope, or other token claims must be validated and normalized.
+
 `ScopePolicy` uses exact scope matching by default. If the authorization server
 defines hierarchy, install an explicit matcher:
 

--- a/crates/tower-mcp/src/oauth/token.rs
+++ b/crates/tower-mcp/src/oauth/token.rs
@@ -283,7 +283,18 @@ impl TokenValidator for JwtValidator {
 ///
 /// This allows reusing existing `Validate` implementations with the OAuth
 /// middleware. The adapter creates minimal `TokenClaims` from a successful
-/// validation.
+/// validation. Because [`Validate`](crate::auth::Validate) does not return a
+/// validated token audience, the adapter is audience-less by default and
+/// therefore fails closed when used with [`OAuthLayer`](super::OAuthLayer).
+/// Call [`with_audience`](Self::with_audience) to explicitly bind every
+/// credential accepted by the inner validator to one protected resource.
+///
+/// That binding is a server-side trust assertion, not validation of an `aud`
+/// claim carried by the credential. Only use it when the inner validator
+/// accepts credentials issued or provisioned exclusively for that resource.
+/// The configured value should exactly match
+/// [`ProtectedResourceMetadata::resource`](super::ProtectedResourceMetadata::resource);
+/// the outer OAuth layer still performs its independent audience check.
 ///
 /// # Example
 ///
@@ -292,17 +303,41 @@ impl TokenValidator for JwtValidator {
 /// use tower_mcp::oauth::ValidateAdapter;
 ///
 /// let bearer = StaticBearerValidator::new(vec!["token123".to_string()]);
-/// let oauth_validator = ValidateAdapter::new(bearer);
+/// let oauth_validator = ValidateAdapter::new(bearer)
+///     .with_audience("https://mcp.example.com");
 /// ```
 #[derive(Clone)]
 pub struct ValidateAdapter<V> {
     inner: V,
+    audience: Option<String>,
 }
 
 impl<V> ValidateAdapter<V> {
-    /// Create a new adapter wrapping an existing `Validate` implementation.
+    /// Create an audience-less adapter wrapping an existing `Validate`
+    /// implementation.
+    ///
+    /// Successful validations produce claims with no audience. This preserves
+    /// fail-closed behavior under [`OAuthLayer`](super::OAuthLayer), which
+    /// rejects those claims until [`with_audience`](Self::with_audience) binds
+    /// the adapter to the protected resource.
     pub fn new(inner: V) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            audience: None,
+        }
+    }
+
+    /// Bind every credential accepted by the inner validator to `audience`.
+    ///
+    /// The adapter emits this value as a single [`TokenAudience`] in the
+    /// normalized claims. It does not extract or verify an audience from the
+    /// credential itself. Treat this as a deployment-policy assertion: use it
+    /// only when every accepted credential is dedicated to this exact
+    /// protected resource, and configure the same canonical value in
+    /// [`ProtectedResourceMetadata`](super::ProtectedResourceMetadata).
+    pub fn with_audience(mut self, audience: impl Into<String>) -> Self {
+        self.audience = Some(audience.into());
+        self
     }
 }
 
@@ -313,7 +348,7 @@ impl<V: crate::auth::Validate> TokenValidator for ValidateAdapter<V> {
                 let claims = TokenClaims {
                     sub: info.as_ref().map(|i| i.client_id.clone()),
                     iss: None,
-                    aud: None,
+                    aud: self.audience.clone().map(TokenAudience::Single),
                     exp: None,
                     scope: None,
                     client_id: info.as_ref().map(|i| i.client_id.clone()),
@@ -1084,7 +1119,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_validate_adapter() {
+    async fn test_validate_adapter_is_audience_less_by_default() {
         use crate::auth::StaticBearerValidator;
 
         let bearer = StaticBearerValidator::new(vec!["valid-token".to_string()]);
@@ -1095,9 +1130,27 @@ mod tests {
 
         let claims = result.unwrap();
         assert!(claims.sub.is_some());
+        assert!(claims.aud.is_none());
+        assert!(!claims.audience_matches("https://mcp.example.com"));
 
         let result = adapter.validate_token("invalid-token").await;
         assert!(matches!(result, Err(OAuthError::InvalidToken { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_validate_adapter_binds_a_single_audience() {
+        use crate::auth::StaticBearerValidator;
+
+        let adapter = ValidateAdapter::new(StaticBearerValidator::new(["valid-token".to_string()]))
+            .with_audience("https://mcp.example.com");
+
+        let claims = adapter.validate_token("valid-token").await.unwrap();
+        assert!(matches!(
+            claims.aud.as_ref(),
+            Some(TokenAudience::Single(audience)) if audience == "https://mcp.example.com"
+        ));
+        assert!(claims.audience_matches("https://mcp.example.com"));
+        assert!(!claims.audience_matches("https://other.example.com"));
     }
 
     // JWKS-specific unit tests

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -120,6 +120,99 @@ async fn oauth_resource_server_setup_is_path_aware_and_audience_bound() {
 }
 
 #[cfg(feature = "oauth")]
+fn oauth_validate_adapter_app(audience: Option<&str>) -> axum::Router {
+    let resource = "http://localhost:3000/mcp";
+    let validator = crate::oauth::ValidateAdapter::new(crate::auth::StaticBearerValidator::new([
+        "valid-token".to_string(),
+    ]));
+    let validator = match audience {
+        Some(audience) => validator.with_audience(audience),
+        None => validator,
+    };
+    let metadata = crate::oauth::ProtectedResourceMetadata::new(resource)
+        .authorization_server("https://auth.example.com");
+
+    HttpTransport::new(create_test_router())
+        .disable_origin_validation()
+        .disable_host_validation()
+        .into_oauth_router_at(
+            "/mcp",
+            validator,
+            metadata,
+            crate::oauth::ScopePolicy::new(),
+        )
+        .unwrap()
+}
+
+#[cfg(feature = "oauth")]
+fn oauth_validate_adapter_request() -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("Authorization", "Bearer valid-token")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json, text/event-stream")
+        .body(initialize_body())
+        .unwrap()
+}
+
+#[cfg(feature = "oauth")]
+#[tokio::test]
+async fn oauth_validate_adapter_matching_audience_reaches_mcp_router() {
+    let response = oauth_validate_adapter_app(Some("http://localhost:3000/mcp"))
+        .oneshot(oauth_validate_adapter_request())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json.get("result").is_some(), "unexpected response: {json}");
+}
+
+#[cfg(feature = "oauth")]
+#[tokio::test]
+async fn oauth_validate_adapter_mismatched_audience_is_rejected() {
+    let response = oauth_validate_adapter_app(Some("http://localhost:3000/other"))
+        .oneshot(oauth_validate_adapter_request())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        response
+            .headers()
+            .get("WWW-Authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("audience")
+    );
+}
+
+#[cfg(feature = "oauth")]
+#[tokio::test]
+async fn oauth_validate_adapter_missing_audience_is_rejected() {
+    let response = oauth_validate_adapter_app(None)
+        .oneshot(oauth_validate_adapter_request())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        response
+            .headers()
+            .get("WWW-Authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .contains("audience")
+    );
+}
+
+#[cfg(feature = "oauth")]
 #[test]
 fn oauth_resource_server_setup_validates_metadata() {
     let result = HttpTransport::new(create_test_router()).into_oauth_router(


### PR DESCRIPTION
## Summary

- add an explicit audience binding for ValidateAdapter credentials
- preserve the audience-less, fail-closed default and the OAuth layer's exact audience check
- document the server-side trust assertion and shared-credential risk
- cover matching, mismatched, and missing audiences through the composed HTTP router

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features

Closes #1392