### PR TITLE
feat(stdio): add bidirectional middleware seam

### DIFF
--- a/crates/tower-mcp/src/transport/service.rs
+++ b/crates/tower-mcp/src/transport/service.rs
@@ -118,7 +118,9 @@ where
 /// wrapper converts it into a JSON-RPC internal error response using the
 /// request ID from the original request. This allows error information to
 /// flow through the normal response path rather than requiring special
-/// error handling at the transport level.
+/// error handling at the transport level. Both readiness and call errors are
+/// converted; inner readiness and backpressure are awaited inside the
+/// response future, once the request ID is available.
 pub struct CatchError<S> {
     inner: S,
 }
@@ -186,17 +188,20 @@ where
 {
     type Response = RouterResponse;
     type Error = Infallible;
-    type Future = CatchErrorFuture<S::Future>;
+    type Future = CatchErrorFuture<tower::util::Oneshot<S, RouterRequest>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(|_| unreachable!())
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Readiness errors need the request ID in order to become correlated
+        // JSON-RPC responses. Poll the inner service from `call` instead,
+        // where the request is available, and await its backpressure there.
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
         // Capture the request ID before passing the request to the inner service.
         // We need this to build a proper JSON-RPC error response if the middleware fails.
         let request_id = req.id.clone();
-        let fut = self.inner.call(req);
+        let fut = tower::ServiceExt::oneshot(self.inner.clone(), req);
 
         CatchErrorFuture {
             inner: fut,
@@ -208,10 +213,40 @@ where
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
 
     use super::*;
-    use crate::protocol::{CallToolParams, CallToolResult, RequestId, ToolAnnotations};
+    use crate::jsonrpc::JsonRpcService;
+    use crate::protocol::{
+        CallToolParams, CallToolResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+        JsonRpcResponseMessage, RequestId, ToolAnnotations,
+    };
     use crate::router::McpRouter;
+
+    #[derive(Clone)]
+    struct RejectReadinessOnce {
+        inner: McpRouter,
+        reject_next: Arc<AtomicBool>,
+    }
+
+    impl Service<RouterRequest> for RejectReadinessOnce {
+        type Response = RouterResponse;
+        type Error = std::io::Error;
+        type Future =
+            Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            if self.reject_next.swap(false, Ordering::SeqCst) {
+                return Poll::Ready(Err(std::io::Error::other("middleware was not ready")));
+            }
+            Service::poll_ready(&mut self.inner, cx).map_err(|never| match never {})
+        }
+
+        fn call(&mut self, request: RouterRequest) -> Self::Future {
+            let future = Service::call(&mut self.inner, request);
+            Box::pin(async move { Ok(future.await.expect("MCP router service is infallible")) })
+        }
+    }
 
     #[test]
     #[cfg(any(feature = "http", feature = "websocket"))]
@@ -236,6 +271,85 @@ mod tests {
         assert!(result.is_ok());
         let response = result.unwrap();
         assert!(response.inner.is_ok());
+    }
+
+    #[tokio::test]
+    async fn readiness_error_is_correlated_once_through_jsonrpc_service() {
+        let router = McpRouter::new().server_info("test", "1.0.0");
+        let reject_next = Arc::new(AtomicBool::new(true));
+        let mut service = JsonRpcService::new(CatchError::new(RejectReadinessOnce {
+            inner: router,
+            reject_next,
+        }));
+
+        std::future::poll_fn(|cx| Service::<JsonRpcRequest>::poll_ready(&mut service, cx))
+            .await
+            .expect("adapter is infallible");
+        let first = Service::<JsonRpcRequest>::call(&mut service, JsonRpcRequest::new(1, "ping"))
+            .await
+            .expect("JSON-RPC service call");
+        let JsonRpcResponse::Error(first) = first else {
+            panic!("readiness failure must become an error response")
+        };
+        assert_eq!(first.id, Some(RequestId::Number(1)));
+        assert_eq!(first.error.code, -32603);
+        assert_eq!(first.error.message, "middleware was not ready");
+
+        std::future::poll_fn(|cx| Service::<JsonRpcRequest>::poll_ready(&mut service, cx))
+            .await
+            .expect("adapter remains infallible");
+        let second = Service::<JsonRpcRequest>::call(&mut service, JsonRpcRequest::new(2, "ping"))
+            .await
+            .expect("JSON-RPC service call after readiness failure");
+        let JsonRpcResponse::Result(second) = second else {
+            panic!("readiness failure must be consumed exactly once")
+        };
+        assert_eq!(second.id, RequestId::Number(2));
+    }
+
+    #[tokio::test]
+    async fn readiness_error_is_not_duplicated_across_a_jsonrpc_batch() {
+        let router = McpRouter::new().server_info("test", "1.0.0");
+        let reject_next = Arc::new(AtomicBool::new(true));
+        let mut service = JsonRpcService::new(CatchError::new(RejectReadinessOnce {
+            inner: router,
+            reject_next,
+        }))
+        .protocol_versions(["2025-03-26"])
+        .expect("stable-only protocol support");
+
+        std::future::poll_fn(|cx| Service::<JsonRpcMessage>::poll_ready(&mut service, cx))
+            .await
+            .expect("adapter is infallible");
+        let response = Service::<JsonRpcMessage>::call(
+            &mut service,
+            JsonRpcMessage::Batch(vec![
+                JsonRpcRequest::new(1, "ping"),
+                JsonRpcRequest::new(2, "ping"),
+                JsonRpcRequest::new(3, "ping"),
+            ]),
+        )
+        .await
+        .expect("JSON-RPC batch call");
+        let JsonRpcResponseMessage::Batch(responses) = response else {
+            panic!("valid stable batch must return a response batch")
+        };
+
+        assert_eq!(responses.len(), 3);
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| matches!(response, JsonRpcResponse::Error(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| matches!(response, JsonRpcResponse::Result(_)))
+                .count(),
+            2
+        );
     }
 
     #[test]

--- a/crates/tower-mcp/src/transport/stdio.rs
+++ b/crates/tower-mcp/src/transport/stdio.rs
@@ -2029,10 +2029,10 @@ struct PendingRequest {
 ///     Ok(())
 /// }
 /// ```
-pub struct BidirectionalStdioTransport {
+pub struct BidirectionalStdioTransport<S = McpRouter> {
     /// Fires when the read loop ends (#1252).
     stopping: tokio::sync::watch::Sender<bool>,
-    service: JsonRpcService<McpRouter>,
+    service: JsonRpcService<S>,
     router: McpRouter,
     /// Channel for receiving outgoing requests to send to the client
     request_rx: OutgoingRequestReceiver,
@@ -2046,7 +2046,7 @@ pub struct BidirectionalStdioTransport {
     control_rx: mpsc::UnboundedReceiver<StdioControl>,
 }
 
-impl BidirectionalStdioTransport {
+impl BidirectionalStdioTransport<McpRouter> {
     /// Create a new bidirectional stdio transport
     pub fn new(router: McpRouter) -> Self {
         let (request_tx, request_rx) = outgoing_request_channel(32);
@@ -2074,6 +2074,71 @@ impl BidirectionalStdioTransport {
         }
     }
 
+    /// Apply a tower middleware layer to inbound MCP requests.
+    ///
+    /// The transport installs its legacy client requester before the layer is
+    /// applied, so sampling and elicitation remain available from handler
+    /// contexts. Notification routing, final subscriptions, protocol support,
+    /// and response multiplexing are preserved as well.
+    ///
+    /// Use [`tower::ServiceBuilder`] to compose multiple layers:
+    ///
+    /// ```rust,no_run
+    /// use std::time::Duration;
+    /// use tower::ServiceBuilder;
+    /// use tower::timeout::TimeoutLayer;
+    /// use tower_mcp::{BidirectionalStdioTransport, BoxError, McpRouter};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), BoxError> {
+    ///     let router = McpRouter::new().server_info("my-server", "1.0.0");
+    ///     let mut transport = BidirectionalStdioTransport::new(router).layer(
+    ///         ServiceBuilder::new()
+    ///             .layer(TimeoutLayer::new(Duration::from_secs(5)))
+    ///             .into_inner(),
+    ///     );
+    ///
+    ///     transport.run().await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn layer<L>(
+        self,
+        layer: L,
+    ) -> BidirectionalStdioTransport<InjectAnnotations<CatchError<L::Service>>>
+    where
+        L: tower::Layer<McpRouter>,
+        L::Service: Service<RouterRequest, Response = RouterResponse> + Clone + Send + 'static,
+        <L::Service as Service<RouterRequest>>::Error: std::fmt::Display + Send,
+        <L::Service as Service<RouterRequest>>::Future: Send,
+    {
+        let protocol_support = self.service.configured_protocol_support().clone();
+        let annotations = self.router.tool_annotations_map();
+        let wrapped = layer.layer(self.router.clone());
+        let service = InjectAnnotations::new(CatchError::new(wrapped), annotations);
+
+        BidirectionalStdioTransport {
+            stopping: self.stopping,
+            service: JsonRpcService::new(service).protocol_support(protocol_support),
+            router: self.router,
+            request_rx: self.request_rx,
+            client_requester: self.client_requester,
+            pending_requests: self.pending_requests,
+            notification_rx: self.notification_rx,
+            control_tx: self.control_tx,
+            control_rx: self.control_rx,
+        }
+    }
+}
+
+impl<S> BidirectionalStdioTransport<S>
+where
+    S: Service<RouterRequest, Response = RouterResponse, Error = std::convert::Infallible>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+{
     /// Return a cloneable handle for graceful subscription closure or server
     /// shutdown while [`Self::run`] is active.
     pub fn handle(&self) -> StdioTransportHandle {

--- a/crates/tower-mcp/tests/stdio_loop.rs
+++ b/crates/tower-mcp/tests/stdio_loop.rs
@@ -733,6 +733,50 @@ async fn stdio_runtime_protocol_allow_list_is_exact() {
     );
 }
 
+/// Converting bidirectional stdio to a layered service must not reset the
+/// runtime protocol policy configured before `.layer()`.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn bidi_layer_preserves_runtime_protocol_allow_list() {
+    let mut transport = BidirectionalStdioTransport::new(modern_router())
+        .protocol_support(ProtocolSupport::stable())
+        .layer(tower::layer::util::Identity::new());
+    let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+    let handle = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+
+    let request = serde_json::json!({
+        "jsonrpc": "2.0", "id": 1, "method": "server/discover",
+        "params": {
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
+        }
+    });
+    stdin_writer
+        .write_all(format!("{request}\n").as_bytes())
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let mut reader = BufReader::new(server_stdout_reader);
+    let response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layered protocol rejection");
+    assert_eq!(response["error"]["code"], -32022);
+    assert_eq!(
+        response["error"]["data"]["requested"],
+        tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28
+    );
+
+    drop(stdin_writer);
+    handle
+        .await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+}
+
 #[cfg(feature = "stateless")]
 fn subscription_router() -> McpRouter {
     let emit = ToolBuilder::new("emit_changes")
@@ -1150,7 +1194,8 @@ async fn middleware_wrapped_stdio_preserves_subscription_routing() {
 #[cfg(feature = "stateless")]
 #[tokio::test]
 async fn bidi_stdio_preserves_subscription_routing() {
-    let mut transport = BidirectionalStdioTransport::new(subscription_router());
+    let mut transport = BidirectionalStdioTransport::new(subscription_router())
+        .layer(tower::layer::util::Identity::new());
     let control = transport.handle();
     let (mut server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
     let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
@@ -1182,6 +1227,40 @@ async fn bidi_stdio_preserves_subscription_routing() {
         71
     );
 
+    let emit = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 72,
+        "method": "tools/call",
+        "params": {
+            "name": "emit_changes",
+            "arguments": {},
+            "_meta": final_meta(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28)
+        }
+    });
+    server_stdin_writer
+        .write_all(format!("{emit}\n").as_bytes())
+        .await
+        .unwrap();
+    server_stdin_writer.flush().await.unwrap();
+    let deliveries = [
+        timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("bidirectional subscription delivery"),
+        timeout(Duration::from_secs(2), read_frame(&mut reader))
+            .await
+            .expect("bidirectional tool response"),
+    ];
+    let notification = deliveries
+        .iter()
+        .find(|frame| frame.get("method").is_some())
+        .expect("tagged notification must share the bidirectional stream");
+    assert_eq!(notification["method"], "notifications/tools/list_changed");
+    assert_eq!(
+        notification["params"]["_meta"]["io.modelcontextprotocol/subscriptionId"],
+        71
+    );
+    assert!(deliveries.iter().any(|frame| frame["id"] == 72));
+
     control
         .close_subscription(tower_mcp::RequestId::Number(71))
         .unwrap();
@@ -1203,7 +1282,8 @@ async fn bidi_stdio_preserves_subscription_routing() {
 #[cfg(feature = "stateless")]
 #[tokio::test]
 async fn bidi_final_handlers_cannot_initiate_client_requests() {
-    let mut transport = BidirectionalStdioTransport::new(modern_router());
+    let mut transport = BidirectionalStdioTransport::new(modern_router())
+        .layer(tower::layer::util::Identity::new());
     let (server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
     let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
     let handle = tokio::spawn(async move {
@@ -1459,7 +1539,8 @@ async fn bidi_transport_elicitation_round_trip() {
     let router = McpRouter::new()
         .server_info("bidi-elicit-test", "0.0.0")
         .tool(confirm);
-    let mut transport = BidirectionalStdioTransport::new(router);
+    let mut transport =
+        BidirectionalStdioTransport::new(router).layer(tower::layer::util::Identity::new());
 
     let (server_stdin_writer, server_stdin) = tokio::io::duplex(8192);
     let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
@@ -1521,6 +1602,237 @@ async fn bidi_transport_elicitation_round_trip() {
         .await
         .expect("elicitation round-trip over bidirectional stdio timed out (deadlock)");
     let _ = timeout(Duration::from_secs(2), handle).await;
+}
+
+/// Bidirectional stdio used to have no service seam at all. A layer now sees
+/// accepted inbound requests while the transport continues to own the
+/// client-requester, validation, and framing machinery.
+#[tokio::test]
+async fn bidi_layer_observes_an_inbound_tool_request() {
+    use std::sync::{Arc, Mutex};
+    use tower::ServiceExt as _;
+    use tower_mcp::router::RouterRequest;
+
+    let observed = Arc::new(Mutex::new(Vec::new()));
+    let layer = tower::layer::layer_fn({
+        let observed = observed.clone();
+        move |inner: McpRouter| {
+            let observed = observed.clone();
+            tower::service_fn(move |request: RouterRequest| {
+                let inner = inner.clone();
+                let observed = observed.clone();
+                async move {
+                    observed
+                        .lock()
+                        .expect("observation lock")
+                        .push(request.inner.method_name().to_string());
+                    inner.oneshot(request).await
+                }
+            })
+        }
+    });
+    let tool = ToolBuilder::new("observed")
+        .description("Return a fixed result")
+        .handler(|_: serde_json::Value| async { Ok(CallToolResult::text("seen")) })
+        .build();
+    let router = McpRouter::new()
+        .server_info("bidi-layer-test", "0.0.0")
+        .tool(tool);
+    let mut transport = BidirectionalStdioTransport::new(router).layer(layer);
+
+    let (mut stdin_writer, server_stdin) = tokio::io::duplex(8192);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(8192);
+    let task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let mut reader = BufReader::new(server_stdout_reader);
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-11-25\",\"capabilities\":{},\"clientInfo\":{\"name\":\"t\",\"version\":\"0\"}}}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let init = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layered initialize response");
+    assert_eq!(init["id"], 1);
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}\n")
+        .await
+        .unwrap();
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"observed\",\"arguments\":{}}}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let call = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layered tool response");
+    assert_eq!(call["id"], 2);
+    assert_eq!(call["result"]["content"][0]["text"], "seen");
+
+    drop(stdin_writer);
+    task.await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+    assert_eq!(
+        *observed.lock().expect("observation lock"),
+        ["initialize", "tools/call"]
+    );
+}
+
+#[derive(Clone)]
+struct RejectFirstReadiness {
+    inner: McpRouter,
+    reject_next: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl tower::Service<tower_mcp::router::RouterRequest> for RejectFirstReadiness {
+    type Response = tower_mcp::router::RouterResponse;
+    type Error = std::io::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        use std::sync::atomic::Ordering;
+
+        if self.reject_next.swap(false, Ordering::SeqCst) {
+            return std::task::Poll::Ready(Err(std::io::Error::other("middleware was not ready")));
+        }
+        tower::Service::poll_ready(&mut self.inner, cx).map_err(|never| match never {})
+    }
+
+    fn call(&mut self, request: tower_mcp::router::RouterRequest) -> Self::Future {
+        let future = tower::Service::call(&mut self.inner, request);
+        Box::pin(async move { Ok(future.await.expect("MCP router service is infallible")) })
+    }
+}
+
+/// A readiness failure occurs before middleware receives the request, but it
+/// must still become an ID-preserving response and leave stdout usable.
+#[tokio::test]
+async fn bidi_layer_readiness_errors_become_framed_jsonrpc_errors() {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+
+    let reject_next = Arc::new(AtomicBool::new(true));
+    let layer = tower::layer::layer_fn(move |inner: McpRouter| RejectFirstReadiness {
+        inner,
+        reject_next: reject_next.clone(),
+    });
+    let mut transport = BidirectionalStdioTransport::new(router()).layer(layer);
+    let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+    let task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let mut reader = BufReader::new(server_stdout_reader);
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":7,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layer readiness error response");
+    assert_jsonrpc_error_response(&response);
+    assert_eq!(response["id"], 7);
+    assert_eq!(response["error"]["code"], -32603);
+    assert_eq!(response["error"]["message"], "middleware was not ready");
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":8,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("request after layer readiness error response");
+    assert_eq!(response["id"], 8);
+    assert!(response.get("result").is_some());
+
+    drop(stdin_writer);
+    task.await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
+}
+
+/// Middleware failures stay inside the JSON-RPC response path instead of
+/// escaping it or corrupting the newline-delimited stream.
+#[tokio::test]
+async fn bidi_layer_errors_become_framed_jsonrpc_errors() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tower::ServiceExt as _;
+    use tower_mcp::router::{RouterRequest, RouterResponse};
+
+    let reject_next = Arc::new(AtomicBool::new(true));
+    let layer = tower::layer::layer_fn(move |inner: McpRouter| {
+        let reject_next = reject_next.clone();
+        tower::service_fn(move |request: RouterRequest| {
+            let inner = inner.clone();
+            let reject = reject_next.swap(false, Ordering::SeqCst);
+            async move {
+                if reject {
+                    return Err::<RouterResponse, _>(std::io::Error::other(
+                        "middleware rejected request",
+                    ));
+                }
+                Ok(inner
+                    .oneshot(request)
+                    .await
+                    .expect("MCP router service is infallible"))
+            }
+        })
+    });
+    let mut transport = BidirectionalStdioTransport::new(router()).layer(layer);
+    let (mut stdin_writer, server_stdin) = tokio::io::duplex(4096);
+    let (server_stdout, server_stdout_reader) = tokio::io::duplex(4096);
+    let task = tokio::spawn(async move {
+        transport
+            .run_with_streams(server_stdin, server_stdout)
+            .await
+    });
+    let mut reader = BufReader::new(server_stdout_reader);
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":9,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("layer error response");
+    assert_jsonrpc_error_response(&response);
+    assert_eq!(response["id"], 9);
+    assert_eq!(response["error"]["code"], -32603);
+    assert_eq!(response["error"]["message"], "middleware rejected request");
+
+    stdin_writer
+        .write_all(b"{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"ping\"}\n")
+        .await
+        .unwrap();
+    stdin_writer.flush().await.unwrap();
+    let response = timeout(Duration::from_secs(2), read_frame(&mut reader))
+        .await
+        .expect("request after layer error response");
+    assert_eq!(response["id"], 10);
+    assert!(response.get("result").is_some());
+
+    drop(stdin_writer);
+    task.await
+        .expect("transport task join")
+        .expect("run_with_streams ok");
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- add a typed `.layer(...)` seam to `BidirectionalStdioTransport`
- preserve client requester wiring, notification and subscription routing, pending responses, and runtime protocol policy across layering
- convert both middleware readiness and call failures into correlated JSON-RPC errors without breaking stdout framing
- cover layered tool observation, elicitation, final behavior, subscriptions, protocol policy, and continued service after middleware failures

## Validation

- `cargo test --workspace --all-targets --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `cargo test --workspace --doc --all-features`
- `cargo check -p tower-mcp --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #1402