### PR TITLE
feat(tasks): add live execution lifecycle handle

### DIFF
--- a/crates/tower-mcp/src/deployment.rs
+++ b/crates/tower-mcp/src/deployment.rs
@@ -119,6 +119,15 @@
 //! If you serve the router yourself with `into_router()`, the equivalent of
 //! all this is `axum::serve(..).with_graceful_shutdown(..)`.
 //!
+//! A built-in live Task handler is detached after its `tools/call` returns a
+//! Task object, so transport request drain does not wait for that handler.
+//! Obtain [`McpRouter::live_task_execution_handle`](crate::McpRouter::live_task_execution_handle)
+//! before moving the router, close its admission when shutdown begins, and
+//! then either await natural settlement or call
+//! [`cancel_all`](crate::LiveTaskExecutionHandle::cancel_all) before a
+//! caller-bounded [`drained`](crate::LiveTaskExecutionHandle::drained) wait.
+//! The transport intentionally does not choose that cancellation policy.
+//!
 //! # Health Checks
 //!
 //! [`HttpTransport`] exposes `GET /health` returning `200 OK` with a JSON

--- a/crates/tower-mcp/src/guides/deployment.rs
+++ b/crates/tower-mcp/src/guides/deployment.rs
@@ -348,6 +348,51 @@ unbounded by default, and a client holding an SSE notification stream open
 counts as in flight, so a server that has to stop within a deadline should
 set it.
 
+A Task-backed `tools/call` stops counting as an HTTP request after its Task
+object has been returned, while a built-in live handler can continue running.
+Use the router's live-execution handle when shutdown must also settle those
+detached futures:
+
+```rust,no_run
+use std::time::Duration;
+
+use tower_mcp::{BoxError, HttpTransport, McpRouter};
+
+#[tokio::main]
+async fn main() -> Result<(), BoxError> {
+    let router = McpRouter::new();
+    let executions = router.live_task_execution_handle();
+    let shutdown_executions = executions.clone();
+
+    HttpTransport::new(router)
+        .drain_timeout(Duration::from_secs(10))
+        .serve_with_shutdown("0.0.0.0:3000", async move {
+            let _ = tokio::signal::ctrl_c().await;
+            // Shares the same registry as every transport-owned router clone.
+            shutdown_executions.close_admission();
+        })
+        .await?;
+
+    // This policy chooses cancellation after HTTP and subscription drain.
+    // Cancelling earlier, or allowing natural settlement, is also a valid
+    // application choice.
+    executions.cancel_all("server shutting down");
+    if tokio::time::timeout(Duration::from_secs(20), executions.drained())
+        .await
+        .is_err()
+    {
+        tracing::warn!("live task execution drain timed out");
+    }
+    Ok(())
+}
+```
+
+The handle covers `live_task_handler` executions, including task preparation;
+it does not treat every durable `TaskStore` record as in-process work. The
+transport deliberately does not call `cancel_all` or choose a live-execution
+deadline. Close admission before cancellation so an execution cannot arrive
+after the cancellation pass, and keep timeout/escalation policy in the host.
+
 Own the axum lifecycle instead when the MCP endpoint is one route among
 several, or is mounted somewhere other than the root:
 
@@ -384,7 +429,7 @@ metric labels.
 - [ ] Decide whether legacy sessions are optional or required.
 - [ ] Use affinity and/or shared stores according to the legacy features in use.
 - [ ] Disable proxy buffering and set stream-aware idle timeouts.
-- [ ] Bound bodies, sessions, handler execution, and graceful drain time.
+- [ ] Bound bodies, sessions, handler execution, HTTP drain, and live Task drain time.
 - [ ] Test JSON responses, POST SSE, legacy GET SSE/resumption if supported,
       final `subscriptions/listen`, 202 notifications, and error bodies.
 - [ ] Separate liveness from dependency-aware readiness.

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -562,6 +562,7 @@ pub mod session;
 pub mod session_store;
 #[cfg(feature = "stateless")]
 pub mod stateless;
+mod task_execution;
 pub mod tasks;
 #[cfg(feature = "testing")]
 pub mod testing;
@@ -699,6 +700,7 @@ pub use router::{
     ToolAnnotationsMap,
 };
 pub use session::{SessionPhase, SessionState};
