### PR TITLE
feat(tasks): add configurable TTL and expiry cleanup

### DIFF
--- a/crates/tower-mcp/src/async_task.rs
+++ b/crates/tower-mcp/src/async_task.rs
@@ -8,10 +8,11 @@
 //! Task state lives behind the pluggable [`TaskStore`] trait, mirroring the
 //! shape of [`crate::session_store`] and [`crate::event_store`]: a trait, an
 //! error enum, and an in-memory default. By default routers use
-//! [`MemoryTaskStore`], which keeps tasks in an in-process map (behavior
-//! identical to earlier versions). External stores (Redis, Postgres, etc.) can
-//! be plugged in so `tasks/get` works on any instance behind a load balancer
-//! in the sessionless 2026-07-28 flows (SEP-2663).
+//! [`MemoryTaskStore`], which keeps tasks in an in-process map and
+//! automatically signals and reclaims expired records. External stores
+//! (Redis, Postgres, etc.) can be plugged in so `tasks/get` works on any
+//! instance behind a load balancer in the sessionless 2026-07-28 flows
+//! (SEP-2663).
 //!
 //! Nothing here is advertised until a server asks for it:
 //! [`McpRouter::with_tasks`](crate::McpRouter::with_tasks) is the runtime
@@ -60,7 +61,10 @@
 //! task can expire while still working. Past that point every read returns
 //! `None` and every transition returns `Ok(false)`, whether or not the entry
 //! has been reclaimed: an expired task is indistinguishable from one that
-//! never existed.
+//! never existed. Reaching the deadline also raises the task's
+//! [`CancellationToken`] and wakes completion/input waiters, so invisible work
+//! is not left suspended. [`MemoryTaskStore`] schedules this automatically;
+//! external stores must bridge their expiry mechanism to the returned token.
 //!
 //! ```rust
 //! use tower_mcp::CallToolResult;
@@ -212,8 +216,7 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write as _;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, RwLock, Weak};
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
@@ -221,14 +224,122 @@ use async_trait::async_trait;
 use crate::error::JsonRpcError;
 use crate::protocol::{CallToolResult, InputRequests, InputResponses, TaskObject, TaskStatus};
 
-/// Default time-to-live for a task (5 minutes, in milliseconds).
+/// Cancellation signal shared by a task store and the work it owns.
+///
+/// Cloned tokens share the same underlying signal: cancelling any clone
+/// cancels them all. The token is backed by
+/// [`tokio_util::sync::CancellationToken`], so it can be checked synchronously
+/// or awaited. A store must raise the same signal for explicit cancellation
+/// and expiry; see [`TaskStore::create_task`].
+///
+/// This task-lifecycle token is intentionally a separate type from
+/// [`crate::context::CancellationToken`], which belongs to the originating
+/// request.
+#[derive(Clone, Debug, Default)]
+pub struct CancellationToken {
+    inner: tokio_util::sync::CancellationToken,
+}
+
+impl CancellationToken {
+    /// Create a new, un-cancelled token.
+    ///
+    /// [`TaskStore::create_task`] has to return one of these, so the public
+    /// constructor lets external task stores create the process-local signal
+    /// they bridge to durable cancellation and expiry state.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check whether cancellation or expiry has been signalled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.is_cancelled()
+    }
+
+    /// Signal cancellation or expiry to every clone and waiter.
+    pub fn cancel(&self) {
+        self.inner.cancel();
+    }
+
+    /// Wait until cancellation or expiry is signalled.
+    ///
+    /// Completes immediately if the token was already signalled.
+    pub async fn cancelled(&self) {
+        self.inner.cancelled().await;
+    }
+}
+
+/// Default time-to-live for a task (5 minutes).
 ///
 /// Per SEP-2663 the TTL runs from task creation, not from the moment the task
 /// reaches a terminal state.
-const DEFAULT_TTL_MS: u64 = 300_000;
+const DEFAULT_TASK_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Default interval between physical reclamation passes.
+const DEFAULT_TASK_CLEANUP_INTERVAL: Duration = Duration::from_secs(60);
 
 /// Default poll interval suggestion (2 seconds, in milliseconds)
 const DEFAULT_POLL_INTERVAL_MS: u64 = 2_000;
