### PR TITLE
test: eliminate task presence timing race

### DIFF
--- a/crates/tower-mcp/tests/task_presence.rs
+++ b/crates/tower-mcp/tests/task_presence.rs
@@ -67,12 +67,15 @@ async fn another_principals_tasks_are_indistinguishable_from_missing() {
 #[tokio::test]
 async fn the_owner_can_tell_expired_from_missing() {
     let store = MemoryTaskStore::new();
-    let (expired, _) = store
-        .create_task("work", json!({}), Some(1), Some("alice".into()))
-        .await
-        .expect("create");
     let (present, _) = store
         .create_task("work", json!({}), Some(60_000), Some("alice".into()))
+        .await
+        .expect("create");
+    // Task admission may reclaim expired tombstones, so create the short-lived
+    // record last. Otherwise crossing its 1 ms deadline during the second
+    // create makes this assertion depend on scheduler timing.
+    let (expired, _) = store
+        .create_task("work", json!({}), Some(1), Some("alice".into()))
         .await
         .expect("create");
     tokio::time::sleep(std::time::Duration::from_millis(30)).await;


### PR DESCRIPTION
## Summary

- create the long-lived task before the 1 ms task in the task-presence regression
- document why the short-lived task must be admitted last

## Why

The macOS stable lane in PR #1407 failed because creating the second task can reclaim the first task after its 1 ms TTL. Depending on scheduler timing, the assertion then observes Missing instead of Expired.

Failing job: https://github.com/joshrotenberg/tower-mcp/actions/runs/32656865837/job/97237117757?pr=1407

## Validation

- 25 repeated task_presence integration-test runs
- cargo test --all-targets --all-features
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- RUSTDOCFLAGS=-Dwarnings cargo doc --workspace --all-features --no-deps
- cargo test --workspace --doc --all-features