+pub use task_execution::LiveTaskExecutionHandle;
 #[cfg(feature = "stateless")]
 pub use tool::MrtrToolHandler;
 pub use tool::{

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::{Arc, RwLock};
 use std::task::{Context, Poll};
 
 use tower_service::Service;
@@ -50,23 +50,6 @@ fn prompt_not_found(name: &str) -> Error {
     Error::JsonRpc(JsonRpcError::method_not_found(&format!(
         "Prompt not found: {name}"
     )))
-}
-
-/// Releases a live task's registry entry however its handler leaves.
-///
-/// The handler can return, panic, or be dropped. Unregistering only on the
-/// return path left a panicking handler's entry installed, so a later
-/// `tasks/cancel` found a handle nobody was reading and took the live path
-/// instead of the store one (#1305).
-struct LiveTaskRegistration {
-    router: McpRouter,
-    task_id: String,
-}
-
-impl Drop for LiveTaskRegistration {
-    fn drop(&mut self) {
-        self.router.unregister_live_task(&self.task_id);
-    }
 }
 
 /// Whether this request is using the final, stateless 2026-07-28 lifecycle.
@@ -193,12 +176,9 @@ struct McpRouterInner {
     /// `None` derives from whether a notification channel is attached, which
     /// is what this router has always advertised (#1338).
     advertise_mcp_logging: Option<bool>,
-    /// Live tasks currently running, keyed by task id (#1246).
-    ///
-    /// A live handler parks inside its own future rather than returning, so
-    /// the router needs a handle to wake it when `tasks/update` commits and
-    /// to signal it when `tasks/cancel` arrives.
-    live_tasks: Arc<Mutex<HashMap<String, Arc<crate::tool::LiveTask>>>>,
+    /// Admission, cancellation, and drain boundary for built-in live task
+    /// handlers. Shared by every clone and fresh logical session.
+    live_task_executions: crate::LiveTaskExecutionHandle,
     /// In-flight requests for cancellation tracking (shared across clones).
     ///
     /// Keyed by request id for lookup, but each id holds one entry per
@@ -681,7 +661,7 @@ impl McpRouter {
                 advertise_prompts_list_changed: None,
                 advertise_resources_list_changed: None,
                 advertise_mcp_logging: None,
-                live_tasks: Arc::new(Mutex::new(HashMap::new())),
+                live_task_executions: crate::LiveTaskExecutionHandle::new(),
                 in_flight: Arc::new(RwLock::new(HashMap::new())),
                 next_dispatch: Arc::new(AtomicU64::new(0)),
                 notification_tx: None,
@@ -866,6 +846,21 @@ impl McpRouter {
         T: Send + Sync + 'static,
     {
         self.task_owner_resolver(move |extensions| extensions.get::<T>().map(&map))
+    }
+
+    /// Return host-side lifecycle control for built-in live Task executions.
+    ///
+    /// Clone this handle before moving the router into a transport. It can
+    /// close live-handler admission, inspect active execution IDs, request
+    /// cancellation, and wait for settlement during graceful shutdown.
+    /// Replay task handlers and durable [`TaskStore`] records are not tracked.
+    ///
+    /// The handle is shared by all clones and fresh sessions of this router.
+    /// Transport shutdown remains separate: the application chooses when to
+    /// close admission, whether to cancel, and how long to await
+    /// [`crate::LiveTaskExecutionHandle::drained`].
+    pub fn live_task_execution_handle(&self) -> crate::LiveTaskExecutionHandle {
+        self.inner.live_task_executions.clone()
     }
 
     /// Set the root router's client-visible Task error policy.
@@ -2035,6 +2030,30 @@ impl McpRouter {
                                 TaskFailure::Internal("Task owner resolver failed"),
                             )
                         })?;
+
+                    // Reserve a live-execution slot before allocating durable
+                    // Task state. The reservation spans creation and
+                    // preparation, so close + drain cannot miss an invocation
+                    // in the gap before its task ID is registered (#1398).
+                    let mut live_admission = if tool.live_handler.is_some() {
+                        Some(
+                            self.inner
+                                .live_task_executions
+                                .registry
+                                .admit()
+                                .ok_or_else(|| {
+                                    self.task_error(
+                                        TaskOperation::Create,
+                                        None,
+                                        TaskFailure::Internal(
+                                            "Live task execution admission is closed",
+                                        ),
+                                    )
+                                })?,
+                        )
+                    } else {
+                        None
+                    };
                     // Create the task
                     let (task_id, cancellation_token) = self
                         .inner
@@ -2069,7 +2088,13 @@ impl McpRouter {
                     );
 
                     let task_store = self.inner.task_store.clone();
-                    let task_context = crate::tool::TaskContext::new(task_id.clone());
+                    let task_context = match live_admission.as_ref() {
+                        Some(admission) => crate::tool::TaskContext::with_cancellation(
+                            task_id.clone(),
+                            admission.cancellation(),
+                        ),
+                        None => crate::tool::TaskContext::new(task_id.clone()),
+                    };
                     let mut ctx = ctx;
                     ctx.extensions_mut().insert(task_context.clone());
                     let preparation = match tool
@@ -2121,40 +2146,36 @@ impl McpRouter {
 
                     let tool_name = params.name.clone();
                     let notifier = self.clone();
+                    let live_execution = tool.live_handler.clone().map(|live_handler| {
+                        let admission = live_admission
+                            .take()
+                            .expect("a live handler reserved execution admission");
+                        let cancellation = admission.cancellation();
+                        let handle = std::sync::Arc::new(crate::tool::LiveTask {
+                            store: task_store.clone(),
+                            error_policy: notifier.inner.task_error_policy.clone(),
+                            input_ready: tokio::sync::Notify::new(),
+                            cancellation: cancellation.clone(),
+                        });
+                        if cancellation_token.is_cancelled() {
+                            cancellation.cancel(None);
+                        }
+                        // Promotion replaces the anonymous preparation
+                        // reservation with an ID-bearing registration under a
+                        // single lock. It happens before spawn, so close +
+                        // drain cannot observe an empty registry between the
+                        // two lifecycle phases (#1398).
+                        let registration = admission.promote(task_id_clone.clone(), handle.clone());
+                        (live_handler, handle, cancellation, registration)
+                    });
                     tokio::spawn(async move {
                         // A live handler owns its execution: it parks inside
                         // its own future rather than returning, so it is never
                         // replayed and nothing else writes its terminal state
                         // (#1246).
-                        if let Some(live_handler) = tool.live_handler.clone() {
-                            let handle = std::sync::Arc::new(crate::tool::LiveTask {
-                                store: task_store.clone(),
-                                error_policy: notifier.inner.task_error_policy.clone(),
-                                input_ready: tokio::sync::Notify::new(),
-                                cancelled: crate::context::CancellationToken::new(),
-                            });
-                            // Register before inspecting the store token, not
-                            // after. A `tasks/cancel` landing between the two
-                            // used to find no live handle, take the store path,
-                            // terminalize, and acknowledge, after which the
-                            // handle was registered uncancelled and the handler
-                            // ran on against an already-cancelled task (#1294).
-                            //
-                            // In this order a cancel before registration is
-                            // caught by the check below, and one after it
-                            // signals the handle directly. There is no ordering
-                            // left where cancellation selects the store path
-                            // while live execution is running and cannot see it.
-                            notifier.register_live_task(&task_id_clone, handle.clone());
-                            // Released on drop, so the entry goes whether the
-                            // handler returns, panics, or is dropped (#1305).
-                            let registration = LiveTaskRegistration {
-                                router: notifier.clone(),
-                                task_id: task_id_clone.clone(),
-                            };
-                            if cancellation_token.is_cancelled() {
-                                handle.cancelled.cancel();
-                            }
+                        if let Some((live_handler, handle, cancellation, registration)) =
+                            live_execution
+                        {
                             let live_ctx =
                                 crate::tool::TaskContext::with_live(task_id_clone.clone(), handle);
 
@@ -2203,20 +2224,31 @@ impl McpRouter {
                                     .record_task_failure(&task_id_clone, error)
                                     .await
                                     .then_some("failed"),
-                                Ok(crate::tool::TaskOutcome::Cancelled { message }) => notifier
-                                    .record_task_cancellation(&task_id_clone, message.as_deref())
-                                    .await
-                                    .then_some("cancelled"),
+                                Ok(crate::tool::TaskOutcome::Cancelled { message }) => {
+                                    let message = message.or_else(|| cancellation.reason());
+                                    notifier
+                                        .record_task_cancellation(
+                                            &task_id_clone,
+                                            message.as_deref(),
+                                        )
+                                        .await
+                                        .then_some("cancelled")
+                                }
                                 // Propagating the cancellation error is the
                                 // ordinary way a live handler unwinds, so it
                                 // ends the task cancelled rather than failed.
-                                Err(crate::error::Error::TaskCancelled) => notifier
-                                    .record_task_cancellation(
-                                        &task_id_clone,
-                                        Some("handler observed cancellation"),
-                                    )
-                                    .await
-                                    .then_some("cancelled"),
+                                Err(crate::error::Error::TaskCancelled) => {
+                                    let reason = cancellation.reason();
+                                    notifier
+                                        .record_task_cancellation(
+                                            &task_id_clone,
+                                            reason
+                                                .as_deref()
+                                                .or(Some("handler observed cancellation")),
+                                        )
+                                        .await
+                                        .then_some("cancelled")
+                                }
                                 // An unclassified error is an execution
                                 // failure the handler declined to describe.
                                 Err(Error::JsonRpc(error)) => notifier
@@ -3071,7 +3103,7 @@ impl McpRouter {
                     // stopped, so completion can still legitimately win the
                     // race. SEP-2663 describes cancellation as eventually
                     // consistent, which is exactly this (#1246).
-                    if self.signal_live_cancellation(&params.task_id) {
+                    if self.signal_live_cancellation(&params.task_id, params.reason.as_deref()) {
                         self.notify_task_state(&params.task_id).await;
                         return Ok(McpResponse::FinalTaskAck(
                             crate::tasks::TaskAcknowledgement::new(),
@@ -3112,7 +3144,7 @@ impl McpRouter {
 
                 // Same reasoning as the final path: a live task owns its own
                 // teardown, so it is signalled and left non-terminal (#1246).
-                if self.signal_live_cancellation(&params.task_id) {
+                if self.signal_live_cancellation(&params.task_id, params.reason.as_deref()) {
                     self.notify_task_state(&params.task_id).await;
                     return Ok(McpResponse::CancelTask(EmptyResult {}));
                 }

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -395,10 +395,7 @@ impl McpRouter {
     /// Returns false when the task is not live, which is how the caller knows
     /// to fall back to replay (#1246).
     pub(super) fn wake_live_task(&self, task_id: &str) -> bool {
-        let Ok(live) = self.inner.live_tasks.lock() else {
-            return false;
-        };
-        match live.get(task_id) {
+        match self.inner.live_task_executions.registry.get(task_id) {
             Some(handle) => {
                 // `notify_one`, not `notify_waiters`: a waiter only registers
                 // when its future is polled, so a `notify_waiters` landing
@@ -415,28 +412,13 @@ impl McpRouter {
     ///
     /// The task stays non-terminal: its handler decides when it has finished
     /// unwinding and says so by returning `TaskOutcome::Cancelled`.
-    pub(super) fn signal_live_cancellation(&self, task_id: &str) -> bool {
-        let Ok(live) = self.inner.live_tasks.lock() else {
-            return false;
-        };
-        match live.get(task_id) {
+    pub(super) fn signal_live_cancellation(&self, task_id: &str, reason: Option<&str>) -> bool {
+        match self.inner.live_task_executions.registry.get(task_id) {
             Some(handle) => {
-                handle.cancelled.cancel();
+                handle.cancellation.cancel(reason.map(str::to_owned));
                 true
             }
             None => false,
-        }
-    }
-
-    pub(super) fn register_live_task(&self, task_id: &str, handle: Arc<crate::tool::LiveTask>) {
-        if let Ok(mut live) = self.inner.live_tasks.lock() {
-            live.insert(task_id.to_string(), handle);
-        }
-    }
-
-    pub(super) fn unregister_live_task(&self, task_id: &str) {
-        if let Ok(mut live) = self.inner.live_tasks.lock() {
-            live.remove(task_id);
         }
     }
 

--- a/crates/tower-mcp/src/task_execution.rs
+++ b/crates/tower-mcp/src/task_execution.rs
@@ -1,0 +1,335 @@
+//! Lifecycle control for built-in live Task executions.
+//!
+//! A live task handler keeps running after its `tools/call` response has
+//! returned. This registry gives the embedding application a process-lifetime
+//! boundary around those detached futures without coupling transport shutdown
+//! to an application cancellation policy.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::context::CancellationToken;
+
+/// A cloneable host-side handle for built-in live Task executions.
+///
+/// Obtain this from [`crate::McpRouter::live_task_execution_handle`] before
+/// moving the router into a transport. The handle covers only handlers built
+/// with [`crate::ToolBuilder::live_task_handler`] (and its context-aware
+/// variant). Replay handlers and arbitrary records in a [`crate::TaskStore`]
+/// are intentionally outside its scope.
+///
+/// Admission closure is permanent for this router. A typical graceful
+/// shutdown closes admission when listener shutdown begins, lets the transport
+/// finish its own drain, then either waits for live executions or requests
+/// cancellation and waits with a caller-owned timeout.
+#[derive(Clone)]
+pub struct LiveTaskExecutionHandle {
+    pub(crate) registry: Arc<LiveTaskExecutionRegistry>,
+}
+
+impl std::fmt::Debug for LiveTaskExecutionHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LiveTaskExecutionHandle")
+            .field("active_count", &self.active_count())
+            .finish_non_exhaustive()
+    }
+}
+
+impl LiveTaskExecutionHandle {
+    pub(crate) fn new() -> Self {
+        Self {
+            registry: Arc::new(LiveTaskExecutionRegistry::new()),
+        }
+    }
+
+    /// Permanently stop admitting new built-in live Task executions.
+    ///
+    /// Calls already admitted continue to preparation or execution and remain
+    /// visible to [`active_count`](Self::active_count) and
+    /// [`drained`](Self::drained). Calls rejected after this point fail before
+    /// the [`crate::TaskStore`] allocates a Task record.
+    pub fn close_admission(&self) {
+        self.registry.close_admission();
+    }
+
+    /// Return the number of admitted executions that have not settled.
+    ///
+    /// This includes reservations whose task preparation has not reached the
+    /// point where an ID can be published. Consequently this count can exceed
+    /// the length of [`active_task_ids`](Self::active_task_ids).
+    pub fn active_count(&self) -> usize {
+        self.registry.active_count()
+    }
+
+    /// Return the IDs of admitted executions that have finished preparation.
+    ///
+    /// IDs are returned in lexical order for stable logs and diagnostics.
+    /// Preparing reservations count as active but do not appear here until
+    /// they atomically promote to an ID-bearing execution.
+    pub fn active_task_ids(&self) -> Vec<String> {
+        self.registry.active_task_ids()
+    }
+
+    /// Request cancellation of every execution admitted at this instant.
+    ///
+    /// Returns the number of reservations and ID-bearing executions signalled.
+    /// The reason is propagated to the Task's terminal status when a handler
+    /// observes cancellation without supplying a more specific message.
+    ///
+    /// This method does not close admission. During graceful shutdown call
+    /// [`close_admission`](Self::close_admission) first if later executions
+    /// must not escape this cancellation pass.
+    pub fn cancel_all(&self, reason: impl Into<String>) -> usize {
+        self.registry.cancel_all(reason.into())
+    }
+
+    /// Wait until every admitted execution has settled.
+    ///
+    /// Settlement means the handler future has left its lifecycle boundary and
+    /// any terminal Task-store write has completed. This method deliberately
+    /// has no built-in deadline; the embedding application owns shutdown
+    /// timeout and escalation policy. It does not close admission, so call
+    /// [`close_admission`](Self::close_admission) first when no execution may
+    /// begin after this wait resolves.
+    pub async fn drained(&self) {
+        self.registry.drained().await;
+    }
+}
+
+pub(crate) struct LiveTaskCancellation {
+    token: CancellationToken,
+    state: Mutex<CancellationState>,
+}
+
+#[derive(Default)]
+struct CancellationState {
+    requested: bool,
+    reason: Option<String>,
+}
+
+impl LiveTaskCancellation {
+    pub(crate) fn new() -> Self {
+        Self {
+            token: CancellationToken::new(),
+            state: Mutex::new(CancellationState::default()),
+        }
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.token.cancelled().await;
+    }
+
+    pub(crate) fn cancel(&self, reason: Option<String>) {
+        {
+            let mut state = lock_recover(&self.state);
+            if !state.requested {
+                state.requested = true;
+                state.reason = reason;
+            }
+        }
+        // Publish the reason before waking a waiter so it can immediately read
+        // the reason associated with the signal it observed.
+        self.token.cancel();
+    }
+
+    pub(crate) fn reason(&self) -> Option<String> {
+        lock_recover(&self.state).reason.clone()
+    }
+}
+
+pub(crate) struct LiveTaskExecutionRegistry {
+    state: Mutex<RegistryState>,
+    active_count_tx: tokio::sync::watch::Sender<usize>,
+}
+
+struct RegistryState {
+    admission_open: bool,
+    next_reservation: u64,
+    reservations: HashMap<u64, Arc<LiveTaskCancellation>>,
+    executions: HashMap<String, Arc<crate::tool::LiveTask>>,
+}
+
+impl LiveTaskExecutionRegistry {
+    fn new() -> Self {
+        let (active_count_tx, _active_count_rx) = tokio::sync::watch::channel(0);
+        Self {
+            state: Mutex::new(RegistryState {
+                admission_open: true,
+                next_reservation: 0,
+                reservations: HashMap::new(),
+                executions: HashMap::new(),
+            }),
+            active_count_tx,
+        }
+    }
+
+    pub(crate) fn admit(self: &Arc<Self>) -> Option<LiveTaskAdmission> {
+        let cancellation = Arc::new(LiveTaskCancellation::new());
+        let reservation = {
+            let mut state = lock_recover(&self.state);
+            if !state.admission_open {
+                return None;
+            }
+            let reservation = state.next_reservation;
+            state.next_reservation = state.next_reservation.wrapping_add(1);
+            state.reservations.insert(reservation, cancellation.clone());
+            // Publish while holding the state lock. Otherwise two mutations
+            // could compute ordered counts but send them in reverse order,
+            // leaving a drain asleep on a stale nonzero value.
+            self.active_count_tx.send_replace(state.active_count());
+            reservation
+        };
+        Some(LiveTaskAdmission {
+            registry: self.clone(),
+            reservation: Some(reservation),
+            cancellation,
+        })
+    }
+
+    fn close_admission(&self) {
+        lock_recover(&self.state).admission_open = false;
+    }
+
+    fn active_count(&self) -> usize {
+        lock_recover(&self.state).active_count()
+    }
+
+    fn active_task_ids(&self) -> Vec<String> {
+        let mut ids: Vec<_> = lock_recover(&self.state)
+            .executions
+            .keys()
+            .cloned()
+            .collect();
+        ids.sort();
+        ids
+    }
+
+    fn cancel_all(&self, reason: String) -> usize {
+        let cancellations: Vec<_> = {
+            let state = lock_recover(&self.state);
+            state
+                .reservations
+                .values()
+                .cloned()
+                .chain(
+                    state
+                        .executions
+                        .values()
+                        .map(|live| live.cancellation.clone()),
+                )
+                .collect()
+        };
+        let count = cancellations.len();
+        for cancellation in cancellations {
+            cancellation.cancel(Some(reason.clone()));
+        }
+        count
+    }
+
+    async fn drained(&self) {
+        let mut active_count = self.active_count_tx.subscribe();
+        while *active_count.borrow_and_update() != 0 {
+            // The sender is owned by this registry and therefore cannot close
+            // while this borrowed registry is alive.
+            active_count
+                .changed()
+                .await
+                .expect("live task execution count sender remains open");
+        }
+    }
+
+    fn release_reservation(&self, reservation: u64) {
+        let mut state = lock_recover(&self.state);
+        state.reservations.remove(&reservation);
+        self.active_count_tx.send_replace(state.active_count());
+    }
+
+    fn unregister(&self, task_id: &str) {
+        let mut state = lock_recover(&self.state);
+        state.executions.remove(task_id);
+        self.active_count_tx.send_replace(state.active_count());
+    }
+
+    pub(crate) fn get(&self, task_id: &str) -> Option<Arc<crate::tool::LiveTask>> {
+        lock_recover(&self.state).executions.get(task_id).cloned()
+    }
+}
+
+impl RegistryState {
+    fn active_count(&self) -> usize {
+        self.reservations.len() + self.executions.len()
+    }
+}
+
+/// An execution admitted before any durable Task record is allocated.
+///
+/// Dropping this value releases the reservation, including every error path
+/// through task creation and preparation.
+pub(crate) struct LiveTaskAdmission {
+    registry: Arc<LiveTaskExecutionRegistry>,
+    reservation: Option<u64>,
+    cancellation: Arc<LiveTaskCancellation>,
+}
+
+impl LiveTaskAdmission {
+    pub(crate) fn cancellation(&self) -> Arc<LiveTaskCancellation> {
+        self.cancellation.clone()
+    }
+
+    pub(crate) fn promote(
+        mut self,
+        task_id: String,
+        live: Arc<crate::tool::LiveTask>,
+    ) -> LiveTaskRegistration {
+        let reservation = self
+            .reservation
+            .take()
+            .expect("a live task admission promotes only once");
+        {
+            let mut state = lock_recover(&self.registry.state);
+            let removed = state.reservations.remove(&reservation);
+            debug_assert!(
+                removed.is_some(),
+                "admission reservation remains registered"
+            );
+            let replaced = state.executions.insert(task_id.clone(), live);
+            debug_assert!(replaced.is_none(), "task IDs are unique");
+        }
+        // Reservation removal and task insertion happen under one lock and do
+        // not change the active count, so a drain can never observe a gap.
+        LiveTaskRegistration {
+            registry: self.registry.clone(),
+            task_id,
+        }
+    }
+}
+
+impl Drop for LiveTaskAdmission {
+    fn drop(&mut self) {
+        if let Some(reservation) = self.reservation.take() {
+            self.registry.release_reservation(reservation);
+        }
+    }
+}
+
+/// Releases an ID-bearing execution however its handler future leaves.
+pub(crate) struct LiveTaskRegistration {
+    registry: Arc<LiveTaskExecutionRegistry>,
+    task_id: String,
+}
+
+impl Drop for LiveTaskRegistration {
+    fn drop(&mut self) {
+        self.registry.unregister(&self.task_id);
+    }
+}
+
+fn lock_recover<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/tower-mcp/src/tool/task.rs
+++ b/crates/tower-mcp/src/tool/task.rs
@@ -14,6 +14,7 @@ use super::*;
 pub struct TaskContext {
     task_id: String,
     live: Option<Arc<LiveTask>>,
+    cancellation: Option<Arc<crate::task_execution::LiveTaskCancellation>>,
 }
 
 impl std::fmt::Debug for TaskContext {
@@ -21,6 +22,7 @@ impl std::fmt::Debug for TaskContext {
         f.debug_struct("TaskContext")
             .field("task_id", &self.task_id)
             .field("live", &self.live.is_some())
+            .field("cancellable", &self.cancellation.is_some())
             .finish()
     }
 }
@@ -43,7 +45,7 @@ pub(crate) struct LiveTask {
     pub(crate) error_policy: crate::router::TaskErrorPolicy,
     /// Signalled after responses are durably recorded, never before.
     pub(crate) input_ready: tokio::sync::Notify,
-    pub(crate) cancelled: crate::context::CancellationToken,
+    pub(crate) cancellation: Arc<crate::task_execution::LiveTaskCancellation>,
 }
 
 /// How a live task ended.
@@ -67,7 +69,8 @@ pub enum TaskOutcome {
     ///
     /// Returned by the handler rather than imposed by the store, so a task
     /// stays non-terminal between the `tasks/cancel` acknowledgement and the
-    /// worker confirming it stopped.
+    /// worker confirming it stopped. If `message` is absent, the router uses
+    /// the reason from the first client or host cancellation request.
     Cancelled {
         /// Optional detail for the task's status message.
         message: Option<String>,
@@ -79,13 +82,27 @@ impl TaskContext {
         Self {
             task_id,
             live: None,
+            cancellation: None,
+        }
+    }
+
+    pub(crate) fn with_cancellation(
+        task_id: String,
+        cancellation: Arc<crate::task_execution::LiveTaskCancellation>,
+    ) -> Self {
+        Self {
+            task_id,
+            live: None,
+            cancellation: Some(cancellation),
         }
     }
 
     pub(crate) fn with_live(task_id: String, live: Arc<LiveTask>) -> Self {
+        let cancellation = live.cancellation.clone();
         Self {
             task_id,
             live: Some(live),
+            cancellation: Some(cancellation),
         }
     }
 
@@ -218,7 +235,7 @@ impl TaskContext {
         }
         let asked: Vec<String> = requests.keys().cloned().collect();
 
-        if live.cancelled.is_cancelled() {
+        if live.cancellation.is_cancelled() {
             return Err(crate::error::Error::TaskCancelled);
         }
 
@@ -282,22 +299,40 @@ impl TaskContext {
 
     /// Whether this task has been asked to cancel.
     ///
+    /// Available during live-task preparation as well as handler execution.
     /// A live task stays non-terminal until its handler returns, so this being
     /// true means the request arrived, not that the task is over.
     pub fn is_cancelled(&self) -> bool {
-        self.live
+        self.cancellation
             .as_ref()
-            .is_some_and(|live| live.cancelled.is_cancelled())
+            .is_some_and(|cancellation| cancellation.is_cancelled())
+    }
+
+    /// Return the reason supplied with the first cancellation request.
+    ///
+    /// Both client `tasks/cancel` reasons and host reasons from
+    /// [`crate::LiveTaskExecutionHandle::cancel_all`] reach this method. The
+    /// returned string is a snapshot because cancellation state is shared
+    /// across the handler and host control handle.
+    pub fn cancellation_reason(&self) -> Option<String> {
+        self.cancellation
+            .as_ref()
+            .and_then(|cancellation| cancellation.reason())
     }
 
     /// Resolves when this task is asked to cancel.
     ///
-    /// Only needed by a handler that interleaves teardown with its own work.
+    /// A live handler uses this when it interleaves teardown with its own
+    /// work. Task preparation receives the same signal, so a cooperative
+    /// preparer can release resources and return when a host cancels its
+    /// anonymous admission reservation. Replay contexts have no live
+    /// cancellation source and wait forever here.
+    ///
     /// A handler that awaits [`require_input`](Self::require_input) gets
-    /// correct behaviour from the error it returns.
+    /// correct behaviour from the error it returns without calling this.
     pub async fn cancelled(&self) {
-        match self.live.as_ref() {
-            Some(live) => live.cancelled.cancelled().await,
+        match self.cancellation.as_ref() {
+            Some(cancellation) => cancellation.cancelled().await,
             None => std::future::pending().await,
         }
     }
@@ -308,6 +343,7 @@ impl Clone for TaskContext {
         Self {
             task_id: self.task_id.clone(),
             live: self.live.clone(),
+            cancellation: self.cancellation.clone(),
         }
     }
 }
@@ -387,7 +423,7 @@ impl PendingInput {
     pub async fn wait(self) -> Result<InputResponses> {
         let live = &self.live;
 
-        if live.cancelled.is_cancelled() {
+        if live.cancellation.is_cancelled() {
             return Err(crate::error::Error::TaskCancelled);
         }
 
@@ -408,7 +444,7 @@ impl PendingInput {
                     ))
                 })?;
             let Some(outstanding) = outstanding else {
-                if live.cancelled.is_cancelled() {
+                if live.cancellation.is_cancelled() {
                     return Err(crate::error::Error::TaskCancelled);
                 }
                 return Err(crate::error::Error::JsonRpc(
@@ -425,7 +461,7 @@ impl PendingInput {
 
             tokio::select! {
                 _ = woken => {}
-                _ = live.cancelled.cancelled() => {
+                _ = live.cancellation.cancelled() => {
                     return Err(crate::error::Error::TaskCancelled);
                 }
             }
@@ -443,7 +479,7 @@ impl PendingInput {
                 ))
             })?;
         let Some(all) = all else {
-            if live.cancelled.is_cancelled() {
+            if live.cancellation.is_cancelled() {
                 return Err(crate::error::Error::TaskCancelled);
             }
             return Err(crate::error::Error::JsonRpc(

--- a/crates/tower-mcp/src/tool/tests.rs
+++ b/crates/tower-mcp/src/tool/tests.rs
@@ -136,7 +136,7 @@ async fn live_working_reports_a_terminal_race_through_the_task_policy() {
             crate::error::JsonRpcError::internal_error("mapped terminal race")
         }),
         input_ready: tokio::sync::Notify::new(),
-        cancelled: crate::context::CancellationToken::new(),
+        cancellation: Arc::new(crate::task_execution::LiveTaskCancellation::new()),
     });
     let context = TaskContext::with_live("task_terminal".into(), live);
 
@@ -162,7 +162,7 @@ fn mapped_live(store: TerminalStatusStore) -> Arc<LiveTask> {
             crate::error::JsonRpcError::internal_error("mapped missing input state")
         }),
         input_ready: tokio::sync::Notify::new(),
-        cancelled: crate::context::CancellationToken::new(),
+        cancellation: Arc::new(crate::task_execution::LiveTaskCancellation::new()),
     })
 }
 

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -227,7 +227,7 @@ async fn cancellation_is_confirmed_by_the_handler_rather_than_imposed() {
     await_status(&store, &task_id, TaskStatus::InputRequired).await;
 
     client
-        .task_cancel(&task_id, None)
+        .task_cancel(&task_id, Some("client stopped".to_string()))
         .await
         .expect("cancel accepted");
 
@@ -237,6 +237,310 @@ async fn cancellation_is_confirmed_by_the_handler_rather_than_imposed() {
         1,
         "the handler ran its teardown rather than being abandoned"
     );
+    let task = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        task.status_message.as_deref(),
+        Some("Cancelled: client stopped"),
+        "a live cancellation must preserve the client's reason"
+    );
+}
+
+// ============================================================================
+// Host lifecycle control (#1398)
+// ============================================================================
+
+/// The public handle reports ID-bearing executions and does not finish its
+/// drain until the handler has settled and its terminal state is durable.
+#[tokio::test]
+async fn live_execution_handle_reports_ids_and_drains_after_terminal_write() {
+    let started = Arc::new(tokio::sync::Notify::new());
+    let release = Arc::new(tokio::sync::Notify::new());
+    let handler_started = started.clone();
+    let handler_release = release.clone();
+    let tool = ToolBuilder::new("live")
+        .description("Waits for the test to release it")
+        .live_task_handler(move |_task: TaskContext, _input: NoArgs| {
+            let started = handler_started.clone();
+            let release = handler_release.clone();
+            async move {
+                started.notify_one();
+                release.notified().await;
+                Ok(TaskOutcome::Completed(CallToolResult::text("done")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let executions = router.live_task_execution_handle();
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    started.notified().await;
+
+    assert_eq!(executions.active_count(), 1);
+    assert_eq!(executions.active_task_ids(), vec![task_id.clone()]);
+
+    let drain_handle = executions.clone();
+    let mut drain = tokio::spawn(async move { drain_handle.drained().await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(30), &mut drain)
+            .await
+            .is_err(),
+        "drain must remain pending while the handler owns its execution"
+    );
+
+    release.notify_one();
+    tokio::time::timeout(std::time::Duration::from_secs(5), drain)
+        .await
+        .expect("drain timed out")
+        .expect("drain task panicked");
+
+    assert_eq!(executions.active_count(), 0);
+    assert!(executions.active_task_ids().is_empty());
+    let task = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(
+        task.status,
+        TaskStatus::Completed,
+        "terminal state must be durable before drained resolves"
+    );
+}
+
+/// Host cancellation reaches the handler, permits observable cleanup, and
+/// supplies the reason used when the handler returns no more-specific one.
+#[tokio::test]
+async fn host_cancel_all_propagates_reason_and_waits_for_cleanup() {
+    let started = Arc::new(tokio::sync::Notify::new());
+    let handler_started = started.clone();
+    let cleaned_up = Arc::new(AtomicUsize::new(0));
+    let handler_cleaned_up = cleaned_up.clone();
+    let tool = ToolBuilder::new("live")
+        .description("Cleans up after host cancellation")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let started = handler_started.clone();
+            let cleaned_up = handler_cleaned_up.clone();
+            async move {
+                started.notify_one();
+                task.cancelled().await;
+                assert_eq!(
+                    task.cancellation_reason().as_deref(),
+                    Some("deployment shutdown")
+                );
+                cleaned_up.fetch_add(1, Ordering::SeqCst);
+                Ok(TaskOutcome::Cancelled { message: None })
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let executions = router.live_task_execution_handle();
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    started.notified().await;
+
+    executions.close_admission();
+    assert_eq!(executions.cancel_all("deployment shutdown"), 1);
+    tokio::time::timeout(std::time::Duration::from_secs(5), executions.drained())
+        .await
+        .expect("live execution did not drain");
+
+    assert_eq!(cleaned_up.load(Ordering::SeqCst), 1);
+    let task = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(task.status, TaskStatus::Cancelled);
+    assert_eq!(
+        task.status_message.as_deref(),
+        Some("Cancelled: deployment shutdown")
+    );
+}
+
+/// Preparation is inside the lifecycle boundary even though no ID has yet
+/// been published. Cancellation cannot be lost when that reservation promotes
+/// to a registered task immediately before spawning the handler.
+#[tokio::test]
+async fn close_cancel_and_drain_cover_a_blocked_task_preparation() {
+    let preparing = Arc::new(tokio::sync::Notify::new());
+    let prepare_started = preparing.clone();
+    let preparation_cleaned_up = Arc::new(AtomicUsize::new(0));
+    let prepare_cleaned_up = preparation_cleaned_up.clone();
+    let tool = ToolBuilder::new("live")
+        .description("Blocks in preparation")
+        .live_task_handler(|task: TaskContext, _input: NoArgs| async move {
+            // A cancellation raised against the anonymous reservation must be
+            // present as soon as the ID-bearing handler begins.
+            task.require_input(ask("never")).await?;
+            Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+        })
+        .build()
+        .with_task_preparation(move |task: TaskContext, _args: serde_json::Value| {
+            let started = prepare_started.clone();
+            let cleaned_up = prepare_cleaned_up.clone();
+            async move {
+                started.notify_one();
+                // Host cancellation must reach the anonymous reservation, not
+                // wait until preparation happens to finish on its own.
+                task.cancelled().await;
+                assert_eq!(
+                    task.cancellation_reason().as_deref(),
+                    Some("shutdown during preparation")
+                );
+                cleaned_up.fetch_add(1, Ordering::SeqCst);
+                Ok(tower_mcp::TaskPreparation::new())
+            }
+        });
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let executions = router.live_task_execution_handle();
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let call = tokio::spawn(async move { client.call_tool_as_task("live", json!({}), None).await });
+    preparing.notified().await;
+    assert_eq!(executions.active_count(), 1);
+    assert!(
+        executions.active_task_ids().is_empty(),
+        "a preparation reservation has no public task ID yet"
+    );
+
+    let drain_handle = executions.clone();
+    let mut drain = tokio::spawn(async move { drain_handle.drained().await });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(30), &mut drain)
+            .await
+            .is_err(),
+        "a blocked preparation reservation must hold the drain open"
+    );
+
+    executions.close_admission();
+    assert_eq!(executions.cancel_all("shutdown during preparation"), 1);
+    let task_id = call
+        .await
+        .expect("call task panicked")
+        .expect("task created")
+        .task
+        .task_id;
+    tokio::time::timeout(std::time::Duration::from_secs(5), drain)
+        .await
+        .expect("drain timed out")
+        .expect("drain task panicked");
+
+    assert_eq!(preparation_cleaned_up.load(Ordering::SeqCst), 1);
+    let task = store.get_task(&task_id).await.unwrap().unwrap();
+    assert_eq!(task.status, TaskStatus::Cancelled);
+    assert_eq!(
+        task.status_message.as_deref(),
+        Some("Cancelled: shutdown during preparation")
+    );
+}
+
+/// Closing admission fails before task allocation and does not affect any
+/// other router operation.
+#[tokio::test]
+async fn closed_live_admission_rejects_without_creating_a_task() {
+    let handler_calls = Arc::new(AtomicUsize::new(0));
+    let calls = handler_calls.clone();
+    let tool = ToolBuilder::new("live")
+        .description("Must never start")
+        .live_task_handler(move |_task: TaskContext, _input: NoArgs| {
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(TaskOutcome::Completed(CallToolResult::text("unexpected")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("live", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let executions = router.live_task_execution_handle();
+    executions.close_admission();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let error = client
+        .call_tool_as_task("live", json!({}), None)
+        .await
+        .expect_err("closed admission must reject the call");
+    assert!(
+        error.to_string().contains("admission is closed"),
+        "rejection should be a clean protocol error: {error}"
+    );
+    assert_eq!(handler_calls.load(Ordering::SeqCst), 0);
+    assert!(store.list_tasks(None).await.unwrap().is_empty());
+    assert_eq!(executions.active_count(), 0);
+    tokio::time::timeout(std::time::Duration::from_secs(1), executions.drained())
+        .await
+        .expect("an empty registry drains immediately");
+}
+
+/// The host handle is deliberately not a proxy for all TaskStore activity.
+/// Closing it must leave the replay-based task executor unchanged.
+#[tokio::test]
+async fn closed_live_admission_does_not_reject_replay_tasks() {
+    let tool = ToolBuilder::new("replay")
+        .description("Uses the replay task path")
+        .task_support(tower_mcp::TaskSupportMode::Required)
+        .handler(|_input: NoArgs| async move { Ok(CallToolResult::text("done")) })
+        .build();
+    let store = Arc::new(MemoryTaskStore::new());
+    let router = McpRouter::new()
+        .server_info("replay", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let executions = router.live_task_execution_handle();
+    executions.close_admission();
+
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+    let task_id = client
+        .call_tool_as_task("replay", json!({}), None)
+        .await
+        .expect("replay task remains admitted")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::Completed).await;
+    assert_eq!(executions.active_count(), 0);
+    assert!(executions.active_task_ids().is_empty());
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- expose a cloneable host-side handle for built-in live Task executions
- close admission, inspect active executions, cancel all with a host reason, and await drain
- reserve lifecycle admission before TaskStore allocation and atomically promote before spawn
- propagate first-wins client/host cancellation reasons while preserving terminal-write-before-unregister ordering
- document caller-owned transport shutdown, cancellation, and timeout policy
- cover blocked preparation, host cancellation cleanup, admission rejection, drain ordering, panic cleanup, and replay isolation

## Validation
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features
- cargo check -p tower-mcp --no-default-features
- cargo test -p tower-mcp --test live_tasks --no-default-features --features stateless
- independent post-rebase concurrency/API review

Closes #1398