+
+/// Runtime policy for the in-memory task store.
+///
+/// The default task TTL remains five minutes for source and behavior
+/// compatibility. Final-protocol clients cannot choose a TTL, so
+/// [`default_ttl`](Self::default_ttl) is the server's retention and execution
+/// bound for those tasks. Legacy clients that send an explicit TTL continue
+/// to use that value.
+///
+/// Expiry signalling is scheduled independently of
+/// [`cleanup_interval`](Self::cleanup_interval). The interval controls only
+/// when expired records are physically removed from memory; at the TTL
+/// deadline the task has already become invisible and its cancellation token
+/// and completion waiters have already been woken.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MemoryTaskStoreConfig {
+    /// TTL used when [`TaskStore::create_task`] receives `None`.
+    pub default_ttl: Duration,
+    /// Interval between automatic physical cleanup passes.
+    pub cleanup_interval: Duration,
+}
+
+impl MemoryTaskStoreConfig {
+    /// Create the default five-minute TTL, one-minute cleanup policy.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set the TTL used for tasks that do not provide one.
+    #[must_use]
+    pub fn default_ttl(mut self, ttl: Duration) -> Self {
+        self.default_ttl = ttl;
+        self
+    }
+
+    /// Set how frequently expired task records are physically reclaimed.
+    ///
+    /// A zero interval is accepted and treated as one millisecond to avoid a
+    /// busy cleanup loop.
+    #[must_use]
+    pub fn cleanup_interval(mut self, interval: Duration) -> Self {
+        self.cleanup_interval = interval;
+        self
+    }
+}
+
+impl Default for MemoryTaskStoreConfig {
+    fn default() -> Self {
+        Self {
+            default_ttl: DEFAULT_TASK_TTL,
+            cleanup_interval: DEFAULT_TASK_CLEANUP_INTERVAL,
+        }
+    }
+}
+
+fn duration_millis_saturated(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
 
 /// Internal task representation with full state
 ///
@@ -253,7 +364,7 @@ pub struct Task {
     pub created_at_str: String,
     /// ISO 8601 timestamp of last state change
     pub last_updated_at_str: String,
-    /// Time-to-live in milliseconds (for cleanup after completion)
+    /// Time-to-live in milliseconds, measured from creation
     pub ttl: u64,
     /// Suggested polling interval in milliseconds
     pub poll_interval: u64,
@@ -302,10 +413,9 @@ impl Task {
         id: String,
         tool_name: String,
         arguments: serde_json::Value,
-        ttl: Option<u64>,
+        ttl: u64,
         owner: TaskOwner,
     ) -> Self {
-        let cancelled = Arc::new(AtomicBool::new(false));
         let now_str = chrono_now_iso8601();
         Self {
             id,
@@ -315,7 +425,7 @@ impl Task {
             created_at: Instant::now(),
             created_at_str: now_str.clone(),
             last_updated_at_str: now_str,
-            ttl: ttl.unwrap_or(DEFAULT_TTL_MS),
+            ttl,
             poll_interval: DEFAULT_POLL_INTERVAL_MS,
             status_message: Some("Task started".to_string()),
             meta: None,
@@ -326,7 +436,7 @@ impl Task {
             answered_input_keys: BTreeSet::new(),
             input_responses: InputResponses::new(),
             superseded_input_keys: BTreeSet::new(),
-            cancellation_token: CancellationToken { cancelled },
+            cancellation_token: CancellationToken::new(),
             completed_at: None,
             completion_notify: Arc::new(tokio::sync::Notify::new()),
         }
@@ -360,7 +470,15 @@ impl Task {
     /// `ttlMs` bounds how long the server retains the task, not how long it
     /// lingers after finishing.
     pub fn is_expired(&self) -> bool {
-        self.created_at.elapsed() > Duration::from_millis(self.ttl)
+        self.is_expired_at(Instant::now())
+    }
+
+    fn expires_at(&self) -> Option<Instant> {
+        self.created_at.checked_add(Duration::from_millis(self.ttl))
+    }
+
+    fn is_expired_at(&self, now: Instant) -> bool {
+        self.expires_at().is_some_and(|deadline| now >= deadline)
     }
 
     /// Outstanding input requests, if the task is waiting on the client.
@@ -371,6 +489,50 @@ impl Task {
     /// Check if the task has been cancelled
     pub fn is_cancelled(&self) -> bool {
         self.cancellation_token.is_cancelled()
+    }
+}
+
+/// Memory-store-only lifecycle bookkeeping around the public task record.
+///
+/// Keeping expiry signalling state here avoids adding a field to [`Task`],
+/// whose public fields historically allowed downstream struct literals.
+#[derive(Debug)]
+struct StoredTask {
+    task: Task,
+    expiry_signalled: bool,
+}
+
+impl StoredTask {
+    fn new(task: Task) -> Self {
+        Self {
+            task,
+            expiry_signalled: false,
+        }
+    }
+
+    /// Raise the persistent expiry signals exactly once.
+    fn signal_expiry(&mut self) -> bool {
+        if self.expiry_signalled {
+            return false;
+        }
+        self.expiry_signalled = true;
+        self.task.cancellation_token.cancel();
+        self.task.completion_notify.notify_waiters();
+        true
+    }
+}
+
+impl std::ops::Deref for StoredTask {
+    type Target = Task;
+
+    fn deref(&self) -> &Self::Target {
+        &self.task
+    }
+}
+
+impl std::ops::DerefMut for StoredTask {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.task
     }
 }
 
@@ -470,13 +632,28 @@ pub struct TaskResumeContext {
     pub arguments: serde_json::Value,
     /// Every answer accumulated so far, keyed as the requests were issued.
     pub input_responses: InputResponses,
+    /// Cancellation and expiry signal for the resumed execution, when the
+    /// store attached one.
+    ///
+    /// External stores should provide a clone of the token returned by
+    /// [`TaskStore::create_task`], or another token wired to the same durable
+    /// cancellation and expiry source, via
+    /// [`with_cancellation_token`](Self::with_cancellation_token).
+    /// The router fails the replay loudly when this is `None`, because a
+    /// disconnected handler could otherwise run beyond the task deadline.
+    pub cancellation_token: Option<CancellationToken>,
 }
 
 impl TaskResumeContext {
     /// Create the context needed to resume a task handler.
     ///
     /// External [`TaskStore`] implementations use this when reconstructing a
-    /// task from durable state in [`TaskStore::resume_context`].
+    /// task from durable state in [`TaskStore::resume_context`]. This keeps
+    /// the original three-argument constructor source-compatible, but leaves
+    /// [`cancellation_token`](Self::cancellation_token) as `None`; attach the
+    /// task's lifecycle token with
+    /// [`with_cancellation_token`](Self::with_cancellation_token) before
+    /// returning it to the router.
     ///
     /// # Example
     ///
@@ -501,7 +678,20 @@ impl TaskResumeContext {
             tool_name: tool_name.into(),
             arguments,
             input_responses,
+            cancellation_token: None,
         }
+    }
+
+    /// Attach the cancellation and expiry signal for replayed execution.
+    ///
+    /// [`Self::new`] intentionally keeps its original three arguments for
+    /// source compatibility. Stores that support resumption should call this
+    /// builder with the token associated with the task so expiry can stop a
+    /// replayed handler even when that handler does not poll cooperatively.
+    #[must_use]
+    pub fn with_cancellation_token(mut self, token: CancellationToken) -> Self {
+        self.cancellation_token = Some(token);
+        self
     }
 }
 
@@ -509,52 +699,6 @@ impl AppliedInputResponses {
     /// Whether every outstanding request has now been answered.
     pub fn is_complete(&self) -> bool {
         self.still_outstanding.is_empty()
-    }
-}
-
-/// A shareable cancellation token for task management
-///
-/// Handed back by [`TaskStore::create_task`] and raised by
-/// [`TaskStore::cancel_task`]. It is cooperative: setting it does not
-/// interrupt anything, so long-running work has to check it between steps to
-/// notice. Every clone observes the same flag, and it is never lowered again.
-#[derive(Debug, Clone)]
-pub struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
-}
-
-impl CancellationToken {
-    /// Create a new, un-cancelled token.
-    ///
-    /// [`TaskStore::create_task`] has to return one of these, so without a
-    /// public constructor the trait could not be implemented outside this
-    /// crate at all: a struct literal fails with `E0451` and there is nothing
-    /// else to hand back. A SQLite, Redis, or Postgres store is exactly the
-    /// case the trait exists for (#1293).
-    ///
-    /// What an implementor can rely on: the token is cooperative, so raising
-    /// it interrupts nothing by itself; every clone observes the same flag;
-    /// and it is never lowered once raised.
-    pub fn new() -> Self {
-        Self {
-            cancelled: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    /// Check if cancellation has been requested
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Relaxed)
-    }
-
-    /// Request cancellation
-    pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
-    }
-}
-
-impl Default for CancellationToken {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -682,10 +826,14 @@ pub type TaskSnapshot = (TaskObject, Option<CallToolResult>, Option<JsonRpcError
 ///   `None` once `ttlMs` has elapsed since creation, whether or not the entry
 ///   has actually been reclaimed, so callers cannot probe for the existence of
 ///   a task whose retention window has closed.
-/// - [`cancel_task`](Self::cancel_task) must signal the task's
-///   [`CancellationToken`] even if the task is already terminal.
+/// - [`cancel_task`](Self::cancel_task) and TTL expiry must signal the task's
+///   [`CancellationToken`] even if the task is already terminal. The token is
+///   a persistent signal and may be awaited, so it must be the same
+///   cancellation domain returned from creation and carried through
+///   [`TaskResumeContext`].
 /// - [`wait_for_completion`](Self::wait_for_completion) blocks until the task
-///   reaches a terminal state; how an implementation waits (notification,
+///   reaches a terminal state or expires. Expiry wakes an existing waiter,
+///   which then returns `None`; how an implementation waits (notification,
 ///   polling, pub/sub) is an implementation detail and must not leak into the
 ///   trait.
 ///
@@ -831,6 +979,10 @@ pub trait TaskStore: Send + Sync + 'static {
     /// Create and store a new task owned by `owner`.
     ///
     /// Returns the task ID and a cancellation token for the spawned work.
+    /// The token is awaitable and must be raised both by explicit cancellation
+    /// and when the task's TTL elapses. An external store backed by a remote
+    /// database is responsible for bridging its durable expiry signal to this
+    /// process-local token.
     /// `owner` is the authenticated principal responsible for the task, or
     /// `None` when the request carried no authenticated context.
     async fn create_task(
@@ -875,8 +1027,8 @@ pub trait TaskStore: Send + Sync + 'static {
     /// Wait for a task to reach a terminal state, then return its snapshot.
     ///
     /// If the task is already terminal, returns immediately. Otherwise blocks
-    /// until the task completes, fails, or is cancelled. Returns `None` if
-    /// the task is unknown.
+    /// until the task completes, fails, is cancelled, or expires. Returns
+    /// `None` if the task is unknown or expires while waiting.
     async fn wait_for_completion(&self, task_id: &str) -> Result<Option<TaskSnapshot>>;
 
     /// List all tasks, optionally filtered by status.
@@ -1165,6 +1317,12 @@ pub trait TaskStore: Send + Sync + 'static {
     /// before resumption existed keeps compiling and fails loudly instead of
     /// hanging; implement it to support the flow (#1208).
     ///
+    /// The returned context must also carry the task's cancellation/expiry
+    /// signal. Construct it with [`TaskResumeContext::new`] and attach the
+    /// token with [`TaskResumeContext::with_cancellation_token`]. Reusing the
+    /// signal returned from [`create_task`](Self::create_task) lets the router
+    /// stop a replayed handler exactly when the task expires.
+    ///
     /// # Example
     ///
     /// The answers accumulate across rounds, because the handler is re-run
@@ -1366,16 +1524,191 @@ pub trait TaskStore: Send + Sync + 'static {
     async fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Result<Option<TaskObject>>;
 }
 
+#[derive(Debug, Default)]
+struct WorkerSignalState {
+    generation: u64,
+    shutdown: bool,
+}
+
+/// Condvar used only to reschedule or stop the memory-store worker.
+///
+/// It is deliberately separate from [`MemoryTaskStoreState`]. The worker may
+/// hold this strongly while it sleeps, but holds only a [`Weak`] reference to
+/// the actual task state, so dropping the final store clone is enough to stop
+/// and release the state.
+#[derive(Debug, Default)]
+struct WorkerSignal {
+    state: Mutex<WorkerSignalState>,
+    changed: Condvar,
+}
+
+impl WorkerSignal {
+    fn generation(&self) -> Option<u64> {
+        let state = self.state.lock().ok()?;
+        (!state.shutdown).then_some(state.generation)
+    }
+
+    fn wake(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.generation = state.generation.wrapping_add(1);
+            self.changed.notify_one();
+        }
+    }
+
+    fn shutdown(&self) {
+        if let Ok(mut state) = self.state.lock() {
+            state.shutdown = true;
+            state.generation = state.generation.wrapping_add(1);
+            self.changed.notify_all();
+        }
+    }
+
+    /// Returns true when shutdown was requested.
+    fn wait_for_change(&self, generation: u64, timeout: Duration) -> bool {
+        let Ok(state) = self.state.lock() else {
+            return true;
+        };
+        if state.shutdown {
+            return true;
+        }
+        if state.generation != generation {
+            return false;
+        }
+        match self.changed.wait_timeout(state, timeout) {
+            Ok((state, _)) => state.shutdown,
+            Err(_) => true,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct Retirement {
+    signalled: usize,
+    removed: usize,
+}
+
+#[derive(Debug)]
+struct MemoryTaskStoreState {
+    tasks: RwLock<HashMap<String, StoredTask>>,
+    config: MemoryTaskStoreConfig,
+    worker_signal: Arc<WorkerSignal>,
+    worker_started: OnceLock<std::result::Result<(), String>>,
+}
+
+impl MemoryTaskStoreState {
+    fn retire_expired(&self, remove: bool) -> Retirement {
+        let Ok(mut tasks) = self.tasks.write() else {
+            return Retirement::default();
+        };
+        let now = Instant::now();
+        let mut retirement = Retirement::default();
+        for task in tasks.values_mut() {
+            if task.is_expired_at(now) && task.signal_expiry() {
+                retirement.signalled += 1;
+            }
+        }
+        if remove {
+            let before = tasks.len();
+            tasks.retain(|_, task| !task.is_expired_at(now));
+            retirement.removed = before - tasks.len();
+        }
+        retirement
+    }
+
+    fn next_expiry(&self) -> Option<Instant> {
+        self.tasks
+            .read()
+            .ok()?
+            .values()
+            .filter_map(|task| {
+                (!task.expiry_signalled)
+                    .then(|| task.expires_at())
+                    .flatten()
+            })
+            .min()
+    }
+}
+
+impl Drop for MemoryTaskStoreState {
+    fn drop(&mut self) {
+        self.worker_signal.shutdown();
+    }
+}
+
+fn next_deadline(a: Option<Instant>, b: Option<Instant>) -> Option<Instant> {
+    match (a, b) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(deadline), None) | (None, Some(deadline)) => Some(deadline),
+        (None, None) => None,
+    }
+}
+
+fn memory_task_store_worker(state: Weak<MemoryTaskStoreState>, signal: Arc<WorkerSignal>) {
+    const MAX_SLEEP: Duration = Duration::from_secs(60 * 60);
+
+    let Some(initial) = state.upgrade() else {
+        return;
+    };
+    let cleanup_interval = if initial.config.cleanup_interval.is_zero() {
+        Duration::from_millis(1)
+    } else {
+        initial.config.cleanup_interval
+    };
+    let mut cleanup_at = Instant::now().checked_add(cleanup_interval);
+    drop(initial);
+
+    loop {
+        let Some(state) = state.upgrade() else {
+            break;
+        };
+        let Some(generation) = signal.generation() else {
+            break;
+        };
+
+        let now = Instant::now();
+        if cleanup_at.is_some_and(|deadline| now >= deadline) {
+            state.retire_expired(true);
+            // Measure the cadence from the end of the pass. With a short
+            // interval and a large map, measuring from `now` above could make
+            // an O(n) pass immediately overdue and keep the worker hot.
+            cleanup_at = Instant::now().checked_add(cleanup_interval);
+        } else {
+            // Expiry signalling is independent from physical cleanup.
+            state.retire_expired(false);
+        }
+
+        let deadline = next_deadline(cleanup_at, state.next_expiry());
+        let timeout = deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+            .unwrap_or(MAX_SLEEP)
+            .min(MAX_SLEEP);
+        drop(state);
+
+        // Comparing generations under the condvar lock closes the gap between
+        // computing `deadline` and beginning the wait: create_task/set_ttl
+        // cannot deliver a notification that gets lost in that window.
+        if signal.wait_for_change(generation, timeout) {
+            break;
+        }
+    }
+}
+
 /// In-memory [`TaskStore`] backed by a `HashMap`.
 ///
 /// This is the default store. Suitable for single-instance deployments. For
 /// horizontal scaling, use an external store that shares state across
-/// instances. Completion wakeups for
+/// instances. A lazy background worker signals task expiry at its exact TTL
+/// deadline and physically removes expired records at the configured cleanup
+/// interval. It uses a standard thread rather than assuming construction
+/// happens inside a Tokio runtime, and holds only weak task state while
+/// sleeping.
+///
+/// Completion wakeups for
 /// [`wait_for_completion`](TaskStore::wait_for_completion) use a per-task
 /// [`tokio::sync::Notify`], which is an implementation detail of this store.
 #[derive(Debug, Clone)]
 pub struct MemoryTaskStore {
-    tasks: Arc<RwLock<HashMap<String, Task>>>,
+    state: Arc<MemoryTaskStoreState>,
 }
 
 impl Default for MemoryTaskStore {
@@ -1385,20 +1718,48 @@ impl Default for MemoryTaskStore {
 }
 
 impl MemoryTaskStore {
-    /// Create a new task store
+    /// Create a task store with the five-minute default TTL and one-minute
+    /// cleanup interval.
     pub fn new() -> Self {
+        Self::with_config(MemoryTaskStoreConfig::default())
+    }
+
+    /// Create a task store with an explicit lifecycle policy.
+    pub fn with_config(config: MemoryTaskStoreConfig) -> Self {
         Self {
-            tasks: Arc::new(RwLock::new(HashMap::new())),
+            state: Arc::new(MemoryTaskStoreState {
+                tasks: RwLock::new(HashMap::new()),
+                config,
+                worker_signal: Arc::new(WorkerSignal::default()),
+                worker_started: OnceLock::new(),
+            }),
         }
     }
 
-    /// Remove expired tasks (call periodically for cleanup).
+    fn ensure_worker(&self) -> Result<()> {
+        let weak = Arc::downgrade(&self.state);
+        let signal = self.state.worker_signal.clone();
+        match self.state.worker_started.get_or_init(|| {
+            std::thread::Builder::new()
+                .name("tower-mcp-task-expiry".to_string())
+                .spawn(move || memory_task_store_worker(weak, signal))
+                .map(drop)
+                .map_err(|error| format!("failed to start task expiry worker: {error}"))
+        }) {
+            Ok(()) => Ok(()),
+            Err(error) => Err(TaskStoreError::Backend(error.clone())),
+        }
+    }
+
+    /// Remove expired tasks immediately.
     ///
     /// Returns the number removed. Not part of the [`TaskStore`] trait;
     /// external backends typically expire entries natively (e.g. Redis TTL).
     ///
-    /// Calling this is an optimization, not a correctness requirement: reads
-    /// already treat an expired task as absent.
+    /// The configured worker already calls this retirement path periodically;
+    /// applications may call it to reclaim memory sooner. Calling it is an
+    /// optimization, not a correctness requirement: expiry has already
+    /// cancelled work, woken waiters, and made the task read as absent.
     ///
     /// # Example
     ///
@@ -1426,19 +1787,13 @@ impl MemoryTaskStore {
     /// # }
     /// ```
     pub fn cleanup_expired(&self) -> usize {
-        if let Ok(mut tasks) = self.tasks.write() {
-            let before = tasks.len();
-            tasks.retain(|_, t| !t.is_expired());
-            before - tasks.len()
-        } else {
-            0
-        }
+        self.state.retire_expired(true).removed
     }
 
     /// Get the number of tasks in the store
     #[cfg(test)]
     pub fn len(&self) -> usize {
-        if let Ok(tasks) = self.tasks.read() {
+        if let Ok(tasks) = self.state.tasks.read() {
             tasks.len()
         } else {
             0
@@ -1461,19 +1816,23 @@ impl TaskStore for MemoryTaskStore {
         ttl: Option<u64>,
         owner: TaskOwner,
     ) -> Result<(String, CancellationToken)> {
+        self.ensure_worker()?;
         let id = generate_task_id();
+        let ttl = ttl.unwrap_or_else(|| duration_millis_saturated(self.state.config.default_ttl));
         let task = Task::new(id.clone(), tool_name.to_string(), arguments, ttl, owner);
         let token = task.cancellation_token.clone();
 
-        if let Ok(mut tasks) = self.tasks.write() {
-            tasks.insert(id.clone(), task);
+        if let Ok(mut tasks) = self.state.tasks.write() {
+            tasks.insert(id.clone(), StoredTask::new(task));
         }
+        self.state.worker_signal.wake();
 
         Ok((id, token))
     }
 
     async fn get_task(&self, task_id: &str) -> Result<Option<TaskObject>> {
-        Ok(if let Ok(tasks) = self.tasks.read() {
+        self.state.retire_expired(false);
+        Ok(if let Ok(tasks) = self.state.tasks.read() {
             tasks
                 .get(task_id)
                 .filter(|t| !t.is_expired())
@@ -1484,7 +1843,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn set_task_meta(&self, task_id: &str, meta: serde_json::Value) -> Result<bool> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|task| !task.is_expired()) else {
@@ -1496,6 +1856,7 @@ impl TaskStore for MemoryTaskStore {
 
     async fn discard_task(&self, task_id: &str) -> Result<bool> {
         Ok(self
+            .state
             .tasks
             .write()
             .ok()
@@ -1504,7 +1865,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn task_owner(&self, task_id: &str) -> Result<Option<TaskOwner>> {
-        Ok(if let Ok(tasks) = self.tasks.read() {
+        self.state.retire_expired(false);
+        Ok(if let Ok(tasks) = self.state.tasks.read() {
             tasks
                 .get(task_id)
                 .filter(|t| !t.is_expired())
@@ -1519,7 +1881,8 @@ impl TaskStore for MemoryTaskStore {
     /// existed (#1249). One read resolves both, so expiry cannot change
     /// between deciding presence and reading the owner.
     async fn task_presence(&self, task_id: &str) -> Result<TaskPresence> {
-        let Ok(tasks) = self.tasks.read() else {
+        self.state.retire_expired(false);
+        let Ok(tasks) = self.state.tasks.read() else {
             return Ok(TaskPresence::Missing);
         };
         Ok(match tasks.get(task_id) {
@@ -1534,7 +1897,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn get_task_result(&self, task_id: &str) -> Result<Option<TaskSnapshot>> {
-        Ok(if let Ok(tasks) = self.tasks.read() {
+        self.state.retire_expired(false);
+        Ok(if let Ok(tasks) = self.state.tasks.read() {
             tasks
                 .get(task_id)
                 .filter(|t| !t.is_expired())
@@ -1545,9 +1909,11 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn wait_for_completion(&self, task_id: &str) -> Result<Option<TaskSnapshot>> {
-        // First check if already terminal and get the notify handle
-        let notify = {
-            let Ok(tasks) = self.tasks.read() else {
+        self.state.retire_expired(false);
+        // Register the wait while holding the read lock, so a transition
+        // cannot notify between the state check and waiter registration.
+        let (mut notified, cancellation) = {
+            let Ok(tasks) = self.state.tasks.read() else {
                 return Ok(None);
             };
             let Some(task) = tasks.get(task_id).filter(|t| !t.is_expired()) else {
@@ -1560,18 +1926,38 @@ impl TaskStore for MemoryTaskStore {
                     task.error.clone(),
                 )));
             }
-            task.completion_notify.clone()
+            let mut notified = Box::pin(task.completion_notify.clone().notified_owned());
+            let _ = notified.as_mut().enable();
+            (notified, task.cancellation_token.clone())
         };
 
-        // Wait for completion notification
-        notify.notified().await;
+        let cancellation_fired = tokio::select! {
+            _ = &mut notified => false,
+            _ = cancellation.cancelled() => true,
+        };
+
+        if cancellation_fired {
+            match self.get_task_result(task_id).await? {
+                // A live handler receives the store token directly and owns
+                // cooperative teardown. Explicit cancellation can therefore
+                // raise the token before the handler confirms a terminal
+                // state. Keep waiting on the already-enabled notification in
+                // that case; expiry returned `None` above and terminal
+                // cancellation returned a terminal snapshot.
+                Some((task, _, _)) if !task.status.is_terminal() => {
+                    notified.await;
+                }
+                snapshot => return Ok(snapshot),
+            }
+        }
 
         // Read the result
         self.get_task_result(task_id).await
     }
 
     async fn list_tasks(&self, status_filter: Option<TaskStatus>) -> Result<Vec<TaskObject>> {
-        Ok(if let Ok(tasks) = self.tasks.read() {
+        self.state.retire_expired(false);
+        Ok(if let Ok(tasks) = self.state.tasks.read() {
             tasks
                 .values()
                 .filter(|t| !t.is_expired())
@@ -1589,7 +1975,8 @@ impl TaskStore for MemoryTaskStore {
         requests: InputRequests,
         message: Option<&str>,
     ) -> Result<bool> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1658,7 +2045,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn outstanding_input_requests(&self, task_id: &str) -> Result<Option<InputRequests>> {
-        Ok(if let Ok(tasks) = self.tasks.read() {
+        self.state.retire_expired(false);
+        Ok(if let Ok(tasks) = self.state.tasks.read() {
             tasks
                 .get(task_id)
                 .filter(|t| !t.is_expired())
@@ -1673,7 +2061,8 @@ impl TaskStore for MemoryTaskStore {
         task_id: &str,
         responses: InputResponses,
     ) -> Result<Option<AppliedInputResponses>> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(None);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1719,7 +2108,8 @@ impl TaskStore for MemoryTaskStore {
                 "set_status is for non-terminal progress; use complete_task, fail_task, or cancel_task to reach {status:?}"
             )));
         }
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1737,7 +2127,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn resume_context(&self, task_id: &str) -> Result<Option<TaskResumeContext>> {
-        let Ok(tasks) = self.tasks.read() else {
+        self.state.retire_expired(false);
+        let Ok(tasks) = self.state.tasks.read() else {
             return Ok(None);
         };
         Ok(tasks
@@ -1749,23 +2140,34 @@ impl TaskStore for MemoryTaskStore {
                     task.arguments.clone(),
                     task.input_responses.clone(),
                 )
+                .with_cancellation_token(task.cancellation_token.clone())
             }))
     }
 
     async fn set_ttl(&self, task_id: &str, ttl_ms: u64) -> Result<bool> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
-        let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
+        let Some(task) = tasks.get_mut(task_id) else {
             return Ok(false);
         };
+        if task.is_expired() {
+            task.signal_expiry();
+            return Ok(false);
+        }
         task.ttl = ttl_ms;
         task.last_updated_at_str = chrono_now_iso8601();
+        if task.is_expired() {
+            task.signal_expiry();
+        }
+        drop(tasks);
+        self.state.worker_signal.wake();
         Ok(true)
     }
 
     async fn complete_task(&self, task_id: &str, result: CallToolResult) -> Result<bool> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1785,7 +2187,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn fail_task(&self, task_id: &str, error: JsonRpcError) -> Result<bool> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(false);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1805,7 +2208,8 @@ impl TaskStore for MemoryTaskStore {
     }
 
     async fn cancel_task(&self, task_id: &str, reason: Option<&str>) -> Result<Option<TaskObject>> {
-        let Ok(mut tasks) = self.tasks.write() else {
+        self.state.retire_expired(false);
+        let Ok(mut tasks) = self.state.tasks.write() else {
             return Ok(None);
         };
         let Some(task) = tasks.get_mut(task_id).filter(|t| !t.is_expired()) else {
@@ -1972,6 +2376,7 @@ mod tests {
 
         assert_eq!(context.tool_name, "build_report");
         assert_eq!(context.arguments, serde_json::json!({"format": "pdf"}));
+        assert!(context.cancellation_token.is_none());
         assert_eq!(
             serde_json::to_value(&context.input_responses).unwrap(),
             serde_json::to_value(&input_responses).unwrap()
@@ -1996,6 +2401,187 @@ mod tests {
             .expect("task should exist");
         assert_eq!(info.task_id, id);
         assert_eq!(info.status, TaskStatus::Working);
+        assert_eq!(info.ttl, Some(300_000));
+    }
+
+    #[tokio::test]
+    async fn configured_default_ttl_is_used_when_creation_omits_one() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default().default_ttl(Duration::from_secs(42)),
+        );
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.get_task(&id).await.unwrap().unwrap().ttl,
+            Some(42_000)
+        );
+    }
+
+    #[tokio::test]
+    async fn working_task_expiry_cancels_and_wakes_completion_waiter() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default()
+                .default_ttl(Duration::from_secs(60))
+                .cleanup_interval(Duration::from_secs(60)),
+        );
+        let (id, cancellation) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+
+        let waiting_store = store.clone();
+        let waiting_id = id.clone();
+        let waiter = tokio::spawn(async move {
+            waiting_store
+                .wait_for_completion(&waiting_id)
+                .await
+                .unwrap()
+        });
+
+        // Poll the waiter to pending while the long initial TTL guarantees
+        // that expiry cannot win setup under a stalled CI process.
+        let mut waiter = waiter;
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+                .await
+                .is_err()
+        );
+        assert!(store.set_ttl(&id, 0).await.unwrap());
+
+        tokio::time::timeout(Duration::from_secs(2), cancellation.cancelled())
+            .await
+            .expect("expiry did not cancel the task token");
+        let snapshot = tokio::time::timeout(Duration::from_secs(2), waiter)
+            .await
+            .expect("expiry did not wake the completion waiter")
+            .unwrap();
+        assert!(
+            snapshot.is_none(),
+            "an expired task has no visible snapshot"
+        );
+        assert!(matches!(
+            store.task_presence(&id).await.unwrap(),
+            TaskPresence::Expired { .. }
+        ));
+        assert!(
+            !store
+                .complete_task(&id, CallToolResult::text("late"))
+                .await
+                .unwrap(),
+            "a terminal write must not resurrect an expired task"
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_cleanup_physically_reclaims_expired_tasks() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default()
+                .default_ttl(Duration::from_secs(60))
+                .cleanup_interval(Duration::from_millis(25)),
+        );
+        let (id, _) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+        assert_eq!(store.len(), 1);
+        assert!(store.set_ttl(&id, 0).await.unwrap());
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !store.is_empty() {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("automatic cleanup did not reclaim the expired record");
+    }
+
+    #[tokio::test]
+    async fn shortening_ttl_reschedules_expiry_from_creation() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default()
+                .default_ttl(Duration::from_secs(60))
+                .cleanup_interval(Duration::from_secs(60)),
+        );
+        let (id, cancellation) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+
+        assert!(store.set_ttl(&id, 250).await.unwrap());
+        tokio::time::timeout(Duration::from_secs(3), cancellation.cancelled())
+            .await
+            .expect("shorter TTL did not reschedule the expiry wakeup");
+        assert!(store.get_task(&id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn manual_and_scheduled_retirement_signal_expiry_only_once() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default()
+                .default_ttl(Duration::from_secs(60))
+                .cleanup_interval(Duration::from_secs(60)),
+        );
+        let (id, cancellation) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+
+        // Mutate under the private store lock without waking the worker. This
+        // makes the two retirement passes deterministic while exercising the
+        // same one-shot path used by both manual and scheduled cleanup.
+        store.state.tasks.write().unwrap().get_mut(&id).unwrap().ttl = 0;
+        let first = store.state.retire_expired(false);
+        let second = store.state.retire_expired(false);
+        assert_eq!(first.signalled + second.signalled, 1);
+        assert!(cancellation.is_cancelled());
+        assert_eq!(store.cleanup_expired(), 1);
+        assert_eq!(store.cleanup_expired(), 0);
+    }
+
+    #[tokio::test]
+    async fn dropping_the_last_store_clone_releases_worker_state() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default().cleanup_interval(Duration::from_secs(60)),
+        );
+        store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+        let weak = Arc::downgrade(&store.state);
+        drop(store);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while weak.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the expiry worker retained the store's task state");
+    }
+
+    #[test]
+    fn creating_a_task_does_not_require_a_tokio_runtime() {
+        let store = MemoryTaskStore::with_config(
+            MemoryTaskStoreConfig::default()
+                .default_ttl(Duration::from_secs(60))
+                .cleanup_interval(Duration::from_secs(60)),
+        );
+        let (id, token) = futures::executor::block_on(store.create_task(
+            "test-tool",
+            serde_json::json!({}),
+            None,
+            None,
+        ))
+        .expect("the standard-thread worker should start without Tokio");
+
+        assert!(!token.is_cancelled());
+        assert!(
+            futures::executor::block_on(store.get_task(&id))
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[tokio::test]
@@ -2185,6 +2771,36 @@ mod tests {
         assert_eq!(task_obj.status, TaskStatus::Completed);
         assert!(result.is_some());
         assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn wait_for_completion_does_not_treat_live_cancellation_signal_as_terminal() {
+        let store = MemoryTaskStore::new();
+        let (id, cancellation) = store
+            .create_task("test-tool", serde_json::json!({}), None, None)
+            .await
+            .unwrap();
+        let waiter_store = store.clone();
+        let waiter_id = id.clone();
+        let mut waiter =
+            tokio::spawn(
+                async move { waiter_store.wait_for_completion(&waiter_id).await.unwrap() },
+            );
+
+        cancellation.cancel();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut waiter)
+                .await
+                .is_err(),
+            "the cooperative signal alone must not return a working snapshot"
+        );
+
+        store
+            .cancel_task(&id, Some("teardown complete"))
+            .await
+            .unwrap();
+        let (task, _, _) = waiter.await.unwrap().unwrap();
+        assert_eq!(task.status, TaskStatus::Cancelled);
     }
 
     #[tokio::test]

--- a/crates/tower-mcp/src/lib.rs
+++ b/crates/tower-mcp/src/lib.rs
@@ -597,7 +597,7 @@ pub use apps::{
     McpUiResourceCsp, McpUiResourceMeta, McpUiToolMeta, McpUiToolVisibility, mcp_app_tool_result,
     mcp_apps_extension,
 };
-pub use async_task::{MemoryTaskStore, Task, TaskPresence, TaskStore};
+pub use async_task::{MemoryTaskStore, MemoryTaskStoreConfig, Task, TaskPresence, TaskStore};
 pub use client::{
     ChannelTransport, ClientHandler, ClientTransport, McpClient, McpClientBuilder,
     NotificationHandler, StdioClientTransport,

--- a/crates/tower-mcp/src/router.rs
+++ b/crates/tower-mcp/src/router.rs
@@ -758,19 +758,25 @@ impl McpRouter {
 
     /// Configure a pluggable [`TaskStore`] for async task state.
     ///
-    /// The default is an in-process [`MemoryTaskStore`]. Supply an external
-    /// store (Redis, Postgres, etc.) to share task state across server
-    /// instances behind a load balancer, so `tasks/get` works regardless of
-    /// which instance created the task (SEP-2663).
+    /// The default is an in-process [`MemoryTaskStore`] with a five-minute task
+    /// TTL and one-minute cleanup cadence. Supply a configured memory store to
+    /// choose the final-protocol task lifetime, or an external store (Redis,
+    /// Postgres, etc.) to share task state across server instances behind a
+    /// load balancer, so `tasks/get` works regardless of which instance
+    /// created the task (SEP-2663).
     ///
     /// # Example
     ///
     /// ```rust
     /// use std::sync::Arc;
+    /// use std::time::Duration;
     /// use tower_mcp::McpRouter;
-    /// use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+    /// use tower_mcp::async_task::{MemoryTaskStore, MemoryTaskStoreConfig, TaskStore};
     ///
-    /// let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::new());
+    /// let config = MemoryTaskStoreConfig::default()
+    ///     .default_ttl(Duration::from_secs(30 * 60))
+    ///     .cleanup_interval(Duration::from_secs(30));
+    /// let store: Arc<dyn TaskStore> = Arc::new(MemoryTaskStore::with_config(config));
     /// let router = McpRouter::new().task_store(store);
     /// ```
     pub fn task_store(mut self, store: Arc<dyn TaskStore>) -> Self {
@@ -2079,6 +2085,16 @@ impl McpRouter {
 
                     tracing::info!(task_id = %task_id, tool = %params.name, "Created async task");
 
+                    // Host/client cancellation keeps its first-wins reason in
+                    // the live-execution registry. Store expiry is a separate
+                    // persistent signal with no reason; observe both without
+                    // letting expiry overwrite that cancellation policy.
+                    if let Some(admission) = live_admission.as_ref() {
+                        admission
+                            .cancellation()
+                            .attach_task_lifecycle(cancellation_token.clone());
+                    }
+
                     // Create a context for the async task execution
                     let progress_token = params.meta.and_then(|m| m.progress_token);
                     let ctx = self.create_context_with_extensions(
@@ -2097,10 +2113,22 @@ impl McpRouter {
                     };
                     let mut ctx = ctx;
                     ctx.extensions_mut().insert(task_context.clone());
-                    let preparation = match tool
-                        .prepare_task(task_context, params.arguments.clone())
-                        .await
-                    {
+                    let preparation = match tokio::select! {
+                        biased;
+                        _ = cancellation_token.cancelled() => {
+                            discard_unprepared_task(&task_store, &task_id).await;
+                            return Err(self.task_error(
+                                TaskOperation::Create,
+                                Some(&task_id),
+                                TaskFailure::Internal(
+                                    "Task cancellation or expiry interrupted preparation",
+                                ),
+                            ));
+                        }
+                        preparation = tool.prepare_task(task_context, params.arguments.clone()) => {
+                            preparation
+                        }
+                    } {
                         Ok(preparation) => preparation,
                         Err(error) => {
                             discard_unprepared_task(&task_store, &task_id).await;
@@ -2157,9 +2185,6 @@ impl McpRouter {
                             input_ready: tokio::sync::Notify::new(),
                             cancellation: cancellation.clone(),
                         });
-                        if cancellation_token.is_cancelled() {
-                            cancellation.cancel(None);
-                        }
                         // Promotion replaces the anonymous preparation
                         // reservation with an ID-bearing registration under a
                         // single lock. It happens before spawn, so close +
@@ -2311,10 +2336,27 @@ impl McpRouter {
                         // answers with `tasks/update` and the router resumes
                         // it (#1208).
                         let start = std::time::Instant::now();
-                        let outcome = notifier
-                            .invoke_tool(&tool, ctx, arguments, &tool_name)
-                            .await;
+                        // Ordinary task handlers do not own a cooperative
+                        // teardown contract. Race the invocation against the
+                        // persistent store token so expiry (and explicit
+                        // cancellation) drops even a handler that never polls.
+                        let outcome = tokio::select! {
+                            biased;
+                            _ = cancellation_token.cancelled() => None,
+                            outcome = notifier.invoke_tool(&tool, ctx, arguments, &tool_name) => {
+                                Some(outcome)
+                            }
+                        };
                         let duration_ms = start.elapsed().as_secs_f64() * 1000.0;
+
+                        let Some(outcome) = outcome else {
+                            tracing::debug!(
+                                task_id = %task_id_clone,
+                                "Task execution stopped by cancellation or expiry"
+                            );
+                            notifier.notify_task_state(&task_id_clone).await;
+                            return;
+                        };
 
                         let result = match outcome {
                             Ok(crate::protocol::RequestOutcome::Complete(result)) => result,

--- a/crates/tower-mcp/src/router/task_error_tests.rs
+++ b/crates/tower-mcp/src/router/task_error_tests.rs
@@ -638,37 +638,73 @@ async fn resume_store_failures_are_mapped_and_persisted_without_backend_details(
 }
 
 #[tokio::test]
-async fn absent_resume_state_and_missing_tools_use_typed_safe_failures() {
+async fn absent_resume_state_token_and_tools_use_typed_safe_failures() {
     const SECRET_TOOL: &str = "private.provider.secret-tool";
+    let handler_calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let invoked = handler_calls.clone();
+    let registered = ToolBuilder::new("registered-but-tokenless")
+        .handler(move |_input: serde_json::Value| {
+            let invoked = invoked.clone();
+            async move {
+                invoked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(CallToolResult::text("must not run"))
+            }
+        })
+        .build();
     let store = Arc::new(
         ScriptedTaskStore::default()
             .with_resumes([
                 Ok(None),
-                Ok(Some(crate::async_task::TaskResumeContext {
-                    tool_name: SECRET_TOOL.to_string(),
-                    arguments: serde_json::json!({}),
-                    input_responses: Default::default(),
-                })),
+                Ok(Some(crate::async_task::TaskResumeContext::new(
+                    "registered-but-tokenless",
+                    serde_json::json!({}),
+                    Default::default(),
+                ))),
+                Ok(Some(
+                    crate::async_task::TaskResumeContext::new(
+                        SECRET_TOOL,
+                        serde_json::json!({}),
+                        Default::default(),
+                    )
+                    .with_cancellation_token(crate::async_task::CancellationToken::new()),
+                )),
             ])
-            .with_failure_results([Ok(true), Ok(true)]),
+            .with_failure_results([Ok(true), Ok(true), Ok(true)]),
     );
     let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let tokenless_failures = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let recorded = calls.clone();
+    let recorded_tokenless = tokenless_failures.clone();
     let router = McpRouter::new()
+        .tool(registered)
         .task_store(store.clone())
         .task_error_policy(TaskErrorPolicy::new(move |context| {
             recorded.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             assert_eq!(context.operation(), TaskOperation::Resume);
             assert!(matches!(context.failure(), TaskFailure::Internal(_)));
+            if matches!(
+                context.failure(),
+                TaskFailure::Internal(message)
+                    if message.contains("cancellation and expiry token")
+            ) {
+                recorded_tokenless.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            }
             JsonRpcError::internal_error("mapped safe resume failure")
         }));
 
     router.resume_task("task_scripted").await;
     router.resume_task("task_scripted").await;
+    router.resume_task("task_scripted").await;
+    tokio::task::yield_now().await;
 
-    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 2);
+    assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 3);
+    assert_eq!(
+        tokenless_failures.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    assert_eq!(handler_calls.load(std::sync::atomic::Ordering::SeqCst), 0);
     let failures = store.recorded_failures.lock().unwrap();
-    assert_eq!(failures.len(), 2);
+    assert_eq!(failures.len(), 3);
     assert!(
         failures
             .iter()

--- a/crates/tower-mcp/src/router/task_ops.rs
+++ b/crates/tower-mcp/src/router/task_ops.rs
@@ -544,6 +544,21 @@ impl McpRouter {
             }
         };
 
+        let Some(cancellation_token) = resume.cancellation_token.clone() else {
+            let error = self.task_json_rpc_error(
+                TaskOperation::Resume,
+                Some(task_id),
+                TaskFailure::Internal(
+                    "this task store returned a resume context without the task's \
+                     cancellation and expiry token; attach it with \
+                     TaskResumeContext::with_cancellation_token",
+                ),
+            );
+            self.record_task_failure(task_id, error).await;
+            self.notify_task_state(task_id).await;
+            return;
+        };
+
         // Static tools first, then dynamic, matching `tools/call`.
         let tool = self.inner.tools.get(&resume.tool_name).cloned();
         #[cfg(feature = "dynamic-tools")]
@@ -593,9 +608,24 @@ impl McpRouter {
         let task_id = task_id.to_string();
         let notifier = self.clone();
         tokio::spawn(async move {
-            let outcome = notifier
-                .invoke_tool(&tool, ctx, resume.arguments, &resume.tool_name)
-                .await;
+            // A replay is ordinary execution, not a live handler with a
+            // cooperative teardown contract. Expiry must therefore win even
+            // when the re-invoked handler never polls its RequestContext.
+            let outcome = tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => None,
+                outcome = notifier.invoke_tool(&tool, ctx, resume.arguments, &resume.tool_name) => {
+                    Some(outcome)
+                }
+            };
+            let Some(outcome) = outcome else {
+                tracing::debug!(
+                    task_id = %task_id,
+                    "replayed task execution stopped by cancellation or expiry"
+                );
+                notifier.notify_task_state(&task_id).await;
+                return;
+            };
             let result = match outcome {
                 Ok(crate::protocol::RequestOutcome::Complete(result)) => result,
                 // A handler may ask again; each round parks and resumes the

--- a/crates/tower-mcp/src/router/tests.rs
+++ b/crates/tower-mcp/src/router/tests.rs
@@ -2708,6 +2708,253 @@ async fn a_task_resumes_after_its_input_is_answered() {
     );
 }
 
+/// #1389: an ordinary task handler may never poll RequestContext. The router
+/// owns that future, so it must drop it when the store's TTL token fires rather
+/// than leaving unreachable work running forever.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn expiry_stops_an_ordinary_task_handler_that_never_polls() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::async_task::{MemoryTaskStore, MemoryTaskStoreConfig, TaskPresence, TaskStore};
+
+    struct CountDrop(std::sync::Arc<AtomicUsize>);
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let started = std::sync::Arc::new(AtomicUsize::new(0));
+    let dropped = std::sync::Arc::new(AtomicUsize::new(0));
+    let handler_started = started.clone();
+    let handler_dropped = dropped.clone();
+    let hangs = ToolBuilder::new("hangs")
+        .description("Never returns or polls cancellation")
+        .task_support(TaskSupportMode::Optional)
+        .handler(move |_input: serde_json::Value| {
+            let started = handler_started.clone();
+            let dropped = handler_dropped.clone();
+            async move {
+                let _drop = CountDrop(dropped);
+                started.fetch_add(1, Ordering::SeqCst);
+                std::future::pending::<()>().await;
+                Ok(CallToolResult::text("unreachable"))
+            }
+        })
+        .build();
+
+    let store = std::sync::Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::default()
+            .default_ttl(std::time::Duration::from_secs(60))
+            .cleanup_interval(std::time::Duration::from_secs(60)),
+    ));
+    let mut router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(hangs)
+        .with_tasks();
+    init_router(&mut router).await;
+
+    let response = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
+                name: "hangs".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    let task_id = match response.inner {
+        Ok(McpResponse::FinalCreateTask(result)) => result.task.metadata.task_id,
+        other => panic!("expected a created task, got {other:?}"),
+    };
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while started.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("ordinary handler never started");
+    assert!(store.set_ttl(&task_id, 0).await.unwrap());
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while dropped.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("expiry did not drop the ordinary handler future");
+    assert_eq!(dropped.load(Ordering::SeqCst), 1);
+    assert!(store.get_task(&task_id).await.unwrap().is_none());
+    assert!(matches!(
+        store.task_presence(&task_id).await.unwrap(),
+        TaskPresence::Expired { .. }
+    ));
+}
+
+/// #1389: the cancellation source survives a park/resume boundary. A replayed
+/// handler that never polls must still be dropped at the original task TTL.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn expiry_stops_a_replayed_task_handler_that_never_polls() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::async_task::{MemoryTaskStore, MemoryTaskStoreConfig, TaskPresence, TaskStore};
+    use crate::protocol::{
+        ElicitFormParams, ElicitFormSchema, ElicitRequestParams, InputRequest, InputRequests,
+        InputRequiredResult, RequestOutcome,
+    };
+
+    struct CountDrop(std::sync::Arc<AtomicUsize>);
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let replay_started = std::sync::Arc::new(AtomicUsize::new(0));
+    let replay_dropped = std::sync::Arc::new(AtomicUsize::new(0));
+    let handler_started = replay_started.clone();
+    let handler_dropped = replay_dropped.clone();
+    let asks_then_hangs = ToolBuilder::new("asks_then_hangs")
+        .description("Parks once, then never returns")
+        .task_support(TaskSupportMode::Optional)
+        .mrtr_handler::<serde_json::Value, _, _>(move |ctx, _input| {
+            let started = handler_started.clone();
+            let dropped = handler_dropped.clone();
+            async move {
+                if ctx.input_responses().is_some() {
+                    started.fetch_add(1, Ordering::SeqCst);
+                    let _drop = CountDrop(dropped);
+                    std::future::pending::<()>().await;
+                    return Ok(RequestOutcome::Complete(CallToolResult::text(
+                        "unreachable",
+                    )));
+                }
+
+                let mut requests: InputRequests = Default::default();
+                requests.insert(
+                    "decision".to_string(),
+                    InputRequest::Elicit(ElicitRequestParams::Form(ElicitFormParams {
+                        mode: None,
+                        message: "approve?".to_string(),
+                        requested_schema: ElicitFormSchema::new(),
+                        meta: None,
+                    })),
+                );
+                Ok(RequestOutcome::input_required(
+                    InputRequiredResult::with_requests(requests),
+                ))
+            }
+        })
+        .build();
+
+    let store = std::sync::Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::default()
+            .default_ttl(std::time::Duration::from_secs(60))
+            .cleanup_interval(std::time::Duration::from_secs(60)),
+    ));
+    let mut router = McpRouter::new()
+        .task_store(store.clone())
+        .tool(asks_then_hangs)
+        .with_tasks();
+    init_router(&mut router).await;
+
+    let response = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(1),
+            inner: McpRequest::CallTool(CallToolParams {
+                input_responses: None,
+                request_state: None,
+                name: "asks_then_hangs".to_string(),
+                arguments: serde_json::json!({}),
+                meta: None,
+                task: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    let task_id = match response.inner {
+        Ok(McpResponse::FinalCreateTask(result)) => result.task.metadata.task_id,
+        other => panic!("expected a created task, got {other:?}"),
+    };
+
+    for _ in 0..50 {
+        if store
+            .get_task(&task_id)
+            .await
+            .unwrap()
+            .is_some_and(|task| task.status == TaskStatus::InputRequired)
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert_eq!(
+        store.get_task(&task_id).await.unwrap().unwrap().status,
+        TaskStatus::InputRequired
+    );
+
+    let update = router
+        .ready()
+        .await
+        .unwrap()
+        .call(RouterRequest {
+            id: RequestId::Number(2),
+            inner: McpRequest::UpdateTask(UpdateTaskParams {
+                task_id: task_id.clone(),
+                input_responses: [(
+                    "decision".to_string(),
+                    serde_json::json!({"action": "accept"}),
+                )]
+                .into_iter()
+                .collect(),
+                meta: None,
+            }),
+            extensions: tasks_client_extensions(),
+        })
+        .await
+        .unwrap();
+    assert!(update.inner.is_ok());
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while replay_started.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("the replay handler never started");
+    assert!(store.set_ttl(&task_id, 0).await.unwrap());
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while replay_dropped.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("expiry did not drop the replay handler future");
+
+    assert_eq!(replay_started.load(Ordering::SeqCst), 1);
+    assert_eq!(replay_dropped.load(Ordering::SeqCst), 1);
+    assert!(store.get_task(&task_id).await.unwrap().is_none());
+    assert!(matches!(
+        store.task_presence(&task_id).await.unwrap(),
+        TaskPresence::Expired { .. }
+    ));
+}
+
 /// #1306: replay uses the root router's selected panic disclosure policy,
 /// just like an ordinary call. The existing replay contract still records a
 /// caught panic as a completed tool error rather than changing task semantics.

--- a/crates/tower-mcp/src/task_execution.rs
+++ b/crates/tower-mcp/src/task_execution.rs
@@ -6,7 +6,7 @@
 //! to an application cancellation policy.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use crate::context::CancellationToken;
 
@@ -98,6 +98,9 @@ impl LiveTaskExecutionHandle {
 
 pub(crate) struct LiveTaskCancellation {
     token: CancellationToken,
+    /// Store-owned cancellation/expiry signal, attached after the durable
+    /// task record is created and before preparation begins.
+    task_lifecycle: OnceLock<crate::async_task::CancellationToken>,
     state: Mutex<CancellationState>,
 }
 
@@ -111,16 +114,34 @@ impl LiveTaskCancellation {
     pub(crate) fn new() -> Self {
         Self {
             token: CancellationToken::new(),
+            task_lifecycle: OnceLock::new(),
             state: Mutex::new(CancellationState::default()),
         }
     }
 
+    pub(crate) fn attach_task_lifecycle(&self, token: crate::async_task::CancellationToken) {
+        let attached = self.task_lifecycle.set(token).is_ok();
+        debug_assert!(attached, "a live execution has one task lifecycle token");
+    }
+
     pub(crate) fn is_cancelled(&self) -> bool {
         self.token.is_cancelled()
+            || self
+                .task_lifecycle
+                .get()
+                .is_some_and(crate::async_task::CancellationToken::is_cancelled)
     }
 
     pub(crate) async fn cancelled(&self) {
-        self.token.cancelled().await;
+        match self.task_lifecycle.get() {
+            Some(task_lifecycle) => {
+                tokio::select! {
+                    _ = self.token.cancelled() => {}
+                    _ = task_lifecycle.cancelled() => {}
+                }
+            }
+            None => self.token.cancelled().await,
+        }
     }
 
     pub(crate) fn cancel(&self, reason: Option<String>) {

--- a/crates/tower-mcp/src/tool/task.rs
+++ b/crates/tower-mcp/src/tool/task.rs
@@ -132,10 +132,11 @@ impl TaskContext {
     ///
     /// # Errors
     ///
-    /// Returns [`crate::Error::TaskCancelled`] if the
-    /// task is cancelled while waiting, so a handler that propagates with `?`
+    /// Returns [`crate::Error::TaskCancelled`] if the task is cancelled or its
+    /// TTL expires while waiting, so a handler that propagates with `?`
     /// unwinds correctly without writing a `select!`. The router maps that
-    /// error to [`TaskOutcome::Cancelled`].
+    /// error to [`TaskOutcome::Cancelled`]; an expired record remains expired
+    /// and cannot be resurrected by that terminal write.
     ///
     /// Request keys must be unique over the task's lifetime (SEP-2663), so
     /// reusing a spent key is an error rather than a fresh question.
@@ -297,7 +298,7 @@ impl TaskContext {
         Ok(())
     }
 
-    /// Whether this task has been asked to cancel.
+    /// Whether this task has been asked to cancel or has expired.
     ///
     /// Available during live-task preparation as well as handler execution.
     /// A live task stays non-terminal until its handler returns, so this being
@@ -320,7 +321,7 @@ impl TaskContext {
             .and_then(|cancellation| cancellation.reason())
     }
 
-    /// Resolves when this task is asked to cancel.
+    /// Resolves when this task is asked to cancel or reaches its TTL.
     ///
     /// A live handler uses this when it interleaves teardown with its own
     /// work. Task preparation receives the same signal, so a cooperative
@@ -416,10 +417,10 @@ impl PendingInput {
     ///
     /// # Errors
     ///
-    /// [`crate::Error::TaskCancelled`] if the task is cancelled while
-    /// waiting, so a handler that propagates with `?` unwinds correctly
+    /// [`crate::Error::TaskCancelled`] if the task is cancelled or expires
+    /// while waiting, so a handler that propagates with `?` unwinds correctly
     /// without writing a `select!`. The router maps that to
-    /// [`TaskOutcome::Cancelled`].
+    /// [`TaskOutcome::Cancelled`]; an expired store record stays absent.
     pub async fn wait(self) -> Result<InputResponses> {
         let live = &self.live;
 

--- a/crates/tower-mcp/tests/client_tasks.rs
+++ b/crates/tower-mcp/tests/client_tasks.rs
@@ -264,3 +264,36 @@ async fn final_task_aware_call_exposes_direct_lifecycle() {
         Some("the answer is 42")
     );
 }
+
+/// Final task creation has no client TTL input, so the configured store
+/// default must be the value advertised on the server-created task.
+#[cfg(feature = "stateless")]
+#[tokio::test]
+async fn final_task_uses_the_server_configured_default_ttl() {
+    use std::sync::Arc;
+
+    use tower_mcp::client::TaskAwareCallToolOutcome;
+    use tower_mcp::{MemoryTaskStore, MemoryTaskStoreConfig};
+
+    let store = Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::default().default_ttl(Duration::from_secs(42)),
+    ));
+    let client = McpClient::builder()
+        .protocol_support(tower_mcp::ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect_simple(ChannelTransport::new(
+            task_router().task_store(store).with_tasks(),
+        ))
+        .await
+        .expect("connect");
+    client.discover("test", "1.0.0").await.expect("discover");
+
+    let outcome = client
+        .call_tool_once_task_aware("compute", serde_json::json!({}), None, None)
+        .await
+        .expect("tools/call");
+    let TaskAwareCallToolOutcome::Task(created) = outcome else {
+        panic!("expected server-created task")
+    };
+    assert_eq!(created.task.metadata.ttl_ms, Some(42_000));
+}

--- a/crates/tower-mcp/tests/external_task_store.rs
+++ b/crates/tower-mcp/tests/external_task_store.rs
@@ -204,6 +204,7 @@ impl TaskStore for ExternalStore {
                 record.arguments.clone(),
                 record.input_responses.clone(),
             )
+            .with_cancellation_token(record.token.clone())
         }))
     }
 
@@ -270,7 +271,13 @@ async fn a_constructed_token_carries_cancellation() {
     let token = CancellationToken::new();
     let clone = token.clone();
     assert!(!token.is_cancelled());
-    clone.cancel();
+    tokio::spawn(async move {
+        tokio::task::yield_now().await;
+        clone.cancel();
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(1), token.cancelled())
+        .await
+        .expect("an external store must be able to await its task token");
     assert!(
         token.is_cancelled(),
         "every clone observes the same flag, which is what the store relies on"
@@ -282,7 +289,7 @@ async fn a_constructed_token_carries_cancellation() {
 #[tokio::test]
 async fn an_external_store_can_construct_a_resume_context() {
     let store = ExternalStore::default();
-    let (task_id, _) = store
+    let (task_id, token) = store
         .create_task("build_report", json!({"format": "pdf"}), None, None)
         .await
         .unwrap();
@@ -291,4 +298,9 @@ async fn an_external_store_can_construct_a_resume_context() {
     assert_eq!(resume.tool_name, "build_report");
     assert_eq!(resume.arguments, json!({"format": "pdf"}));
     assert!(resume.input_responses.is_empty());
+    let replay_token = resume
+        .cancellation_token
+        .expect("external store attached the task lifecycle token");
+    token.cancel();
+    assert!(replay_token.is_cancelled());
 }

--- a/crates/tower-mcp/tests/live_tasks.rs
+++ b/crates/tower-mcp/tests/live_tasks.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use serde::Deserialize;
 use serde_json::json;
-use tower_mcp::async_task::{MemoryTaskStore, TaskStore};
+use tower_mcp::async_task::{MemoryTaskStore, MemoryTaskStoreConfig, TaskPresence, TaskStore};
 use tower_mcp::client::{ChannelTransport, McpClient};
 use tower_mcp::protocol::{
     ElicitAction, ElicitFormParams, ElicitFormSchema, ElicitRequestParams, ElicitResult,
@@ -1254,6 +1254,76 @@ async fn a_cancellation_that_lands_before_wait_is_observed() {
 
     release.notify_one();
     await_status(&store, &task_id, TaskStatus::Cancelled).await;
+}
+
+/// #1389: expiry uses the store token that backs the live TaskContext. A task
+/// parked on input therefore unwinds at its TTL deadline even though the
+/// expired id can no longer be updated or cancelled by a client.
+#[tokio::test]
+async fn expiry_wakes_a_live_handler_parked_for_input() {
+    struct CountDrop(Arc<AtomicUsize>);
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let tore_down = Arc::new(AtomicUsize::new(0));
+    let handler_tore_down = tore_down.clone();
+    let tool = ToolBuilder::new("expiring_live")
+        .description("Parks until its server-selected TTL expires")
+        .live_task_handler(move |task: TaskContext, _input: NoArgs| {
+            let tore_down = handler_tore_down.clone();
+            async move {
+                let _drop = CountDrop(tore_down);
+                task.require_input(ask("never")).await?;
+                Ok(TaskOutcome::Completed(CallToolResult::text("unreachable")))
+            }
+        })
+        .build();
+
+    let store = Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::default()
+            .default_ttl(std::time::Duration::from_secs(60))
+            .cleanup_interval(std::time::Duration::from_secs(60)),
+    ));
+    let router = McpRouter::new()
+        .server_info("live-expiry", "1.0.0")
+        .task_store(store.clone())
+        .tool(tool)
+        .with_tasks();
+    let client = McpClient::connect(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client.initialize("t", "1.0.0").await.expect("init");
+
+    let task_id = client
+        .call_tool_as_task("expiring_live", json!({}), None)
+        .await
+        .expect("task created")
+        .task
+        .task_id;
+    await_status(&store, &task_id, TaskStatus::InputRequired).await;
+    assert!(store.set_ttl(&task_id, 0).await.unwrap());
+
+    tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        while tore_down.load(Ordering::SeqCst) == 0 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("expiry did not wake and unwind the input waiter");
+
+    assert!(store.get_task(&task_id).await.unwrap().is_none());
+    assert!(matches!(
+        store.task_presence(&task_id).await.unwrap(),
+        TaskPresence::Expired { .. }
+    ));
+    assert_eq!(
+        tore_down.load(Ordering::SeqCst),
+        1,
+        "expiry must signal the live execution only once"
+    );
 }
 
 /// `require_input` is the two calls back to back, so it must keep behaving

--- a/crates/tower-mcp/tests/task_preparation.rs
+++ b/crates/tower-mcp/tests/task_preparation.rs
@@ -6,14 +6,14 @@ use std::time::Duration;
 
 use serde::Deserialize;
 use serde_json::{Map, json};
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tower_mcp::client::{ChannelTransport, McpClient, NotificationHandler};
 use tower_mcp::extract::{Extension, Json};
 use tower_mcp::protocol::TaskStatus;
 use tower_mcp::schemars::JsonSchema;
 use tower_mcp::{
-    CallToolResult, McpRouter, ProtocolSupport, TaskContext, TaskPreparation, TaskStore,
-    TaskSupportMode, ToolBuilder,
+    CallToolResult, McpRouter, MemoryTaskStore, MemoryTaskStoreConfig, ProtocolSupport,
+    TaskContext, TaskPreparation, TaskStore, TaskSupportMode, ToolBuilder,
 };
 
 const PREPARED_META: &str = "dev.tower-mcp/prepared";
@@ -201,6 +201,94 @@ async fn preparation_error_discards_the_task_and_skips_background_execution() {
         .expect_err("preparation must reject the call");
     assert!(error.to_string().contains("preparation rejected"));
     assert_eq!(preparation_count.load(Ordering::SeqCst), 1);
+    assert_eq!(handler_count.load(Ordering::SeqCst), 0);
+    assert!(store.list_tasks(None).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn task_expiry_interrupts_preparation_and_discards_the_task() {
+    struct DropSignal(Arc<AtomicUsize>);
+
+    impl Drop for DropSignal {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let preparation_started = Arc::new(AtomicUsize::new(0));
+    let preparation_dropped = Arc::new(AtomicUsize::new(0));
+    let handler_count = Arc::new(AtomicUsize::new(0));
+    let preparation_entered = Arc::new(Notify::new());
+    let prepare_starts = preparation_started.clone();
+    let prepare_drops = preparation_dropped.clone();
+    let prepare_entered = preparation_entered.clone();
+    let handler_calls = handler_count.clone();
+    let store = Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::new()
+            .default_ttl(Duration::from_secs(60))
+            .cleanup_interval(Duration::from_secs(60)),
+    ));
+
+    let tool = ToolBuilder::new("expiring-preparation")
+        .task_support(TaskSupportMode::Required)
+        .handler(move |_input: Input| {
+            let handler_calls = handler_calls.clone();
+            async move {
+                handler_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(CallToolResult::text("should not run"))
+            }
+        })
+        .task_preparation(move |_task, _input| {
+            let prepare_starts = prepare_starts.clone();
+            let prepare_drops = prepare_drops.clone();
+            let prepare_entered = prepare_entered.clone();
+            async move {
+                let _drop_signal = DropSignal(prepare_drops);
+                prepare_starts.fetch_add(1, Ordering::SeqCst);
+                prepare_entered.notify_one();
+                std::future::pending::<tower_mcp::Result<TaskPreparation>>().await
+            }
+        })
+        .build();
+    let router = McpRouter::new()
+        .server_info("task-preparation-test", "1.0.0")
+        .tool(tool)
+        .task_store(store.clone())
+        .with_tasks();
+    let client = McpClient::builder()
+        .protocol_support(ProtocolSupport::try_new(["2026-07-28"]).unwrap())
+        .with_tasks()
+        .connect_simple(ChannelTransport::new(router))
+        .await
+        .expect("connect");
+    client
+        .discover("task-preparation-client", "1.0.0")
+        .await
+        .expect("discover");
+
+    let call = client.call_tool_as_task("expiring-preparation", json!({"value": 1}), None);
+    tokio::pin!(call);
+    tokio::time::timeout(Duration::from_secs(2), async {
+        tokio::select! {
+            result = &mut call => panic!("preparation returned before expiry: {result:?}"),
+            _ = preparation_entered.notified() => {}
+        }
+    })
+    .await
+    .expect("preparation never started");
+
+    let tasks = store.list_tasks(None).await.unwrap();
+    assert_eq!(tasks.len(), 1);
+    assert!(store.set_ttl(&tasks[0].task_id, 0).await.unwrap());
+
+    let error = tokio::time::timeout(Duration::from_secs(2), &mut call)
+        .await
+        .expect("preparation must stop at the task deadline")
+        .expect_err("expired preparation must reject the task call");
+
+    assert!(error.to_string().contains("interrupted preparation"));
+    assert_eq!(preparation_started.load(Ordering::SeqCst), 1);
+    assert_eq!(preparation_dropped.load(Ordering::SeqCst), 1);
     assert_eq!(handler_count.load(Ordering::SeqCst), 0);
     assert!(store.list_tasks(None).await.unwrap().is_empty());
 }

--- a/examples/tasks.rs
+++ b/examples/tasks.rs
@@ -16,11 +16,15 @@
 //! in still returns a normal synchronous result to a client that did not, so
 //! adding `with_tasks()` never changes behavior for existing clients.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use schemars::JsonSchema;
 use serde::Deserialize;
-use tower_mcp::{CallToolResult, McpRouter, StdioTransport, TaskSupportMode, ToolBuilder};
+use tower_mcp::{
+    CallToolResult, McpRouter, MemoryTaskStore, MemoryTaskStoreConfig, StdioTransport,
+    TaskSupportMode, ToolBuilder,
+};
 
 #[derive(Debug, Deserialize, JsonSchema)]
 struct ReportInput {
@@ -46,8 +50,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         })
         .build();
 
+    // Final-protocol clients do not choose a TTL. The server owns that policy;
+    // here tasks may run for thirty minutes, while expired records are
+    // physically reclaimed at most thirty seconds later. The built-in defaults
+    // remain five minutes and one minute respectively.
+    let task_store = Arc::new(MemoryTaskStore::with_config(
+        MemoryTaskStoreConfig::default()
+            .default_ttl(Duration::from_secs(30 * 60))
+            .cleanup_interval(Duration::from_secs(30)),
+    ));
+
     let router = McpRouter::new()
         .server_info("tasks-example", env!("CARGO_PKG_VERSION"))
+        .task_store(task_store)
         .tool(build_report)
         // The runtime opt-in. Without it, registering a task-capable tool
         // advertises nothing and no task is ever created.
@@ -136,4 +151,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //
 // Expiry follows the same rule. `ttlMs` runs from creation, and once it
 // elapses the task reads as absent rather than as expired, so a retention
-// window cannot be probed either.
+// window cannot be probed either. The in-memory store raises the task's
+// cancellation signal at that deadline (including while it waits for input)
+// and reclaims the record on its configured cleanup cadence.


### PR DESCRIPTION
## Summary

- add public in-memory Task-store configuration for the server-selected default TTL and automatic cleanup cadence
- signal expiry exactly at the Task deadline, wake completion/input waiters, and stop ordinary/replayed work that no longer has an addressable Task
- preserve live-execution admission, first-wins host/client cancellation reasons, owner isolation, and external TaskStore compatibility
- document the lifecycle contract and cover working, input-required, preparation, replay, terminal-write, cancellation, cleanup, and worker-shutdown paths

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo clippy -p tower-mcp --all-targets --no-default-features -- -D warnings
- cargo test --workspace --all-targets --all-features
- RUSTDOCFLAGS=-D warnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features

Closes #1389