### PR TITLE
fix(tracing): redact protocol frame payloads

### DIFF
--- a/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
+++ b/crates/tower-mcp/src/transport/http/stateless_dispatch.rs
@@ -280,23 +280,30 @@ impl ModernSubscriptionRegistry {
     /// Route subscription-scoped notifications and return whether the
     /// notification belongs exclusively on listen streams.
     pub(super) fn publish(&self, notification: &ServerNotification) -> bool {
-        let subscription_scoped = matches!(
-            notification,
-            ServerNotification::ResourceUpdated { .. }
-                | ServerNotification::ResourcesListChanged
-                | ServerNotification::ToolsListChanged
-                | ServerNotification::PromptsListChanged
-                | ServerNotification::FinalTaskStatusChanged(_)
-        );
-        if !subscription_scoped {
-            return false;
-        }
+        let notification_kind = match notification {
+            ServerNotification::ResourceUpdated { .. } => {
+                crate::protocol::notifications::RESOURCE_UPDATED
+            }
+            ServerNotification::ResourcesListChanged => {
+                crate::protocol::notifications::RESOURCES_LIST_CHANGED
+            }
+            ServerNotification::ToolsListChanged => {
+                crate::protocol::notifications::TOOLS_LIST_CHANGED
+            }
+            ServerNotification::PromptsListChanged => {
+                crate::protocol::notifications::PROMPTS_LIST_CHANGED
+            }
+            ServerNotification::FinalTaskStatusChanged(_) => {
+                crate::protocol::notifications::TASK_STATUS_CHANGED
+            }
+            _ => return false,
+        };
 
         let removed = {
             let mut subscriptions = self.subscriptions.lock().unwrap();
             tracing::trace!(
                 active_subscriptions = subscriptions.len(),
-                notification = ?notification,
+                notification_kind = %notification_kind,
                 "Routing final-protocol subscription notification"
             );
             let mut removals = Vec::new();

--- a/crates/tower-mcp/src/transport/http/tests.rs
+++ b/crates/tower-mcp/src/transport/http/tests.rs
@@ -19,6 +19,29 @@ use axum::http::Request;
 use proptest::prelude::*;
 use tower::ServiceExt;
 
+#[cfg(feature = "stateless")]
+#[derive(Clone, Default)]
+struct TraceCapture(Arc<std::sync::Mutex<Vec<u8>>>);
+
+#[cfg(feature = "stateless")]
+impl std::io::Write for TraceCapture {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(bytes);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(feature = "stateless")]
+impl TraceCapture {
+    fn contents(&self) -> String {
+        String::from_utf8(self.0.lock().unwrap().clone()).unwrap()
+    }
+}
+
 #[cfg(feature = "oauth")]
 fn oauth_test_token(audience: &str, scope: &str) -> String {
     jsonwebtoken::encode(
@@ -437,6 +460,64 @@ async fn modern_subscription_registry_filters_and_tags_notifications() {
 
     drop(registration.guard);
     assert!(registry.subscriptions.lock().unwrap().is_empty());
+}
+
+#[test]
+#[cfg(feature = "stateless")]
+fn modern_subscription_registry_traces_only_bounded_notification_metadata() {
+    const SENTINEL: &str = "private-task-result-1396";
+
+    let captured = TraceCapture::default();
+    let trace_output = captured.clone();
+    let subscriber = tracing_subscriber::fmt()
+        .with_ansi(false)
+        .without_time()
+        .with_max_level(tracing::Level::TRACE)
+        .with_writer(move || captured.clone())
+        .finish();
+
+    let registry = Arc::new(ModernSubscriptionRegistry::default());
+    let _registration = registry
+        .try_register(
+            RequestId::String("listen-1".into()),
+            SubscriptionFilter {
+                task_ids: Some(vec!["task-1".into()]),
+                ..SubscriptionFilter::default()
+            },
+            None,
+        )
+        .unwrap();
+    let notification =
+        ServerNotification::FinalTaskStatusChanged(crate::tasks::TaskStatusNotificationParams {
+            task: crate::tasks::DetailedTask::completed(
+                crate::tasks::TaskMetadata::new(
+                    "task-1",
+                    "2026-07-28T00:00:00Z",
+                    "2026-07-28T00:00:01Z",
+                    Some(60_000),
+                ),
+                serde_json::Map::from_iter([(
+                    "structuredContent".to_string(),
+                    serde_json::json!({ "secret": SENTINEL }),
+                )]),
+            ),
+            meta: None,
+        });
+
+    tracing::subscriber::with_default(subscriber, || {
+        assert!(registry.publish(&notification));
+    });
+
+    let traces = trace_output.contents();
+    assert!(
+        traces.contains("notification_kind=notifications/tasks"),
+        "notification kind missing: {traces}"
+    );
+    assert!(
+        traces.contains("active_subscriptions=1"),
+        "active subscription count missing: {traces}"
+    );
+    assert!(!traces.contains(SENTINEL), "task result leaked: {traces}");
 }
 
 #[test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -93,6 +93,58 @@ use crate::{ProtocolSupport, ProtocolSupportError};
 // Shared helpers
 // ============================================================================
 
+#[derive(Clone, Copy)]
+enum StdioFrameDirection {
+    Inbound,
+    Outbound,
+}
+
+impl StdioFrameDirection {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Inbound => "inbound",
+            Self::Outbound => "outbound",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum StdioFrameKind {
+    Message,
+    Notification,
+    Request,
+    Response,
+    #[cfg(feature = "stateless")]
+    SubscriptionNotification,
+}
+
+impl StdioFrameKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Message => "message",
+            Self::Notification => "notification",
+            Self::Request => "request",
+            Self::Response => "response",
+            #[cfg(feature = "stateless")]
+            Self::SubscriptionNotification => "subscription_notification",
+        }
+    }
+}
+
+/// Log bounded metadata for one UTF-8 JSON-RPC frame.
+///
+/// Deliberately accepts only closed enums and a byte count: callers cannot
+/// accidentally attach the frame body, method, or request ID to this event.
+fn trace_stdio_frame(direction: StdioFrameDirection, kind: StdioFrameKind, utf8_bytes: usize) {
+    tracing::debug!(
+        transport = "stdio",
+        direction = direction.as_str(),
+        frame_kind = kind.as_str(),
+        utf8_bytes,
+        "JSON-RPC frame"
+    );
+}
+
 enum StdioControl {
     #[cfg(feature = "stateless")]
     CloseSubscription(RequestId),
@@ -310,7 +362,7 @@ impl StdioSubscriptions {
             if let Some(request_id) = params.request_id
                 && let Some(subscription) = self.active.remove(&request_id)
             {
-                tracing::debug!(?request_id, "Cancelled stdio subscription");
+                tracing::debug!("Cancelled stdio subscription");
                 self.observe_close(
                     request_id,
                     subscription.started,
@@ -659,17 +711,17 @@ async fn process_line(
     // a parse error naming an internal type (#1272).
     match classify_frame(&parsed) {
         FrameClass::Notification => {
-            let method = parsed.get("method").and_then(|m| m.as_str());
-            if let Err(error) = service
+            if service
                 .inspect_incoming_value(&parsed, crate::inspection::McpDirection::ClientToServer)
+                .is_err()
             {
                 // Still worth surfacing, just not to the client.
-                tracing::debug!(method, %error, "rejected an invalid notification");
+                tracing::debug!("Rejected an invalid notification");
                 return Ok(None);
             }
             match serde_json::from_str::<JsonRpcNotification>(line) {
                 Ok(notification) => handle_notification(router, notification)?,
-                Err(_) => tracing::debug!(method, "unparseable notification"),
+                Err(_) => tracing::debug!("Unparseable notification"),
             }
             return Ok(None);
         }
@@ -1120,7 +1172,11 @@ impl StdioTransport {
                         continue;
                     }
 
-                    tracing::debug!(input = %trimmed, "Received message");
+                    trace_stdio_frame(
+                        StdioFrameDirection::Inbound,
+                        StdioFrameKind::Message,
+                        trimmed.len(),
+                    );
 
                     #[cfg(feature = "stateless")]
                     {
@@ -1165,7 +1221,11 @@ impl StdioTransport {
                         match process_line(&mut service, &router, &owned).await {
                             Ok(Some(response)) => match serde_json::to_string(&response) {
                                 Ok(json) => {
-                                    tracing::debug!(output = %json, "Sending response");
+                                    trace_stdio_frame(
+                                        StdioFrameDirection::Outbound,
+                                        StdioFrameKind::Response,
+                                        json.len(),
+                                    );
                                     Some(json)
                                 }
                                 Err(e) => {
@@ -1205,13 +1265,21 @@ impl StdioTransport {
                     #[cfg(feature = "stateless")]
                     if let Some(frames) = subscriptions.route_notification(&notification) {
                         for json in frames {
-                            tracing::debug!(output = %json, "Sending subscription notification");
+                            trace_stdio_frame(
+                                StdioFrameDirection::Outbound,
+                                StdioFrameKind::SubscriptionNotification,
+                                json.len(),
+                            );
                             write_line_to_stdout(&mut writer, &json).await?;
                         }
                         continue;
                     }
                     if let Some(json) = serialize_notification(&notification) {
-                        tracing::debug!(output = %json, "Sending notification");
+                        trace_stdio_frame(
+                            StdioFrameDirection::Outbound,
+                            StdioFrameKind::Notification,
+                            json.len(),
+                        );
                         write_line_to_stdout(&mut writer, &json).await?;
                     }
                 }
@@ -1517,13 +1585,21 @@ where
                         #[cfg(feature = "stateless")]
                         if let Some(frames) = subscriptions.route_notification(&notification) {
                             for json in frames {
-                                tracing::debug!(output = %json, "Sending subscription notification");
+                                trace_stdio_frame(
+                                    StdioFrameDirection::Outbound,
+                                    StdioFrameKind::SubscriptionNotification,
+                                    json.len(),
+                                );
                                 write_line_to_stdout(&mut writer, &json).await?;
                             }
                             continue;
                         }
                         if let Some(json) = serialize_notification(&notification) {
-                            tracing::debug!(output = %json, "Sending notification");
+                            trace_stdio_frame(
+                                StdioFrameDirection::Outbound,
+                                StdioFrameKind::Notification,
+                                json.len(),
+                            );
                             write_line_to_stdout(&mut writer, &json).await?;
                         }
                     }
@@ -1618,7 +1694,11 @@ where
             return Ok(());
         }
 
-        tracing::debug!(input = %trimmed, "Received message");
+        trace_stdio_frame(
+            StdioFrameDirection::Inbound,
+            StdioFrameKind::Message,
+            trimmed.len(),
+        );
 
         // Check if it's a notification (no id field)
         let parsed: serde_json::Value = match serde_json::from_str(trimmed) {
@@ -1673,15 +1753,11 @@ where
                     .and_then(|n| McpNotification::from_jsonrpc(&n).ok())
                 {
                     Some(notification) => handler(notification),
-                    None => tracing::debug!(
-                        method = parsed.get("method").and_then(|m| m.as_str()),
-                        "Unrecognized notification"
-                    ),
+                    None => tracing::debug!("Unrecognized notification"),
                 },
-                None => tracing::debug!(
-                    method = parsed.get("method").and_then(|m| m.as_str()),
-                    "Received notification but no handler is configured"
-                ),
+                None => {
+                    tracing::debug!("Received notification but no handler is configured");
+                }
             }
             return Ok(());
         }
@@ -1702,7 +1778,11 @@ where
             match service.call_message(message).await {
                 Ok(response) => match serde_json::to_string(&response) {
                     Ok(json) => {
-                        tracing::debug!(output = %json, "Sending response");
+                        trace_stdio_frame(
+                            StdioFrameDirection::Outbound,
+                            StdioFrameKind::Response,
+                            json.len(),
+                        );
                         Some(json)
                     }
                     Err(e) => {
@@ -1816,16 +1896,24 @@ impl SyncStdioTransport {
 
     /// Run the transport synchronously using a tokio runtime
     pub fn run_blocking(&mut self) -> Result<()> {
-        let rt = tokio::runtime::Runtime::new()
-            .map_err(|e| Error::Transport(format!("Failed to create runtime: {}", e)))?;
-
         let stdin = io::stdin();
         let mut input = stdin.lock();
         let mut stdout = io::stdout();
 
+        self.run_blocking_with_streams(&mut input, &mut stdout)
+    }
+
+    fn run_blocking_with_streams<R, W>(&mut self, input: &mut R, stdout: &mut W) -> Result<()>
+    where
+        R: io::BufRead,
+        W: Write,
+    {
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| Error::Transport(format!("Failed to create runtime: {}", e)))?;
+
         tracing::info!("Sync stdio transport started");
 
-        while let Some(frame) = read_frame_blocking(&mut input)? {
+        while let Some(frame) = read_frame_blocking(input)? {
             let line = match frame {
                 InputFrame::Line(line) => line,
                 InputFrame::Undecodable => {
@@ -1844,14 +1932,22 @@ impl SyncStdioTransport {
                 continue;
             }
 
-            tracing::debug!(input = %trimmed, "Received message");
+            trace_stdio_frame(
+                StdioFrameDirection::Inbound,
+                StdioFrameKind::Message,
+                trimmed.len(),
+            );
 
             match rt.block_on(process_line(&mut self.service, &self.router, trimmed)) {
                 Ok(Some(response)) => {
                     let response_json = serde_json::to_string(&response).map_err(|e| {
                         Error::Transport(format!("Failed to serialize response: {}", e))
                     })?;
-                    tracing::debug!(output = %response_json, "Sending response");
+                    trace_stdio_frame(
+                        StdioFrameDirection::Outbound,
+                        StdioFrameKind::Response,
+                        response_json.len(),
+                    );
                     writeln!(stdout, "{}", response_json).map_err(|e| {
                         Error::Transport(format!("Failed to write to stdout: {}", e))
                     })?;
@@ -2088,13 +2184,21 @@ impl BidirectionalStdioTransport {
                     #[cfg(feature = "stateless")]
                     if let Some(frames) = subscriptions.route_notification(&notification) {
                         for json in frames {
-                            tracing::debug!(output = %json, "Sending subscription notification");
+                            trace_stdio_frame(
+                                StdioFrameDirection::Outbound,
+                                StdioFrameKind::SubscriptionNotification,
+                                json.len(),
+                            );
                             self.write_line(&json, writer.clone()).await?;
                         }
                         continue;
                     }
                     if let Some(json) = serialize_notification(&notification) {
-                        tracing::debug!(output = %json, "Sending notification");
+                        trace_stdio_frame(
+                            StdioFrameDirection::Outbound,
+                            StdioFrameKind::Notification,
+                            json.len(),
+                        );
                         self.write_line(&json, writer.clone()).await?;
                     }
                 }
@@ -2138,7 +2242,11 @@ impl BidirectionalStdioTransport {
     where
         W: tokio::io::AsyncWrite + Unpin + Send + 'static,
     {
-        tracing::debug!(input = %line, "Received message");
+        trace_stdio_frame(
+            StdioFrameDirection::Inbound,
+            StdioFrameKind::Message,
+            line.len(),
+        );
 
         // Malformed JSON must produce a JSON-RPC parse error response, not
         // tear down the run loop. Per the spec, id is null when the request
@@ -2222,7 +2330,11 @@ impl BidirectionalStdioTransport {
             };
             match response_json {
                 Ok(json) => {
-                    tracing::debug!(output = %json, "Sending response");
+                    trace_stdio_frame(
+                        StdioFrameDirection::Outbound,
+                        StdioFrameKind::Response,
+                        json.len(),
+                    );
                     if let Err(e) = write_line_locked(&writer, &json).await {
                         tracing::error!(error = %e, "Failed to write response to stdout");
                     }
@@ -2292,7 +2404,7 @@ impl BidirectionalStdioTransport {
                 let _ = pending.response_tx.send(result);
             }
             None => {
-                tracing::warn!(id = ?id, "Received response for unknown request");
+                tracing::warn!("Received response for unknown request");
             }
         }
 
@@ -2319,7 +2431,11 @@ impl BidirectionalStdioTransport {
         let request_json = serde_json::to_string(&request)
             .map_err(|e| Error::Transport(format!("Failed to serialize request: {}", e)))?;
 
-        tracing::debug!(output = %request_json, "Sending request to client");
+        trace_stdio_frame(
+            StdioFrameDirection::Outbound,
+            StdioFrameKind::Request,
+            request_json.len(),
+        );
 
         // Store pending request
         {
@@ -2380,6 +2496,74 @@ mod tests {
         LogLevel, LoggingMessageParams, ProgressParams, ProgressToken, TaskStatus, TaskStatusParams,
     };
     use tower_mcp_types::testing::assert_jsonrpc_error_response;
+
+    #[derive(Clone, Default)]
+    struct TraceWriter(Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl Write for TraceWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("trace capture lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl TraceWriter {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().expect("trace capture lock").clone())
+                .expect("tracing output is UTF-8")
+        }
+    }
+
+    #[test]
+    fn sync_stdio_traces_frame_metadata_without_bodies() {
+        const SECRET: &str = "sync-frame-secret-9df387";
+
+        let frame = format!(r#"{{"jsonrpc":"2.0","id":"{SECRET}","method":"ping"}}"#);
+        let mut input = io::Cursor::new(format!("{frame}\n").into_bytes());
+        let mut output = Vec::new();
+
+        let captured = TraceWriter::default();
+        let trace_output = captured.clone();
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+
+        SyncStdioTransport::new(make_router())
+            .run_blocking_with_streams(&mut input, &mut output)
+            .expect("sync stdio loop");
+
+        let response = String::from_utf8(output).expect("response is UTF-8");
+        assert!(
+            response.contains(SECRET),
+            "the wire response must still correlate the request: {response}"
+        );
+
+        let traces = trace_output.contents();
+        assert!(!traces.contains(SECRET), "frame body leaked: {traces}");
+        assert!(traces.contains("direction=\"inbound\""), "{traces}");
+        assert!(traces.contains("direction=\"outbound\""), "{traces}");
+        assert!(traces.contains("frame_kind=\"message\""), "{traces}");
+        assert!(traces.contains("frame_kind=\"response\""), "{traces}");
+        assert!(
+            traces.contains(&format!("utf8_bytes={}", frame.len())),
+            "{traces}"
+        );
+        assert!(
+            traces.contains(&format!("utf8_bytes={}", response.trim().len())),
+            "{traces}"
+        );
+    }
 
     // =========================================================================
     // parse_error_response tests -- wire-format invariants on the stdio

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -59,6 +59,311 @@ where
 }
 
 // ============================================================================
+// Safe frame tracing (#1388)
+// ============================================================================
+
+mod safe_frame_tracing {
+    use super::*;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+    use tower_mcp::GenericStdioTransport;
+    use tower_mcp::context::{ServerNotification, notification_channel};
+    use tower_mcp::protocol::{LogLevel, LoggingMessageParams};
+
+    static TRACE_CAPTURE_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CaptureWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("trace capture lock")
+                .extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl CaptureWriter {
+        fn contents(&self) -> String {
+            String::from_utf8(self.0.lock().expect("trace capture lock").clone())
+                .expect("tracing output is UTF-8")
+        }
+    }
+
+    async fn trace_ping<F, Fut>(sentinel: &str, run: F) -> (usize, usize)
+    where
+        F: FnOnce(tokio::io::DuplexStream, tokio::io::DuplexStream) -> Fut,
+        Fut: std::future::Future<Output = ()> + Send + 'static,
+    {
+        let frame = format!(r#"{{"jsonrpc":"2.0","id":"{sentinel}","method":"ping"}}"#);
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        let transport = tokio::spawn(run(server_stdin, server_stdout));
+
+        stdin_writer.write_all(frame.as_bytes()).await.unwrap();
+        stdin_writer.write_all(b"\n").await.unwrap();
+        stdin_writer.flush().await.unwrap();
+        drop(stdin_writer);
+
+        let frames = timeout(
+            Duration::from_secs(5),
+            read_n_frames(BufReader::new(server_stdout_reader), 1),
+        )
+        .await
+        .expect("stdio transport must answer the ping");
+        timeout(Duration::from_secs(5), transport)
+            .await
+            .expect("stdio transport must stop at EOF")
+            .expect("transport task");
+
+        assert_eq!(frames.len(), 1, "expected one ping response: {frames:?}");
+        assert_eq!(frames[0]["id"], sentinel);
+        let response_bytes = serde_json::to_string(&frames[0]).unwrap().len();
+        (frame.len(), response_bytes)
+    }
+
+    /// The three async implementations each run their real read-eval-write
+    /// loop. A secret request ID appears in both wire frames, making one
+    /// sentinel cover inbound request and outbound response disclosure.
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_stdio_variants_trace_metadata_without_frame_bodies() {
+        // The non-ASCII sentinel makes the length assertion distinguish UTF-8
+        // bytes from Unicode scalar values.
+        const PLAIN_SECRET: &str = "plain-stdio-secret-é-e8c2";
+        const LAYERED_SECRET: &str = "layered-stdio-secret-b50a";
+        const GENERIC_SECRET: &str = "generic-stdio-secret-7f43";
+        const BIDI_SECRET: &str = "bidi-stdio-secret-1d69";
+
+        let _trace_capture = TRACE_CAPTURE_LOCK.lock().await;
+        let captured = CaptureWriter::default();
+        let trace_output = captured.clone();
+        let tracing = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(tracing);
+
+        let mut byte_lengths = Vec::new();
+        byte_lengths.push(
+            trace_ping(PLAIN_SECRET, |stdin, stdout| async move {
+                StdioTransport::new(router())
+                    .run_with_streams(stdin, stdout)
+                    .await
+                    .expect("plain stdio loop");
+            })
+            .await,
+        );
+        byte_lengths.push(
+            trace_ping(LAYERED_SECRET, |stdin, stdout| async move {
+                StdioTransport::new(router())
+                    .layer(tower::layer::util::Identity::new())
+                    .run_with_streams(stdin, stdout)
+                    .await
+                    .expect("layered stdio loop");
+            })
+            .await,
+        );
+        byte_lengths.push(
+            trace_ping(GENERIC_SECRET, |stdin, stdout| async move {
+                GenericStdioTransport::new(router())
+                    .run_with_streams(stdin, stdout)
+                    .await
+                    .expect("generic stdio loop");
+            })
+            .await,
+        );
+        byte_lengths.push(
+            trace_ping(BIDI_SECRET, |stdin, stdout| async move {
+                BidirectionalStdioTransport::new(router())
+                    .run_with_streams(stdin, stdout)
+                    .await
+                    .expect("bidirectional stdio loop");
+            })
+            .await,
+        );
+
+        let traces = trace_output.contents();
+        for secret in [PLAIN_SECRET, LAYERED_SECRET, GENERIC_SECRET, BIDI_SECRET] {
+            assert!(!traces.contains(secret), "frame body leaked: {traces}");
+        }
+        assert!(
+            !traces.contains("input="),
+            "raw input field returned: {traces}"
+        );
+        assert!(
+            !traces.contains("output="),
+            "raw output field returned: {traces}"
+        );
+        assert_eq!(
+            traces.matches("direction=\"inbound\"").count(),
+            4,
+            "{traces}"
+        );
+        assert_eq!(
+            traces.matches("direction=\"outbound\"").count(),
+            4,
+            "{traces}"
+        );
+        assert_eq!(
+            traces.matches("frame_kind=\"message\"").count(),
+            4,
+            "{traces}"
+        );
+        assert_eq!(
+            traces.matches("frame_kind=\"response\"").count(),
+            4,
+            "{traces}"
+        );
+        for (inbound, outbound) in byte_lengths {
+            assert!(
+                traces.contains(&format!("utf8_bytes={inbound}")),
+                "{traces}"
+            );
+            assert!(
+                traces.contains(&format!("utf8_bytes={outbound}")),
+                "{traces}"
+            );
+        }
+    }
+
+    /// The bidirectional-only server-to-client request path has a separate
+    /// serializer and log site, so exercise it directly with both a sensitive
+    /// method and sensitive parameters.
+    #[tokio::test(flavor = "current_thread")]
+    async fn bidi_outgoing_request_trace_omits_method_and_params() {
+        const SECRET_METHOD: &str = "private/provider-request-57d1";
+        const SECRET_PARAM: &str = "provider-session-token-43d9";
+
+        let _trace_capture = TRACE_CAPTURE_LOCK.lock().await;
+        let captured = CaptureWriter::default();
+        let trace_output = captured.clone();
+        let tracing = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(tracing);
+
+        let mut transport = BidirectionalStdioTransport::new(router());
+        let requester = transport.client_requester();
+        let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        let transport = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+                .expect("bidirectional stdio loop");
+        });
+        let request = tokio::spawn(async move {
+            requester
+                .request(
+                    SECRET_METHOD.to_string(),
+                    serde_json::json!({ "credential": SECRET_PARAM }),
+                )
+                .await
+        });
+
+        let mut stdout_reader = BufReader::new(server_stdout_reader);
+        let outgoing = timeout(Duration::from_secs(5), read_frame(&mut stdout_reader))
+            .await
+            .expect("server-to-client request");
+        assert_eq!(outgoing["method"], SECRET_METHOD);
+        assert_eq!(outgoing["params"]["credential"], SECRET_PARAM);
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": outgoing["id"],
+            "result": { "accepted": true }
+        });
+        stdin_writer
+            .write_all(format!("{response}\n").as_bytes())
+            .await
+            .unwrap();
+        stdin_writer.flush().await.unwrap();
+        timeout(Duration::from_secs(5), request)
+            .await
+            .expect("request round trip")
+            .expect("request task")
+            .expect("request result");
+        drop(stdin_writer);
+        timeout(Duration::from_secs(5), transport)
+            .await
+            .expect("transport stops at EOF")
+            .expect("transport task");
+
+        let traces = trace_output.contents();
+        assert!(!traces.contains(SECRET_METHOD), "method leaked: {traces}");
+        assert!(!traces.contains(SECRET_PARAM), "params leaked: {traces}");
+        assert!(traces.contains("direction=\"outbound\""), "{traces}");
+        assert!(traces.contains("frame_kind=\"request\""), "{traces}");
+    }
+
+    /// Notification bodies have historically carried terminal output and log
+    /// data, so cover that output category independently from responses.
+    #[tokio::test(flavor = "current_thread")]
+    async fn generic_notification_trace_omits_notification_body() {
+        const SECRET: &str = "notification-terminal-output-82ac";
+
+        let _trace_capture = TRACE_CAPTURE_LOCK.lock().await;
+        let captured = CaptureWriter::default();
+        let trace_output = captured.clone();
+        let tracing = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(move || captured.clone())
+            .finish();
+        let _subscriber = tracing::subscriber::set_default(tracing);
+
+        let (notification_tx, notification_rx) = notification_channel(4);
+        let mut transport = GenericStdioTransport::with_notifications(router(), notification_rx);
+        let (stdin_writer, server_stdin) = tokio::io::duplex(4096);
+        let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+        let transport = tokio::spawn(async move {
+            transport
+                .run_with_streams(server_stdin, server_stdout)
+                .await
+                .expect("generic stdio loop");
+        });
+
+        notification_tx
+            .send(ServerNotification::LogMessage(LoggingMessageParams {
+                level: LogLevel::Info,
+                logger: Some("test".to_string()),
+                data: serde_json::json!(SECRET),
+                meta: None,
+            }))
+            .await
+            .expect("notification receiver");
+        let mut stdout_reader = BufReader::new(server_stdout_reader);
+        let notification = timeout(Duration::from_secs(5), read_frame(&mut stdout_reader))
+            .await
+            .expect("notification frame");
+        assert_eq!(notification["params"]["data"], SECRET);
+
+        drop(stdin_writer);
+        timeout(Duration::from_secs(5), transport)
+            .await
+            .expect("transport stops at EOF")
+            .expect("transport task");
+
+        let traces = trace_output.contents();
+        assert!(!traces.contains(SECRET), "notification leaked: {traces}");
+        assert!(traces.contains("direction=\"outbound\""), "{traces}");
+        assert!(traces.contains("frame_kind=\"notification\""), "{traces}");
+    }
+}
+
+// ============================================================================
 // StdioTransport
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- replace all 15 stdio full-frame debug events with bounded direction, category, and UTF-8 byte-length metadata
- remove peer-controlled stdio method and request-ID fields from transport logs
- trace final HTTP subscription routing with only a canonical notification kind and active count
- add secret-sentinel capture regressions across plain, layered, generic, sync, bidirectional, notification, server-to-client request, and completed-task paths

Full protocol bodies are no longer logged by these paths, including at TRACE.

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- cargo check -p tower-mcp --no-default-features
- independent security review

Closes #1388
Closes #1396