### PR TITLE
fix(router): authorize completion references

### DIFF
--- a/crates/tower-mcp/src/context.rs
+++ b/crates/tower-mcp/src/context.rs
@@ -127,6 +127,7 @@ use crate::protocol::{
     ListTasksParams, ListTasksResult, LogLevel, LoggingMessageParams, ProgressParams,
     ProgressToken, RequestId, TaskObject, TaskStatus,
 };
+use crate::session::SessionState;
 
 /// A notification to be sent to the client
 #[derive(Debug, Clone)]
@@ -341,6 +342,11 @@ pub struct RequestContext {
     client_requester: Option<ClientRequesterHandle>,
     /// Extensions for passing data from router/middleware to handlers
     extensions: Arc<Extensions>,
+    /// Logical MCP session for session-scoped state and authorization claims.
+    ///
+    /// Router-created contexts always attach this. Manually constructed
+    /// contexts leave it absent.
+    session: Option<SessionState>,
     /// Minimum log level set by the client (shared with router for dynamic updates)
     min_log_level: Option<Arc<RwLock<LogLevel>>>,
     /// Resource URIs subscribed by this legacy session. Router-created
@@ -440,6 +446,7 @@ impl RequestContext {
             client_requester: None,
             final_lifecycle: false,
             extensions: Arc::new(Extensions::new()),
+            session: None,
             min_log_level: None,
             resource_subscriptions: None,
         }
@@ -527,6 +534,12 @@ impl RequestContext {
         self
     }
 
+    /// Attach the logical MCP session serving this request.
+    pub(crate) fn with_session(mut self, session: SessionState) -> Self {
+        self.session = Some(session);
+        self
+    }
+
     /// Get a reference to a value from the extensions map.
     ///
     /// Returns `None` if no value of the given type has been inserted.
@@ -565,6 +578,16 @@ impl RequestContext {
     /// Get a reference to the extensions.
     pub fn extensions(&self) -> &Extensions {
         &self.extensions
+    }
+
+    /// Return the logical MCP session serving this request.
+    ///
+    /// Router-created contexts return `Some`, allowing handlers to read
+    /// session-scoped values such as authorization claims. A context created
+    /// directly with [`RequestContext::new`] has no associated session and
+    /// returns `None`.
+    pub fn session(&self) -> Option<&SessionState> {
+        self.session.as_ref()
     }
 
     /// SEP-2575 per-request `_meta` (protocol version, client info, client

--- a/crates/tower-mcp/src/filter.rs
+++ b/crates/tower-mcp/src/filter.rs
@@ -329,6 +329,22 @@ impl<T: Filterable> CapabilityFilter<T> {
         self.denial.to_error(name)
     }
 
+    /// Return a canonical not-found error for the default hidden-capability
+    /// policy while preserving an explicitly configured denial response.
+    ///
+    /// Callers that have a capability-specific unknown error use this to
+    /// keep filtered and absent targets indistinguishable without overriding
+    /// an application's deliberate `Unauthorized` or `Custom` behavior.
+    pub(crate) fn denial_error_or_not_found<F>(&self, name: &str, not_found: F) -> Error
+    where
+        F: FnOnce() -> Error,
+    {
+        match &self.denial {
+            DenialBehavior::NotFound => not_found(),
+            DenialBehavior::Unauthorized | DenialBehavior::Custom(_) => self.denial.to_error(name),
+        }
+    }
+
     /// Create a filter that only shows capabilities whose names are in the list.
     ///
     /// Capabilities not in the list are hidden. This is useful for exposing

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -38,10 +38,19 @@ use crate::tool::Tool;
 
 /// Type alias for completion handler function
 pub(crate) type CompletionHandler = Arc<
-    dyn Fn(CompleteParams) -> Pin<Box<dyn Future<Output = Result<CompleteResult>> + Send>>
+    dyn Fn(
+            RequestContext,
+            CompleteParams,
+        ) -> Pin<Box<dyn Future<Output = Result<CompleteResult>> + Send>>
         + Send
         + Sync,
 >;
+
+fn prompt_not_found(name: &str) -> Error {
+    Error::JsonRpc(JsonRpcError::method_not_found(&format!(
+        "Prompt not found: {name}"
+    )))
+}
 
 /// Releases a live task's registry entry however its handler leaves.
 ///
@@ -314,6 +323,31 @@ impl McpRouter {
         Ok(())
     }
 
+    /// Authorize a resource-template completion without disclosing whether
+    /// the referenced template exists under the default denial policy.
+    fn authorize_completion_resource_template(
+        &self,
+        context: &CapabilityFilterContext<'_>,
+        template: &ResourceTemplate,
+        target: &str,
+    ) -> Result<()> {
+        if let Some(filter) = &self.inner.resource_template_filter {
+            if !filter.is_visible_with_context(context, template) {
+                return Err(filter.denial_error_or_not_found(target, || {
+                    Error::JsonRpc(JsonRpcError::resource_not_found(target))
+                }));
+            }
+        } else if let Some(filter) = &self.inner.resource_filter {
+            // An exact-resource filter cannot authorize a template. Match
+            // resources/read's fail-closed policy, but use the completion
+            // reference's canonical unknown response for default NotFound.
+            return Err(filter.denial_error_or_not_found(target, || {
+                Error::JsonRpc(JsonRpcError::resource_not_found(target))
+            }));
+        }
+        Ok(())
+    }
+
     /// Authorize access to an exact statically registered resource.
     ///
     /// Legacy resource subscriptions deliberately retain their existing
@@ -347,6 +381,146 @@ impl McpRouter {
         }
 
         Ok(())
+    }
+
+    /// Authorize the capability named by a completion request.
+    ///
+    /// Completion is a second access path to prompts and resources, so it
+    /// must resolve and authorize the same winning registration as the
+    /// ordinary get/read paths before the application handler sees the
+    /// request. In particular, a denied static registration must not fall
+    /// through to a dynamic registration with the same name or URI.
+    fn authorize_completion_reference(
+        &self,
+        request_extensions: &Extensions,
+        reference: &CompletionReference,
+    ) -> Result<()> {
+        match reference {
+            CompletionReference::Prompt { name } => {
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(initializer) = &self.inner.prompt_initializer {
+                    initializer()?;
+                }
+
+                if self.inner.disabled_prompts.read().unwrap().contains(name) {
+                    return Err(prompt_not_found(name));
+                }
+
+                let prompt = self.inner.prompts.get(name).cloned();
+                #[cfg(feature = "dynamic-tools")]
+                let prompt = prompt.or_else(|| {
+                    self.inner
+                        .dynamic_prompts
+                        .as_ref()
+                        .and_then(|dynamic| dynamic.get(name))
+                });
+                let prompt = prompt.ok_or_else(|| prompt_not_found(name))?;
+
+                let context = self.capability_filter_context(
+                    request_extensions,
+                    CapabilityOperation::Access { target: name },
+                );
+                if let Some(filter) = &self.inner.prompt_filter
+                    && !filter.is_visible_with_context(&context, &prompt)
+                {
+                    return Err(filter.denial_error_or_not_found(name, || prompt_not_found(name)));
+                }
+                Ok(())
+            }
+            CompletionReference::Resource { uri } => {
+                if self.inner.disabled_resources.read().unwrap().contains(uri) {
+                    return Err(Error::JsonRpc(JsonRpcError::resource_not_found(uri)));
+                }
+
+                let context = self.capability_filter_context(
+                    request_extensions,
+                    CapabilityOperation::Access { target: uri },
+                );
+
+                // Exact resources take precedence over templates, matching
+                // resources/read. Static resources likewise shadow dynamic
+                // resources with the same URI.
+                if let Some(resource) = self.inner.resources.get(uri) {
+                    if let Some(filter) = &self.inner.resource_filter
+                        && !filter.is_visible_with_context(&context, resource)
+                    {
+                        return Err(filter.denial_error_or_not_found(uri, || {
+                            Error::JsonRpc(JsonRpcError::resource_not_found(uri))
+                        }));
+                    }
+                    return Ok(());
+                }
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(resource) = self
+                    .inner
+                    .dynamic_resources
+                    .as_ref()
+                    .and_then(|dynamic| dynamic.get(uri))
+                {
+                    if let Some(filter) = &self.inner.resource_filter
+                        && !filter.is_visible_with_context(&context, &resource)
+                    {
+                        return Err(filter.denial_error_or_not_found(uri, || {
+                            Error::JsonRpc(JsonRpcError::resource_not_found(uri))
+                        }));
+                    }
+                    return Ok(());
+                }
+
+                // A completion reference may contain either a resource URI
+                // or the registered URI-template pattern. Check exact
+                // patterns before treating the value as a concrete URI so a
+                // template definition authorizes its own completion request.
+                if let Some(template) = self
+                    .inner
+                    .resource_templates
+                    .iter()
+                    .find(|template| template.uri_template == *uri)
+                {
+                    return self.authorize_completion_resource_template(&context, template, uri);
+                }
+                #[cfg(feature = "dynamic-tools")]
+                if let Some(template) =
+                    self.inner
+                        .dynamic_resource_templates
+                        .as_ref()
+                        .and_then(|dynamic| {
+                            dynamic
+                                .list()
+                                .into_iter()
+                                .find(|template| template.uri_template == *uri)
+                        })
+                {
+                    return self.authorize_completion_resource_template(&context, &template, uri);
+                }
+
+                // Concrete URIs produced by a template are resource
+                // references too. Preserve resources/read's first-match and
+                // static-before-dynamic routing semantics.
+                if let Some(template) = self
+                    .inner
+                    .resource_templates
+                    .iter()
+                    .find(|template| template.match_uri(uri).is_some())
+                {
+                    return self.authorize_completion_resource_template(&context, template, uri);
+                }
+                #[cfg(feature = "dynamic-tools")]
+                if let Some((template, _variables)) = self
+                    .inner
+                    .dynamic_resource_templates
+                    .as_ref()
+                    .and_then(|dynamic| dynamic.match_uri(uri))
+                {
+                    return self.authorize_completion_resource_template(&context, &template, uri);
+                }
+
+                Err(Error::JsonRpc(JsonRpcError::resource_not_found(uri)))
+            }
+            _ => Err(Error::JsonRpc(JsonRpcError::invalid_params(
+                "Unsupported completion reference",
+            ))),
+        }
     }
 
     /// Generate request-filtered instructions from registered capabilities.
@@ -1038,7 +1212,9 @@ impl McpRouter {
             ctx
         };
 
-        let ctx = ctx.with_extensions(Arc::new(merged));
+        let ctx = ctx
+            .with_extensions(Arc::new(merged))
+            .with_session(self.session.clone());
 
         // Set up log level filtering
         let ctx = ctx.with_min_log_level(self.inner.min_log_level.clone());
@@ -2552,10 +2728,7 @@ impl McpRouter {
                     .unwrap()
                     .contains(&params.name)
                 {
-                    return Err(Error::JsonRpc(JsonRpcError::method_not_found(&format!(
-                        "Prompt not found: {}",
-                        params.name
-                    ))));
+                    return Err(prompt_not_found(&params.name));
                 }
 
                 // Look up static prompts first, then dynamic
@@ -2567,12 +2740,7 @@ impl McpRouter {
                         .as_ref()
                         .and_then(|d| d.get(&params.name))
                 });
-                let prompt = prompt.ok_or_else(|| {
-                    Error::JsonRpc(JsonRpcError::method_not_found(&format!(
-                        "Prompt not found: {}",
-                        params.name
-                    )))
-                })?;
+                let prompt = prompt.ok_or_else(|| prompt_not_found(&params.name))?;
 
                 // Check prompt filter if configured
                 let filter_context = self.capability_filter_context(
@@ -2926,7 +3094,24 @@ impl McpRouter {
 
                 // Delegate to registered completion handler if available
                 if let Some(ref handler) = self.inner.completion_handler {
-                    let result = handler(params).await?;
+                    self.authorize_completion_reference(&extensions, &params.reference)?;
+                    let progress_token = params
+                        .meta
+                        .as_ref()
+                        .and_then(|meta| meta.get("progressToken"))
+                        .map(|token| serde_json::from_value(token.clone()))
+                        .transpose()
+                        .map_err(|error| {
+                            Error::invalid_params(format!(
+                                "Invalid completion progress token: {error}"
+                            ))
+                        })?;
+                    let ctx = self.create_context_with_extensions(
+                        request_id,
+                        progress_token,
+                        &extensions,
+                    );
+                    let result = handler(ctx, params).await?;
                     Ok(McpResponse::Complete(result))
                 } else {
                     // No completion handler registered, return empty completions

--- a/crates/tower-mcp/src/router/builder.rs
+++ b/crates/tower-mcp/src/router/builder.rs
@@ -928,6 +928,8 @@ impl McpRouter {
     ///
     /// The handler receives `CompleteParams` containing the reference (prompt or resource)
     /// and the argument being completed, and should return completion suggestions.
+    /// The referenced prompt, resource, or resource template must be registered, enabled,
+    /// and visible to the request before this handler is invoked.
     ///
     /// # Example
     ///
@@ -957,7 +959,37 @@ impl McpRouter {
         Fut: Future<Output = Result<CompleteResult>> + Send + 'static,
     {
         Arc::make_mut(&mut self.inner).completion_handler =
-            Some(Arc::new(move |params| Box::pin(handler(params))));
+            Some(Arc::new(move |_ctx, params| Box::pin(handler(params))));
+        self
+    }
+
+    /// Register a request-aware completion handler for `completion/complete` requests.
+    ///
+    /// The [`RequestContext`] exposes router and per-request extensions, negotiated
+    /// capabilities, progress, and cancellation. As with [`Self::completion_handler`],
+    /// the referenced capability is resolved and authorized before dispatch.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{CompleteParams, CompleteResult, McpRouter, RequestContext};
+    ///
+    /// let router = McpRouter::new().completion_handler_with_context(
+    ///     |ctx: RequestContext, params: CompleteParams| async move {
+    ///         if ctx.is_cancelled() {
+    ///             return Ok(CompleteResult::new(vec![]));
+    ///         }
+    ///         Ok(CompleteResult::new(vec![params.argument.value]))
+    ///     },
+    /// );
+    /// ```
+    pub fn completion_handler_with_context<F, Fut>(mut self, handler: F) -> Self
+    where
+        F: Fn(RequestContext, CompleteParams) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<CompleteResult>> + Send + 'static,
+    {
+        Arc::make_mut(&mut self.inner).completion_handler =
+            Some(Arc::new(move |ctx, params| Box::pin(handler(ctx, params))));
         self
     }
 

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -4713,6 +4713,11 @@ fn without_server_notifications_composes_with_explicit_overrides() {
 async fn test_completion_handler() {
     let router = McpRouter::new()
         .server_info("test", "1.0")
+        .prompt(
+            crate::prompt::PromptBuilder::new("test-prompt")
+                .description("Completion target")
+                .user_message("test"),
+        )
         .completion_handler(|params: CompleteParams| async move {
             // Return suggestions based on the argument value
             let prefix = &params.argument.value;
@@ -4785,6 +4790,457 @@ async fn test_completion_handler() {
         }
         _ => panic!("Expected Complete response"),
     }
+}
+
+async fn request_completion(
+    router: &mut McpRouter,
+    request_id: i64,
+    reference: CompletionReference,
+    extensions: Extensions,
+    meta: Option<serde_json::Value>,
+) -> std::result::Result<CompleteResult, JsonRpcError> {
+    let request = RouterRequest {
+        id: RequestId::Number(request_id),
+        inner: McpRequest::Complete(CompleteParams {
+            reference,
+            argument: CompletionArgument::new("value", "a"),
+            context: None,
+            meta,
+        }),
+        extensions,
+    };
+    let response = router.ready().await.unwrap().call(request).await.unwrap();
+    match response.inner {
+        Ok(McpResponse::Complete(result)) => Ok(result),
+        Err(error) => Err(error),
+        other => panic!("expected completion response, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn completion_handler_with_context_receives_request_state() {
+    #[derive(Clone)]
+    struct RouterState(&'static str);
+    #[derive(Clone)]
+    struct RequestState(&'static str);
+    #[derive(Clone)]
+    struct SessionClaim(&'static str);
+
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let mut router = McpRouter::new()
+        .with_state(RouterState("router"))
+        .prompt(
+            crate::prompt::PromptBuilder::new("contextual")
+                .description("Context completion target")
+                .user_message("test"),
+        )
+        .completion_handler_with_context(|ctx: RequestContext, _params| async move {
+            assert_eq!(ctx.request_id(), &RequestId::Number(41));
+            assert_eq!(ctx.extension::<RouterState>().unwrap().0, "router");
+            assert_eq!(ctx.extension::<RequestState>().unwrap().0, "request");
+            assert_eq!(
+                ctx.session()
+                    .and_then(|session| session.get::<SessionClaim>())
+                    .unwrap()
+                    .0,
+                "session"
+            );
+            assert_eq!(
+                ctx.progress_token(),
+                Some(&ProgressToken::String("completion-progress".to_string()))
+            );
+            assert!(ctx.is_cancelled());
+            assert!(ctx.negotiated_extensions().is_some());
+            Ok(CompleteResult::new(vec!["authorized".to_string()]))
+        });
+    router.session().insert(SessionClaim("session"));
+    init_router(&mut router).await;
+
+    let mut extensions = Extensions::new();
+    extensions.insert(RequestState("request"));
+    extensions.insert(cancellation);
+    let result = request_completion(
+        &mut router,
+        41,
+        CompletionReference::prompt("contextual"),
+        extensions,
+        Some(serde_json::json!({"progressToken": "completion-progress"})),
+    )
+    .await
+    .unwrap();
+    assert_eq!(result.completion.values, vec!["authorized"]);
+
+    let error = request_completion(
+        &mut router,
+        42,
+        CompletionReference::prompt("contextual"),
+        Extensions::new(),
+        Some(serde_json::json!({"progressToken": true})),
+    )
+    .await
+    .expect_err("a malformed progress token must be rejected before dispatch");
+    assert_eq!(error.code, crate::error::ErrorCode::InvalidParams as i32);
+}
+
+#[tokio::test]
+async fn completion_denies_hidden_disabled_and_unknown_prompts_before_dispatch() {
+    use crate::filter::CapabilityFilter;
+    use crate::prompt::{Prompt, PromptBuilder};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls = calls.clone();
+    let mut router = McpRouter::new()
+        .prompt(PromptBuilder::new("public").user_message("public"))
+        .prompt(PromptBuilder::new("hidden").user_message("hidden"))
+        .prompt(PromptBuilder::new("disabled").user_message("disabled"))
+        .prompt_filter(CapabilityFilter::new(|_, prompt: &Prompt| {
+            prompt.name != "hidden"
+        }))
+        .completion_handler(move |_params| {
+            let calls = handler_calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CompleteResult::new(vec!["ok".to_string()]))
+            }
+        });
+    router.disable_prompt("disabled");
+    init_router(&mut router).await;
+
+    request_completion(
+        &mut router,
+        1,
+        CompletionReference::prompt("public"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+    for (request_id, name) in [(2, "hidden"), (3, "disabled"), (4, "unknown")] {
+        let error = request_completion(
+            &mut router,
+            request_id,
+            CompletionReference::prompt(name),
+            Extensions::new(),
+            None,
+        )
+        .await
+        .expect_err("an inaccessible prompt must not reach completion");
+        let Error::JsonRpc(expected) = prompt_not_found(name) else {
+            unreachable!("prompt_not_found always returns JSON-RPC")
+        };
+        assert_eq!(error.code, expected.code);
+        assert_eq!(error.message, expected.message);
+        assert_eq!(error.data, expected.data);
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn completion_authorizes_resources_and_templates_before_dispatch() {
+    use crate::filter::{CapabilityFilter, ResourceTemplateFilter};
+    use crate::resource::{Resource, ResourceBuilder, ResourceTemplate, ResourceTemplateBuilder};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let template = |pattern: &'static str, name: &'static str| {
+        ResourceTemplateBuilder::new(pattern)
+            .name(name)
+            .handler(|uri, _variables| async move { Ok(ReadResourceResult::text(uri, "body")) })
+    };
+    let calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls = calls.clone();
+    let mut router = McpRouter::new()
+        .resource(
+            ResourceBuilder::new("memory://public")
+                .name("Public")
+                .text("public"),
+        )
+        .resource(
+            ResourceBuilder::new("memory://hidden")
+                .name("Hidden")
+                .text("hidden"),
+        )
+        .resource(
+            ResourceBuilder::new("memory://disabled")
+                .name("Disabled")
+                .text("disabled"),
+        )
+        .resource_template(template("records://public/{id}", "Public Template"))
+        .resource_template(template("records://hidden/{id}", "Hidden Template"))
+        .resource_filter(CapabilityFilter::new(|_, resource: &Resource| {
+            resource.name != "Hidden"
+        }))
+        .resource_template_filter(ResourceTemplateFilter::new(
+            |_, template: &ResourceTemplate| template.name != "Hidden Template",
+        ))
+        .completion_handler(move |_params| {
+            let calls = handler_calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CompleteResult::new(vec!["ok".to_string()]))
+            }
+        });
+    router.disable_resource("memory://disabled");
+    init_router(&mut router).await;
+
+    for (request_id, uri) in [
+        (1, "memory://public"),
+        (2, "records://public/{id}"),
+        (3, "records://public/42"),
+    ] {
+        request_completion(
+            &mut router,
+            request_id,
+            CompletionReference::resource(uri),
+            Extensions::new(),
+            None,
+        )
+        .await
+        .unwrap();
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+    for (request_id, uri) in [
+        (4, "memory://hidden"),
+        (5, "memory://disabled"),
+        (6, "memory://unknown"),
+        (7, "records://hidden/{id}"),
+        (8, "records://hidden/42"),
+    ] {
+        let error = request_completion(
+            &mut router,
+            request_id,
+            CompletionReference::resource(uri),
+            Extensions::new(),
+            None,
+        )
+        .await
+        .expect_err("an inaccessible resource must not reach completion");
+        let expected = JsonRpcError::resource_not_found(uri);
+        assert_eq!(error.code, expected.code);
+        assert_eq!(error.message, expected.message);
+        assert_eq!(error.data, expected.data);
+    }
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn completion_resource_template_fails_closed_without_template_filter() {
+    use crate::filter::CapabilityFilter;
+    use crate::resource::{Resource, ResourceTemplateBuilder};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls = calls.clone();
+    let mut router = McpRouter::new()
+        .resource_template(
+            ResourceTemplateBuilder::new("vault://{id}")
+                .name("Vault")
+                .handler(
+                    |uri, _variables| async move { Ok(ReadResourceResult::text(uri, "secret")) },
+                ),
+        )
+        .resource_filter(CapabilityFilter::new(|_, _resource: &Resource| true))
+        .completion_handler(move |_params| {
+            let calls = handler_calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CompleteResult::new(vec!["secret".to_string()]))
+            }
+        });
+    init_router(&mut router).await;
+
+    let error = request_completion(
+        &mut router,
+        1,
+        CompletionReference::resource("vault://{id}"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .expect_err("a resource filter cannot authorize a template");
+    let expected = JsonRpcError::resource_not_found("vault://{id}");
+    assert_eq!(error.code, expected.code);
+    assert_eq!(error.message, expected.message);
+    assert_eq!(error.data, expected.data);
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn completion_preserves_explicit_filter_denial_behavior() {
+    use crate::filter::{CapabilityFilter, DenialBehavior};
+    use crate::prompt::{Prompt, PromptBuilder};
+    use crate::resource::{Resource, ResourceBuilder};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls = calls.clone();
+    let mut router = McpRouter::new()
+        .prompt(PromptBuilder::new("premium").user_message("premium"))
+        .resource(
+            ResourceBuilder::new("vault://secret")
+                .name("Secret")
+                .text("secret"),
+        )
+        .prompt_filter(
+            CapabilityFilter::new(|_, _prompt: &Prompt| false)
+                .denial_behavior(DenialBehavior::Unauthorized),
+        )
+        .resource_filter(
+            CapabilityFilter::new(|_, _resource: &Resource| false).denial_behavior(
+                DenialBehavior::custom(|target| {
+                    Error::JsonRpc(
+                        JsonRpcError::forbidden("completion policy denied")
+                            .with_data(serde_json::json!({"target": target})),
+                    )
+                }),
+            ),
+        )
+        .completion_handler(move |_params| {
+            let calls = handler_calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CompleteResult::new(vec![]))
+            }
+        });
+    init_router(&mut router).await;
+
+    let prompt_error = request_completion(
+        &mut router,
+        1,
+        CompletionReference::prompt("premium"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .expect_err("explicit Unauthorized must be preserved");
+    assert_eq!(prompt_error.code, -32007);
+    assert!(prompt_error.message.contains("Unauthorized"));
+
+    let resource_error = request_completion(
+        &mut router,
+        2,
+        CompletionReference::resource("vault://secret"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .expect_err("a custom denial must be preserved");
+    assert_eq!(resource_error.code, -32007);
+    assert_eq!(resource_error.message, "completion policy denied");
+    assert_eq!(
+        resource_error.data,
+        Some(serde_json::json!({"target": "vault://secret"}))
+    );
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+}
+
+#[cfg(feature = "dynamic-tools")]
+#[tokio::test]
+async fn completion_resolves_dynamic_prompts_resources_and_templates() {
+    use crate::prompt::PromptBuilder;
+    use crate::resource::{ResourceBuilder, ResourceTemplateBuilder};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let (router, prompt_registry) = McpRouter::new()
+        .resource(
+            ResourceBuilder::new("memory://shadow")
+                .name("Denied Static Shadow")
+                .text("static"),
+        )
+        .resource_filter(crate::ResourceFilter::new(|_, resource| {
+            resource.name.starts_with("Dynamic")
+        }))
+        .resource_template_filter(crate::ResourceTemplateFilter::new(|_, _template| true))
+        .with_dynamic_prompts();
+    let initializer_registry = prompt_registry.clone();
+    let router = router.dynamic_prompt_initializer(move || {
+        if !initializer_registry.contains("dynamic-prompt") {
+            initializer_registry
+                .register(PromptBuilder::new("dynamic-prompt").user_message("dynamic"));
+        }
+        Ok(())
+    });
+    let (router, resource_registry) = router.with_dynamic_resources();
+    resource_registry.register(
+        ResourceBuilder::new("memory://dynamic")
+            .name("Dynamic Resource")
+            .text("dynamic"),
+    );
+    resource_registry.register(
+        ResourceBuilder::new("memory://shadow")
+            .name("Dynamic Shadow")
+            .text("dynamic"),
+    );
+    let (router, template_registry) = router.with_dynamic_resource_templates();
+    template_registry.register(
+        ResourceTemplateBuilder::new("dynamic://{id}")
+            .name("Dynamic Template")
+            .handler(|uri, _variables| async move { Ok(ReadResourceResult::text(uri, "dynamic")) }),
+    );
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let handler_calls = calls.clone();
+    let mut router = router.completion_handler(move |_params| {
+        let calls = handler_calls.clone();
+        async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(CompleteResult::new(vec!["dynamic".to_string()]))
+        }
+    });
+    init_router(&mut router).await;
+
+    request_completion(
+        &mut router,
+        1,
+        CompletionReference::prompt("dynamic-prompt"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .unwrap();
+    request_completion(
+        &mut router,
+        2,
+        CompletionReference::resource("memory://dynamic"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .unwrap();
+    request_completion(
+        &mut router,
+        3,
+        CompletionReference::resource("dynamic://{id}"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
+
+    let error = request_completion(
+        &mut router,
+        4,
+        CompletionReference::resource("memory://shadow"),
+        Extensions::new(),
+        None,
+    )
+    .await
+    .expect_err("a denied static resource must not fall through to its dynamic shadow");
+    let expected = JsonRpcError::resource_not_found("memory://shadow");
+    assert_eq!(error.code, expected.code);
+    assert_eq!(error.message, expected.message);
+    assert_eq!(error.data, expected.data);
+    assert_eq!(calls.load(Ordering::SeqCst), 3);
 }
 
 #[tokio::test]

--- a/crates/tower-mcp/tests/http_client.rs
+++ b/crates/tower-mcp/tests/http_client.rs
@@ -603,7 +603,7 @@ async fn test_http_client_complete_resource_uri() {
 
     // Complete with "src/" prefix
     let result = client
-        .complete_resource_uri("file:///{path}", "path", "src/")
+        .complete_resource_uri("file:///{+path}", "path", "src/")
         .await
         .unwrap();
     assert_eq!(result.completion.values.len(), 2);
@@ -617,7 +617,7 @@ async fn test_http_client_complete_resource_uri() {
 
     // Complete with "C" prefix
     let result = client
-        .complete_resource_uri("file:///{path}", "path", "C")
+        .complete_resource_uri("file:///{+path}", "path", "C")
         .await
         .unwrap();
     assert_eq!(result.completion.values, vec!["Cargo.toml"]);


### PR DESCRIPTION
## Summary
- authorize prompt, resource, and resource-template references before completion dispatch, including filters, disabled state, dynamic registries, and non-enumerating default denials
- add a request-aware completion handler while preserving the existing contextless builder
- expose the logical session through RequestContext and propagate request metadata, cancellation, negotiated capabilities, and session claims to completion handlers

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- cargo check -p tower-mcp --no-default-features

Closes #1401