### PR TITLE
feat(tasks): add task owner resolver

### DIFF
--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -166,6 +166,8 @@ struct McpRouterInner {
     panic_policy: Option<PanicPolicy>,
     /// Root-owned mapping for client-visible Task lifecycle failures.
     task_error_policy: TaskErrorPolicy,
+    /// Root-owned mapping from request extensions to a durable Task owner.
+    task_owner_resolver: TaskOwnerResolver,
     auto_instructions: Option<AutoInstructionsConfig>,
     tools: HashMap<String, Arc<Tool>>,
     resources: HashMap<String, Arc<Resource>>,
@@ -668,6 +670,7 @@ impl McpRouter {
                 instructions: None,
                 panic_policy: None,
                 task_error_policy: TaskErrorPolicy::default(),
+                task_owner_resolver: default_task_owner_resolver(),
                 auto_instructions: None,
                 tools: HashMap::new(),
                 resources: HashMap::new(),
@@ -793,6 +796,76 @@ impl McpRouter {
     pub fn task_store(mut self, store: Arc<dyn TaskStore>) -> Self {
         Arc::make_mut(&mut self.inner).task_store = store;
         self
+    }
+
+    /// Resolve the authenticated principal used for Task ownership.
+    ///
+    /// The resolver runs for Task creation and every later Task operation. It
+    /// receives the request's transport- and middleware-supplied extensions
+    /// and returns a durable owner key, or `None` for an anonymous request.
+    /// Owned and anonymous callers remain strictly distinct: neither can act
+    /// on the other's Tasks.
+    ///
+    /// Owner keys become authorization data in the configured [`TaskStore`].
+    /// They must be deterministic, nonempty, and collision-resistant across
+    /// every issuer and tenant that can reach the store. Include that
+    /// qualification in the returned value. Never return a bearer token, API
+    /// key, session cookie, or other credential.
+    ///
+    /// Empty or whitespace-only values and panics fail closed. Creation is
+    /// rejected, while an existing Task is reported as absent. Rust's
+    /// process-global panic hook still runs before a panic is caught.
+    ///
+    /// Installing a resolver replaces the default OAuth `TokenClaims.sub`
+    /// mapping. Configure this on the root router: [`merge`](Self::merge) and
+    /// [`nest`](Self::nest) import capabilities, not router policy.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use tower_mcp::{Extensions, McpRouter};
+    ///
+    /// #[derive(Clone)]
+    /// struct Principal {
+    ///     issuer: String,
+    ///     subject: String,
+    /// }
+    ///
+    /// let router = McpRouter::new().task_owner_resolver(|extensions: &Extensions| {
+    ///     extensions
+    ///         .get::<Principal>()
+    ///         .map(|principal| format!("{}:{}", principal.issuer, principal.subject))
+    /// });
+    /// # let _ = router;
+    /// ```
+    #[must_use]
+    pub fn task_owner_resolver<F>(mut self, resolver: F) -> Self
+    where
+        F: Fn(&crate::context::Extensions) -> Option<String> + Send + Sync + 'static,
+    {
+        Arc::make_mut(&mut self.inner).task_owner_resolver = custom_task_owner_resolver(resolver);
+        self
+    }
+
+    /// Resolve Task owners from one request extension type.
+    ///
+    /// This is the convenient counterpart to [`task_owner_resolver`](Self::task_owner_resolver)
+    /// for extensions registered with
+    /// [`HttpTransport::bridge_extension`](crate::HttpTransport::bridge_extension)
+    /// or inserted by Tower middleware. A request without `T` is anonymous;
+    /// the mapping only runs when the extension is present.
+    ///
+    /// The returned value has the same durability and secrecy requirements as
+    /// [`task_owner_resolver`](Self::task_owner_resolver).
+    #[must_use]
+    pub fn task_owner_from_extension<T>(
+        self,
+        map: impl Fn(&T) -> String + Send + Sync + 'static,
+    ) -> Self
+    where
+        T: Send + Sync + 'static,
+    {
+        self.task_owner_resolver(move |extensions| extensions.get::<T>().map(&map))
     }
 
     /// Set the root router's client-visible Task error policy.
@@ -1953,6 +2026,15 @@ impl McpRouter {
                 }
 
                 if let Some(task_ttl) = task_ttl {
+                    let owner = (self.inner.task_owner_resolver)(&extensions)
+                        .into_owner()
+                        .ok_or_else(|| {
+                            self.task_error(
+                                TaskOperation::Create,
+                                None,
+                                TaskFailure::Internal("Task owner resolver failed"),
+                            )
+                        })?;
                     // Create the task
                     let (task_id, cancellation_token) = self
                         .inner
@@ -1969,7 +2051,7 @@ impl McpRouter {
                                 params.arguments.clone()
                             },
                             task_ttl,
-                            request_principal(&extensions),
+                            owner,
                         )
                         .await
                         .map_err(|error| {
@@ -3536,7 +3618,10 @@ mod pagination;
 mod policy;
 mod task_ops;
 
-use capabilities::{final_client_capabilities, request_principal};
+use capabilities::{
+    TaskOwnerResolver, custom_task_owner_resolver, default_task_owner_resolver,
+    final_client_capabilities,
+};
 use pagination::paginate;
 use policy::panic_message;
 

--- a/crates/tower-mcp/src/router/capabilities.rs
+++ b/crates/tower-mcp/src/router/capabilities.rs
@@ -6,21 +6,89 @@
 
 use super::*;
 
-/// The authenticated principal for this request, if any.
+pub(super) type TaskOwnerResolver =
+    Arc<dyn Fn(&crate::context::Extensions) -> TaskOwnerResolution + Send + Sync + 'static>;
+
+/// The result of resolving the caller that owns a Task.
 ///
-/// Sourced from the OAuth `sub` claim that the HTTP and WebSocket transports
-/// bridge into MCP extensions. Without the `oauth` feature there is no
-/// principal, so tasks are unowned and behave as they did before ownership
-/// existed.
+/// `Invalid` is deliberately distinct from anonymous. Collapsing a broken
+/// application resolver to `None` would let it match an unowned Task and turn
+/// an authentication failure into authorization.
+pub(super) enum TaskOwnerResolution {
+    Resolved(crate::async_task::TaskOwner),
+    Invalid,
+}
+
+impl TaskOwnerResolution {
+    pub(super) fn into_owner(self) -> Option<crate::async_task::TaskOwner> {
+        match self {
+            Self::Resolved(owner) => Some(owner),
+            Self::Invalid => None,
+        }
+    }
+
+    pub(super) fn matches(&self, owner: &crate::async_task::TaskOwner) -> bool {
+        match self {
+            Self::Resolved(principal) => {
+                crate::async_task::owner_matches(owner, principal.as_deref())
+            }
+            Self::Invalid => false,
+        }
+    }
+}
+
+/// Build the source-compatible default Task owner resolver.
+///
+/// OAuth subjects are deliberately copied verbatim. Existing deployments may
+/// persist those strings outside this process, so prefixing or normalizing
+/// them here would strand their Tasks.
+pub(super) fn default_task_owner_resolver() -> TaskOwnerResolver {
+    Arc::new(|extensions| TaskOwnerResolution::Resolved(oauth_task_owner(extensions)))
+}
+
+/// Wrap application mapping code in the Task authorization boundary.
+pub(super) fn custom_task_owner_resolver<F>(resolver: F) -> TaskOwnerResolver
+where
+    F: Fn(&crate::context::Extensions) -> Option<String> + Send + Sync + 'static,
+{
+    Arc::new(move |extensions| {
+        let resolved =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| resolver(extensions)));
+        match resolved {
+            Ok(Some(owner)) if !owner.trim().is_empty() => {
+                TaskOwnerResolution::Resolved(Some(owner))
+            }
+            Ok(Some(_)) => {
+                tracing::error!(
+                    target: "mcp::tasks",
+                    "task owner resolver returned an empty owner; denying the operation"
+                );
+                TaskOwnerResolution::Invalid
+            }
+            Ok(None) => TaskOwnerResolution::Resolved(None),
+            Err(_) => {
+                // Do not log the panic payload or extensions. Either may
+                // contain credentials supplied to the application resolver.
+                tracing::error!(
+                    target: "mcp::tasks",
+                    "task owner resolver panicked; denying the operation"
+                );
+                TaskOwnerResolution::Invalid
+            }
+        }
+    })
+}
+
+/// The default authenticated Task owner for this request, if any.
 #[cfg(feature = "oauth")]
-pub(super) fn request_principal(extensions: &crate::context::Extensions) -> Option<String> {
+fn oauth_task_owner(extensions: &crate::context::Extensions) -> Option<String> {
     extensions
         .get::<crate::oauth::token::TokenClaims>()
         .and_then(|claims| claims.sub.clone())
 }
 
 #[cfg(not(feature = "oauth"))]
-pub(super) fn request_principal(_extensions: &crate::context::Extensions) -> Option<String> {
+fn oauth_task_owner(_extensions: &crate::context::Extensions) -> Option<String> {
     None
 }
 

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -64,9 +64,10 @@ impl McpRouter {
         extensions: &crate::context::Extensions,
         presence: crate::async_task::TaskPresence,
     ) -> Error {
-        let owns = presence.owner().is_some_and(|owner| {
-            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
-        });
+        let principal = (self.inner.task_owner_resolver)(extensions);
+        let owns = presence
+            .owner()
+            .is_some_and(|owner| principal.matches(owner));
         match presence {
             crate::async_task::TaskPresence::Expired { .. } if owns => {
                 self.task_error(operation, Some(task_id), TaskFailure::Expired)
@@ -139,7 +140,7 @@ impl McpRouter {
             return Err(self.task_error(operation, Some(task_id), TaskFailure::NotFound));
         };
 
-        if crate::async_task::owner_matches(owner, request_principal(extensions).as_deref()) {
+        if (self.inner.task_owner_resolver)(extensions).matches(owner) {
             match presence {
                 // The owner is told the difference; nobody else reaches here.
                 crate::async_task::TaskPresence::Expired { .. } => {
@@ -175,9 +176,8 @@ impl McpRouter {
             .task_owner(task_id)
             .await
             .map_err(|error| self.task_store_error(TaskOperation::Get, Some(task_id), error))?;
-        let allowed = owner.as_ref().is_some_and(|owner| {
-            crate::async_task::owner_matches(owner, request_principal(extensions).as_deref())
-        });
+        let principal = (self.inner.task_owner_resolver)(extensions);
+        let allowed = owner.as_ref().is_some_and(|owner| principal.matches(owner));
         if allowed {
             return Ok(());
         }

--- a/crates/tower-mcp/tests/subscriptions_listen.rs
+++ b/crates/tower-mcp/tests/subscriptions_listen.rs
@@ -1124,6 +1124,120 @@ mod tasks {
         assert!(body.contains(&task_id));
     }
 
+    #[derive(Clone)]
+    struct ApplicationPrincipal(String);
+
+    async fn attach_application_principal(
+        mut request: Request<Body>,
+        next: axum::middleware::Next,
+    ) -> axum::response::Response {
+        if let Some(subject) = request
+            .headers()
+            .get("x-test-principal")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+        {
+            request
+                .extensions_mut()
+                .insert(ApplicationPrincipal(subject));
+        }
+        next.run(request).await
+    }
+
+    fn application_request(
+        id: &str,
+        method: &str,
+        params: serde_json::Value,
+        subject: Option<&str>,
+    ) -> Request<Body> {
+        let mut request = final_request(id, method, params);
+        if let Some(subject) = subject {
+            request
+                .headers_mut()
+                .insert("x-test-principal", subject.parse().unwrap());
+        }
+        request
+    }
+
+    /// A host-authenticated extension crosses the HTTP bridge for both
+    /// creation and the transport-owned subscription path.
+    #[tokio::test]
+    async fn application_principal_listen_accepts_only_the_task_owner() {
+        let router = task_router().task_owner_from_extension::<ApplicationPrincipal>(|principal| {
+            format!("https://identity.example#{}", principal.0)
+        });
+        let (app, handle) = HttpTransport::new(router)
+            .disable_origin_validation()
+            .disable_host_validation()
+            .bridge_extension::<ApplicationPrincipal>()
+            .into_router_with_handle();
+        let app = app.layer(axum::middleware::from_fn(attach_application_principal));
+
+        let create = app
+            .clone()
+            .oneshot(application_request(
+                "call-alice",
+                "tools/call",
+                serde_json::json!({
+                    "_meta": meta(true),
+                    "name": "slow",
+                    "arguments": {},
+                }),
+                Some("alice"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(create.status(), StatusCode::OK);
+        let created: serde_json::Value = serde_json::from_str(&body_string(create).await).unwrap();
+        let task_id = created["result"]["taskId"].as_str().unwrap().to_string();
+
+        let listen_params = || {
+            serde_json::json!({
+                "_meta": meta(true),
+                "notifications": { "taskIds": [&task_id] },
+            })
+        };
+        for (id, subject) in [("listen-bob", Some("bob")), ("listen-anon", None)] {
+            let denied = app
+                .clone()
+                .oneshot(application_request(
+                    id,
+                    "subscriptions/listen",
+                    listen_params(),
+                    subject,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(denied.status(), StatusCode::BAD_REQUEST);
+            let denied: serde_json::Value =
+                serde_json::from_str(&body_string(denied).await).unwrap();
+            assert_eq!(denied["error"]["code"], -32602);
+            assert!(
+                denied["error"]["message"]
+                    .as_str()
+                    .unwrap()
+                    .contains("not found")
+            );
+        }
+        assert_eq!(handle.subscription_count(), 0);
+
+        let owned = app
+            .oneshot(application_request(
+                "listen-alice",
+                "subscriptions/listen",
+                listen_params(),
+                Some("alice"),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(owned.status(), StatusCode::OK);
+        assert_eq!(handle.subscription_count(), 1);
+        assert_eq!(handle.close_subscriptions(), 1);
+        let body = body_string(owned).await;
+        assert!(body.contains("notifications/subscriptions/acknowledged"));
+        assert!(body.contains(&task_id));
+    }
+
     /// SEP-2663: requesting task notifications without declaring the extension
     /// is answered with the missing-capability error, not a silent drop.
     #[tokio::test]

--- a/crates/tower-mcp/tests/task_owner_resolver.rs
+++ b/crates/tower-mcp/tests/task_owner_resolver.rs
@@ -1,0 +1,314 @@
+//! Application-authenticated Task ownership (#1397).
+//!
+//! These tests use the public router seam rather than OAuth claims. They keep
+//! the authorization contract strict: only the exact resolved owner can
+//! observe or mutate a Task, and a broken resolver never degrades to an
+//! anonymous principal.
+
+#![cfg(feature = "stateless")]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tower::ServiceExt;
+use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+use tower_mcp::stateless::StatelessRequestMeta;
+use tower_mcp::{
+    CallToolParams, CallToolResult, CancelTaskParams, ClientCapabilities, Extensions,
+    GetTaskInfoParams, McpRequest, McpResponse, McpRouter, RequestId, RouterRequest,
+    SubscriptionFilter, SubscriptionsListenParams, TASKS_EXTENSION_ID, TaskSupportMode,
+    ToolBuilder, UpdateTaskParams,
+};
+
+#[derive(Clone)]
+struct Principal {
+    issuer: &'static str,
+    subject: &'static str,
+}
+
+#[derive(Clone)]
+struct UnrelatedExtension(&'static str);
+
+fn request_extensions(subject: Option<&'static str>) -> Extensions {
+    let mut extensions = Extensions::new();
+    extensions.insert(StatelessRequestMeta {
+        protocol_version: Some(tower_mcp::protocol::PROTOCOL_VERSION_2026_07_28.to_string()),
+        client_capabilities: Some(ClientCapabilities {
+            extensions: Some(
+                [(TASKS_EXTENSION_ID.to_string(), serde_json::json!({}))]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        }),
+        ..Default::default()
+    });
+    if let Some(subject) = subject {
+        extensions.insert(Principal {
+            issuer: "https://identity.example",
+            subject,
+        });
+    }
+    extensions
+}
+
+fn base_task_router() -> McpRouter {
+    let slow = ToolBuilder::new("slow")
+        .task_support(TaskSupportMode::Optional)
+        .handler(|_: serde_json::Value| async move {
+            tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            Ok(CallToolResult::text("done"))
+        })
+        .build();
+
+    McpRouter::new().tool(slow).with_tasks()
+}
+
+fn task_router() -> McpRouter {
+    base_task_router().task_owner_from_extension::<Principal>(|principal| {
+        format!("{}#{}", principal.issuer, principal.subject)
+    })
+}
+
+async fn dispatch(
+    router: &McpRouter,
+    id: i64,
+    request: McpRequest,
+    extensions: Extensions,
+) -> Result<McpResponse, tower_mcp::JsonRpcError> {
+    router
+        .clone()
+        .oneshot(RouterRequest {
+            id: RequestId::Number(id),
+            inner: request,
+            extensions,
+        })
+        .await
+        .unwrap()
+        .inner
+}
+
+fn get(task_id: &str) -> McpRequest {
+    McpRequest::GetTaskInfo(GetTaskInfoParams {
+        task_id: task_id.to_string(),
+        meta: None,
+    })
+}
+
+fn update(task_id: &str) -> McpRequest {
+    McpRequest::UpdateTask(UpdateTaskParams {
+        task_id: task_id.to_string(),
+        input_responses: HashMap::new(),
+        meta: None,
+    })
+}
+
+fn cancel(task_id: &str) -> McpRequest {
+    McpRequest::CancelTask(CancelTaskParams {
+        task_id: task_id.to_string(),
+        reason: Some("test complete".to_string()),
+        meta: None,
+    })
+}
+
+fn listen(task_id: &str) -> McpRequest {
+    McpRequest::SubscriptionsListen(SubscriptionsListenParams {
+        notifications: Some(SubscriptionFilter {
+            task_ids: Some(vec![task_id.to_string()]),
+            ..Default::default()
+        }),
+        meta: None,
+    })
+}
+
+#[tokio::test]
+async fn application_principal_owns_every_task_operation() {
+    let router = task_router();
+    let mut alice = request_extensions(Some("alice"));
+    alice.insert(UnrelatedExtension("trace-1"));
+    assert_eq!(alice.get::<UnrelatedExtension>().unwrap().0, "trace-1");
+
+    let created = dispatch(
+        &router,
+        1,
+        McpRequest::CallTool(CallToolParams {
+            name: "slow".to_string(),
+            arguments: serde_json::json!({}),
+            input_responses: None,
+            request_state: None,
+            meta: None,
+            task: None,
+        }),
+        alice.clone(),
+    )
+    .await
+    .unwrap();
+    let McpResponse::FinalCreateTask(created) = created else {
+        panic!("expected a Task creation response")
+    };
+    let task_id = created.task.metadata.task_id;
+
+    assert!(
+        dispatch(&router, 2, get(&task_id), alice.clone())
+            .await
+            .is_ok()
+    );
+    assert!(
+        dispatch(&router, 3, update(&task_id), alice.clone())
+            .await
+            .is_ok()
+    );
+
+    // Changing an extension the resolver does not read cannot change the
+    // owner. Removing the actual principal does.
+    let mut alice_with_different_trace = request_extensions(Some("alice"));
+    alice_with_different_trace.insert(UnrelatedExtension("trace-2"));
+    assert_eq!(
+        alice_with_different_trace
+            .get::<UnrelatedExtension>()
+            .unwrap()
+            .0,
+        "trace-2"
+    );
+    assert!(
+        dispatch(&router, 4, get(&task_id), alice_with_different_trace)
+            .await
+            .is_ok()
+    );
+
+    for (label, extensions) in [
+        ("Bob", request_extensions(Some("bob"))),
+        ("anonymous", request_extensions(None)),
+    ] {
+        for (offset, request) in [get(&task_id), update(&task_id), cancel(&task_id)]
+            .into_iter()
+            .enumerate()
+        {
+            let denied = dispatch(&router, 10 + offset as i64, request, extensions.clone())
+                .await
+                .expect_err(label);
+            assert_eq!(denied.code, -32602);
+            assert!(
+                denied.message.contains("not found"),
+                "{label} learned that the Task exists: {}",
+                denied.message
+            );
+        }
+    }
+
+    assert!(dispatch(&router, 20, cancel(&task_id), alice).await.is_ok());
+}
+
+#[tokio::test]
+async fn invalid_or_panicking_resolvers_fail_closed() {
+    async fn rejected_creation(
+        resolver: impl Fn(&Extensions) -> Option<String> + Send + Sync + 'static,
+    ) {
+        let store = Arc::new(MemoryTaskStore::new());
+        let router = base_task_router()
+            .task_store(store.clone())
+            .task_owner_resolver(resolver);
+        let error = dispatch(
+            &router,
+            1,
+            McpRequest::CallTool(CallToolParams {
+                name: "slow".to_string(),
+                arguments: serde_json::json!({}),
+                input_responses: None,
+                request_state: None,
+                meta: None,
+                task: None,
+            }),
+            request_extensions(Some("alice")),
+        )
+        .await
+        .expect_err("a broken resolver must reject creation");
+        assert_eq!(error.code, -32603);
+        assert_eq!(error.message, "Task owner resolver failed");
+        assert!(
+            store.list_tasks(None).await.unwrap().is_empty(),
+            "a failed resolver must not persist an anonymous Task"
+        );
+    }
+
+    rejected_creation(|_| Some("  ".to_string())).await;
+    rejected_creation(|_| panic!("resolver panic")).await;
+
+    // Invalid resolution is not anonymous: it cannot read a deliberately
+    // unowned Task already present in a shared store.
+    let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+    let (task_id, _) = store
+        .create_task("slow", serde_json::Value::Null, None, None)
+        .await
+        .unwrap();
+    let router = task_router()
+        .task_store(store)
+        .task_owner_resolver(|_| Some(String::new()));
+    for (offset, request) in [
+        get(&task_id),
+        update(&task_id),
+        cancel(&task_id),
+        listen(&task_id),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let denied = dispatch(
+            &router,
+            2 + offset as i64,
+            request,
+            request_extensions(None),
+        )
+        .await
+        .expect_err("invalid resolution must not match an unowned Task");
+        assert_eq!(denied.code, -32602);
+        assert!(denied.message.contains("not found"));
+    }
+}
+
+#[cfg(feature = "oauth")]
+#[tokio::test]
+async fn oauth_default_persists_the_subject_without_rewriting_it() {
+    use tower_mcp::oauth::TokenClaims;
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = base_task_router().task_store(store.clone());
+    let subject = "issuer.example/tenant-a::subject:alice";
+    let mut extensions = request_extensions(None);
+    extensions.insert(TokenClaims {
+        sub: Some(subject.to_string()),
+        iss: None,
+        aud: None,
+        exp: None,
+        scope: None,
+        client_id: None,
+        extra: HashMap::new(),
+    });
+
+    let created = dispatch(
+        &router,
+        1,
+        McpRequest::CallTool(CallToolParams {
+            name: "slow".to_string(),
+            arguments: serde_json::json!({}),
+            input_responses: None,
+            request_state: None,
+            meta: None,
+            task: None,
+        }),
+        extensions,
+    )
+    .await
+    .unwrap();
+    let McpResponse::FinalCreateTask(created) = created else {
+        panic!("expected a Task creation response")
+    };
+
+    assert_eq!(
+        store
+            .task_owner(&created.task.metadata.task_id)
+            .await
+            .unwrap(),
+        Some(Some(subject.to_string()))
+    );
+}


### PR DESCRIPTION
## Summary
- add configurable task-owner resolution from request extensions
- preserve OAuth subject ownership as the default behavior
- fail closed for invalid or panicking resolvers across task lifecycle and subscriptions
- cover application principals, OAuth compatibility, HTTP bridge propagation, and denial paths

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- cargo check -p tower-mcp --no-default-features
- cargo test -p tower-mcp --test task_owner_resolver --no-default-features --features stateless

Closes #1397